### PR TITLE
bug fix: defining the function `get_reference_answer` at `PromptOnlyEnv`

### DIFF
--- a/tinker_cookbook/distillation/datasets.py
+++ b/tinker_cookbook/distillation/datasets.py
@@ -107,9 +107,9 @@ class PromptOnlyEnv(ProblemEnv):
         # Always return False - no answer checking for distillation
         return False
 
-    def get_reference_answer(self) -> str | None:
+    def get_reference_answer(self) -> str:
         """No reference answer needed for distillation."""
-        pass
+        return ""
 
     async def step(self, action: Action) -> StepResult:
         """Return zero reward always."""


### PR DESCRIPTION
When running:
```bash
python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
    model_name=Qwen/Qwen3-8B-Base \
    dataset=deepmath \
    learning_rate=1e-4 \
    groups_per_batch=512 \
    lora_rank=128 \
    wandb_project=cookbook_distillation
```

The following error occurs:
```bash
TypeError: Can't instantiate abstract class PromptOnlyEnv with abstract method get_reference_answer
```

Suggested fix:
Define a pass function `get_reference_answer` as it is defined as an abstract method in `Problem Env`