### PR TITLE
Add some more options to play_w_env.py

### DIFF
--- a/tinker_cookbook/rl/play_w_env.py
+++ b/tinker_cookbook/rl/play_w_env.py
@@ -84,7 +84,9 @@ def print_trajectory_summary(trajectory: Trajectory):
     print(colored("===================", "cyan", attrs=["bold"]))
 
 
-async def play_env(env: Env, tokenizer: Tokenizer, multiline: bool = True, show_observation: bool = True):
+async def play_env(
+    env: Env, tokenizer: Tokenizer, multiline: bool = True, show_observation: bool = True
+):
     """Play a single-player environment interactively."""
     print(colored("Starting interactive environment session...", "cyan", attrs=["bold"]))
     print("Type your actions when prompted. The episode will end when the episode is done.")


### PR DESCRIPTION
Add a multiline option to play_w_env.
Also add a show_observation parameter, so you can disable the printout. (I found this useful in cases where I had another wrapper doing printouts, and I wanted to get rid of the redundancy.)