### PR TITLE
rl_loop: Support general model inputs

### DIFF
--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -202,7 +202,7 @@ def main(config: Config):
                 sampled_tokens_G_T, logprobs_G_T, advantages_G
             ):
                 ob_len = prompt.length - 1
-                model_input = prompt.append(types.EncodedTextChunk(tokens=sampled_tokens[:-1]))                
+                model_input = prompt.append(types.EncodedTextChunk(tokens=sampled_tokens[:-1]))
                 target_tokens = [0] * ob_len + sampled_tokens
                 padded_logprobs = [0.0] * ob_len + logprobs
                 padded_advantages = [0.0] * ob_len + [advantage] * (model_input.length - ob_len)


### PR DESCRIPTION
Keep prompt as ModelInput in rl_loop, to allow for general input chunks, in particular image chunks.