### PR TITLE
Update tool-use READMEs and expose max_trajectory_tokens

### DIFF
--- a/tinker_cookbook/recipes/code_rl/README.md
+++ b/tinker_cookbook/recipes/code_rl/README.md
@@ -6,7 +6,11 @@ Competitive programming problems are a common testbed for RL with LLMs. The rece
 
 ### Sandboxing
 
-Sandboxing is essential for safely executing generated code during training and evaluation. We use [Sandbox Fusion](https://bytedance.github.io/SandboxFusion/) to sandbox code execution. You can start a local sandbox in Docker with:
+Sandboxing is essential for safely executing generated code during training and evaluation. Two sandbox backends are supported:
+
+#### SandboxFusion (Default)
+
+[Sandbox Fusion](https://bytedance.github.io/SandboxFusion/) provides local Docker-based sandboxing. You can start a local sandbox in Docker with:
 
 ```bash
 docker run -it -p 8080:8080 \
@@ -21,6 +25,27 @@ export SANDBOX_URL=http://localhost:8080/run_code
 ```
 
 If you prefer not to use Docker, you can set up the sandbox manually by following the instructions in the [Sandbox Fusion repository](https://github.com/bytedance/SandboxFusion?tab=readme-ov-file#installation).
+
+#### Modal (Alternative)
+
+[Modal](https://modal.com/docs/guide/sandbox) provides cloud-based sandboxed execution without local Docker setup. To use Modal:
+
+1. Install Modal and authenticate:
+```bash
+pip install modal
+modal token new
+```
+
+2. Set the sandbox backend in your training command:
+```bash
+python -m tinker_cookbook.recipes.code_rl.train \
+    sandbox_backend=modal \
+    ...
+```
+
+Optional environment variables for Modal:
+- `MODAL_POOL_SIZE`: Number of concurrent sandboxes (default: 32)
+- `MODAL_CREATION_RATE_LIMIT`: Max sandboxes created per second (default: 4)
 
 ### Example command
 

--- a/tinker_cookbook/recipes/search_tool/README.md
+++ b/tinker_cookbook/recipes/search_tool/README.md
@@ -38,6 +38,8 @@ With the default hyperparameters, you can expect performance like:
 
 A successful run generally learns multi-turn search within 10-25 steps, which can be monitored by checking if `env/all/turns_per_episode` has increased over 2 turns.
 
+**Note:** The `max_trajectory_tokens` parameter (default: 32,768) limits the total context length for multi-turn interactions. If your searches require longer contexts, you can adjust it with `max_trajectory_tokens=<value>`.
+
 To speed up training, you may consider turning on `--stream_minibatch`. In principle, this system improvement should have minimal effect on training.
 
 ### Extensions: How to Include Other Tools?

--- a/tinker_cookbook/recipes/search_tool/search_env.py
+++ b/tinker_cookbook/recipes/search_tool/search_env.py
@@ -210,6 +210,7 @@ class SearchR1DatasetBuilder(RLDatasetBuilder):
     renderer_name: str | None = None
     max_turns: int = 5
     format_coef: float = 0.1
+    max_trajectory_tokens: int = 32 * 1024
     seed: int = 0
 
     async def __call__(self) -> tuple[RLDataset, RLDataset | None]:
@@ -234,6 +235,7 @@ class SearchR1DatasetBuilder(RLDatasetBuilder):
                 group_size=self.group_size,
                 chroma_tool=chroma_tool,
                 format_coef=self.format_coef,
+                max_trajectory_tokens=self.max_trajectory_tokens,
             )
             for datum in data
         ]

--- a/tinker_cookbook/recipes/search_tool/train.py
+++ b/tinker_cookbook/recipes/search_tool/train.py
@@ -33,6 +33,7 @@ class CLIConfig:
     group_size: int = 8
     max_turns: int = 5
     format_coef: float = 0.1
+    max_trajectory_tokens: int = 32 * 1024
 
     # Chroma configuration
     chroma_host: str = "localhost"
@@ -81,6 +82,7 @@ async def cli_main(cli_config: CLIConfig) -> None:
         seed=cli_config.seed,
         max_turns=cli_config.max_turns,
         format_coef=cli_config.format_coef,
+        max_trajectory_tokens=cli_config.max_trajectory_tokens,
     )
 
     # Configure streaming minibatch

--- a/tinker_cookbook/tool_use/README.md
+++ b/tinker_cookbook/tool_use/README.md
@@ -100,5 +100,5 @@ async def make_envs(self) -> Sequence[Env]:
 
 For examples of using the tool-use library, see the the following:
 
-- [code_rl recipe](/tinker_cookbook/recipes/code_rl/) - Code generation with python execution tool
-- [search_tool recipe](/tinker_cookbook/recipes/search_tool/) - Multi-hop QA with search tool
+- [code_rl recipe](../recipes/code_rl/) - Code generation with python execution tool
+- [search_tool recipe](../recipes/search_tool/) - Multi-hop QA with search tool


### PR DESCRIPTION
### Summary

Updates READMEs and configuration for the tool-use library (on top of PR #311):

1. **tool_use/README.md**: Fixed example paths to use relative paths instead of absolute
2. **code_rl/README.md**: Added documentation for Modal sandbox as an alternative to SandboxFusion
3. **search_tool**: Exposed `max_trajectory_tokens` parameter in CLI config and documented it

### Changes

- Fix relative paths in tool_use README examples
- Document Modal sandbox backend option for code_rl (with authentication and environment variables)
- Add `max_trajectory_tokens` parameter to search_tool CLI config (default: 32,768)
- Document `max_trajectory_tokens` in search_tool README

### Testing

- Code review: Verified all changes are documentation and configuration only
- No functional changes to core logic

---

**Note:** This PR is stacked on top of PR #311 and should be merged after that PR is merged.