### PR TITLE
[tinker-cookbook] add a way to register custom renderers & tokenizers

### DIFF
--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -5,8 +5,10 @@ Use viz_sft_dataset to visualize the output of different renderers. E.g.,
     python -m tinker_cookbook.supervised.viz_sft_dataset dataset_path=Tulu3Builder renderer_name=role_colon
 """
 
+from collections.abc import Callable
+from typing import Any
+
 from tinker_cookbook.image_processing_utils import ImageProcessor
-from tinker_cookbook.tokenizer_utils import Tokenizer
 
 # Types and utilities used by external code
 from tinker_cookbook.renderers.base import (
@@ -14,21 +16,21 @@ from tinker_cookbook.renderers.base import (
     ContentPart,
     ImagePart,
     Message,
+    # Streaming types
+    MessageDelta,
+    # Renderer base
+    RenderContext,
+    Renderer,
     Role,
+    StreamingMessageHeader,
+    StreamingTextDelta,
+    StreamingThinkingDelta,
     TextPart,
     ThinkingPart,
     ToolCall,
     ToolSpec,
-    # Streaming types
-    MessageDelta,
-    StreamingMessageHeader,
-    StreamingTextDelta,
-    StreamingThinkingDelta,
-    Utf8TokenDecoder,
-    # Renderer base
-    RenderContext,
-    Renderer,
     TrainOnWhat,
+    Utf8TokenDecoder,
     # Utility functions
     ensure_text,
     format_content_as_string,
@@ -40,6 +42,54 @@ from tinker_cookbook.renderers.base import (
 from tinker_cookbook.renderers.deepseek_v3 import DeepSeekV3ThinkingRenderer
 from tinker_cookbook.renderers.gpt_oss import GptOssRenderer
 from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
+from tinker_cookbook.tokenizer_utils import Tokenizer
+
+# Global registry for custom renderer factories
+_CUSTOM_RENDERER_REGISTRY: dict[str, Callable[[Tokenizer, Any], Renderer]] = {}
+
+
+def register_renderer(
+    name: str,
+    factory: Callable[[Tokenizer, Any], Renderer],
+) -> None:
+    """Register a custom renderer factory.
+
+    Args:
+        name: The renderer name
+        factory: A callable that takes (tokenizer, image_processor) and returns a Renderer.
+
+    Example:
+        def my_renderer_factory(tokenizer, image_processor=None):
+            return MyCustomRenderer(tokenizer)
+
+        register_renderer("Foo/foo_renderer", my_renderer_factory)
+    """
+    _CUSTOM_RENDERER_REGISTRY[name] = factory
+
+
+def get_registered_renderer_names() -> list[str]:
+    """Return a list of all registered custom renderer names."""
+    return list(_CUSTOM_RENDERER_REGISTRY.keys())
+
+
+def is_renderer_registered(name: str) -> bool:
+    """Check if a renderer name is registered."""
+    return name in _CUSTOM_RENDERER_REGISTRY
+
+
+def unregister_renderer(name: str) -> bool:
+    """Unregister a custom renderer factory.
+
+    Args:
+        name: The renderer name to unregister.
+
+    Returns:
+        True if the renderer was unregistered, False if it wasn't registered.
+    """
+    if name in _CUSTOM_RENDERER_REGISTRY:
+        del _CUSTOM_RENDERER_REGISTRY[name]
+        return True
+    return False
 
 
 def get_renderer(
@@ -64,6 +114,7 @@ def get_renderer(
             - "gpt_oss_low_reasoning": GPT-OSS with low reasoning
             - "gpt_oss_medium_reasoning": GPT-OSS with medium reasoning
             - "gpt_oss_high_reasoning": GPT-OSS with high reasoning
+            - Custom renderers registered via register_renderer()
         tokenizer: The tokenizer to use.
         image_processor: Required for VL renderers.
 
@@ -74,6 +125,10 @@ def get_renderer(
         ValueError: If the renderer name is unknown.
         AssertionError: If a VL renderer is requested without an image_processor.
     """
+    # Check custom registry first
+    if (renderer := _CUSTOM_RENDERER_REGISTRY.get(name)) is not None:
+        return renderer(tokenizer, image_processor)
+
     # Import renderer classes lazily to avoid circular imports and keep exports minimal
     from tinker_cookbook.renderers.deepseek_v3 import DeepSeekV3DisableThinkingRenderer
     from tinker_cookbook.renderers.gpt_oss import GptOssRenderer
@@ -122,7 +177,9 @@ def get_renderer(
     elif name == "gpt_oss_high_reasoning":
         return GptOssRenderer(tokenizer, use_system_prompt=True, reasoning_effort="high")
     else:
-        raise ValueError(f"Unknown renderer: {name}")
+        raise ValueError(
+            f"Unknown renderer: {name}. If this is a custom renderer, please register it via register_renderer()."
+        )
 
 
 __all__ = [
@@ -150,6 +207,11 @@ __all__ = [
     "format_content_as_string",
     "get_text_content",
     "parse_content_blocks",
+    # Registry
+    "register_renderer",
+    "unregister_renderer",
+    "get_registered_renderer_names",
+    "is_renderer_registered",
     # Factory
     "get_renderer",
     # Renderer classes (used by tests)

--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -7,6 +7,7 @@ Avoid importing AutoTokenizer and PreTrainedTokenizer until runtime, because the
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import cache
 from typing import TYPE_CHECKING, Any, TypeAlias
 
@@ -19,9 +20,68 @@ else:
     # make it importable from other files as a type in runtime
     Tokenizer: TypeAlias = Any
 
+# Global registry for custom tokenizer factories
+_CUSTOM_TOKENIZER_REGISTRY: dict[str, Callable[[], Tokenizer]] = {}
+
+
+def register_tokenizer(
+    name: str,
+    factory: Callable[[], Tokenizer],
+) -> None:
+    """Register a custom tokenizer factory.
+
+    Args:
+        name: The tokenizer name
+        factory: A callable that takes no arguments and returns a Tokenizer.
+
+    Example:
+        def my_tokenizer_factory():
+            return MyCustomTokenizer()
+
+        register_tokenizer("Foo/foo_tokenizer", my_tokenizer_factory)
+    """
+    _CUSTOM_TOKENIZER_REGISTRY[name] = factory
+
+
+def get_registered_tokenizer_names() -> list[str]:
+    """Return a list of all registered custom tokenizer names."""
+    return list(_CUSTOM_TOKENIZER_REGISTRY.keys())
+
+
+def is_tokenizer_registered(name: str) -> bool:
+    """Check if a tokenizer name is registered."""
+    return name in _CUSTOM_TOKENIZER_REGISTRY
+
+
+def unregister_tokenizer(name: str) -> bool:
+    """Unregister a custom tokenizer factory.
+
+    Args:
+        name: The tokenizer name to unregister.
+
+    Returns:
+        True if the tokenizer was unregistered, False if it wasn't registered.
+    """
+    if name in _CUSTOM_TOKENIZER_REGISTRY:
+        del _CUSTOM_TOKENIZER_REGISTRY[name]
+        return True
+    return False
+
+
+def get_tokenizer(model_name: str) -> Tokenizer:
+    """Get a tokenizer by name.
+
+    Checks custom registry first, then falls back to HuggingFace AutoTokenizer.
+    """
+    # Check custom registry first (not cached, factory handles caching if needed)
+    if (tokenizer := _CUSTOM_TOKENIZER_REGISTRY.get(model_name)) is not None:
+        return tokenizer()
+
+    return _get_hf_tokenizer(model_name)
+
 
 @cache
-def get_tokenizer(model_name: str) -> Tokenizer:
+def _get_hf_tokenizer(model_name: str) -> Tokenizer:
     from transformers.models.auto.tokenization_auto import AutoTokenizer
 
     model_name = model_name.split(":")[0]


### PR DESCRIPTION
This adds a way to dynamically register new renderers and tokenizers. This allows users to use renderers + tokenizers not in the cookbook repo and have all of the tinker cookbook `get_renderer()`, `get_tokenizer()` continue to work without any changes.