### PR TITLE
Support 'fast' ImageProcessor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "termcolor",
     "tinker>=0.6.1",
     "torch",
+    "torchvision",
     "transformers",
     "blobfile",
     "inspect-ai",
@@ -26,6 +27,7 @@ dependencies = [
     "textarena>=0.7.4",
     "math-verify",
     "scipy",
+    "Pillow"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "textarena>=0.7.4",
     "math-verify",
     "scipy",
-    "Pillow"
 ]
 
 [project.urls]

--- a/tinker_cookbook/image_processing_utils.py
+++ b/tinker_cookbook/image_processing_utils.py
@@ -26,7 +26,9 @@ else:
 def get_image_processor(model_name: str) -> ImageProcessor:
     from transformers.models.auto.image_processing_auto import AutoImageProcessor
 
-    return AutoImageProcessor.from_pretrained(model_name, use_fast=True)
+    processor =  AutoImageProcessor.from_pretrained(model_name, use_fast=True)
+    assert processor.is_fast, f"Could not load fast image processor for {model_name}"
+    return processor
 
 
 def resize_image(image: Image.Image, max_size: int) -> Image.Image:

--- a/tinker_cookbook/image_processing_utils.py
+++ b/tinker_cookbook/image_processing_utils.py
@@ -26,7 +26,7 @@ else:
 def get_image_processor(model_name: str) -> ImageProcessor:
     from transformers.models.auto.image_processing_auto import AutoImageProcessor
 
-    processor =  AutoImageProcessor.from_pretrained(model_name, use_fast=True)
+    processor = AutoImageProcessor.from_pretrained(model_name, use_fast=True)
     assert processor.is_fast, f"Could not load fast image processor for {model_name}"
     return processor
 


### PR DESCRIPTION
get_image_processor was falling back to the non-fast version due to no 'torchvision' in the env. The non-fast has a [bug](https://github.com/huggingface/transformers/issues/42910) causing inconsistent/wrong patch counts for certain dimensions.

This PR adds torchvision to the requirements, and asserts that the loaded processor is fast