### PR TITLE
Refactor tool use recipe to use renderer's tool calling methods

### DIFF
--- a/tinker_cookbook/recipes/tool_use/search/offline_eval.py
+++ b/tinker_cookbook/recipes/tool_use/search/offline_eval.py
@@ -71,7 +71,7 @@ async def evaluate_single_item(
         item["answer"],
         chroma_tool_client,
         renderer,
-        convo_prefix=SearchEnv.standard_fewshot_prefix(),
+        convo_prefix=SearchEnv.standard_fewshot_prefix(renderer, chroma_tool_client.get_tool_schemas()),
     )
     async with rollout_semaphore:
         trajectory = await do_single_rollout(policy, env)

--- a/tinker_cookbook/recipes/tool_use/search/offline_eval.py
+++ b/tinker_cookbook/recipes/tool_use/search/offline_eval.py
@@ -71,7 +71,9 @@ async def evaluate_single_item(
         item["answer"],
         chroma_tool_client,
         renderer,
-        convo_prefix=SearchEnv.standard_fewshot_prefix(renderer, chroma_tool_client.get_tool_schemas()),
+        convo_prefix=SearchEnv.standard_fewshot_prefix(
+            renderer, chroma_tool_client.get_tool_schemas()
+        ),
     )
     async with rollout_semaphore:
         trajectory = await do_single_rollout(policy, env)

--- a/tinker_cookbook/recipes/tool_use/search/tools.py
+++ b/tinker_cookbook/recipes/tool_use/search/tools.py
@@ -2,8 +2,6 @@ import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
-
 import chromadb
 import chz
 from chromadb.api import AsyncClientAPI
@@ -14,14 +12,14 @@ from tinker_cookbook.recipes.tool_use.search.embedding import (
     get_gemini_client,
     get_gemini_embedding,
 )
-from tinker_cookbook.renderers import Message, ToolCall
+from tinker_cookbook.renderers import Message, ToolCall, ToolSpec
 
 logger = logging.getLogger(__name__)
 
 
 class ToolClientInterface(ABC):
     @abstractmethod
-    def get_tool_schemas(self) -> list[dict[str, Any]]: ...
+    def get_tool_schemas(self) -> list[ToolSpec]: ...
 
     @abstractmethod
     async def invoke(self, tool_call: ToolCall) -> list[Message]: ...
@@ -89,13 +87,12 @@ class ChromaToolClient(ToolClientInterface):
             chroma_config.retrieval_config.embedding_config,
         )
 
-    def get_tool_schemas(self) -> list[dict[str, Any]]:
+    def get_tool_schemas(self) -> list[ToolSpec]:
         return [
             {
                 "name": "search",
-                "title": "Wikipedia search",
                 "description": "Searches Wikipedia for relevant information based on the given query.",
-                "inputSchema": {
+                "parameters": {
                     "type": "object",
                     "properties": {
                         "query_list": {
@@ -105,10 +102,6 @@ class ChromaToolClient(ToolClientInterface):
                         }
                     },
                     "required": ["query_list"],
-                },
-                "outputSchema": {
-                    "type": "string",
-                    "description": "The search results in JSON format",
                 },
             }
         ]


### PR DESCRIPTION
## Summary

- Use `renderer.create_conversation_prefix_with_tools()` instead of hardcoding tool schema in system prompt
- Update `ToolClientInterface.get_tool_schemas()` to return `ToolSpec` format
- Replace `ensure_text()` with `get_text_content()` for proper text extraction
- Remove duplicate `build_generation_prompt()` call

The renderer now handles model-specific tool schema formatting (Qwen3 uses `<tools>` XML, DeepSeek uses markdown headers, etc.), making the recipe work correctly across different model families.

**Note:** While testing this, we discovered that the Qwen3 tool use declaration had slightly wrong formatting, which is being fixed in sister PR #255.

## Test plan

- [x] Verified transcript format is correct with Qwen3 model
- [x] Ran training loop successfully with refactored code

🤖 Generated with [Claude Code](https://claude.com/claude-code)