### PR TITLE
qwen_instruct and search_env recipe fixes

### DIFF
--- a/tinker_cookbook/recipes/tool_use/search/search_env.py
+++ b/tinker_cookbook/recipes/tool_use/search/search_env.py
@@ -32,7 +32,7 @@ _CONNECTION_SEMAPHORE = asyncio.Semaphore(128)
 
 SEARCH_TOOL_SYSTEM_PROMPT = """
 You are an expert assistant who solves tasks using a Wikipedia search tool.
-Tool calling. Execute the tool by wrapping calls in <function_call>...</function_call>
+Tool calling. Execute the tool by wrapping calls in <tool_call>...</tool_call>
 
 The search tool you are given has the following schema:
 ```
@@ -69,9 +69,9 @@ Here is an example of solving a real question:
 “Between 2020 and 2025, which year did New York City see the most population growth and how did San Francisco population change in that year?”
 
 1. Think step by step: In order to answer this question, I need to know the population of New York City and San Francisco between 2020 and 2025. I will search for the population of New York City in each year
-2. Calling search tool: <function_call>{"name": "search", "args": {"query_list": ["Population New York city between 2020 and 2025"]}}</function_call> (Output omitted for brevity)
+2. Calling search tool: <tool_call>{"name": "search", "args": {"query_list": ["Population New York city between 2020 and 2025"]}}</tool_call> (Output omitted for brevity)
 3. Think step by step again: I have the population of New York City in each year, and I see that the population of New York City grew the most in 2024. I need to know the population of San Francisco in 2024. I will search for the population of San Francisco in each year.
-<function_call>{"name": "search", "args": {"query_list": ["Population San Francisco between 2023 and 2024"]}}</function_call> (Output omitted for brevity)
+<tool_call>{"name": "search", "args": {"query_list": ["Population San Francisco between 2023 and 2024"]}}</tool_call> (Output omitted for brevity)
 4. Answer: The population of New York City grew the most in 2024, and the population of San Francisco changed by XXXX in 2024.
 """
 

--- a/tinker_cookbook/renderers.py
+++ b/tinker_cookbook/renderers.py
@@ -481,13 +481,20 @@ class Qwen3InstructRenderer(Qwen3Renderer):
         ob_str = f"{maybe_newline}<|im_start|>{message['role']}\n"
         ac_content = message["content"]
         # Observation (prompt) part
-        ac_str = f"{ac_content}<|im_end|>"
+        if "tool_calls" in message:
+            ac_content += "\n".join(
+                [
+                    f"<tool_call>\n{json.dumps(tool_call)}\n</tool_call>"
+                    for tool_call in message["tool_calls"]
+                ]
+            )
+        ac_content += "<|im_end|>"
         # Action part
         ac_tail_str = ""  # No action tail needed for Qwen format
         # Action part that's only included in the last message in SFT
         return (
             self.tokenizer.encode(ob_str, add_special_tokens=False),
-            self.tokenizer.encode(ac_str, add_special_tokens=False),
+            self.tokenizer.encode(ac_content, add_special_tokens=False),
             self.tokenizer.encode(ac_tail_str, add_special_tokens=False),
         )
 


### PR DESCRIPTION
This is the same idea as https://github.com/thinking-machines-lab/tinker-cookbook/pull/58/files but for `Qwen3InstructRenderer`, which overrides `_render_message`.  Also, the `search_env` recipe has `Qwen/Qwen3-4B-Instruct-2507` as default, so changing the tool description / sys prompt there to s/function_call/tool_call as well