### PR TITLE
Add shuffle flag to supervised dataset

### DIFF
--- a/tinker_cookbook/supervised/data.py
+++ b/tinker_cookbook/supervised/data.py
@@ -173,7 +173,9 @@ class FromConversationFileBuilder(ChatDatasetBuilder):
 
         # Create supervised dataset
         supervised_dataset = SupervisedDatasetFromHFDataset(
-            train_ds, batch_size=self.common_config.batch_size, map_fn=map_fn,
+            train_ds,
+            batch_size=self.common_config.batch_size,
+            map_fn=map_fn,
             shuffle=self.shuffle,
         )
 


### PR DESCRIPTION
## Summary
- Add a `shuffle` boolean parameter (default `True`) to `SupervisedDatasetFromHFDataset` and `FromConversationFileBuilder`
- When `shuffle=False`, `set_epoch` skips shuffling, allowing ordered or reproducible data iteration

## Test plan
- [ ] Verify existing behavior unchanged with default `shuffle=True`
- [ ] Test `shuffle=False` produces deterministic, ordered batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)