### PR TITLE
Modal Sandboxes - maintain warm pool

### DIFF
--- a/tinker_cookbook/sandbox/README.md
+++ b/tinker_cookbook/sandbox/README.md
@@ -47,7 +47,7 @@ Example usage:
 from tinker_cookbook.sandbox.modal_sandbox import ModalSandbox, ModalSandboxPool
 
 # Single sandbox
-sandbox = ModalSandbox()
+sandbox = await ModalSandbox.create()
 exit_code, stdout, stderr = await sandbox.run_in_workdir(
     files={"code.py": "print('hello')"},
     command=["python", "code.py"],

--- a/tinker_cookbook/sandbox/modal_sandbox.py
+++ b/tinker_cookbook/sandbox/modal_sandbox.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import uuid
 
 import modal
@@ -38,18 +39,26 @@ class ModalSandbox:
     """
 
     def __init__(
-        self,
-        app_name: str = "tinker-cookbook-runner",
-        default_timeout: int = 240,
-        image: modal.Image | None = None,
-    ):
-        self._app_name = app_name
-        self._default_timeout = default_timeout
-        self._image = image or modal.Image.debian_slim()
+        self, timeout: int, image: modal.Image, app: modal.App, sandbox: modal.Sandbox
+    ) -> None:
+        self._timeout = timeout  # Timeout for the entire Sandbox instance
+        self._image = image
+        self._app = app
+        self._sandbox = sandbox
+        self._created_at = asyncio.get_running_loop().time()
 
+    @classmethod
+    async def create(
+        cls,
+        app_name: str = "tinker-cookbook-runner",
+        timeout: int = 1800,
+        image: modal.Image | None = None,
+    ) -> ModalSandbox:
         # Create the Modal sandbox
-        self._app = modal.App.lookup(self._app_name, create_if_missing=True)
-        self._sandbox = modal.Sandbox.create(app=self._app, image=self._image)
+        image = image or modal.Image.debian_slim()
+        app = await modal.App.lookup.aio(app_name, create_if_missing=True)
+        sandbox = await modal.Sandbox.create.aio(app=app, image=image, timeout=timeout)
+        return cls(timeout=timeout, image=image, app=app, sandbox=sandbox)
 
     async def write_file(self, path: str, content: str) -> None:
         """Write a file into the sandbox filesystem."""
@@ -73,10 +82,10 @@ class ModalSandbox:
         Returns:
             Tuple of (exit_code, stdout, stderr)
         """
-        timeout = timeout if timeout is not None else self._default_timeout
-
         try:
-            proc = await self._sandbox.exec.aio(*args, workdir=workdir, timeout=timeout)
+            proc = await self._sandbox.exec.aio(
+                *args, workdir=workdir, timeout=timeout or self._timeout
+            )
             stdout = await proc.stdout.read.aio()
             stderr = await proc.stderr.read.aio()
             exit_code = await proc.wait.aio()
@@ -111,24 +120,25 @@ class ModalSandbox:
             Tuple of (exit_code, stdout, stderr)
         """
         workdir = f"/workspace/{uuid.uuid4().hex[:12]}"
-        try:
-            proc = await self._sandbox.exec.aio("mkdir", "-p", workdir)
-            ret = await proc.wait.aio()
-            if ret != 0:
-                return ret, "", f"Failed to create workdir: {workdir}"
 
-            if files:
-                await asyncio.gather(
-                    *(
-                        self.write_file(f"{workdir}/{filename}", content)
-                        for filename, content in files.items()
-                    )
+        proc = await self._sandbox.exec.aio("mkdir", "-p", workdir)
+        ret = await proc.wait.aio()
+        if ret != 0:
+            return ret, "", f"Failed to create workdir: {workdir}"
+
+        if files:
+            await asyncio.gather(
+                *(
+                    self.write_file(f"{workdir}/{filename}", content)
+                    for filename, content in files.items()
                 )
-            exit_code, stdout, stderr = await self.exec(*command, workdir=workdir, timeout=timeout)
-            return exit_code, stdout, stderr
-        finally:
-            proc = await self._sandbox.exec.aio("rm", "-rf", workdir)
-            await proc.wait.aio()
+            )
+        exit_code, stdout, stderr = await self.exec(*command, workdir=workdir, timeout=timeout)
+        return exit_code, stdout, stderr
+
+    async def terminate(self) -> None:
+        """Terminate the Modal sandbox."""
+        await self._sandbox.terminate.aio()
 
 
 class ModalSandboxPool:
@@ -141,30 +151,59 @@ class ModalSandboxPool:
 
     def __init__(
         self,
-        pool_size: int | None = None,
+        *,
+        pool_size: int | None = None,  # Number of warm sandboxes to maintain during the job run.
+        pool_recycle_timeout_secs: float = 1800,  # Time after which a sandbox is too old and removed from pool.
+        pool_sandbox_timeout_secs: float = 2400,  # Time after which a sandbox is terminated.
         image: modal.Image | None = None,
         app_name: str = "tinker-cookbook-runner",
-        default_timeout: int = 240,
     ):
-        self._pool_size = pool_size or int(os.getenv("MODAL_POOL_SIZE", "32"))
+        self._pool_size = pool_size or int(os.getenv("MODAL_POOL_SIZE", "16"))
+
+        # The difference between these timeouts is the guaranteed "remaining
+        # lifetime" of a sandbox when borrowed from the pool.
+        self._pool_recycle_timeout_secs = pool_recycle_timeout_secs
+        self._pool_sandbox_timeout_secs = pool_sandbox_timeout_secs
+
         self._image = image
         self._app_name = app_name
-        self._default_timeout = default_timeout
+        self._terminated = False
 
+        self._warm_pool: list[ModalSandbox] = []
+        asyncio.create_task(self._maintain_pool())
+
+    async def _create(self) -> ModalSandbox:
+        return await ModalSandbox.create(
+            app_name=self._app_name, timeout=self._pool_sandbox_timeout_secs, image=self._image
+        )
+
+    async def _maintain_pool(self) -> None:
+        while not self._terminated:
+            try:
+                await self._maintain_pool_step()
+            except Exception as e:
+                print(f"Error maintaining ModalSandboxPool: {e}", file=sys.stderr)
+            await asyncio.sleep(5)
+
+    async def _maintain_pool_step(self) -> None:
         # Fill pool with sandbox instances
-        self._sandboxes = [
-            ModalSandbox(
-                app_name=app_name,
-                image=image,
-                default_timeout=default_timeout,
-            )
-            for _ in range(self._pool_size)
-        ]
+        now = asyncio.get_running_loop().time()
+        new_pool: list[ModalSandbox] = []
+        for sandbox in self._warm_pool:
+            age = now - sandbox._created_at
+            if age < self._pool_recycle_timeout_secs:
+                new_pool.append(sandbox)
+            else:
+                await sandbox._sandbox.terminate.aio()
+        self._warm_pool = new_pool
 
-        # Queue for borrowing/returning sandboxes
-        self._queue: asyncio.Queue[ModalSandbox] = asyncio.Queue()
-        for sb in self._sandboxes:
-            self._queue.put_nowait(sb)
+        if len(self._warm_pool) >= self._pool_size:
+            return
+
+        new_sandboxes = await asyncio.gather(
+            self._create() for _ in range(self._pool_size - len(self._warm_pool))
+        )
+        self._warm_pool.extend(new_sandboxes)
 
     async def run_in_workdir(
         self,
@@ -184,8 +223,18 @@ class ModalSandboxPool:
         Returns:
             Tuple of (exit_code, stdout, stderr)
         """
-        sandbox = await self._queue.get()
+        if self._terminated:
+            raise RuntimeError("ModalSandboxPool has been terminated and cannot run new tasks.")
+        if self._warm_pool:
+            sandbox = self._warm_pool.pop(0)
+        else:
+            sandbox = await self._create()
         try:
             return await sandbox.run_in_workdir(files, command, timeout)
         finally:
-            await self._queue.put(sandbox)
+            asyncio.create_task(sandbox.terminate())  # Don't reuse sandboxes after intial use
+
+    async def terminate(self) -> None:
+        """Exit the pool and terminate all sandboxes."""
+        self._terminated = True
+        await asyncio.gather(*(sb.terminate() for sb in self._warm_pool))

--- a/tinker_cookbook/sandbox/modal_sandbox.py
+++ b/tinker_cookbook/sandbox/modal_sandbox.py
@@ -25,7 +25,7 @@ class ModalSandbox:
     Persistent Modal sandbox for code execution.
 
     Usage:
-        sandbox = ModalSandbox()
+        sandbox = await ModalSandbox.create()
 
         # Manual file write and exec:
         await sandbox.write_file("/workspace/code.py", "print('hello')")
@@ -186,7 +186,6 @@ class ModalSandboxPool:
             await asyncio.sleep(5)
 
     async def _maintain_pool_step(self) -> None:
-        # Fill pool with sandbox instances
         now = asyncio.get_running_loop().time()
         new_pool: list[ModalSandbox] = []
         for sandbox in self._warm_pool:
@@ -200,6 +199,7 @@ class ModalSandboxPool:
         if len(self._warm_pool) >= self._pool_size:
             return
 
+        # Fill pool with sandbox instances
         new_sandboxes = await asyncio.gather(
             self._create() for _ in range(self._pool_size - len(self._warm_pool))
         )

--- a/tinker_cookbook/sandbox/modal_sandbox.py
+++ b/tinker_cookbook/sandbox/modal_sandbox.py
@@ -151,8 +151,8 @@ class ModalSandboxPool:
         self,
         *,
         pool_size: int | None = None,  # Number of warm sandboxes to maintain during the job run.
-        pool_recycle_timeout_secs: float = 600,  # Time after which a sandbox is too old and removed from pool.
-        pool_sandbox_timeout_secs: float = 1200,  # Time after which a sandbox is terminated.
+        pool_recycle_timeout_secs: int = 600,  # Time after which a sandbox is too old and removed from pool.
+        pool_sandbox_timeout_secs: int = 1200,  # Time after which a sandbox is terminated.
         image: modal.Image | None = None,
         app_name: str = "tinker-cookbook-runner",
     ):

--- a/tinker_cookbook/sandbox/modal_sandbox.py
+++ b/tinker_cookbook/sandbox/modal_sandbox.py
@@ -5,7 +5,7 @@ Modal provides cloud-based sandboxed execution environments.
 Requires Modal authentication: `modal token new`
 
 Configuration via environment variables:
-    MODAL_POOL_SIZE: Number of sandboxes in the pool (default: 32)
+    MODAL_POOL_SIZE: Number of sandboxes in the warm pool (default: 32)
 
 See: https://modal.com/docs/guide/sandbox
 """
@@ -108,8 +108,6 @@ class ModalSandbox:
     ) -> tuple[int, str, str]:
         """
         Execute a command in an isolated workdir with the given files.
-
-        Creates a unique workdir, writes files, runs command, then cleans up.
 
         Args:
             files: Files to write {filename: content}

--- a/tinker_cookbook/sandbox/modal_sandbox.py
+++ b/tinker_cookbook/sandbox/modal_sandbox.py
@@ -212,7 +212,7 @@ class ModalSandboxPool:
             else:
                 self._warm_pool.append(sb)
         if failures:
-            raise ExceptionGroup(f"Errors creating {len(failures)} Modal sandboxes", failures)
+            raise BaseExceptionGroup(f"Errors creating {len(failures)} Modal sandboxes", failures)
 
     async def run_in_workdir(
         self,


### PR DESCRIPTION
Changes:

- Maintain the pool over time, removing old sandboxes and adding fresh ones after a configurable duration (lower than the actual timeout) — this also means we don't reuse sandboxes
- Configure a container timeout for the sandboxes themselves, not just the exec (default is 600 seconds = 10 minutes, previously not configured)
- Add a `terminate()` method to ModalSandboxPool so people can kill the pool when they're done.