### PR TITLE
Fix rl_loop metric key to match rl/train.py convention

### DIFF
--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -229,7 +229,7 @@ def main(config: Config):
 
         # Log metrics[]
         metrics["time/total"] = time.time() - t_start
-        metrics["reward/mean"] = sum(batch_rewards) / len(batch_rewards)
+        metrics["reward/total"] = sum(batch_rewards) / len(batch_rewards)
         ml_logger.log_metrics(metrics, step=batch_idx)
 
         # Save final checkpoint


### PR DESCRIPTION
## Summary
- Changed `reward/mean` to `reward/total` in `rl_loop.py` to align with the metric key used by `rl/train.py`
- Resolves confusion when users follow rl-basic tutorial and then try to plot using rl-loops documentation snippet

## Problem
Users following the [rl-basic tutorial](https://tinker-docs.thinkingmachines.ai/rl/rl-basic) run into a KeyError when trying to plot results using the code snippet from the [rl-loops documentation](https://tinker-docs.thinkingmachines.ai/rl/rl-loops). This is because:

1. `rl_loop.py` logs the metric as `reward/mean`
2. `rl/train.py` (via `metric_util.py`) logs it as `env/all/reward/total`
3. Documentation shows plotting `df["reward/mean"]` but rl_basic produces `env/all/reward/total`

## Solution
Changed the metric key in `rl_loop.py` from `reward/mean` to `reward/total` to match the production code pattern. This makes the pedagogical example consistent with the more feature-rich implementation.

## Related Issue
Fixes thinking-machines-lab/tinker-feedback#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)