### PR TITLE
Fix Qwen rendering and parsing for tool calls

### DIFF
--- a/tinker_cookbook/renderers.py
+++ b/tinker_cookbook/renderers.py
@@ -336,21 +336,20 @@ class Qwen3Renderer(Renderer):
             # <think> in the assistant messages, we so don't need to re-add it in those cases.
             ob_str += "<think>\n"
         # Observation (prompt) part
-        ac_str = f"{ac_content}<|im_end|>"
         if "tool_calls" in message:
-            ac_str += "\n".join(
+            ac_content += "\n".join(
                 [
                     f"<tool_call>\n{json.dumps(tool_call)}\n</tool_call>"
                     for tool_call in message["tool_calls"]
                 ]
             )
-        ac_str += "<|im_end|>"
+        ac_content += "<|im_end|>"
         # Action part
         ac_tail_str = ""  # No action tail needed for Qwen format
         # Action part that's only included in the last message in SFT
         return (
             self.tokenizer.encode(ob_str, add_special_tokens=False),
-            self.tokenizer.encode(ac_str, add_special_tokens=False),
+            self.tokenizer.encode(ac_content, add_special_tokens=False),
             self.tokenizer.encode(ac_tail_str, add_special_tokens=False),
         )
 


### PR DESCRIPTION
1. Rendering: `Message` can have `tool_calls` which are currently ignored -- this renders them in with how Qwen docs refer to them.
2. Parsing: `<tool_call>` seems more widely used in official Qwen docs than `<function_call>`, so switched the `parse_response` implementation to use that.

Looked at the unit tests to update but they seem commented out for Qwen models, so didn't touch them
