### PR TITLE
fix(wandb): recursively serialize nested objects in dump_config

### DIFF
--- a/tinker_cookbook/utils/ml_log.py
+++ b/tinker_cookbook/utils/ml_log.py
@@ -50,9 +50,11 @@ def dump_config(config: Any) -> Any:
     if hasattr(config, "to_dict"):
         return config.to_dict()
     elif chz.is_chz(config):
-        return chz.asdict(config)
+        # Recursively dump values to handle nested non-serializable fields
+        return {k: dump_config(v) for k, v in chz.asdict(config).items()}
     elif is_dataclass(config) and not isinstance(config, type):
-        return asdict(config)
+        # Recursively dump values to handle nested non-serializable fields
+        return {k: dump_config(v) for k, v in asdict(config).items()}
     elif isinstance(config, dict):
         return {k: dump_config(v) for k, v in config.items()}
     elif isinstance(config, (list, tuple)):


### PR DESCRIPTION
Fixes #63

This is an alternative solution to #168 that addresses the root cause rather than suppressing the error.

## The Problem

When using `@chz.chz` decorated classes that contain non-serializable objects (like `vf_env` in `VerifiersRLDatasetBuilder`), wandb throws a `ConfigError` on resume:

```
ConfigError: Attempted to change value of key "vf_env" from 
<verifiers.envs.singleturn_env.SingleTurnEnv object at 0x7fd46752da30> to 
<verifiers.envs.singleturn_env.SingleTurnEnv object at 0x7fd46752db40>
```

This happens because `dump_config` calls `chz.asdict()` which returns the raw object reference. When resuming, the same object type gets a different memory address, and wandb sees this as a changed value.

## Why This Fix is Better

PR #168 proposes `allow_val_change=True` which suppresses the error but doesn't fix the underlying problem - the config still logs useless memory addresses like `<SingleTurnEnv object at 0x...>`.

This PR fixes the root cause by making `dump_config` recursively serialize nested objects. Now `vf_env` logs as:
```python
{'max_turns': 5, 'reward_scale': 1.0}
```

Instead of:
```python
<SingleTurnEnv object at 0x7fd46752da30>
```

## The Fix

Two lines changed - recursively apply `dump_config` to values from `chz.asdict()` and `asdict()`:

```python
# Before
elif chz.is_chz(config):
    return chz.asdict(config)

# After  
elif chz.is_chz(config):
    return {k: dump_config(v) for k, v in chz.asdict(config).items()}
```

## Testing

I reproduced the exact error and validated the fix:

```python
# Reproduction
builder1 = VerifiersRLDatasetBuilder(vf_env=SingleTurnEnv())
builder2 = VerifiersRLDatasetBuilder(vf_env=SingleTurnEnv())

config1 = dump_config(builder1)  # Different memory addresses
config2 = dump_config(builder2)

wandb.config.update(config1)
wandb.config.update(config2)  # ConfigError before fix, works after
```

Also verified that existing functionality still works:
- Simple chz classes
- Nested chz classes  
- Regular dataclasses
- Dicts, lists, enums