### PR TITLE
[tinker-cookbook] set_scope_context: add helper

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 import tinker
 
 from tinker_cookbook.utils.file_utils import read_jsonl
-from tinker_cookbook.utils.trace import scope, set_scope_context
+from tinker_cookbook.utils.trace import scope, update_scope_context
 
 CHECKPOINTS_BASE_NAME = "checkpoints.jsonl"
 
@@ -22,7 +22,7 @@ def load_checkpoints_file(log_dir: str) -> list[dict[str, Any]]:
         return []
 
     logger.info(f"Reading checkpoints from {checkpoint_path}")
-    set_scope_context({"checkpoint_path": checkpoint_path})
+    update_scope_context({"checkpoint_path": checkpoint_path})
     return read_jsonl(checkpoint_path)
 
 
@@ -77,7 +77,7 @@ async def save_checkpoint_async(
 
     results = {k: await v.result_async() for k, v in futures.items()}
     paths = {k + "_path": v.path for k, v in results.items()}
-    set_scope_context(paths)
+    update_scope_context(paths)
     logger.info(f"Saved checkpoints: {paths}")
     full_dict = {"name": name, **loop_state, **paths}
     with open(os.path.join(log_path, "checkpoints.jsonl"), "a") as f:

--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -39,7 +39,7 @@ from tinker_cookbook.rl.types import (
 from tinker_cookbook.tokenizer_utils import Tokenizer
 from tinker_cookbook.utils import ml_log
 from tinker_cookbook.utils.misc_utils import safezip, timed
-from tinker_cookbook.utils.trace import scope, set_scope_context, trace_init
+from tinker_cookbook.utils.trace import scope, update_scope_context, trace_init
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +225,7 @@ async def do_train_step_and_get_sampling_client(
     dataset_indices_P: List[int],
     teacher_clients: List[tinker.SamplingClient],
 ) -> tuple[tinker.SamplingClient, dict[str, Any]]:
-    set_scope_context({"step": i_batch})
+    update_scope_context({"step": i_batch})
 
     metrics = {}
     data_D, prepare_minibatch_metrics = await prepare_minibatch(

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -41,7 +41,7 @@ from tinker_cookbook.rl.types import (
 from tinker_cookbook.tokenizer_utils import Tokenizer
 from tinker_cookbook.utils import logtree, ml_log
 from tinker_cookbook.utils.misc_utils import safezip, split_list, timed
-from tinker_cookbook.utils.trace import scope, set_scope_context, trace_init
+from tinker_cookbook.utils.trace import scope, update_scope_context, trace_init
 
 logger = logging.getLogger(__name__)
 
@@ -809,7 +809,7 @@ async def do_train_step_streaming_and_get_sampling_client(
     # Number of groups per minibatch in each optimizer substep
     groups_per_minibatch = groups_per_substep // cfg.stream_minibatch_config.num_minibatches
 
-    set_scope_context({"step": i_batch})
+    update_scope_context({"step": i_batch})
 
     metrics = {}
 
@@ -903,7 +903,7 @@ async def do_train_step_and_get_sampling_client(
     env_group_builders_P: Sequence[EnvGroupBuilder],
     trajectory_groups_P: list[TrajectoryGroup],
 ) -> tuple[tinker.SamplingClient, dict[str, Any]]:
-    set_scope_context({"step": i_batch})
+    update_scope_context({"step": i_batch})
 
     metrics = {}
     data_D, prepare_minibatch_metrics = await prepare_minibatch(

--- a/tinker_cookbook/tests/test_trace.py
+++ b/tinker_cookbook/tests/test_trace.py
@@ -6,7 +6,7 @@ import threading
 from tinker_cookbook.utils.trace import (
     get_scope_context,
     scope,
-    set_scope_context,
+    update_scope_context,
     trace_init,
     trace_shutdown,
 )
@@ -37,7 +37,7 @@ def ced():
 @scope
 async def baz():
     await asyncio.sleep(0.02)
-    set_scope_context({"baz": "baz"})
+    update_scope_context({"baz": "baz"})
     ced()
 
 

--- a/tinker_cookbook/utils/trace.py
+++ b/tinker_cookbook/utils/trace.py
@@ -407,12 +407,12 @@ def get_scope_context() -> ScopeContext:
     return result
 
 
-def set_scope_context(values: dict[str, Any]) -> None:
-    """Set the current scope's context. Example usage:
+def update_scope_context(values: dict[str, Any]) -> None:
+    """Update the current scope's context. Example usage:
 
     @scope
     async def foo(step: int):
-        set_scope_context({"step": step})
+        update_scope_context({"step": step})
         await bar()
 
     """


### PR DESCRIPTION
This adds a helper to make it easier to set context when tracing, and changes the existing callsites to use the new helper.