### PR TITLE
Fix numerical instability in DPO loss calculation

### DIFF
--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 import chz
 import tinker
 import torch
+import torch.nn.functional as F
 from tinker_cookbook import checkpoint_utils
 from tinker_cookbook.eval.evaluators import Evaluator, EvaluatorBuilder
 from tinker_cookbook.supervised.train import run_evals
@@ -133,7 +134,7 @@ def compute_dpo_loss(
     )
 
     # Compute DPO loss
-    losses = -torch.log(torch.sigmoid(dpo_beta * (chosen_log_ratio - rejected_log_ratio)))
+    losses = -F.logsigmoid(dpo_beta * (chosen_log_ratio - rejected_log_ratio))
     loss = losses.mean()
 
     # Compute metrics


### PR DESCRIPTION
Replaces the numerically unstable `-torch.log(torch.sigmoid(...))` with `F.logsigmoid(...)`. This prevents `NaN` gradients caused by floating point underflow when the scaled log-ratios are large negative numbers.

This aligns with standard implementations in [Torchtune](https://github.com/meta-pytorch/torchtune/blob/44271b570af36cfda8ee20a4479d2652770378c0/torchtune/rlhf/loss/dpo.py#L76-L79) and [TRL](https://github.com/huggingface/trl/blob/20691d0bd16ccdc015654f18866f8e037f408403/trl/trainer/dpo_trainer.py#L1098-L1102).