### PR TITLE
Correct for gradient bias in GRPO style reward centering.

### DIFF
--- a/tinker_cookbook/rl/data_processing.py
+++ b/tinker_cookbook/rl/data_processing.py
@@ -28,7 +28,7 @@ def compute_advantages(trajectory_groups_P: List[TrajectoryGroup]) -> List[torch
         # Correct for bias introduced by reward centering
         G = len(rewards_G)
         if G > 1:
-            advantages_G *= G / (G-1)
+            advantages_G *= G / (G - 1)
         advantages_P.append(advantages_G)
 
     return advantages_P


### PR DESCRIPTION
# Motivation

GRPO style centering introduces bias into the gradient estimate. The bias introduced is equal to $$\frac{G-1}{G}$$, where $$G$$ is the group size. While this factor is generally small, and can be incorporated into the learning rate, it would be prefered to not have learning rate dependant on group size in this way.

References
* See https://arxiv.org/pdf/2503.20783 (Pg.14)

Changes

* Added a correction to the advantages to adjust for the bias introduced by GRPO reward centering.