### PR TITLE
Pass HF token to AutoTokenizer for gated repos

### DIFF
--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -7,6 +7,7 @@ Avoid importing AutoTokenizer and PreTrainedTokenizer until runtime, because the
 
 from __future__ import annotations
 
+import os
 from functools import cache
 from typing import TYPE_CHECKING, Any, TypeAlias
 
@@ -29,6 +30,12 @@ def get_tokenizer(model_name: str) -> Tokenizer:
         model_name = "thinkingmachineslabinc/meta-llama-3-tokenizer"
 
     kwargs: dict[str, Any] = {}
+
+    # Pass HF token if available (needed for gated/private repos)
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if hf_token:
+        kwargs["token"] = hf_token
+
     if model_name == "moonshotai/Kimi-K2-Thinking":
         kwargs["trust_remote_code"] = True
         kwargs["revision"] = "612681931a8c906ddb349f8ad0f582cb552189cd"


### PR DESCRIPTION
This PR fixes #194 by passing the HuggingFace token to `AutoTokenizer.from_pretrained()` when available.

## The Problem

When loading tokenizers from gated or private HuggingFace repos (like `thinkingmachineslabinc/meta-llama-3-tokenizer`), the call to `AutoTokenizer.from_pretrained()` fails with a 401 because no auth token is passed.

## The Fix

Check for `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` environment variables and pass them to `AutoTokenizer.from_pretrained()` if available.

```python
hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
if hf_token:
    kwargs["token"] = hf_token
```

## Note

This is a workaround that lets users with proper HF access continue working. The underlying issue (the private `thinkingmachineslabinc/meta-llama-3-tokenizer` repo) may still need to be addressed separately.