### PR TITLE
Remove ToolCallPart/UnparsedToolCallPart from ContentPart

### DIFF
--- a/tinker_cookbook/renderers/deepseek_v3.py
+++ b/tinker_cookbook/renderers/deepseek_v3.py
@@ -123,7 +123,6 @@ class _DeepSeekV3BaseRenderer(Renderer):
                             rendered_parts.append(f"<think>{p['thinking']}</think>")
                     elif p["type"] == "text":
                         rendered_parts.append(p["text"])
-                    # ToolCallPart handled via message's tool_calls field
                 output_content = "".join(rendered_parts)
             else:
                 # String content - pass through as-is.


### PR DESCRIPTION
## Summary

- Remove `ToolCallPart` and `UnparsedToolCallPart` from the `ContentPart` union. Tool calls now live exclusively in `message["tool_calls"]` / `message["unparsed_tool_calls"]`.
- Change `parse_content_blocks()` to return `tuple[list[ContentPart], list[ToolCall | UnparsedToolCall]] | None` — content parts (thinking/text) and tool calls are separated.
- Update Qwen3 `parse_response` to use the new return type.
- Clean up `format_content_as_string`, `to_openai_message`, and renderer comments that referenced the removed types.

## Motivation

Tool calls had two redundant representations: `ToolCallPart` in `message["content"]` and `message["tool_calls"]`. Only Qwen3's `parse_response` produced `ToolCallPart` in content. All renderers, consumers, and fixtures use `message["tool_calls"]` exclusively. No renderer interleaves tool calls with text — they're always a trailing section. The dual representation created inconsistency without benefit.

## Breaking changes (monorepo)

See `~/monorepo-tool-call-breakage.md` for detailed migration notes. Summary:

| File | Severity | Issue |
|------|----------|-------|
| `lib/message_list_completer/.../tinker_jwt_completer.py` | HIGH | `parse_content_blocks` return type changed |
| `lib/rust_ext/chat/message_v2.py` | HIGH | Imports deleted `ToolCallPart` |
| `projects/data/worm_data_synth/oss_message_completer.py` | MEDIUM | Content iteration checks `"tool_call"` type (now dead) |
| `personal/rafael/.../oss_message_completer.py` | LOW | Same as above |

## Test plan

- [x] `pytest tinker_cookbook/tests/test_renderer_parsing.py` — 44 passed
- [x] `pytest tinker_cookbook/tests/test_renderers.py` — 108 passed
- [x] `pytest tinker_cookbook/tests/test_tool_calling.py` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)