### PR TITLE
Use ephemeral weight sync in rl_loop.py

### DIFF
--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -144,14 +144,9 @@ def main(config: Config):
         batch_end = min((batch_idx + 1) * config.batch_size, len(train_dataset))
         batch_rows = train_dataset.select(range(batch_start, batch_end))
 
-        sampling_path = (
-            training_client.save_weights_for_sampler(
-                name=f"{batch_idx:06d}", ttl_seconds=config.ttl_seconds
-            )
-            .result()
-            .path
+        sampling_client = training_client.save_weights_and_get_sampling_client(
+            name=f"{batch_idx:06d}"
         )
-        sampling_client = service_client.create_sampling_client(model_path=sampling_path)
 
         datums_D: list[types.Datum] = []
         rewards_P: list[float] = []

--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -144,9 +144,7 @@ def main(config: Config):
         batch_end = min((batch_idx + 1) * config.batch_size, len(train_dataset))
         batch_rows = train_dataset.select(range(batch_start, batch_end))
 
-        sampling_client = training_client.save_weights_and_get_sampling_client(
-            name=f"{batch_idx:06d}"
-        )
+        sampling_client = training_client.save_weights_and_get_sampling_client()
 
         datums_D: list[types.Datum] = []
         rewards_P: list[float] = []


### PR DESCRIPTION
Use `save_weights_and_get_sampling_client` instead of `save_weights_for_sampler` for per-batch weight sync. The per-batch sync only needs a temporary sampling client for the next rollout, but it doesn't need a persistent tinker:// path. 

Resumption is unaffected since it uses the separate `save_every` checkpoint logic.

Matches behavior in other rl scripts such as `rl/train.py`