### PR TITLE
Fix inspect_utils to handle list content from parse_response

### DIFF
--- a/tinker_cookbook/eval/inspect_utils.py
+++ b/tinker_cookbook/eval/inspect_utils.py
@@ -140,11 +140,7 @@ class InspectAPIFromTinkerSampling(InspectAIModelAPI):
         parsed_responses = [
             self.renderer.parse_response(r.tokens)[0] for r in sampled_token_sequences
         ]
-        responses_text: list[str] = []
-        for r in parsed_responses:
-            content = r["content"]
-            assert isinstance(content, str), "Expected string content from parser"
-            responses_text.append(content)
+        responses_text: list[str] = [renderers.get_text_content(r) for r in parsed_responses]
         all_choices = [
             InspectAIModelOutputChoice(
                 message=InspectAIChatMessageAssistant(content=r, model=self.model_name),


### PR DESCRIPTION
## Summary
- Fix bug where `inspect_utils.py` assumed `parse_response` always returns string content
- Renderers like `Qwen3Renderer` return list content (with `ThinkingPart`, `ToolCallPart`, etc.) when responses contain `<think>` or `<tool_call>` blocks
- Use `renderers.get_text_content()` which handles both string and list content

## Test plan
The following command used to fail with `AssertionError: Expected string content from parser`:

```bash
python -m tinker_cookbook.eval.run_inspect_evals \
    model_name=Qwen/Qwen3-8B \
    tasks=inspect_evals/ifeval \
    renderer_name=qwen3
```

After this fix, it runs successfully.