### PR TITLE
Fix plural form in docs-outline.mdx

### DIFF
--- a/docs/docs-outline.mdx
+++ b/docs/docs-outline.mdx
@@ -6,7 +6,7 @@ The first half, "Using the Tinker API", walks you through the fundamentals of Ti
 
 - [Installation](./install) explains how to install both `tinker` and `tinker-cookbook`, and points you to the Tinker Console for your API key.
 - [Training and Sampling](./training-sampling) takes you through your first training run: setting up your training data, performing the run, and sampling from the model to test the run.
-- [Loss Functions](./losses) starts to get into the detail. Tinker supports a variety of built-in loss function, but also allows you to use arbitrary differentiable loss functions.
+- [Loss Functions](./losses) starts to get into the detail. Tinker supports a variety of built-in loss functions, but also allows you to use arbitrary differentiable loss functions.
 - [Saving and Loading](./save-load) explains the checkpoint types available in Tinker, and how to restart a run from a checkpoint.
 - [Async and Futures](./async) explains Tinker's `sync` and `async` API variants, and how Futures works as Tinker's requests structure.
 - [Model Lineup](./model-lineup) is regularly updated with the models available to fine-tune in Tinker.


### PR DESCRIPTION
## Summary
- Fixed grammatical error in `docs/docs-outline.mdx`
- Changed "a variety of built-in loss function" to "a variety of built-in loss functions"

## Changes
- Line 9: Corrected singular "function" to plural "functions" to properly match "a variety of"

This is a minor grammatical correction to improve documentation consistency.

Generated with Claude Code