### PR TITLE
Fix empty token chunk causing 400 errors in model requests

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -885,6 +885,7 @@ class Renderer(ABC):
             output_chunks = rendered_message.output
             if header_chunk:
                 chunks.append(header_chunk)
+            # Filter out empty EncodedTextChunks, which cause 400 errors in model requests
             chunks.extend([
                 x for x in output_chunks
                 if not isinstance(x, tinker.EncodedTextChunk) or x.tokens

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -886,10 +886,9 @@ class Renderer(ABC):
             if header_chunk:
                 chunks.append(header_chunk)
             # Filter out empty EncodedTextChunks, which cause 400 errors in model requests
-            chunks.extend([
-                x for x in output_chunks
-                if not isinstance(x, tinker.EncodedTextChunk) or x.tokens
-            ])
+            chunks.extend(
+                [x for x in output_chunks if not isinstance(x, tinker.EncodedTextChunk) or x.tokens]
+            )
 
         suffix_ctx = RenderContext(
             idx=len(messages),

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -885,7 +885,10 @@ class Renderer(ABC):
             output_chunks = rendered_message.output
             if header_chunk:
                 chunks.append(header_chunk)
-            chunks.extend([x for x in output_chunks if x and x.tokens])
+            chunks.extend([
+                x for x in output_chunks
+                if not isinstance(x, tinker.EncodedTextChunk) or x.tokens
+            ])
 
         suffix_ctx = RenderContext(
             idx=len(messages),

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -885,7 +885,7 @@ class Renderer(ABC):
             output_chunks = rendered_message.output
             if header_chunk:
                 chunks.append(header_chunk)
-            chunks.extend([x for x in output_chunks if x])
+            chunks.extend([x for x in output_chunks if x and x.tokens])
 
         suffix_ctx = RenderContext(
             idx=len(messages),


### PR DESCRIPTION
EncodedTextChunk(tokens=[]) is truthy as a pydantic object, so the `if x` filter didn't remove it. Check `x.tokens` explicitly to drop empty chunks.
We should also handle this case in the SDK and backend, but fixing the renderer for now.