### PR TITLE
[logtree][properly logging newline characters]

### DIFF
--- a/tinker_cookbook/utils/logtree.py
+++ b/tinker_cookbook/utils/logtree.py
@@ -71,7 +71,7 @@ class Node:
         lines = [f"{ind}<{self.tag}{attrs_str}>\n"]
         for child in self.children:
             if isinstance(child, str):
-                lines.append(f"{ind}  {child}\n")
+                lines.append(child)
             else:
                 lines.append(child.to_html(indent + 1))
         lines.append(f"{ind}</{self.tag}>\n")
@@ -208,6 +208,7 @@ body {
 
 .lt-p {
     margin: 0.5rem 0;
+    white-space: pre-wrap;
 }
 
 .lt-details {


### PR DESCRIPTION
In the previous `logtree` the new line characters are not visualized correctly. 

Now it looks like this. 


<img width="1514" height="440" alt="logtree" src="https://github.com/user-attachments/assets/08c9a27a-3995-4562-8052-5225f7d24983" />
