### PR TITLE
Fix a minor typo in the doc

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1755,7 +1755,7 @@ The player model (which we fine-tune) is also based on that same model.
 You can run the training script as follows:
 
 ```bash
-uv run python -m tinker_cookbook.recipes.twenty_questions.train
+uv run python -m tinker_cookbook.recipes.multiplayer_rl.twenty_questions.train
 ```
 
 


### PR DESCRIPTION
There is a new multiplayer_rl dir. I don't know if this file contributes to the website but the website has a typo: https://tinker-docs.thinkingmachines.ai/rl/rl-envs