### PR TITLE
Persist renderer metadata on training runs and auto-resolve it in evals

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 import tinker
 
+from tinker_cookbook import model_info
 from tinker_cookbook.utils.file_utils import read_jsonl
 from tinker_cookbook.utils.trace import scope, update_scope_context
 
@@ -109,8 +110,6 @@ def resolve_renderer_name_from_checkpoint_or_default(
             )
             return renderer_name
 
-    from tinker_cookbook import model_info
-
     return model_info.get_recommended_renderer_name(model_name)
 
 
@@ -139,8 +138,6 @@ async def resolve_renderer_name_from_checkpoint_or_default_async(
                 renderer_name,
             )
             return renderer_name
-
-    from tinker_cookbook import model_info
 
     return model_info.get_recommended_renderer_name(model_name)
 

--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -25,7 +25,7 @@ def _handle_checkpoint_renderer_check_result(
     checkpoint_path: str,
     expected_renderer_name: str,
     checkpoint_renderer_name: str | None,
-) -> str | None:
+) -> None:
     if checkpoint_renderer_name is None:
         logger.info("Checkpoint %s has no renderer metadata.", checkpoint_path)
     elif checkpoint_renderer_name != expected_renderer_name:
@@ -41,7 +41,7 @@ def _handle_checkpoint_renderer_check_result(
             checkpoint_path,
             expected_renderer_name,
         )
-    return checkpoint_renderer_name
+    return None
 
 
 def get_renderer_name_from_checkpoint(
@@ -82,28 +82,27 @@ def check_renderer_name_for_checkpoint(
     service_client: tinker.ServiceClient,
     checkpoint_path: str,
     expected_renderer_name: str | None,
-) -> str | None:
+) -> None:
     """
     Inspect a checkpoint's originating training run metadata and compare renderer name.
 
-    Returns:
-        The renderer name found in checkpoint metadata, if present.
     """
     if expected_renderer_name is None:
         return None
 
     checkpoint_renderer_name = get_renderer_name_from_checkpoint(service_client, checkpoint_path)
 
-    return _handle_checkpoint_renderer_check_result(
+    _handle_checkpoint_renderer_check_result(
         checkpoint_path, expected_renderer_name, checkpoint_renderer_name
     )
+    return None
 
 
 async def check_renderer_name_for_checkpoint_async(
     service_client: tinker.ServiceClient,
     checkpoint_path: str,
     expected_renderer_name: str | None,
-) -> str | None:
+) -> None:
     """
     Compare an expected renderer with renderer metadata attached to a checkpoint's training run.
 
@@ -113,8 +112,6 @@ async def check_renderer_name_for_checkpoint_async(
     - Logs info if metadata is missing or matches.
     - Logs warning if the checkpoint renderer differs from the expected renderer.
 
-    Returns:
-        The renderer name found in checkpoint metadata, or None if unavailable.
     """
     if expected_renderer_name is None:
         return None
@@ -123,9 +120,10 @@ async def check_renderer_name_for_checkpoint_async(
         service_client, checkpoint_path
     )
 
-    return _handle_checkpoint_renderer_check_result(
+    _handle_checkpoint_renderer_check_result(
         checkpoint_path, expected_renderer_name, checkpoint_renderer_name
     )
+    return None
 
 
 @scope

--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 RENDERER_NAME_METADATA_KEY = "renderer_name"
 
 
-def add_renderer_name_to_user_metadata(user_metadata: dict[str, str], renderer_name: str | None) -> None:
+def add_renderer_name_to_user_metadata(
+    user_metadata: dict[str, str], renderer_name: str | None
+) -> None:
     """Attach renderer name to training-run metadata when available."""
     if renderer_name:
         user_metadata[RENDERER_NAME_METADATA_KEY] = renderer_name

--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -44,6 +44,40 @@ def _handle_checkpoint_renderer_check_result(
     return checkpoint_renderer_name
 
 
+def get_renderer_name_from_checkpoint(
+    service_client: tinker.ServiceClient, checkpoint_path: str
+) -> str | None:
+    """Read renderer_name metadata from the training run referenced by a checkpoint path."""
+    try:
+        rest_client = service_client.create_rest_client()
+        training_run = rest_client.get_training_run_by_tinker_path(checkpoint_path).result()
+        return (training_run.user_metadata or {}).get(RENDERER_NAME_METADATA_KEY)
+    except (tinker.TinkerError, ValueError) as e:
+        logger.warning(
+            "Could not fetch renderer metadata for checkpoint %s: %s",
+            checkpoint_path,
+            e,
+        )
+        return None
+
+
+async def get_renderer_name_from_checkpoint_async(
+    service_client: tinker.ServiceClient, checkpoint_path: str
+) -> str | None:
+    """Async version of get_renderer_name_from_checkpoint."""
+    try:
+        rest_client = service_client.create_rest_client()
+        training_run = await rest_client.get_training_run_by_tinker_path_async(checkpoint_path)
+        return (training_run.user_metadata or {}).get(RENDERER_NAME_METADATA_KEY)
+    except (tinker.TinkerError, ValueError) as e:
+        logger.warning(
+            "Could not fetch renderer metadata for checkpoint %s: %s",
+            checkpoint_path,
+            e,
+        )
+        return None
+
+
 def check_renderer_name_for_checkpoint(
     service_client: tinker.ServiceClient,
     checkpoint_path: str,

--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -92,17 +92,7 @@ def check_renderer_name_for_checkpoint(
     if expected_renderer_name is None:
         return None
 
-    try:
-        rest_client = service_client.create_rest_client()
-        training_run = rest_client.get_training_run_by_tinker_path(checkpoint_path).result()
-        checkpoint_renderer_name = (training_run.user_metadata or {}).get(RENDERER_NAME_METADATA_KEY)
-    except (tinker.TinkerError, ValueError) as e:
-        logger.warning(
-            "Could not verify renderer metadata for checkpoint %s: %s",
-            checkpoint_path,
-            e,
-        )
-        return None
+    checkpoint_renderer_name = get_renderer_name_from_checkpoint(service_client, checkpoint_path)
 
     return _handle_checkpoint_renderer_check_result(
         checkpoint_path, expected_renderer_name, checkpoint_renderer_name
@@ -123,17 +113,9 @@ async def check_renderer_name_for_checkpoint_async(
     if expected_renderer_name is None:
         return None
 
-    try:
-        rest_client = service_client.create_rest_client()
-        training_run = await rest_client.get_training_run_by_tinker_path_async(checkpoint_path)
-        checkpoint_renderer_name = (training_run.user_metadata or {}).get(RENDERER_NAME_METADATA_KEY)
-    except (tinker.TinkerError, ValueError) as e:
-        logger.warning(
-            "Could not verify renderer metadata for checkpoint %s: %s",
-            checkpoint_path,
-            e,
-        )
-        return None
+    checkpoint_renderer_name = await get_renderer_name_from_checkpoint_async(
+        service_client, checkpoint_path
+    )
 
     return _handle_checkpoint_renderer_check_result(
         checkpoint_path, expected_renderer_name, checkpoint_renderer_name

--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -105,10 +105,16 @@ async def check_renderer_name_for_checkpoint_async(
     expected_renderer_name: str | None,
 ) -> str | None:
     """
-    Async version of check_renderer_name_for_checkpoint.
+    Compare an expected renderer with renderer metadata attached to a checkpoint's training run.
+
+    Behavior:
+    - If ``expected_renderer_name`` is None, returns None and does no check.
+    - Otherwise fetches ``renderer_name`` from the run referenced by ``checkpoint_path``.
+    - Logs info if metadata is missing or matches.
+    - Logs warning if the checkpoint renderer differs from the expected renderer.
 
     Returns:
-        The renderer name found in checkpoint metadata, if present.
+        The renderer name found in checkpoint metadata, or None if unavailable.
     """
     if expected_renderer_name is None:
         return None

--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -80,6 +80,71 @@ async def get_renderer_name_from_checkpoint_async(
         return None
 
 
+def resolve_renderer_name_from_checkpoint_or_default(
+    *,
+    model_name: str,
+    explicit_renderer_name: str | None,
+    load_checkpoint_path: str | None,
+    base_url: str | None = None,
+) -> str:
+    """
+    Resolve renderer name for training/eval setup.
+
+    Precedence:
+    1) explicit renderer name, if provided
+    2) renderer metadata from load checkpoint path, if available
+    3) recommended renderer for model_name
+    """
+    if explicit_renderer_name is not None:
+        return explicit_renderer_name
+
+    if load_checkpoint_path is not None:
+        service_client = tinker.ServiceClient(base_url=base_url)
+        renderer_name = get_renderer_name_from_checkpoint(service_client, load_checkpoint_path)
+        if renderer_name is not None:
+            logger.info(
+                "Using renderer from checkpoint metadata for %s: %s",
+                load_checkpoint_path,
+                renderer_name,
+            )
+            return renderer_name
+
+    from tinker_cookbook import model_info
+
+    return model_info.get_recommended_renderer_name(model_name)
+
+
+async def resolve_renderer_name_from_checkpoint_or_default_async(
+    *,
+    model_name: str,
+    explicit_renderer_name: str | None,
+    load_checkpoint_path: str | None,
+    base_url: str | None = None,
+) -> str:
+    """
+    Async version of resolve_renderer_name_from_checkpoint_or_default.
+    """
+    if explicit_renderer_name is not None:
+        return explicit_renderer_name
+
+    if load_checkpoint_path is not None:
+        service_client = tinker.ServiceClient(base_url=base_url)
+        renderer_name = await get_renderer_name_from_checkpoint_async(
+            service_client, load_checkpoint_path
+        )
+        if renderer_name is not None:
+            logger.info(
+                "Using renderer from checkpoint metadata for %s: %s",
+                load_checkpoint_path,
+                renderer_name,
+            )
+            return renderer_name
+
+    from tinker_cookbook import model_info
+
+    return model_info.get_recommended_renderer_name(model_name)
+
+
 def check_renderer_name_for_checkpoint(
     service_client: tinker.ServiceClient,
     checkpoint_path: str,

--- a/tinker_cookbook/eval/inspect_evaluators.py
+++ b/tinker_cookbook/eval/inspect_evaluators.py
@@ -24,7 +24,7 @@ class InspectEvaluatorBuilder:
 
     # Required parameters
     tasks: Tasks
-    renderer_name: str
+    renderer_name: str | None = None
     # TODO: remove model_name once the SDK adds a get_tokenizer method to sampling client
     model_name: str | None = None
     # Random seed for sampling. If None, sampling is non-deterministic.
@@ -80,6 +80,8 @@ class InspectEvaluator(SamplingClientEvaluator):
         """
         if self.config.model_name is None:
             raise ValueError("model_name must be set before running evaluation")
+        if self.config.renderer_name is None:
+            raise ValueError("renderer_name must be set before running evaluation")
         # Create the inspect API wrapper
         api = InspectAPIFromTinkerSampling(
             renderer_name=self.config.renderer_name,

--- a/tinker_cookbook/eval/run_inspect_evals.py
+++ b/tinker_cookbook/eval/run_inspect_evals.py
@@ -19,36 +19,32 @@ async def main(config: Config):
 
     # Create a sampling client from the model path
     service_client = tinker.ServiceClient()
+    model_path = config.model_path
+    model_name = config.model_name
+    renderer_name = config.renderer_name
 
-    if config.model_path is None and config.model_name is None:
-        raise ValueError("model_path or model_name must be provided")
-
-    if config.model_path is not None:
-        model_path = config.model_path
+    # Resolve model name from checkpoint when needed, and validate explicit model_name if provided.
+    if model_path is not None:
         rest_client = service_client.create_rest_client()
         training_run = await rest_client.get_training_run_by_tinker_path_async(model_path)
-        if config.model_name:
-            if config.model_name != training_run.base_model:
-                raise ValueError(
-                    f"Model name {config.model_name} does not match training run base model {training_run.base_model}"
-                )
-        else:
-            config = chz.replace(config, model_name=training_run.base_model)
-
-        if config.renderer_name is None:
-            renderer_name = await checkpoint_utils.get_renderer_name_from_checkpoint_async(
-                service_client, model_path
+        if model_name is not None and model_name != training_run.base_model:
+            raise ValueError(
+                f"Model name {model_name} does not match training run base model {training_run.base_model}"
             )
-            if renderer_name is None:
-                assert config.model_name is not None
-                renderer_name = model_info.get_recommended_renderer_name(config.model_name)
-            config = chz.replace(config, renderer_name=renderer_name)
-    elif config.renderer_name is None:
-        # No checkpoint metadata available; fall back to model default.
-        assert config.model_name is not None
-        config = chz.replace(
-            config, renderer_name=model_info.get_recommended_renderer_name(config.model_name)
+        model_name = model_name or training_run.base_model
+
+    if model_name is None:
+        raise ValueError("model_path or model_name must be provided")
+
+    # Resolve renderer with precedence: explicit config > checkpoint metadata > model default.
+    if renderer_name is None and model_path is not None:
+        renderer_name = await checkpoint_utils.get_renderer_name_from_checkpoint_async(
+            service_client, model_path
         )
+    if renderer_name is None:
+        renderer_name = model_info.get_recommended_renderer_name(model_name)
+
+    config = chz.replace(config, model_name=model_name, renderer_name=renderer_name)
 
     logger.info(f"Using base model: {config.model_name}")
     logger.info(f"Using renderer: {config.renderer_name}")

--- a/tinker_cookbook/recipes/chat_sl/train.py
+++ b/tinker_cookbook/recipes/chat_sl/train.py
@@ -7,7 +7,7 @@ import asyncio
 from datetime import datetime
 
 import chz
-from tinker_cookbook import cli_utils, model_info, renderers
+from tinker_cookbook import checkpoint_utils, cli_utils, renderers
 from tinker_cookbook.eval.evaluators import EvaluatorBuilder
 from tinker_cookbook.recipes.chat_sl import chat_datasets
 from tinker_cookbook.supervised import train
@@ -126,8 +126,11 @@ def cli_main(cli_config: CLIConfig):
         wandb_name = run_name
 
     cli_utils.check_log_dir(log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists)
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
     config = train.Config(
         log_path=log_path,

--- a/tinker_cookbook/recipes/chat_sl/train.py
+++ b/tinker_cookbook/recipes/chat_sl/train.py
@@ -132,6 +132,7 @@ def cli_main(cli_config: CLIConfig):
     config = train.Config(
         log_path=log_path,
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         load_checkpoint_path=cli_config.load_checkpoint_path,
         dataset_builder=get_dataset_builder(
             cli_config.dataset,

--- a/tinker_cookbook/recipes/code_rl/train.py
+++ b/tinker_cookbook/recipes/code_rl/train.py
@@ -88,6 +88,7 @@ async def cli_main(cli_config: CLIConfig) -> None:
         learning_rate=cli_config.learning_rate,
         dataset_builder=dataset_builder,
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,
         wandb_project=cli_config.wandb_project,

--- a/tinker_cookbook/recipes/code_rl/train.py
+++ b/tinker_cookbook/recipes/code_rl/train.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import chz
 
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.recipes.code_rl.code_env import DeepcoderDatasetBuilder
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
 from tinker_cookbook.sandbox import SandboxBackend
@@ -55,8 +55,11 @@ class CLIConfig:
 
 
 async def cli_main(cli_config: CLIConfig) -> None:
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
 
     model_tag = cli_config.model_name.replace("/", "-")

--- a/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
+++ b/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
@@ -170,6 +170,7 @@ def cli_main(cli_config: CLIConfig):
     config = train.Config(
         log_path=log_path,
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         load_checkpoint_path=cli_config.load_checkpoint_path,
         dataset_builder=dataset_builder,
         evaluator_builders=[],

--- a/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
+++ b/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
@@ -22,7 +22,7 @@ from typing import cast
 import chz
 import datasets
 import tinker
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.renderers import Message, TrainOnWhat
 from tinker_cookbook.supervised import train
 from tinker_cookbook.supervised.data import (
@@ -126,8 +126,11 @@ def cli_main(cli_config: CLIConfig):
     """Convert CLI config to full config and run training."""
 
     # Get renderer name
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
 
     # Create log path if not specified

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -33,7 +33,7 @@ from typing import Any
 
 import chz
 from tinker.types import LossFnType
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.distillation import train_on_policy
 from tinker_cookbook.distillation.datasets import (
     DistillationDatasetConfig,
@@ -98,8 +98,11 @@ async def cli_main(cli_config: CLIConfig):
     """Convert CLI config to full config and run training."""
 
     # Get renderer name
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
 
     # Create log path if not specified

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -147,6 +147,7 @@ async def cli_main(cli_config: CLIConfig):
         learning_rate=cli_config.learning_rate,
         dataset_configs=[dataset_config],
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,
         kl_penalty_coef=cli_config.kl_penalty_coef,

--- a/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import chz
 from tinker.types import LossFnType
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.distillation import train_on_policy
 from tinker_cookbook.distillation.datasets import (
     DistillationDatasetConfig,
@@ -90,8 +90,11 @@ class CLIConfig:
 
 async def cli_main(cli_config: CLIConfig):
     """Convert CLI config to full config and run training."""
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
 
     # Create log path if not specified

--- a/tinker_cookbook/recipes/if_rl/train.py
+++ b/tinker_cookbook/recipes/if_rl/train.py
@@ -77,6 +77,7 @@ async def cli_main(cli_config: CLIConfig):
 
     config = train.Config(
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         log_path=log_path,
         dataset_builder=builder,
         learning_rate=cli_config.learning_rate,

--- a/tinker_cookbook/recipes/if_rl/train.py
+++ b/tinker_cookbook/recipes/if_rl/train.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 
 import chz
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.recipes.if_rl.env import IfBenchDatasetBuilder, RewardType
 from tinker_cookbook.rl import train
 
@@ -40,8 +40,10 @@ class CLIConfig:
 
 async def cli_main(cli_config: CLIConfig):
     # Get renderer name
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
     )
 
     # Build dataset builder

--- a/tinker_cookbook/recipes/math_rl/train.py
+++ b/tinker_cookbook/recipes/math_rl/train.py
@@ -128,6 +128,7 @@ async def cli_main(cli_config: CLIConfig):
             seed=cli_config.seed,
         ),
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,
         temperature=cli_config.temperature,

--- a/tinker_cookbook/recipes/math_rl/train.py
+++ b/tinker_cookbook/recipes/math_rl/train.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 
 import chz
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.recipes.math_rl import (
     arithmetic_env,
     math_env,
@@ -101,8 +101,11 @@ async def cli_main(cli_config: CLIConfig):
     """Convert CLI config to full config and run training."""
 
     # Get tokenizer for stop sequences
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
     model_name = cli_config.model_name.replace("/", "-")
     run_name = f"{cli_config.env}-{model_name}-{cli_config.lora_rank}rank-{cli_config.learning_rate}lr-{cli_config.group_size}group-{cli_config.groups_per_batch}batch-{cli_config.loss_fn}-seed{cli_config.seed}-{datetime.now().strftime('%Y-%m-%d-%H-%M')}"

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/train.py
@@ -50,6 +50,7 @@ def build_config(cli_config: CLIConfig) -> train.Config:
 
     return train.Config(
         model_name=model_name,
+        renderer_name=renderer_name,
         log_path=log_path,
         dataset_builder=dataset_builder,
         learning_rate=cli_config.learning_rate,

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/train.py
@@ -52,6 +52,7 @@ def build_config(cli_config: CLIConfig) -> train.Config:
 
     return train.Config(
         model_name=model_name,
+        renderer_name=renderer_name,
         log_path=log_path,
         dataset_builder=dataset_builder,
         learning_rate=cli_config.learning_rate,

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/train.py
@@ -52,6 +52,7 @@ def build_config(cli_config: CLIConfig) -> train.Config:
 
     return train.Config(
         model_name=model_name,
+        renderer_name=renderer_name,
         log_path=log_path,
         dataset_builder=dataset_builder,
         learning_rate=cli_config.learning_rate,

--- a/tinker_cookbook/recipes/preference/dpo/train.py
+++ b/tinker_cookbook/recipes/preference/dpo/train.py
@@ -101,6 +101,7 @@ def cli_main(cli_config: CLIConfig):
     config = train_dpo.Config(
         log_path=log_path,
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         dataset_builder=get_dataset_builder(
             cli_config.dataset,
             cli_config.model_name,

--- a/tinker_cookbook/recipes/preference/dpo/train.py
+++ b/tinker_cookbook/recipes/preference/dpo/train.py
@@ -5,7 +5,7 @@ Basic CLI for training with Direct Preference Optimization (DPO). It only suppor
 from datetime import datetime
 
 import chz
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.preference import train_dpo
 from tinker_cookbook.preference.dpo_datasets import (
     DPODatasetBuilderFromComparisons,
@@ -81,8 +81,11 @@ def get_dataset_builder(
 def cli_main(cli_config: CLIConfig):
     """Main CLI function that builds the full config and calls the training function."""
     # Build full config
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
     date_and_time = datetime.now().strftime("%Y-%m-%d-%H-%M")
     model_name = cli_config.model_name.replace("/", "-")

--- a/tinker_cookbook/recipes/preference/rlhf/rlhf_pipeline.py
+++ b/tinker_cookbook/recipes/preference/rlhf/rlhf_pipeline.py
@@ -77,6 +77,7 @@ def sft_stage(
     config = supervised_train.Config(
         log_path=log_path,
         model_name=base_model,
+        renderer_name=renderer_name,
         dataset_builder=dataset_builder,
         evaluator_builders=[],  # Could add evaluators here
         num_epochs=1,
@@ -129,6 +130,7 @@ def train_rm(
     config = supervised_train.Config(
         log_path=log_path,
         model_name=base_model,
+        renderer_name=renderer_name,
         dataset_builder=dataset_builder,
         evaluator_builders=[],  # Could add evaluators here
         num_epochs=1,
@@ -212,6 +214,7 @@ async def train_rl(
 
     config = train.Config(
         model_name=base_model,
+        renderer_name=renderer_name,
         dataset_builder=rl_dataset_builder,
         load_checkpoint_path=sft_checkpoint,
         learning_rate=learning_rate,

--- a/tinker_cookbook/recipes/preference/shorter/train.py
+++ b/tinker_cookbook/recipes/preference/shorter/train.py
@@ -26,6 +26,7 @@ def build_config() -> train.Config:
 
     return train.Config(
         model_name=model_name,
+        renderer_name=renderer_name,
         log_path=f"/tmp/tinker-examples/shorter/{int(time())}",
         dataset_builder=dataset_builder,
         learning_rate=3e-5,

--- a/tinker_cookbook/recipes/prompt_distillation/train.py
+++ b/tinker_cookbook/recipes/prompt_distillation/train.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 
 import chz
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.renderers import TrainOnWhat
 from tinker_cookbook.supervised import train
 from tinker_cookbook.supervised.data import FromConversationFileBuilder
@@ -73,8 +73,11 @@ def cli_main(cli_config: CLIConfig):
 
     cli_utils.check_log_dir(log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists)
 
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
 
     common_config = ChatDatasetBuilderCommonConfig(

--- a/tinker_cookbook/recipes/prompt_distillation/train.py
+++ b/tinker_cookbook/recipes/prompt_distillation/train.py
@@ -93,6 +93,7 @@ def cli_main(cli_config: CLIConfig):
     config = train.Config(
         log_path=log_path,
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         load_checkpoint_path=cli_config.load_checkpoint_path,
         dataset_builder=dataset,
         learning_rate=cli_config.learning_rate,

--- a/tinker_cookbook/recipes/rl_basic.py
+++ b/tinker_cookbook/recipes/rl_basic.py
@@ -20,6 +20,7 @@ def build_config_blueprint() -> chz.Blueprint[train.Config]:
     return chz.Blueprint(train.Config).apply(
         {
             "model_name": model_name,
+            "renderer_name": renderer_name,
             "log_path": "/tmp/tinker-examples/rl_basic",
             "dataset_builder": builder,
             "learning_rate": 4e-5,

--- a/tinker_cookbook/recipes/rubric/prometheus_experimental.py
+++ b/tinker_cookbook/recipes/rubric/prometheus_experimental.py
@@ -107,6 +107,7 @@ async def cli_main(cli_config: CLIConfig):
             test_group_size=cli_config.test_group_size,
         ),
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,
         temperature=cli_config.temperature,

--- a/tinker_cookbook/recipes/rubric/prometheus_experimental.py
+++ b/tinker_cookbook/recipes/rubric/prometheus_experimental.py
@@ -1,7 +1,7 @@
 import chz
 import asyncio
 from datetime import datetime
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
 from tinker_cookbook.rl.types import RLDatasetBuilder
 from tinker.types import LossFnType
@@ -79,8 +79,11 @@ async def cli_main(cli_config: CLIConfig):
     """Convert CLI config to full config and run training."""
 
     # Get tokenizer for stop sequences
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
     model_name = cli_config.model_name.replace("/", "-")
     run_name = f"prometheus_experimental-{model_name}-{cli_config.lora_rank}rank-{cli_config.learning_rate}lr-{cli_config.train_group_size}group_size-{cli_config.groups_per_batch}batch-{cli_config.loss_fn}-seed{cli_config.seed}-{datetime.now().strftime('%Y-%m-%d-%H-%M')}"

--- a/tinker_cookbook/recipes/rubric/train.py
+++ b/tinker_cookbook/recipes/rubric/train.py
@@ -1,7 +1,7 @@
 import chz
 import asyncio
 from datetime import datetime
-from tinker_cookbook import cli_utils, model_info
+from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
 from tinker_cookbook.rl.types import RLDatasetBuilder
 from tinker.types import LossFnType
@@ -88,8 +88,11 @@ async def cli_main(cli_config: CLIConfig):
     """Convert CLI config to full config and run training."""
 
     # Get tokenizer for stop sequences
-    renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-        cli_config.model_name
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cli_config.model_name,
+        explicit_renderer_name=cli_config.renderer_name,
+        load_checkpoint_path=cli_config.load_checkpoint_path,
+        base_url=cli_config.base_url,
     )
     model_name = cli_config.model_name.replace("/", "-")
     run_name = f"{model_name}-{cli_config.lora_rank}rank-{cli_config.learning_rate}lr-{cli_config.train_group_size}group_size-{cli_config.groups_per_batch}batch-{cli_config.loss_fn}-seed{cli_config.seed}-{datetime.now().strftime('%Y-%m-%d-%H-%M')}"

--- a/tinker_cookbook/recipes/rubric/train.py
+++ b/tinker_cookbook/recipes/rubric/train.py
@@ -118,6 +118,7 @@ async def cli_main(cli_config: CLIConfig):
             test_group_size=cli_config.test_group_size,
         ),
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,
         temperature=cli_config.temperature,

--- a/tinker_cookbook/recipes/search_tool/train.py
+++ b/tinker_cookbook/recipes/search_tool/train.py
@@ -126,6 +126,7 @@ async def cli_main(cli_config: CLIConfig) -> None:
     # Build training config
     config = train.Config(
         model_name=cli_config.model_name,
+        renderer_name=renderer_name,
         log_path=log_path,
         dataset_builder=builder,
         learning_rate=cli_config.learning_rate,

--- a/tinker_cookbook/recipes/sl_basic.py
+++ b/tinker_cookbook/recipes/sl_basic.py
@@ -30,6 +30,7 @@ def build_config_blueprint() -> chz.Blueprint[train.Config]:
         {
             "log_path": "/tmp/tinker-examples/sl_basic",
             "model_name": model_name,
+            "renderer_name": renderer_name,
             "dataset_builder": dataset,
             "learning_rate": 2e-4,
             "lr_schedule": "linear",

--- a/tinker_cookbook/recipes/verifiers_rl/evaluate.py
+++ b/tinker_cookbook/recipes/verifiers_rl/evaluate.py
@@ -10,7 +10,7 @@ import numpy as np
 import verifiers as vf
 from verifiers.utils.message_utils import messages_to_printable
 
-from tinker_cookbook import model_info, renderers
+from tinker_cookbook import checkpoint_utils, model_info, renderers
 from tinker_cookbook.recipes.verifiers_rl.tinker_openai import TinkerAsyncOpenAIClient
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
@@ -91,7 +91,14 @@ async def evaluate(
 
     env = vf.load_environment(vf_env_id, **vf_env_args)
     tokenizer = get_tokenizer(model_name)
-    renderer_name = model_info.get_recommended_renderer_name(model_name)
+    renderer_name = None
+    if model_path is not None:
+        renderer_name = await checkpoint_utils.get_renderer_name_from_checkpoint_async(
+            service, model_path
+        )
+    if renderer_name is None:
+        renderer_name = model_info.get_recommended_renderer_name(model_name)
+    print(f"Using renderer: {renderer_name}")
     renderer = renderers.get_renderer(renderer_name, tokenizer)
 
     # Create sampling client from checkpoint path or base model

--- a/tinker_cookbook/recipes/vlm_classifier/sweep.py
+++ b/tinker_cookbook/recipes/vlm_classifier/sweep.py
@@ -127,6 +127,7 @@ def run_experiment(experiment_config: ExperimentConfig):
     config = train.Config(
         log_path=experiment_path,
         model_name=experiment_config.model_name,
+        renderer_name=experiment_config.renderer_name,
         dataset_builder=dataset_builder,
         evaluator_builders=evaluator_builders,
         infrequent_evaluator_builders=[],

--- a/tinker_cookbook/recipes/vlm_classifier/train.py
+++ b/tinker_cookbook/recipes/vlm_classifier/train.py
@@ -133,6 +133,7 @@ def run_experiment(experiment_config: ExperimentConfig):
     config = train.Config(
         log_path=experiment_path,
         model_name=experiment_config.model_name,
+        renderer_name=experiment_config.renderer_name,
         load_checkpoint_path=experiment_config.load_checkpoint_path,
         dataset_builder=dataset_builder,
         evaluator_builders=evaluator_builders,

--- a/tinker_cookbook/xmux/examples/async_rl_sweep.py
+++ b/tinker_cookbook/xmux/examples/async_rl_sweep.py
@@ -28,6 +28,7 @@ def build_rl_basic_config(max_steps_off_policy: int, name: str) -> rl_train.Conf
     )
     return rl_train.Config(
         model_name=model_name,
+        renderer_name=renderer_name,
         log_path=f"/tmp/tinker-examples/async_rl_sweep_{name}",
         dataset_builder=builder,
         learning_rate=4e-5,


### PR DESCRIPTION
## Summary
- persist `renderer_name` in training-run metadata across supervised, RL, DPO, and distillation training flows
- validate renderer compatibility when loading checkpoints (warn on mismatch)
- auto-resolve renderer in eval/offline-eval scripts with precedence:
  1. explicit config renderer
  2. checkpoint metadata renderer
  3. model default renderer
- auto-resolve renderer in training CLIs (for two-stage pipelines like SFT -> RL) when `load_checkpoint_path` is provided, using the same precedence

## Additional cleanup
- simplified `run_inspect_evals` model/renderer resolution flow
- removed unused return values from renderer check helpers
- refactored renderer-check helper duplication (sync/async)
- moved PR-introduced inline imports in `checkpoint_utils` to module top
- applied pre-commit formatting fixes

## Why
This reduces renderer drift across multi-stage pipelines and makes checkpoint consumers safer by default. If a checkpoint already encodes renderer metadata, train/eval flows can now use it automatically instead of relying on manual renderer flags.

## Validation
- `py_compile` on modified files
- `pyright` checks on core modified files
- pre-commit hooks run and fixed (`ruff-format`)
- live metadata roundtrip against Tinker:
  - create training run with `renderer_name`
  - save checkpoint
  - retrieve matching `renderer_name` from checkpoint-linked training run
