### PR TITLE
Remove duplicate word in llms-full.txt

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1656,7 +1656,7 @@ The table below shows the models that are currently available in Tinker. We plan
 
 - In general, use MoE models, which are more cost effective than the dense models.
 - Use Base models only if you're doing research or are running the full post-training pipeline yourself
-- If you want to create a model that is good at a specific task or domain, use an existing post-trained model model, and fine-tune it on your own data or environment.
+- If you want to create a model that is good at a specific task or domain, use an existing post-trained model, and fine-tune it on your own data or environment.
     - If you care about latency, use one of the Instruction models, which will start outputting tokens without a chain-of-thought.
     - If you care about intelligence and robustness, use one of the Hybrid or Reasoning models, which can use long chain-of-thought.
 


### PR DESCRIPTION
## Summary
- Fixed typo in `llms-full.txt`
- Removed duplicate word "model" in the phrase "post-trained model model"

## Changes
- Line 1659: "post-trained model model" → "post-trained model"

This corrects the same typo as in model-lineup.mdx but in what appears to be a compiled documentation file.

Generated with Claude Code