### PR TITLE
Fix CI for structured content PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/__pycache__
 .env
 .env.*
+.venv
 uv.lock

--- a/tinker_cookbook/tests/test_logtree.py
+++ b/tinker_cookbook/tests/test_logtree.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from pathlib import Path
 
+from tinker_cookbook.renderers.base import Message
 from tinker_cookbook.utils import logtree
 
 
@@ -375,7 +376,7 @@ def test_formatter():
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "formatter.html"
 
-        messages = [
+        messages: list[Message] = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there!"},
             {"role": "user", "content": "How are you?"},
@@ -404,9 +405,9 @@ def test_formatter_css_deduplication():
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = Path(tmpdir) / "dedup.html"
 
-        messages1 = [{"role": "user", "content": "Message 1"}]
-        messages2 = [{"role": "assistant", "content": "Message 2"}]
-        messages3 = [{"role": "user", "content": "Message 3"}]
+        messages1: list[Message] = [{"role": "user", "content": "Message 1"}]
+        messages2: list[Message] = [{"role": "assistant", "content": "Message 2"}]
+        messages3: list[Message] = [{"role": "user", "content": "Message 3"}]
 
         with logtree.init_trace("Dedup Test", path=output_path):
             # Log three conversation formatters

--- a/tinker_cookbook/utils/logtree_formatters.py
+++ b/tinker_cookbook/utils/logtree_formatters.py
@@ -26,9 +26,9 @@ def _render_content_html(content: Content) -> str:
             escaped = html.escape(part["thinking"])
             parts_html.append(
                 f'<details class="lt-thinking-part">'
-                f'<summary>💭 Thinking</summary>'
-                f'<pre>{escaped}</pre>'
-                f'</details>'
+                f"<summary>💭 Thinking</summary>"
+                f"<pre>{escaped}</pre>"
+                f"</details>"
             )
         elif part["type"] == "tool_call":
             tc = part["tool_call"]
@@ -37,8 +37,8 @@ def _render_content_html(content: Content) -> str:
             parts_html.append(
                 f'<div class="lt-tool-call-part">'
                 f'<span class="lt-tool-call-label">🔧 Tool Call:</span> '
-                f'<code>{name}({args})</code>'
-                f'</div>'
+                f"<code>{name}({args})</code>"
+                f"</div>"
             )
         elif part["type"] == "unparsed_tool_call":
             raw = html.escape(part["raw_text"])
@@ -46,9 +46,9 @@ def _render_content_html(content: Content) -> str:
             parts_html.append(
                 f'<div class="lt-unparsed-tool-call-part">'
                 f'<span class="lt-tool-call-label">⚠️ Unparsed Tool Call:</span> '
-                f'<code>{raw}</code>'
+                f"<code>{raw}</code>"
                 f'<div class="lt-error">{error}</div>'
-                f'</div>'
+                f"</div>"
             )
         elif part["type"] == "image":
             parts_html.append('<span class="lt-image-part">🖼️ [Image]</span>')


### PR DESCRIPTION
## Summary
- Fix ruff format violations in `logtree_formatters.py` (single quotes -> double quotes in f-strings)
- Fix pyright type errors in `test_logtree.py` (annotate message lists as `list[Message]`)
- Add `.venv` to `.gitignore` to prevent accidental commits of fallback venvs in worktrees

## Test plan
- [ ] pre-commit check passes
- [ ] type-check passes
- [ ] tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)