### PR TITLE
fix(wandb): allow config value changes on resume

### DIFF
--- a/tinker_cookbook/utils/ml_log.py
+++ b/tinker_cookbook/utils/ml_log.py
@@ -227,7 +227,7 @@ class WandbLogger(Logger):
     def log_hparams(self, config: Any) -> None:
         """Log hyperparameters to wandb."""
         if self.run and wandb is not None:
-            wandb.config.update(dump_config(config))
+            wandb.config.update(dump_config(config), allow_val_change=True)
 
     def log_metrics(self, metrics: Dict[str, Any], step: int | None = None) -> None:
         """Log metrics to wandb."""


### PR DESCRIPTION
I faced wandb error when I tried to run `python -m tinker_cookbook.recipes.preference.shorter.train`
Also it's related to the https://github.com/thinking-machines-lab/tinker-cookbook/issues/63

Fix mighr be `allow_val_change=True`

> wandb: ERROR Attempted to change value of key "dataset_builder" from {'comparison_builder': {'swap': False}, 'batch_size': 32, 'policy_renderer_name': 'qwen3_instruct', 'policy_model_name': 'Qwen/Qwen3-4B-Instruct-2507', 'tournament_pattern': 'ALL_PAIRS_BOTH_WAYS', 'group_size': 16, 'content_preprocessor': None} to {'comparison_builder': {'swap': False}, 'batch_size': 32, 'policy_renderer_name': 'qwen3_instruct', 'policy_model_name': 'Qwen/Qwen3-4B-Instruct-2507', 'tournament_pattern': 'ALL_PAIRS_BOTH_WAYS', 'group_size': 16, 'content_preprocessor': None, 'preference_model_builder': {}}
> wandb: ERROR If you really want to do this, pass allow_val_change=True to config.update()
> Traceback (most recent call last):
>   File "<frozen runpy>", line 198, in _run_module_as_main
>   File "<frozen runpy>", line 88, in _run_code
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/tinker_cookbook/recipes/preference/shorter/train.py", line 48, in <module>
>     main()
>     ~~~~^^
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/tinker_cookbook/recipes/preference/shorter/train.py", line 44, in main
>     asyncio.run(train.main(config))
>     ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
>   File "/Users/piotr/miniconda3/lib/python3.13/asyncio/runners.py", line 195, in run
>     return runner.run(main)
>            ~~~~~~~~~~^^^^^^
>   File "/Users/piotr/miniconda3/lib/python3.13/asyncio/runners.py", line 118, in run
>     return self._loop.run_until_complete(task)
>            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
>   File "/Users/piotr/miniconda3/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
>     return future.result()
>            ~~~~~~~~~~~~~^^
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/tinker_cookbook/utils/trace.py", line 332, in async_wrapper
>     return await func(*args, **kwargs)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/tinker_cookbook/rl/train.py", line 1102, in main
>     ml_logger = ml_log.setup_logging(
>         log_dir=cfg.log_path,
>     ...<2 lines>...
>         wandb_name=cfg.wandb_name,
>     )
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/tinker_cookbook/utils/ml_log.py", line 470, in setup_logging
>     ml_logger.log_hparams(config)
>     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/tinker_cookbook/utils/ml_log.py", line 349, in log_hparams
>     logger.log_hparams(config)
>     ~~~~~~~~~~~~~~~~~~^^^^^^^^
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/tinker_cookbook/utils/ml_log.py", line 230, in log_hparams
>     wandb.config.update(dump_config(config))
>     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/.venv/lib/python3.13/site-packages/wandb/sdk/wandb_config.py", line 187, in update
>     sanitized = self._update(d, allow_val_change)
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/.venv/lib/python3.13/site-packages/wandb/sdk/wandb_config.py", line 180, in _update
>     sanitized = self._sanitize_dict(
>         parsed_dict, allow_val_change, ignore_keys=locked_keys
>     )
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/.venv/lib/python3.13/site-packages/wandb/sdk/wandb_config.py", line 267, in _sanitize_dict
>     k, v = self._sanitize(k, v, allow_val_change)
>            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/piotr/Desktop/explore/tinker/tinker-cookbook/.venv/lib/python3.13/site-packages/wandb/sdk/wandb_config.py", line 288, in _sanitize
>     raise config_util.ConfigError(
>     ...<4 lines>...
>     )
> wandb.sdk.lib.config_util.ConfigError: Attempted to change value of key "dataset_builder" from {'comparison_builder': {'swap': False}, 'batch_size': 32, 'policy_renderer_name': 'qwen3_instruct', 'policy_model_name': 'Qwen/Qwen3-4B-Instruct-2507', 'tournament_pattern': 'ALL_PAIRS_BOTH_WAYS', 'group_size': 16, 'content_preprocessor': None} to {'comparison_builder': {'swap': False}, 'batch_size': 32, 'policy_renderer_name': 'qwen3_instruct', 'policy_model_name': 'Qwen/Qwen3-4B-Instruct-2507', 'tournament_pattern': 'ALL_PAIRS_BOTH_WAYS', 'group_size': 16, 'content_preprocessor': None, 'preference_model_builder': {}}
> If you really want to do this, pass allow_val_change=True to config.update()
> wandb: 
> wandb: 🚀 View run tinker-examples/shorter at: 
> wandb: Find logs at: ../../../../../../tmp/tinker-examples/shorter/1765671682/wandb/run-20251213_192123-9sjlhye7/logs