### PR TITLE
Fix Qwen3 tool declaration format to match HuggingFace template

### DIFF
--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -298,7 +298,11 @@ class Qwen3Renderer(Renderer):
         """
         tools_text = ""
         if tools:
-            tool_lines = "\n".join(json.dumps(tool, separators=(",", ":")) for tool in tools)
+            # Wrap tools in OpenAI-style format to match HuggingFace Qwen3 chat template
+            tool_lines = "\n".join(
+                json.dumps({"type": "function", "function": tool}, separators=(",", ":"))
+                for tool in tools
+            )
             tools_text = f"""
 
 # Tools

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -291,14 +291,16 @@ class Qwen3Renderer(Renderer):
     ) -> list[Message]:
         """Create system message with Qwen3 tool specifications.
 
-        Qwen3 uses XML `<tools>` tags with JSON tool definitions appended to the
-        system message content.
+        Qwen3 uses XML `<tools>` tags containing JSON tool definitions in OpenAI format,
+        appended to the system message content.
 
-        Reference: https://huggingface.co/Qwen/Qwen3-8B/blob/main/tokenizer_config.json
+        References:
+        - https://qwen.readthedocs.io/en/latest/getting_started/concepts.html#tool-calling
+        - https://huggingface.co/Qwen/Qwen3-8B/blob/main/tokenizer_config.json
         """
         tools_text = ""
         if tools:
-            # Wrap tools in OpenAI-style format to match HuggingFace Qwen3 chat template
+            # Each tool is wrapped in {"type": "function", "function": {...}} per OpenAI format
             tool_lines = "\n".join(
                 json.dumps({"type": "function", "function": tool}, separators=(",", ":"))
                 for tool in tools


### PR DESCRIPTION
Wrap tools in OpenAI-style {"type": "function", "function": {...}} format in create_conversation_prefix_with_tools. This matches the HuggingFace Qwen3 chat template which expects tools in this format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)