### PR TITLE
[tinker-cookbook] rl: trace compute_post_kl and incorporate_kl_penalty

### DIFF
--- a/tinker_cookbook/rl/metrics.py
+++ b/tinker_cookbook/rl/metrics.py
@@ -12,6 +12,7 @@ import numpy as np
 import tinker
 import torch
 from tinker_cookbook.utils.misc_utils import safezip
+from tinker_cookbook.utils.trace import scope
 
 
 def compute_kl_sample_train(
@@ -48,6 +49,7 @@ def compute_kl_sample_train(
     }
 
 
+@scope
 async def compute_post_kl(
     data_D: List[tinker.Datum], post_sampling_client: tinker.SamplingClient
 ) -> Dict[str, float]:
@@ -81,6 +83,7 @@ async def compute_post_kl(
     return {"kl_pre_post_v1": kl_post_v1, "kl_pre_post_v2": kl_post_v2}
 
 
+@scope
 async def incorporate_kl_penalty(
     data_D: List[tinker.Datum],
     base_sampling_client: tinker.SamplingClient,


### PR DESCRIPTION
This allows us to see in traces how long these functions are taking.

<img width="2488" height="1231" alt="Screenshot 2025-10-15 at 11 47 53 AM" src="https://github.com/user-attachments/assets/c78e7ac8-8553-45fc-9507-3bab628d4958" />

Example with `rl_basic.py` with an async enabled and `compute_post_kl=True`