### PR TITLE
Remove reference to removed alternative llama 3 tokenizer

### DIFF
--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -24,8 +24,4 @@ else:
 def get_tokenizer(model_name: str) -> Tokenizer:
     from transformers.models.auto.tokenization_auto import AutoTokenizer
 
-    # Avoid gating of Llama 3 models:
-    if model_name.startswith("meta-llama/Llama-3"):
-        model_name = "baseten/Meta-Llama-3-tokenizer"
-
     return AutoTokenizer.from_pretrained(model_name, use_fast=True)


### PR DESCRIPTION
We use an alternative source for the llama 3 tokenizer to avoid the gating around the [meta-llama](https://huggingface.co/meta-llama) repos.

However, this source - [baseten/Meta-Llama-3-tokenizer](https://huggingface.co/models/baseten/Meta-Llama-3-tokenizer) - has been removed as of a few hours ago.

This results in attempting to use llama 3 models with `tinker_cookbook` failing. 

This commit removes this to use the default tokenizer source. This is then gated and so will fail without a huggingface token with access. We may want to switch to a different alternative reference to the llama 3 tokenizer instead.