### PR TITLE
Make sl_loop.py work when training count is not a multiple of batch_size

### DIFF
--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -4,6 +4,7 @@ Uses existing modules but with a simple, flat training loop.
 """
 
 import logging
+import math
 import time
 
 import chz
@@ -55,7 +56,7 @@ def main(config: Config):
     assert isinstance(dataset, datasets.DatasetDict)
     train_dataset = dataset["train"]
 
-    n_train_batches = len(train_dataset) // config.batch_size
+    n_train_batches = math.ceil(len(train_dataset) / config.batch_size)
     logger.info(f"Train batches: {n_train_batches}")
 
     # Setup training client


### PR DESCRIPTION
This was previously using flooring divison, which would cause the last 'len(train_dataset) % config.batch_size' rows to be silently ignored.