### PR TITLE
fix docstrings and renderers example

### DIFF
--- a/tinker_cookbook/renderers.py
+++ b/tinker_cookbook/renderers.py
@@ -1,6 +1,6 @@
 """
 Use viz_sft_dataset to visualize the output of different renderers. E.g.,
-    python -m tinker_cookbook.viz_sft_dataset dataset_name=wildchat_v0 renderer_name=role_colon
+    python -m tinker_cookbook.supervised.viz_sft_dataset dataset_path=Tulu3Builder renderer_name=role_colon
 """
 
 import json

--- a/tinker_cookbook/supervised/viz_sft_dataset.py
+++ b/tinker_cookbook/supervised/viz_sft_dataset.py
@@ -30,7 +30,7 @@ def run(cfg: Config):
         batch_size=n_examples_total,
     )
     dataset_builder = lookup_func(
-        cfg.dataset_path, default_module="tinker_cookbook.supervised.chat_datasets"
+        cfg.dataset_path, default_module="tinker_cookbook.recipes.chat_sl.chat_datasets"
     )(common_config=common_config)
     assert isinstance(dataset_builder, SupervisedDatasetBuilder)
     tokenizer = get_tokenizer(cfg.model_name)


### PR DESCRIPTION
Docstring in `tinker_cookbook/renderers.py` currently doesn't work (looks like after some code movement)

```
python -m tinker_cookbook.viz_sft_dataset dataset_name=wildchat_v0 renderer_name=role_colon
```

this change makes `python -m tinker_cookbook.viz_sft_dataset dataset_name=wildchat_v0 renderer_name=role_colon` work