### PR TITLE
Rename RenderedMessage fields: prefix/content/suffix → header/output/stop_overlap

### DIFF
--- a/tinker_cookbook/tests/test_tool_calling.py
+++ b/tinker_cookbook/tests/test_tool_calling.py
@@ -38,23 +38,23 @@ def test_qwen3_tool_response_rendering(model_name: str, renderer_name: str):
     tool_message: Message = {"role": "tool", "content": '{"weather": "sunny", "high": 72}'}
 
     rendered = renderer.render_message(0, tool_message)
-    prefix = rendered.get("prefix")
-    assert prefix is not None, "Expected prefix in rendered message"
-    content = rendered["content"]
-    assert len(content) > 0, "Expected content in rendered message"
+    header = rendered.get("header")
+    assert header is not None, "Expected header in rendered message"
+    output = rendered["output"]
+    assert len(output) > 0, "Expected output in rendered message"
 
-    prefix_str = tokenizer.decode(list(prefix.tokens))
-    # Content[0] is an EncodedTextChunk for text-only messages
-    content_chunk = content[0]
-    assert isinstance(content_chunk, tinker.EncodedTextChunk), "Expected EncodedTextChunk"
-    content_str = tokenizer.decode(list(content_chunk.tokens))
+    header_str = tokenizer.decode(list(header.tokens))
+    # output[0] is an EncodedTextChunk for text-only messages
+    output_chunk = output[0]
+    assert isinstance(output_chunk, tinker.EncodedTextChunk), "Expected EncodedTextChunk"
+    output_str = tokenizer.decode(list(output_chunk.tokens))
 
     # Tool messages should be rendered as "user" role
-    assert "<|im_start|>user" in prefix_str
+    assert "<|im_start|>user" in header_str
     # Content should be wrapped in tool_response tags
-    assert "<tool_response>" in content_str
-    assert "</tool_response>" in content_str
-    assert '"weather": "sunny"' in content_str
+    assert "<tool_response>" in output_str
+    assert "</tool_response>" in output_str
+    assert '"weather": "sunny"' in output_str
 
 
 # =============================================================================


### PR DESCRIPTION
## Human-Written Overview

I noticed that in the large PR #161, `render_message` was upgraded to be a part of the `Renderer` interface, and its return value was changed to `RenderedMessage`. But when I was reading `RenderedMessage`, it wasn't clear to me what should go in the `prefix` / `content` / `suffix` members -- the docstring wasn't very clear. Later, I realized that `content` didn't just correspond to `message["content"]` -- it usually included the stop token, which I found confusing. So I renamed the fields on `RenderedMessage` and added more documentation in various places. I also realized that `Renderer` was a protocol but would make more sense as an `ABC`, so I changed that too.

It looks like a big diff, but most of the diff is from renaming.

Below summary is written by Claude.

---

## Summary

Two related improvements to the Renderer protocol:

### 1. Rename RenderedMessage fields for clarity

| Old Name | New Name | Why |
|----------|----------|-----|
| `prefix` | `header` | Clearly indicates this is the introductory role identifier |
| `content` | `output` | Clarifies this is what the model *generates*, not the message content |
| `suffix` | `stop_overlap` | Explicitly documents its edge-case nature |

**Problem with old names:**
- `content` was misleading—it includes end-of-turn tokens, not just message text
- `prefix`/`suffix` implied false symmetry, but `suffix` is an obscure edge case only RoleColonRenderer uses

### 2. Convert Renderer from Protocol to ABC

**Why ABC is more appropriate:**
- All renderers already explicitly inherit from `Renderer`, so we're not benefiting from Protocol's structural subtyping
- `@abstractmethod` provides static type checking (vs runtime `NotImplementedError`)
- The class provides default implementations (`build_generation_prompt`, `build_supervised_example`), which is an ABC pattern

### 3. Improved documentation

- Added mathematical formula showing token assembly (with caveat that it's for the simple case)
- Documented when `build_supervised_example` should be overridden
- Added concrete examples for each RenderedMessage field
- Fixed double-escaped newlines in docstrings

## Test plan
- [x] All 26 renderer tests pass
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)