### PR TITLE
Allow ttl_seconds to be None

### DIFF
--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -55,7 +55,7 @@ class Config:
     save_every: int = 20
     eval_every: int = 10
     infrequent_eval_every: int = 100
-    ttl_seconds: int = 604800  # 7 days
+    ttl_seconds: int | None = 604800  # 7 days
 
     # Adam optimizer parameters
     adam_beta1: float = 0.9

--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -43,7 +43,7 @@ class Config:
     lora_rank: int = 32
     save_every: int = 20  # 0 = disabled
     max_tokens: int = 256
-    ttl_seconds: int = 604800  # 7 days
+    ttl_seconds: int | None = 604800  # 7 days
 
 
 def get_reward(response: str, answer: str) -> float:

--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -30,7 +30,7 @@ class Config:
     train_on_what: renderers.TrainOnWhat = renderers.TrainOnWhat.ALL_ASSISTANT_MESSAGES
     lora_rank: int = 32
     save_every: int = 20  # 0 = disabled
-    ttl_seconds: int = 604800  # 7 days
+    ttl_seconds: int | None = 604800  # 7 days
 
 
 def main(config: Config):

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -307,7 +307,7 @@ class Config:
     remove_constant_reward_groups: bool = False
     eval_every: int = 20  # 0 = disabled
     save_every: int = 20  # 0 = disabled
-    ttl_seconds: int = 604800  # 7 days
+    ttl_seconds: int | None = 604800  # 7 days
     load_checkpoint_path: str | None = None
 
     async_config: AsyncConfig | None = None

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -64,7 +64,7 @@ class Config:
     save_every: int = 20
     eval_every: int = 10
     infrequent_eval_every: int = 100
-    ttl_seconds: int = 604800  # 7 days
+    ttl_seconds: int | None = 604800  # 7 days
 
     # Adam optimizer parameters
     adam_beta1: float = 0.9

--- a/tinker_cookbook/tests/compare_sampling_training_logprobs.py
+++ b/tinker_cookbook/tests/compare_sampling_training_logprobs.py
@@ -27,7 +27,7 @@ async def get_row(
     timeout_sec: float,
     saved_path_for_trainer: str | None = None,
     saved_path_for_sampler: str | None = None,
-    ttl_seconds: int = 604800,
+    ttl_seconds: int | None = 604800,
 ) -> dict:
     async def _inner():
         tstart = time.time()
@@ -98,7 +98,7 @@ class Config:
     model_name_filter: list[str] | None = chz.field(default_factory=lambda: ["loadtest"])
     state_for_trainer: str | None = None
     state_for_sampler: str | None = None
-    ttl_seconds: int = 604800  # 7 days
+    ttl_seconds: int | None = 604800  # 7 days
 
 
 async def main(config: Config):


### PR DESCRIPTION
It would be good to have the option to not apply a time-to-live. 

A `None` TTL is already supported by the saving functions, however because the config restricts the type `int`, we must always specify a time-limit. I've relaxed the type to include `None` which allows the option to turn off the TTL retention policy.