### PR TITLE
[renderer] fix regression in renderer with no user messages

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -983,7 +983,8 @@ class Renderer(ABC):
             )
 
         last_user_idx = max(
-            idx for idx, message in enumerate(messages) if message["role"] == "user"
+            (idx for idx, message in enumerate(messages) if message["role"] == "user"),
+            default=-1,
         )
 
         for idx, message in enumerate(messages):


### PR DESCRIPTION
# Description 
In https://github.com/thinking-machines-lab/tinker-cookbook/pull/341 we created a regression to assume that there will always be a User Message when taking the max operation over all messages. This will raise a `ValueError` if there is None. 

We already assume in https://github.com/andy-thinkingmachines/tinker-cookbook/blob/1c6497626c18553bf4022b633a4d97b9f946d487/tinker_cookbook/renderers/base.py#L1003 that if there are no user messages then `last_user_idx=-1` so this just sets this default explicitly. 

# Tests
-[x] Added pytest`test_supervised_example_no_user_messages` in `tinker_cookbook/tests/test_renderers.py` to catch for this regression. 