### PR TITLE
Handle repeated role_colon stop delimiters gracefully

### DIFF
--- a/tinker_cookbook/renderers/role_colon.py
+++ b/tinker_cookbook/renderers/role_colon.py
@@ -75,10 +75,13 @@ class RoleColonRenderer(Renderer):
             before, _after = splitted
             return Message(role="assistant", content=before.strip()), not terminated_with_eos
         else:
-            raise ValueError(
-                f"When parsing response, expected to split into 1 or 2 pieces using stop tokens, but got {len(splitted)}. "
-                "You probably are using the wrong stop tokens when sampling"
+            logger.warning(
+                "RoleColonRenderer.parse_response saw multiple stop delimiters "
+                "(count=%d). Returning parse_success=False. Full response:\n%s",
+                len(splitted) - 1,
+                str_response,
             )
+            return Message(role="assistant", content=splitted[0].strip()), False
 
     @property
     def _bos_tokens(self) -> list[int]:


### PR DESCRIPTION
## Summary
This PR makes `RoleColonRenderer.parse_response` robust to rare cases where the sampled completion contains multiple `\n\nUser:` delimiters.

## Problem
In rare rollouts, stop-sequence handling can miss the first delimiter and the sampled text may include multiple pseudo-turn boundaries. Previously, this path raised an exception and could abort training/eval loops.

## Change
- In `tinker_cookbook/renderers/role_colon.py`, when parsing sees more than one delimiter:
  - return the content before the first delimiter as the assistant message,
  - set `parse_success=False`,
  - emit a warning log with the full response for debugging.
- For normal cases (0 or 1 delimiter), behavior is unchanged.

## Why this is safe
- The renderer now treats this as a parse failure (non-fatal) rather than crashing.
- Existing reward/training logic already handles `parse_success=False` paths.

## Validation
- Type check: pyright passes for the modified file.
- Scope: single-file, targeted fix in RoleColon parsing only.