### PR TITLE
Fix subject-verb agreement in math_rl README

### DIFF
--- a/tinker_cookbook/recipes/math_rl/README.md
+++ b/tinker_cookbook/recipes/math_rl/README.md
@@ -1,6 +1,6 @@
 # Using Reinforcement Learning to Solve Math Problems
 
-Math problems have been the most active testbed for RL with LLMs. This recipe collects environments and grading functions that allows you to test on several popular math datasets.
+Math problems have been the most active testbed for RL with LLMs. This recipe collects environments and grading functions that allow you to test on several popular math datasets.
 
 
 ## RL on arithmetic.


### PR DESCRIPTION
## Summary
- Fixed grammatical error in `/tinker_cookbook/recipes/math_rl/README.md`
- Changed "functions that allows" to "functions that allow" for correct subject-verb agreement with plural subject

## Changes
- Line 3: "that allows you" → "that allow you"

This is a minor grammatical correction to improve documentation clarity.

Generated with Claude Code