### PR TITLE
Add metadata to InspectEvaluatorBuilder

### DIFF
--- a/tinker_cookbook/eval/inspect_evaluators.py
+++ b/tinker_cookbook/eval/inspect_evaluators.py
@@ -50,6 +50,8 @@ class InspectEvaluatorBuilder:
     # Maximum concurrent sampling requests to Tinker.
     max_connections: int = 512
     log_level: str = "INFO"
+    # Metadata to associate with this evaluation run (visible in inspect logs)
+    metadata: Optional[dict[str, str]] = None
 
     def __call__(self) -> SamplingClientEvaluator:
         return InspectEvaluator(self)
@@ -115,6 +117,7 @@ class InspectEvaluator(SamplingClientEvaluator):
             log_level=self.config.log_level,
             log_realtime=False,
             log_buffer=1000,
+            metadata=self.config.metadata,
         )
 
         # Extract metrics from results


### PR DESCRIPTION
## Summary
- Adds optional `metadata` field to `InspectEvaluatorBuilder`
- Passes it through to the inspect `eval()` call so it appears in inspect logs

## Test plan
- [ ] Verify pyright passes
- [ ] Test with downstream usage in monorepo `projects/thinker_lmp/eval/run_inspect.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)