### PR TITLE
[hyperparam_utils.py] add hidden sizes for a couple models

### DIFF
--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -95,6 +95,10 @@ def _get_hidden_size(model_name: str) -> int:
             "deepseek-ai/DeepSeek-V3.1-Base": 7168,
         }[model_name]
 
+    if "openai/gpt-oss" in model_name:
+        # Both gpt-oss-20b and gpt-oss-120b have hidden_size=2880
+        return 2880
+
     config = AutoConfig.from_pretrained(model_name)
     return config.hidden_size
 
@@ -165,6 +169,8 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
     elif model_name == "moonshotai/Kimi-K2-Thinking":
         exponent_model = 0.0775
     elif "deepseek-v3" in model_name.lower():
+        exponent_model = 0.0775
+    elif "gpt-oss" in model_name.lower():
         exponent_model = 0.0775
     else:
         assert False, f"Unknown model: {model_name}"

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -86,17 +86,12 @@ def _get_hidden_size(model_name: str) -> int:
             "meta-llama/Llama-3.3-70B-Instruct": 8192,
         }[model_name]
 
-    if model_name == "moonshotai/Kimi-K2-Thinking":
+    if model_name in (
+        "deepseek-ai/DeepSeek-V3.1",
+        "deepseek-ai/DeepSeek-V3.1-Base",
+        "moonshotai/Kimi-K2-Thinking",
+    ):
         return 7168
-
-    if "deepseek-ai/DeepSeek-V3" in model_name:
-        return {
-            "deepseek-ai/DeepSeek-V3.1": 7168,
-            "deepseek-ai/DeepSeek-V3.1-Base": 7168,
-        }[model_name]
-
-    if model_name in ("openai/gpt-oss-20b", "openai/gpt-oss-120b"):
-        return 2880
 
     config = AutoConfig.from_pretrained(model_name)
     return config.hidden_size

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -165,14 +165,9 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
         exponent_model = 0.781
     elif "qwen" in model_name.lower():
         exponent_model = 0.0775
-    elif model_name == "moonshotai/Kimi-K2-Thinking":
-        exponent_model = 0.0775
-    elif "deepseek-v3" in model_name.lower():
-        exponent_model = 0.0775
-    elif model_name in ("openai/gpt-oss-20b", "openai/gpt-oss-120b"):
-        exponent_model = 0.0775
     else:
-        assert False, f"Unknown model: {model_name}"
+        raise ValueError(f"Unknown model: {model_name}")
+    # TODO: sweep to determine LR multipliers for other models
     lr = lr * (2000 / _get_hidden_size(model_name)) ** exponent_model
     return lr
 

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -95,8 +95,7 @@ def _get_hidden_size(model_name: str) -> int:
             "deepseek-ai/DeepSeek-V3.1-Base": 7168,
         }[model_name]
 
-    if "openai/gpt-oss" in model_name:
-        # Both gpt-oss-20b and gpt-oss-120b have hidden_size=2880
+    if model_name in ("openai/gpt-oss-20b", "openai/gpt-oss-120b"):
         return 2880
 
     config = AutoConfig.from_pretrained(model_name)
@@ -170,7 +169,7 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
         exponent_model = 0.0775
     elif "deepseek-v3" in model_name.lower():
         exponent_model = 0.0775
-    elif "gpt-oss" in model_name.lower():
+    elif model_name in ("openai/gpt-oss-20b", "openai/gpt-oss-120b"):
         exponent_model = 0.0775
     else:
         assert False, f"Unknown model: {model_name}"

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -89,6 +89,12 @@ def _get_hidden_size(model_name: str) -> int:
     if model_name == "moonshotai/Kimi-K2-Thinking":
         return 7168
 
+    if "deepseek-ai/DeepSeek-V3" in model_name:
+        return {
+            "deepseek-ai/DeepSeek-V3.1": 7168,
+            "deepseek-ai/DeepSeek-V3.1-Base": 7168,
+        }[model_name]
+
     config = AutoConfig.from_pretrained(model_name)
     return config.hidden_size
 
@@ -157,6 +163,8 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
     elif "qwen" in model_name.lower():
         exponent_model = 0.0775
     elif model_name == "moonshotai/Kimi-K2-Thinking":
+        exponent_model = 0.0775
+    elif "deepseek-v3" in model_name.lower():
         exponent_model = 0.0775
     else:
         assert False, f"Unknown model: {model_name}"


### PR DESCRIPTION
Based on @bledden's PRs, add hidden size for a couple of the models we host. I'd like to support other models in the `get_lr` function, but the Qwen and Llama values are based on some actual LR sweeps we did, so I don't want to just make up values for these models. Left a TODO to redo some of the LR sweeps.

Supersedes #199 and #197.