### PR TITLE
Fix pyright CI hang by scoping analysis

### DIFF
--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -22,4 +22,4 @@ jobs:
         run: uv venv && uv sync --all-extras
 
       - name: pyright
-        run: uv run pyright
+        run: uv run pyright tinker_cookbook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,9 @@ exclude = [
 ]
 
 [tool.pyright]
+include = ["tinker_cookbook"]
 exclude = [
+    ".venv",
     # Vendored from HuggingFace, kept identical to upstream
     "kimi-k2.5-hf-tokenizer/tool_declaration_ts.py",
 ]


### PR DESCRIPTION
## Summary
- scope pyright analysis to the package source (`tinker_cookbook`) in CI
- configure pyright include/exclude so it does not enumerate repository-root virtualenv files
- keep existing vendored-file exclusion

## Why
The pyright job can appear to hang because it discovers and analyzes `.venv/site-packages` when run from repo root with all extras installed. That blows up file count and memory churn.

## Validation
- Reproduced prior behavior locally: pyright discovered ~16k files and repeatedly evicted type cache at ~3.7GB.
- Re-ran with this patch and CI-equivalent setup (`uv sync --all-extras` + `uv run pyright tinker_cookbook --stats`): completes in ~17s without hang behavior.