### PR TITLE
fix: correct pig latin training examples for proper consonant cluster…

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -765,11 +765,11 @@ Let's create some training examples and convert them to a format expected by Tin
 examples = [
     {
         "input": "banana split",
-        "output": "anana-bay plit-say"
+        "output": "anana-bay it-splay"
     },
     {
         "input": "quantum physics",
-        "output": "uantum-qay ysics-phay"
+        "output": "antum-quay ysics-phay"
     },
     {
         "input": "donut shop",
@@ -2597,3 +2597,4 @@ class UnloadModelResponse(BaseModel):
 
     type: Optional[Literal["unload_model"]] = None
 ```
+


### PR DESCRIPTION
fix: #165 
correct pig latin training examples for proper consonant cluster handling

- Fix "split" → "it-splay" (move entire "spl" consonant cluster)
- Fix "quantum" → "antum-quay" (treat "qu" as single phonetic unit)
- Resolves inconsistent phonological rules in training data
- Addresses Issue #165: flawed tinker code for pig latin

This ensures the model learns consistent linguistic patterns instead of
contradictory character-level rules that lead to training confusion.