### PR TITLE
fix(math_rl): increase max_tokens for Qwen3-8B MATH training

### DIFF
--- a/tinker_cookbook/recipes/math_rl/README.md
+++ b/tinker_cookbook/recipes/math_rl/README.md
@@ -14,8 +14,10 @@ python -m tinker_cookbook.recipes.math_rl.train model_name="meta-llama/Llama-3.2
 ## RL on MATH dataset.
 
 ```bash
-python -m tinker_cookbook.recipes.math_rl.train env=math model_name="Qwen/Qwen3-8B" group_size=16 groups_per_batch=64 learning_rate=2e-5 max_tokens=512
+python -m tinker_cookbook.recipes.math_rl.train env=math model_name="Qwen/Qwen3-8B" group_size=16 groups_per_batch=64 learning_rate=2e-5 max_tokens=2048
 ```
+
+> **Note:** Qwen3-8B uses thinking mode by default (with `<think>` blocks for chain-of-thought reasoning). This requires sufficient `max_tokens` (2048+) to complete the reasoning and produce the final `\boxed{}` answer. Using a lower value like 512 will cause responses to be truncated before the answer, resulting in 0% format scores.
 
 After 180 steps of training, we observe `"test/env/all/correct": 0.767578125`, which is logged to `/tmp/tinker-examples/math_rl/math-Qwen_Qwen3-8B-32rank-2e-05lr-${DATE}/metrics.jsonl`.
 


### PR DESCRIPTION
## Summary

- Increased `max_tokens` from 512 to 2048 for the MATH dataset example with Qwen3-8B
- Added a note explaining why sufficient `max_tokens` is required for Qwen3's thinking mode

## Root Cause Analysis

The README example was originally created on **October 1, 2025** when `Qwen3Renderer` inherited from `Qwen2p5Renderer` and did NOT add `<think>` blocks. The model responded directly without chain-of-thought reasoning, and 512 tokens was sufficient.

On **November 23, 2025** (commit f996a59), `Qwen3Renderer` was updated to force `<think>` blocks for Qwen3 models:
```python
elif message["role"] == "assistant" and "<think>" not in ac_content:
    ob_str += "<think>\n"
```

This change made the model use chain-of-thought reasoning in `<think>...</think>` blocks, which requires significantly more tokens. With `max_tokens=512`, responses were being truncated mid-thought before the model could produce the final `\boxed{}` answer.

## Validation

Tested multiple configurations:

| Config | Format (step 0) | Correct (step 0) | Tokens/turn |
|--------|-----------------|------------------|-------------|
| `max_tokens=512` (broken) | 0.0% | ~0.5% | 512 (hitting limit) |
| `max_tokens=2048` (fixed) | **30.4%** | **43.4%** | ~1850 (completing naturally) |

Alternative approach also works but changes the model behavior:
| `max_tokens=512, renderer=qwen3_disable_thinking` | 55.6% | 53.0% | ~400 |

The thinking-enabled approach is the intended behavior for this example (the README shows `<think>` blocks in the example output), so we increase `max_tokens` to accommodate the chain-of-thought reasoning.

## Test plan

- [x] Reproduce the issue with original command (`max_tokens=512`)
- [x] Verify fix works with `max_tokens=2048`
- [x] Confirm model produces complete `<think>...</think>\boxed{answer}` responses
- [x] Trace the git history to understand why this broke

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)