### PR TITLE
Support structured content in ConversationFormatter

### DIFF
--- a/tinker_cookbook/utils/logtree_formatters.py
+++ b/tinker_cookbook/utils/logtree_formatters.py
@@ -8,7 +8,51 @@ from logtree and can be logged using `logtree.log_formatter()`.
 
 import html
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Sequence
+
+from tinker_cookbook.renderers.base import Content, Message
+
+
+def _render_content_html(content: Content) -> str:
+    """Render message content as HTML with styled parts for thinking/tool calls."""
+    if isinstance(content, str):
+        return f'<span class="lt-text-part">{html.escape(content)}</span>'
+
+    parts_html = []
+    for part in content:
+        if part["type"] == "text":
+            parts_html.append(f'<span class="lt-text-part">{html.escape(part["text"])}</span>')
+        elif part["type"] == "thinking":
+            escaped = html.escape(part["thinking"])
+            parts_html.append(
+                f'<details class="lt-thinking-part">'
+                f'<summary>💭 Thinking</summary>'
+                f'<pre>{escaped}</pre>'
+                f'</details>'
+            )
+        elif part["type"] == "tool_call":
+            tc = part["tool_call"]
+            name = html.escape(tc.function.name)
+            args = html.escape(tc.function.arguments)
+            parts_html.append(
+                f'<div class="lt-tool-call-part">'
+                f'<span class="lt-tool-call-label">🔧 Tool Call:</span> '
+                f'<code>{name}({args})</code>'
+                f'</div>'
+            )
+        elif part["type"] == "unparsed_tool_call":
+            raw = html.escape(part["raw_text"])
+            error = html.escape(part["error"])
+            parts_html.append(
+                f'<div class="lt-unparsed-tool-call-part">'
+                f'<span class="lt-tool-call-label">⚠️ Unparsed Tool Call:</span> '
+                f'<code>{raw}</code>'
+                f'<div class="lt-error">{error}</div>'
+                f'</div>'
+            )
+        elif part["type"] == "image":
+            parts_html.append('<span class="lt-image-part">🖼️ [Image]</span>')
+    return "\n".join(parts_html)
 
 
 @dataclass
@@ -17,9 +61,10 @@ class ConversationFormatter:
     Formatter for conversation messages.
 
     Renders a list of messages as a styled conversation with role-based coloring.
+    Supports structured content with thinking parts, tool calls, and text.
     """
 
-    messages: Sequence[Mapping[str, Any]]
+    messages: Sequence[Message]
     """List of messages, each with 'role' and 'content' keys."""
 
     def to_html(self) -> str:
@@ -27,10 +72,10 @@ class ConversationFormatter:
         parts = ['<div class="lt-conversation">']
         for msg in self.messages:
             role = html.escape(msg["role"])
-            content = html.escape(msg["content"])
+            content_html = _render_content_html(msg["content"])
             parts.append(f'  <div class="lt-message lt-message-{role}">')
             parts.append(f'    <span class="lt-message-role">{role}:</span>')
-            parts.append(f'    <span class="lt-message-content">{content}</span>')
+            parts.append(f'    <div class="lt-message-content">{content_html}</div>')
             parts.append("  </div>")
         parts.append("</div>")
         return "\n".join(parts)
@@ -104,5 +149,93 @@ CONVERSATION_CSS = """
 
 .lt-message-tool .lt-message-role {
     color: #2e7d32;
+}
+
+/* Content part styling */
+.lt-text-part {
+    display: block;
+}
+
+.lt-thinking-part {
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    background: #fef3c7;
+    border: 1px solid #fbbf24;
+    border-radius: 4px;
+}
+
+.lt-thinking-part summary {
+    cursor: pointer;
+    font-weight: 500;
+    color: #92400e;
+}
+
+.lt-thinking-part pre {
+    margin: 0.5rem 0 0 0;
+    padding: 0.5rem;
+    background: #fffbeb;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+}
+
+.lt-tool-call-part {
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    background: #dbeafe;
+    border: 1px solid #3b82f6;
+    border-radius: 4px;
+}
+
+.lt-tool-call-label {
+    font-weight: 500;
+    color: #1e40af;
+}
+
+.lt-tool-call-part code {
+    display: block;
+    margin-top: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    background: #eff6ff;
+    border-radius: 2px;
+    font-size: 0.875rem;
+    overflow-x: auto;
+}
+
+.lt-unparsed-tool-call-part {
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    background: #fee2e2;
+    border: 1px solid #ef4444;
+    border-radius: 4px;
+}
+
+.lt-unparsed-tool-call-part .lt-tool-call-label {
+    color: #991b1b;
+}
+
+.lt-unparsed-tool-call-part code {
+    display: block;
+    margin-top: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    background: #fef2f2;
+    border-radius: 2px;
+    font-size: 0.875rem;
+    overflow-x: auto;
+}
+
+.lt-error {
+    margin-top: 0.25rem;
+    font-size: 0.875rem;
+    color: #dc2626;
+}
+
+.lt-image-part {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    background: #e0e7ff;
+    border-radius: 4px;
+    color: #3730a3;
 }
 """


### PR DESCRIPTION
## Summary
- Use proper `Message` type instead of `Mapping[str, Any]` for pyright type safety
- Render `ThinkingPart` as collapsible `<details>` element with amber/yellow styling
- Render `ToolCallPart` with blue styling showing function name and arguments
- Render `UnparsedToolCallPart` with red error styling
- Render `ImagePart` as placeholder badge

## Test plan
- [x] pyright passes on the modified file
- [ ] Visual inspection of logtree output with thinking model responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)