### PR TITLE
Fix tool calling bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "textarena>=0.7.4",
     "math-verify",
     "scipy",
+    "pytest>=9.0.2",
+    "tiktoken>=0.12.0", # Required for Kimi tokenizer
 ]
 
 [project.urls]

--- a/tinker_cookbook/renderers.py
+++ b/tinker_cookbook/renderers.py
@@ -599,14 +599,35 @@ class Qwen3Renderer(Renderer):
         super().__init__(tokenizer)
         self.strip_thinking_from_history = strip_thinking_from_history
 
+    def _get_qwen_role_for_message(self, message: Message) -> str:
+        """Get the role to use for rendering a message in Qwen format.
+
+        Per HuggingFace Qwen3 chat template, tool messages are rendered with role "user".
+        """
+        role = message["role"]
+        if role == "tool":
+            return "user"
+        return role
+
+    def _wrap_qwen_tool_response(self, content: str) -> str:
+        """Wrap tool response content in Qwen's <tool_response> tags."""
+        return f"<tool_response>\n{content}\n</tool_response>"
+
     def render_message(self, idx: int, message: Message, is_last: bool = False) -> RenderedMessage:
         assert message.get("thinking") is None, "TODO: support CoT in Qwen3 renderer"
         assert isinstance(message["content"], str), (
             "Qwen3Renderer only supports message with string content"
         )
         maybe_newline = "\n" if idx > 0 else ""
-        ob_str = f"{maybe_newline}<|im_start|>{message['role']}\n"
+
+        role = self._get_qwen_role_for_message(message)
+        ob_str = f"{maybe_newline}<|im_start|>{role}\n"
         ac_content = message["content"]
+
+        # Handle tool response wrapping
+        if message["role"] == "tool":
+            ac_content = self._wrap_qwen_tool_response(ac_content)
+
         if (
             self.strip_thinking_from_history
             and message["role"] == "assistant"
@@ -650,9 +671,10 @@ class Qwen3Renderer(Renderer):
     def get_stop_sequences(self) -> list[int]:
         return [self._end_message_token]
 
-    def _parse_tool_call(self, tool_call_str: str) -> list[ToolCall] | None:
+    def _parse_single_tool_call(self, tool_call_str: str) -> ToolCall | None:
+        """Parse a single tool call JSON string into a ToolCall object."""
         try:
-            tool_call = json.loads(tool_call_str)
+            tool_call = json.loads(tool_call_str.strip())
         except json.JSONDecodeError:
             return None
 
@@ -666,12 +688,10 @@ class Qwen3Renderer(Renderer):
         if tool_id is not None and not isinstance(tool_id, str):
             tool_id = None
         # Convert to nested structure with arguments as JSON string
-        return [
-            ToolCall(
-                function=ToolCall.FunctionBody(name=name, arguments=json.dumps(args)),
-                id=tool_id,
-            )
-        ]
+        return ToolCall(
+            function=ToolCall.FunctionBody(name=name, arguments=json.dumps(args)),
+            id=tool_id,
+        )
 
     def parse_response(self, response: list[int]) -> tuple[Message, bool]:
         assistant_message, parse_success = parse_response_for_stop_token(
@@ -684,14 +704,22 @@ class Qwen3Renderer(Renderer):
         # - https://qwen.readthedocs.io/en/latest/getting_started/concepts.html#tool-calling
         # - https://github.com/QwenLM/Qwen-Agent/blob/main/qwen_agent/llm/fncall_prompts/nous_fncall_prompt.py#L279-L282
         assert isinstance(assistant_message["content"], str)
-        match = re.search(r"<tool_call>(.*?)</tool_call>", assistant_message["content"], re.DOTALL)
-        if match:
-            tool_calls = self._parse_tool_call(match.group(1))
-            if tool_calls is None:
+        content = assistant_message["content"]
+
+        # Find all tool calls in the response
+        tool_calls: list[ToolCall] = []
+        for match in re.finditer(r"<tool_call>(.*?)</tool_call>", content, re.DOTALL):
+            parsed = self._parse_single_tool_call(match.group(1))
+            if parsed is None:
                 return assistant_message, False
-            else:
-                assistant_message["tool_calls"] = tool_calls
-                return assistant_message, True
+            tool_calls.append(parsed)
+
+        if tool_calls:
+            assistant_message["tool_calls"] = tool_calls
+            # Strip all tool_call blocks from content
+            content = re.sub(r"\n?<tool_call>.*?</tool_call>", "", content, flags=re.DOTALL)
+            assistant_message["content"] = content.strip()
+
         return assistant_message, True
 
 
@@ -739,8 +767,15 @@ class Qwen3InstructRenderer(Qwen3Renderer):
             "Qwen3InstructRenderer only supports message with string content"
         )
         maybe_newline = "\n" if idx > 0 else ""
-        ob_str = f"{maybe_newline}<|im_start|>{message['role']}\n"
+
+        role = self._get_qwen_role_for_message(message)
+        ob_str = f"{maybe_newline}<|im_start|>{role}\n"
         ac_content = message["content"]
+
+        # Handle tool response wrapping
+        if message["role"] == "tool":
+            ac_content = self._wrap_qwen_tool_response(ac_content)
+
         # Observation (prompt) part
         if "tool_calls" in message:
             ac_content += "\n".join(
@@ -849,12 +884,28 @@ class Qwen3VLRenderer(Qwen3Renderer):
 
         return chunks
 
+    def _wrap_qwen_tool_response_chunks(
+        self, chunks: list[ImagePart | TextPart]
+    ) -> list[ImagePart | TextPart]:
+        """Wrap content chunks in Qwen's <tool_response> tags for multimodal messages."""
+        return (
+            [TextPart(type="text", text="<tool_response>\n")]
+            + chunks
+            + [TextPart(type="text", text="\n</tool_response>")]
+        )
+
     def render_message(self, idx: int, message: Message, is_last: bool = False) -> RenderedMessage:
         assert message.get("thinking") is None, "TODO: support CoT in Qwen3 renderer"
         maybe_newline = "\n" if idx > 0 else ""
-        ob_str = f"{maybe_newline}<|im_start|>{message['role']}\n"
+
+        role = self._get_qwen_role_for_message(message)
+        ob_str = f"{maybe_newline}<|im_start|>{role}\n"
 
         ac_content_chunks = self._preprocess_message_parts(message)
+
+        # Handle tool response wrapping
+        if message["role"] == "tool":
+            ac_content_chunks = self._wrap_qwen_tool_response_chunks(ac_content_chunks)
 
         contains_think_token = any(
             [
@@ -916,9 +967,15 @@ class Qwen3VLInstructRenderer(Qwen3VLRenderer):
     def render_message(self, idx: int, message: Message, is_last: bool = False) -> RenderedMessage:
         assert message.get("thinking") is None, "CoT tokens not supported in Qwen3-VL instruct"
         maybe_newline = "\n" if idx > 0 else ""
-        ob_str = f"{maybe_newline}<|im_start|>{message['role']}\n"
+
+        role = self._get_qwen_role_for_message(message)
+        ob_str = f"{maybe_newline}<|im_start|>{role}\n"
 
         ac_content_chunks = self._preprocess_message_parts(message)
+
+        # Handle tool response wrapping
+        if message["role"] == "tool":
+            ac_content_chunks = self._wrap_qwen_tool_response_chunks(ac_content_chunks)
 
         if "tool_calls" in message:
             ac_content_chunks += [
@@ -1240,16 +1297,28 @@ class KimiK2Renderer(Renderer):
                 tool_calls: list[ToolCall] = []
 
                 # Parse individual tool calls
+                # Tool ID format: "functions.{func_name}:{idx}" e.g. "functions.get_weather:0"
                 tool_call_pattern = r"<\|tool_call_begin\|>(.*?)<\|tool_call_argument_begin\|>(.*?)<\|tool_call_end\|>"
                 for match in re.finditer(tool_call_pattern, tool_section, re.DOTALL):
-                    tool_id = match.group(1)
-                    args_str = match.group(2)
+                    tool_id = match.group(1).strip()
+                    args_str = match.group(2).strip()
+
+                    # Extract function name from tool_id (format: "functions.{name}:{idx}")
+                    func_name = ""
+                    if tool_id and "." in tool_id:
+                        # Split on first dot to get "functions" prefix and the rest
+                        parts = tool_id.split(".", 1)
+                        if len(parts) == 2:
+                            # Split on colon to separate name from index
+                            name_part = parts[1].split(":")[0] if ":" in parts[1] else parts[1]
+                            func_name = name_part
+
                     # Try to parse as JSON to validate, but store as string
                     try:
                         json.loads(args_str)
                         tool_calls.append(
                             ToolCall(
-                                function=ToolCall.FunctionBody(name="", arguments=args_str),
+                                function=ToolCall.FunctionBody(name=func_name, arguments=args_str),
                                 id=tool_id if tool_id else None,
                             )
                         )

--- a/tinker_cookbook/renderers.py
+++ b/tinker_cookbook/renderers.py
@@ -565,6 +565,8 @@ class Qwen3Renderer(Renderer):
     (with enable_thinking=True, which is the default). This ensures compatibility
     with the OpenAI-compatible /chat/completions endpoint, which uses HF templates.
 
+    Reference: https://huggingface.co/Qwen/Qwen3-8B/blob/main/tokenizer_config.json
+
     Format:
         <|im_start|>system
         You are Qwen, created by Alibaba Cloud.<|im_end|>

--- a/tinker_cookbook/tests/test_tool_calling.py
+++ b/tinker_cookbook/tests/test_tool_calling.py
@@ -174,18 +174,3 @@ def test_qwen3_parse_invalid_tool_call_json():
     message, success = renderer.parse_response(response_tokens)
 
     assert success is False
-
-
-def test_qwen3_parse_no_tool_call():
-    """Test parsing response without tool calls."""
-    model_name = "Qwen/Qwen3-8B"
-    tokenizer = get_tokenizer(model_name)
-    renderer = get_renderer("qwen3", tokenizer)
-
-    response_text = "I don't need to use any tools for this.<|im_end|>"
-    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
-    message, success = renderer.parse_response(response_tokens)
-
-    assert success is True
-    assert "tool_calls" not in message
-    assert message["content"] == "I don't need to use any tools for this."

--- a/tinker_cookbook/tests/test_tool_calling.py
+++ b/tinker_cookbook/tests/test_tool_calling.py
@@ -1,0 +1,188 @@
+"""
+Tests for tool calling bug fixes in renderers.
+
+These tests verify:
+1. Tool response messages are correctly rendered (Issue #74)
+2. Multiple tool calls are correctly parsed
+3. Tool call content is stripped from parsed messages
+4. Kimi K2 tool name extraction works correctly
+"""
+
+import pytest
+
+from tinker_cookbook.renderers import Message, get_renderer
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+
+# =============================================================================
+# Tool Response Rendering Tests
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "model_name,renderer_name",
+    [
+        ("Qwen/Qwen3-8B", "qwen3"),
+        ("Qwen/Qwen3-30B-A3B-Instruct-2507", "qwen3_instruct"),
+    ],
+)
+def test_qwen3_tool_response_rendering(model_name: str, renderer_name: str):
+    """Test that Qwen3 renders tool responses with user role and tool_response tags.
+
+    This verifies the fix for Issue #74: tool messages should render as
+    <|im_start|>user with content wrapped in <tool_response> tags.
+    """
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer(renderer_name, tokenizer)
+
+    tool_message: Message = {"role": "tool", "content": '{"weather": "sunny", "high": 72}'}
+
+    rendered = renderer.render_message(0, tool_message)
+    prefix_str = tokenizer.decode(rendered["prefix"].tokens)
+    content_str = tokenizer.decode(rendered["content"][0].tokens)
+
+    # Tool messages should be rendered as "user" role
+    assert "<|im_start|>user" in prefix_str
+    # Content should be wrapped in tool_response tags
+    assert "<tool_response>" in content_str
+    assert "</tool_response>" in content_str
+    assert '"weather": "sunny"' in content_str
+
+
+# =============================================================================
+# Tool Call Parsing Tests
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "model_name,renderer_name",
+    [
+        ("Qwen/Qwen3-8B", "qwen3"),
+        ("Qwen/Qwen3-30B-A3B-Instruct-2507", "qwen3_instruct"),
+    ],
+)
+def test_qwen3_parse_single_tool_call(model_name: str, renderer_name: str):
+    """Test parsing a single tool call from Qwen3 response."""
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer(renderer_name, tokenizer)
+
+    # Simulate model response with tool call
+    response_text = """I'll search for that information.
+<tool_call>
+{"name": "search", "args": {"query": "weather in NYC"}}
+</tool_call><|im_end|>"""
+
+    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    message, success = renderer.parse_response(response_tokens)
+
+    assert success is True
+    assert message["role"] == "assistant"
+    assert "tool_calls" in message
+    assert len(message["tool_calls"]) == 1
+    assert message["tool_calls"][0].function.name == "search"
+    # Content should have tool_call block stripped
+    assert "<tool_call>" not in message["content"]
+
+
+@pytest.mark.parametrize(
+    "model_name,renderer_name",
+    [
+        ("Qwen/Qwen3-8B", "qwen3"),
+    ],
+)
+def test_qwen3_parse_multiple_tool_calls(model_name: str, renderer_name: str):
+    """Test parsing multiple tool calls from Qwen3 response.
+
+    This verifies the fix for the bug where only the first tool call was parsed.
+    """
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer(renderer_name, tokenizer)
+
+    # Simulate model response with multiple tool calls
+    response_text = """I'll get the weather for both cities.
+<tool_call>
+{"name": "get_weather", "args": {"location": "NYC"}}
+</tool_call>
+<tool_call>
+{"name": "get_weather", "args": {"location": "LA"}}
+</tool_call><|im_end|>"""
+
+    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    message, success = renderer.parse_response(response_tokens)
+
+    assert success is True
+    assert "tool_calls" in message
+    assert len(message["tool_calls"]) == 2
+    assert message["tool_calls"][0].function.name == "get_weather"
+    assert message["tool_calls"][1].function.name == "get_weather"
+    # Verify different arguments
+    assert "NYC" in message["tool_calls"][0].function.arguments
+    assert "LA" in message["tool_calls"][1].function.arguments
+
+
+def test_kimi_k2_parse_tool_call():
+    """Test parsing tool call from Kimi K2 response.
+
+    This verifies the fix for extracting function name from tool_id format
+    "functions.{name}:{idx}".
+    """
+    from tinker_cookbook.renderers import get_renderer
+
+    model_name = "moonshotai/Kimi-K2-Thinking"
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer("kimi_k2", tokenizer)
+
+    # Simulate model response with tool call (Kimi K2 format)
+    response_text = """<think></think>I'll search for that.
+<|tool_calls_section_begin|><|tool_call_begin|>functions.search:0<|tool_call_argument_begin|>{"query": "weather NYC"}<|tool_call_end|><|tool_calls_section_end|><|im_end|>"""
+
+    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    message, success = renderer.parse_response(response_tokens)
+
+    assert success is True
+    assert "tool_calls" in message
+    assert len(message["tool_calls"]) == 1
+    # Verify function name is extracted from tool_id
+    assert message["tool_calls"][0].function.name == "search"
+    assert message["tool_calls"][0].id == "functions.search:0"
+
+
+# =============================================================================
+# Edge Cases and Error Handling
+# =============================================================================
+
+
+def test_qwen3_parse_invalid_tool_call_json():
+    """Test that invalid JSON in tool call returns parse failure."""
+    from tinker_cookbook.renderers import get_renderer
+
+    model_name = "Qwen/Qwen3-8B"
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer("qwen3", tokenizer)
+
+    # Invalid JSON in tool call
+    response_text = """<tool_call>
+{invalid json here}
+</tool_call><|im_end|>"""
+
+    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    message, success = renderer.parse_response(response_tokens)
+
+    assert success is False
+
+
+def test_qwen3_parse_no_tool_call():
+    """Test parsing response without tool calls."""
+    from tinker_cookbook.renderers import get_renderer
+
+    model_name = "Qwen/Qwen3-8B"
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer("qwen3", tokenizer)
+
+    response_text = "I don't need to use any tools for this.<|im_end|>"
+    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    message, success = renderer.parse_response(response_tokens)
+
+    assert success is True
+    assert "tool_calls" not in message
+    assert message["content"] == "I don't need to use any tools for this."

--- a/tinker_cookbook/tests/test_tool_calling.py
+++ b/tinker_cookbook/tests/test_tool_calling.py
@@ -1,11 +1,11 @@
 """
-Tests for tool calling bug fixes in renderers.
+Tests for tool calling support in renderers.
 
-These tests verify:
-1. Tool response messages are correctly rendered (Issue #74)
-2. Multiple tool calls are correctly parsed
-3. Tool call content is stripped from parsed messages
-4. Kimi K2 tool name extraction works correctly
+These tests verify that renderers correctly handle:
+1. Tool response message rendering (role mapping and content wrapping)
+2. Parsing of single and multiple tool calls from model output
+3. Stripping tool call blocks from parsed message content
+4. Extracting function names from model-specific tool call formats
 """
 
 import pytest
@@ -30,7 +30,7 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
 def test_qwen3_tool_response_rendering(model_name: str, renderer_name: str):
     """Test that Qwen3 renders tool responses with user role and tool_response tags.
 
-    This verifies the fix for Issue #74: tool messages should render as
+    Per the Qwen3 chat template, tool messages should render as
     <|im_start|>user with content wrapped in <tool_response> tags.
     """
     tokenizer = get_tokenizer(model_name)
@@ -102,7 +102,7 @@ def test_qwen3_parse_single_tool_call(model_name: str, renderer_name: str):
 def test_qwen3_parse_multiple_tool_calls(model_name: str, renderer_name: str):
     """Test parsing multiple tool calls from Qwen3 response.
 
-    This verifies the fix for the bug where only the first tool call was parsed.
+    When a model response contains multiple <tool_call> blocks, all should be parsed.
     """
     tokenizer = get_tokenizer(model_name)
     renderer = get_renderer(renderer_name, tokenizer)
@@ -132,8 +132,8 @@ def test_qwen3_parse_multiple_tool_calls(model_name: str, renderer_name: str):
 def test_kimi_k2_parse_tool_call():
     """Test parsing tool call from Kimi K2 response.
 
-    This verifies the fix for extracting function name from tool_id format
-    "functions.{name}:{idx}".
+    Kimi K2 uses tool_id format "functions.{name}:{idx}", and the function
+    name should be extracted correctly.
     """
     model_name = "moonshotai/Kimi-K2-Thinking"
     tokenizer = get_tokenizer(model_name)


### PR DESCRIPTION
## Human-Written Overview

There were a few PRs pointing out issues with how tool calls were rendered and parsed. I asked claude to fix them, with reference to the Qwen3 and Kimi K2 documentation. I've reviewed the code changes and they look reasonable, but they could use another pair of eyes.

I think the tool use requires a bit more of a refactor to make sure we can render the tool specs in a model-agnostic way, and I'd like to write some tests that actually query the service with a tool-using prompt and check that we get valid tool calls, but that'll be saved for a future PR.


## Summary

This PR fixes several tool calling bugs identified in GitHub issues:

### Bug Fixes

- **Qwen3 tool response role (Issue #74)**: Tool messages with `role="tool"` now correctly render as `<|im_start|>user` with content wrapped in `<tool_response>` tags, matching HuggingFace's chat template behavior
- **Qwen3 multiple tool calls**: `parse_response` now finds all `<tool_call>` blocks instead of just the first one
- **Qwen3 content stripping**: Tool call blocks are now stripped from message content after parsing
- **Kimi K2 tool name extraction**: Function name is now correctly extracted from the `functions.{name}:{idx}` format

### Renderers Updated

- `Qwen3Renderer`
- `Qwen3InstructRenderer`
- `Qwen3VLRenderer`
- `Qwen3VLInstructRenderer`
- `KimiK2Renderer`

## Test plan

- [ ] Run existing renderer tests to ensure no regressions
- [ ] Test with search_env recipe to verify tool use still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)