### PR TITLE
fix resume checkpoint conflict in frontend

### DIFF
--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -257,7 +257,7 @@ async def do_sync_training_with_stream_minibatch(
     """
     # Initial sampling client
     sampling_client, _ = await save_checkpoint_and_get_sampling_client(
-        training_client, start_batch, cfg.log_path, cfg.save_every
+        training_client, start_batch, cfg.log_path, cfg.save_every, start_batch
     )
 
     for i_batch in range(start_batch, end_batch):
@@ -616,6 +616,7 @@ async def save_checkpoint_and_get_sampling_client(
     i_batch: int,
     log_path: str,
     save_every: int,
+    start_batch: int = 0,
 ) -> tuple[tinker.SamplingClient, dict[str, Any]]:
     metrics = {}
     with timed("save_checkpoint", metrics):
@@ -624,7 +625,7 @@ async def save_checkpoint_and_get_sampling_client(
             name=f"{i_batch:06d}",
             log_path=log_path,
             loop_state={"batch": i_batch},
-            kind="both" if (i_batch > 0 and i_batch % save_every == 0) else "sampler",
+            kind="both" if (i_batch > start_batch and i_batch % save_every == 0) else "sampler",
         )
         return training_client.create_sampling_client(path_dict["sampler_path"]), metrics
 
@@ -885,7 +886,7 @@ async def do_sync_training(
     """Implements fully synchronous on-policy training"""
     # Initial sampling client
     sampling_client, _ = await save_checkpoint_and_get_sampling_client(
-        training_client, start_batch, cfg.log_path, cfg.save_every
+        training_client, start_batch, cfg.log_path, cfg.save_every, start_batch
     )
 
     for i_batch in range(start_batch, end_batch):


### PR DESCRIPTION
This PR fixes a checkpoint conflict (409 error) that can occur when resuming training from an existing checkpoint. For example:
```bash
...
  File "/rscratch/xiuyu/anaconda3/envs/tinker/lib/python3.12/site-packages/tinker/_base_client.py", line 1578, in request
    raise self._make_status_error_from_response(err.response) from None
tinker.ConflictError: Error code: 409 - {'detail': "Checkpoint '000060' already exists for model 951d7759-2db7-4f44-9f36-c6d090bad0a4 in weights. Please choose a different name to avoid overwriting."}
```
The issue likely originates from a backend caveat. This PR proposes a frontend fix that resolves it by skipping the initial save when resuming—matching the behavior of training from scratch.

Specifically, it changes
```python
kind="both" if (i_batch > 0 and i_batch % save_every == 0) else "sampler"
```
to
```python
kind="both" if (i_batch > start_batch and i_batch % save_every == 0) else "sampler"
```
in `save_checkpoint_and_get_sampling_client`, ensuring consistent behavior across resumed and new runs.