### PR TITLE
Add pytest CI workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,25 @@
+name: pytest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install-uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: venv
+        run: uv venv && uv sync --all-extras
+
+      - name: pytest
+        run: uv run pytest tinker_cookbook


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs `uv run pytest tinker_cookbook` on PRs and pushes to main
- Shows up as a separate check from pyright

## Test plan
- [ ] Verify the pytest check appears on this PR
- [ ] Confirm tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)