### PR TITLE
fix: correct margin calculation in DPO training

### DIFF
--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -140,7 +140,7 @@ def compute_dpo_loss(
     accuracy = (chosen_log_ratio > rejected_log_ratio).float().mean().item()
     chosen_rewards = dpo_beta * chosen_log_ratio
     rejected_rewards = dpo_beta * rejected_log_ratio
-    margin = dpo_beta * (chosen_rewards - rejected_rewards).mean().item()
+    margin = (chosen_rewards - rejected_rewards).mean().item()
 
     metrics = {
         "dpo_loss": loss.item(),
@@ -394,3 +394,4 @@ def print_example(datum: tinker.Datum, tokenizer: Tokenizer, label: str = ""):
     weights = datum.loss_fn_inputs["weights"].data
     logger.info(f"\n{label} Example:")
     logger.info(format_colorized(int_tokens, cast(list[float], weights), tokenizer))
+


### PR DESCRIPTION
fix: correct margin calculation in DPO training

Remove redundant dpo_beta multiplication in margin computation.
The chosen_rewards and rejected_rewards already include the dpo_beta
factor, so margin should not multiply by dpo_beta again.

This fix only affects logging metrics and does not impact training.

Fixes #21