### PR TITLE
Allow training runs with saving disabled via `save_every=0`

### DIFF
--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -48,7 +48,7 @@ class Config:
     num_replicas: int = 8
     base_url: str | None = None
 
-    # Checkpointing and evaluation
+    # Checkpointing and evaluation (0 = disabled for *_every fields)
     evaluator_builders: list[EvaluatorBuilder] = chz.field(default_factory=list)
     infrequent_evaluator_builders: list[EvaluatorBuilder] = chz.field(default_factory=list)
     save_every: int = 20

--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -28,7 +28,7 @@ class Config:
     learning_rate: float = 4e-5
     max_length: int = 32768
     lora_rank: int = 32
-    save_every: int = 20
+    save_every: int = 20  # 0 = disabled
     max_tokens: int = 256
 
 

--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -29,7 +29,7 @@ class Config:
     max_length: int = 32768
     train_on_what: renderers.TrainOnWhat = renderers.TrainOnWhat.ALL_ASSISTANT_MESSAGES
     lora_rank: int = 32
-    save_every: int = 20
+    save_every: int = 20  # 0 = disabled
 
 
 def main(config: Config):

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -252,8 +252,8 @@ class Config:
     enable_trace: bool = False
 
     remove_constant_reward_groups: bool = False
-    eval_every: int = 20
-    save_every: int = 20
+    eval_every: int = 20  # 0 = disabled
+    save_every: int = 20  # 0 = disabled
     load_checkpoint_path: str | None = None
 
     async_config: AsyncConfig | None = None

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -58,7 +58,7 @@ class Config:
     # Infrastructure parameters
     base_url: str | None = None
 
-    # Checkpointing and evaluation
+    # Checkpointing and evaluation (0 = disabled for *_every fields)
     evaluator_builders: list[EvaluatorBuilder] = chz.field(default_factory=list)
     infrequent_evaluator_builders: list[EvaluatorBuilder] = chz.field(default_factory=list)
     save_every: int = 20


### PR DESCRIPTION
# Motivation

During testing it can sometimes be useful to disable checkpoint saving. A natural way to do this is to specify `save_every=0`. 

Currently doing this crashes with a divide by zero error. 

This PR modifies the behaviour of `save_every` to instead disable saving, as is already the case for `eval_every`.