### PR TITLE
Move inspect deps to optional `inspect` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "torchvision",
     "transformers>=4.57.6,<5.0.0",
     "blobfile",
-    "inspect-ai",
     "anyio",
     "pylatexenc",
     "sympy",
@@ -63,12 +62,18 @@ verifiers = [
     "verifiers>=0.1.9,<0.1.10",
     "openai",
 ]
+inspect = [
+    "inspect-ai",
+    "inspect-evals>=0.3.106",
+    "instruction-following-eval",
+]
 all = [
     "tinker_cookbook[vector-search]",
     "tinker_cookbook[wandb]",
     "tinker_cookbook[neptune-scale]",
     "tinker_cookbook[trackio]",
     "tinker_cookbook[verifiers]",
+    "tinker_cookbook[inspect]",
 ]
 
 [build-system]
@@ -93,3 +98,6 @@ exclude = [
     # Vendored from HuggingFace, kept identical to upstream
     "kimi-k2.5-hf-tokenizer/tool_declaration_ts.py",
 ]
+
+[tool.uv.sources]
+instruction-following-eval = { git = "https://github.com/josejg/instruction_following_eval" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,4 +104,4 @@ exclude = [
 ]
 
 [tool.uv.sources]
-instruction-following-eval = { git = "https://github.com/josejg/instruction_following_eval" }
+instruction-following-eval = { git = "https://github.com/josejg/instruction_following_eval", rev = "0c495b2f95155e8b10acb919ae283bfb4d5be6e2" }


### PR DESCRIPTION
## Summary
- Moved `inspect-ai`, `inspect-evals`, and `instruction-following-eval` from core `dependencies` to a new `[project.optional-dependencies] inspect` extra
- Added `instruction-following-eval` git source (josejg fork) in `[tool.uv.sources]`
- Added `tinker_cookbook[inspect]` to the `all` extra

Install with `uv sync --extra inspect` or `uv sync --extra all`.

## Test plan
- [ ] `uv sync` (without extras) succeeds and does not install inspect packages
- [ ] `uv sync --extra inspect` installs `inspect-ai`, `inspect-evals`, and `instruction-following-eval`
- [ ] `uv run python -m tinker_cookbook.eval.run_inspect_evals` works with the `inspect` extra installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)