### PR TITLE
Adhere to modal sandbox limits (total instances, creation rates)

### DIFF
--- a/tinker_cookbook/sandbox/modal_sandbox.py
+++ b/tinker_cookbook/sandbox/modal_sandbox.py
@@ -137,8 +137,9 @@ class ModalSandbox:
         return exit_code, stdout, stderr
 
     async def terminate(self) -> None:
-        """Terminate the Modal sandbox."""
+        """Terminate the Modal sandbox and wait for it to fully shut down."""
         await self._sandbox.terminate.aio()
+        await self._sandbox.wait.aio(raise_on_termination=False)
 
 
 class ModalSandboxPool:


### PR DESCRIPTION
### PR Summary

Update warm pool handling to adhere to sandbox count limits and creation rate limits.

I hit a couple hiccups that stemmed from launching RL jobs with >1k simultaneous tool calls:

1. Unbounded sandbox counts: previously if the warm pool was empty, a request would still create a new sandbox. This quickly exceeded modal account sandbox limits.  
1. Async sandbox termination and creation: after fixing the above, sandbox creation and termination were running asynchronously of each other, which allowed for the total number of active sandboxes to exceed the max pool size.
  2. Rate limit violations - Creating all sandboxes in the pool in parallel exceeded Modal's rate limit, causing "Sandbox creation rate limit exceeded" errors. 

###  New behavior:
  - _maintain_pool_step() now handles termination, waits, then creates new sandboxes. The max pool size is never exceeded.
  - MODAL_CREATION_RATE_LIMIT env var (default: 4) controls max creations per second