### PR TITLE
Add .env files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/__pycache__
+.env
+.env.*


### PR DESCRIPTION
## Summary
- Add `.env` and `.env.*` patterns to `.gitignore` to prevent accidentally committing API keys and other secrets
- Addresses part of #97 (env var handling improvements)

## Test plan
- [x] Verify `.env` files are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)