### PR TITLE
Add max_step parameter to on-policy distillation

### DIFF
--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -435,7 +435,7 @@ async def main(
     composite_dataset = CompositeDataset(datasets, groups_per_batch_list)
     num_batches = len(composite_dataset)
     num_batches = min(cfg.max_step, num_batches) if cfg.max_step is not None else num_batches
-    logger.info(f"Will train on {end_batch} batches (dataset has {num_batches})")
+    logger.info(f"Will train on {num_batches} batches (dataset has {num_batches})")
 
     # Training loop
     await do_sync_training(


### PR DESCRIPTION
Adds optional `max_step` config parameter to cap training steps. When set, trains for `min(max_step, dataset_length)`. Default `None` preserves existing behavior.