### PR TITLE
Add missing `@cache` decorators in model_info.py

### DIFF
--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -30,6 +30,7 @@ def get_llama_info() -> dict[str, ModelAttributes]:
     }
 
 
+@cache
 def get_qwen_info() -> dict[str, ModelAttributes]:
     org = "Qwen"
     return {
@@ -52,6 +53,7 @@ def get_qwen_info() -> dict[str, ModelAttributes]:
     }
 
 
+@cache
 def get_deepseek_info() -> dict[str, ModelAttributes]:
     org = "deepseek-ai"
     return {
@@ -60,6 +62,7 @@ def get_deepseek_info() -> dict[str, ModelAttributes]:
     }
 
 
+@cache
 def get_gpt_oss_info() -> dict[str, ModelAttributes]:
     org = "openai"
     return {
@@ -68,6 +71,7 @@ def get_gpt_oss_info() -> dict[str, ModelAttributes]:
     }
 
 
+@cache
 def get_moonshot_info() -> dict[str, ModelAttributes]:
     org = "moonshotai"
     return {


### PR DESCRIPTION
Add `@cache` to the model info functions for consistency with `get_llama_info()`

Tiny fix! Can also remove the caching on `get_llama_info()` if that's preferred.