### PR TITLE
Add learning rate config support for DeepSeek models

### DIFF
--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -89,6 +89,12 @@ def _get_hidden_size(model_name: str) -> int:
     if model_name == "moonshotai/Kimi-K2-Thinking":
         return 7168
 
+    if "deepseek-ai/DeepSeek-V3" in model_name:
+        return {
+            "deepseek-ai/DeepSeek-V3.1": 7168,
+            "deepseek-ai/DeepSeek-V3.1-Base": 7168,
+        }[model_name]
+
     config = AutoConfig.from_pretrained(model_name)
     return config.hidden_size
 
@@ -157,6 +163,8 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
     elif "qwen" in model_name.lower():
         exponent_model = 0.0775
     elif model_name == "moonshotai/Kimi-K2-Thinking":
+        exponent_model = 0.0775
+    elif "deepseek-v3" in model_name.lower():
         exponent_model = 0.0775
     else:
         assert False, f"Unknown model: {model_name}"


### PR DESCRIPTION
## Summary

The `get_lr()` function in `hyperparam_utils.py` was missing support for DeepSeek models, causing it to fail with an `AssertionError` when users tried to get learning rate recommendations for `deepseek-ai/DeepSeek-V3.1` or `deepseek-ai/DeepSeek-V3.1-Base`.

This PR adds the missing configuration:
- Added hidden size lookup for DeepSeek-V3 models (hidden_size=7168)
- Added learning rate scaling exponent for DeepSeek-V3 (0.0775, matching other MoE architectures)

Uses specific model name matching (`deepseek-ai/DeepSeek-V3` and `deepseek-v3`) to avoid conflicts if DeepSeek releases other model families in the future.

## Test plan

- [x] Verified `get_lr("deepseek-ai/DeepSeek-V3.1")` returns a valid learning rate instead of raising an error
- [x] Verified `get_lr("deepseek-ai/DeepSeek-V3.1-Base")` works correctly
- [x] Confirmed existing model support (llama, qwen) is unaffected

## Note on exponent value

The exponent value (0.0775) is based on Qwen's MoE models since DeepSeek-V3 is also an MoE architecture. The existing exponents for Llama (0.781) and Qwen (0.0775) were empirically derived through hyperparameter sweeps. A follow-up eval run would help validate this is optimal for DeepSeek-V3 specifically.

Related to thinking-machines-lab/tinker-feedback#49