### PR TITLE
Remove automatic PR reviews, restrict @claude to trusted users

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,21 +4,10 @@ permissions:
   contents: write        # allow Claude to edit files & push commits
   pull-requests: write   # allow PR comments/reviews & PR creation
   issues: write          # allow issue comments & labels
-
-
-  # id-token: write       # Necessary because otherwise we get:
-    # Error: Failed to setup GitHub token: Error: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
-    # If you instead wish to use this action with a custom GitHub token or custom GitHub app, provide a `github_token` in the `uses` section of the app in your workflow yml file.
-  # ^^^ removed in favor of GITHUB_TOKEN; OIDC stopped working for some reason.
   actions: read
-    # ^^^ Not sure if this is necessary, but my previous working configuration had it.
 
 on:
-  # 1) Automatic PR review (non‑excessive)
-  pull_request:
-    types: [opened, reopened, ready_for_review]
-
-  # 2) Talk to @claude in PRs & issues
+  # Respond to @claude mentions in PRs & issues (trusted users only)
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -27,8 +16,7 @@ on:
     types: [opened]
 
 env:
-  # Shared Claude CLI configuration for all jobs
-  CLAUDE_ARGS_COMMON: >
+  CLAUDE_ARGS: >
     --model claude-opus-4-5-20251101
     --max-turns 50
     --allowedTools "Read" "Write" "Edit" "MultiEdit"
@@ -37,40 +25,20 @@ env:
     "mcp__github_inline_comment__create_inline_comment"
 
 jobs:
-  pr_review:
-    name: Automatic PR review
-    runs-on: ubuntu-latest
-    # Only run this job for pull_request events
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
-
-      - name: Claude PR review
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Official slash command for PR review (context comes from the PR event)
-          # https://code.claude.com/docs/en/github-actions#using-slash-commands
-          prompt: "/review"
-          claude_args: ${{ env.CLAUDE_ARGS_COMMON }}
-          track_progress: true
-          show_full_output: true
-
   claude_mention:
     name: Respond to @claude in issues & PRs
     runs-on: ubuntu-latest
-    # Only run when @claude actually appears
+    # Only trusted users (OWNER, MEMBER, COLLABORATOR) can trigger Claude
     if: >
       (github.event_name == 'issue_comment' &&
-       contains(github.event.comment.body, '@claude')) ||
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@claude')) ||
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'issues' &&
-       contains(github.event.issue.body, '@claude'))
+       contains(github.event.issue.body, '@claude') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -82,6 +50,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # No prompt → action switches to "tag" mode and responds to @claude
-          # https://code.claude.com/docs/en/github-actions#configuration-examples
-          claude_args: ${{ env.CLAUDE_ARGS_COMMON }}
+          claude_args: ${{ env.CLAUDE_ARGS }}


### PR DESCRIPTION
## Summary

- Remove automatic Claude reviews on PR open/reopen
- Restrict `@claude` mentions to trusted users only (OWNER, MEMBER, COLLABORATOR)
- Clean up stale comments in workflow file

## Security Rationale

**Automatic PR reviews had two issues:**

1. **Permission problem with forks**: `pull_request` events from forks run with read-only permissions, causing the "Actor has insufficient permissions" error.

2. **Security risk with `pull_request_target`**: The fix would require `pull_request_target`, which runs with write permissions. Combined with checking out PR code, this creates attack vectors:
   - Supply chain attacks (push malicious code to main)
   - Secret exfiltration (leak `ANTHROPIC_API_KEY` via git remote URLs)
   - Self-approval of malicious PRs

**Restricting `@claude` to trusted users** prevents external actors from triggering Claude with prompt injection attempts that could abuse the `Bash(git:*)` and `Bash(gh:*)` tools.

## What Changes

| Before | After |
|--------|-------|
| Auto-review on PR open | No auto-review |
| Anyone can `@claude` | Only OWNER/MEMBER/COLLABORATOR |

## Usage

Trusted users can still request reviews manually:
```
@claude /review
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)