### PR TITLE
Qwen3 streaming support

### DIFF
--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -10,7 +10,8 @@ Includes:
 """
 
 import json
-from typing import cast
+from dataclasses import dataclass, field
+from typing import Callable, Iterator, cast
 
 import tinker
 
@@ -19,13 +20,18 @@ from tinker_cookbook.renderers.base import (
     ImagePart,
     ImageProcessorProtocol,
     Message,
+    MessageDelta,
     RenderContext,
     RenderedMessage,
     Renderer,
+    StreamingMessageHeader,
+    StreamingTextDelta,
+    StreamingThinkingDelta,
     TextPart,
     ToolCall,
     ToolSpec,
     UnparsedToolCall,
+    Utf8TokenDecoder,
     _tool_call_payload,
     image_to_chunk,
     parse_content_blocks,
@@ -55,6 +61,140 @@ def _merge_consecutive_text_parts(
         else:
             merged.append(chunk)
     return merged
+
+
+_THINK_OPEN_TAG = "<think>"
+_THINK_CLOSE_TAG = "</think>"
+
+
+def _longest_matching_suffix_prefix(text: str, tag: str) -> int:
+    """Find longest suffix of text that matches a prefix of tag."""
+    max_check = min(len(text), len(tag) - 1)
+    for length in range(max_check, 0, -1):
+        if text.endswith(tag[:length]):
+            return length
+    return 0
+
+
+@dataclass
+class Qwen3StreamingParser:
+    """Stateful streaming parser for Qwen3 text output."""
+
+    tokenizer: Tokenizer
+    end_message_token: int
+    parse_final_response: Callable[[list[int]], tuple[Message, bool]]
+
+    _utf8_decoder: Utf8TokenDecoder = field(init=False)
+    _accumulated_text: str = field(init=False, default="")
+    _header_emitted: bool = field(init=False, default=False)
+    _in_thinking: bool = field(init=False, default=False)
+    _content_index: int = field(init=False, default=0)
+    _last_emitted_pos: int = field(init=False, default=0)
+    _finished: bool = field(init=False, default=False)
+    _all_tokens: list[int] = field(init=False, default_factory=list)
+
+    def __post_init__(self) -> None:
+        self._utf8_decoder = Utf8TokenDecoder(self.tokenizer)
+
+    def feed(self, token: int) -> Iterator[MessageDelta]:
+        if self._finished:
+            return
+
+        self._all_tokens.append(token)
+
+        if token == self.end_message_token:
+            self._finished = True
+            return
+
+        decoded = self._utf8_decoder.decode([token])
+        if decoded is None:
+            return
+
+        self._accumulated_text += decoded
+
+        if not self._header_emitted:
+            self._header_emitted = True
+            yield StreamingMessageHeader(role="assistant")
+
+        yield from self._emit_deltas()
+
+    def _emit_deltas(self) -> Iterator[MessageDelta]:
+        text = self._accumulated_text
+        pos = self._last_emitted_pos
+
+        while pos < len(text):
+            if not self._in_thinking:
+                think_start = text.find(_THINK_OPEN_TAG, pos)
+                if think_start == -1:
+                    suffix_from_pos = text[pos:]
+                    keep = _longest_matching_suffix_prefix(suffix_from_pos, _THINK_OPEN_TAG)
+                    safe_end = len(text) - keep
+                    if safe_end > pos:
+                        new_text = text[pos:safe_end]
+                        if new_text:
+                            yield StreamingTextDelta(text=new_text, content_index=self._content_index)
+                        self._last_emitted_pos = safe_end
+                    break
+                if think_start > pos:
+                    new_text = text[pos:think_start]
+                    if new_text:
+                        yield StreamingTextDelta(text=new_text, content_index=self._content_index)
+                    pos = think_start
+
+                if text[pos:].startswith(_THINK_OPEN_TAG):
+                    self._in_thinking = True
+                    self._content_index += 1
+                    pos += len(_THINK_OPEN_TAG)
+                    self._last_emitted_pos = pos
+            else:
+                think_end = text.find(_THINK_CLOSE_TAG, pos)
+                if think_end == -1:
+                    suffix_from_pos = text[pos:]
+                    keep = _longest_matching_suffix_prefix(suffix_from_pos, _THINK_CLOSE_TAG)
+                    safe_end = len(text) - keep
+                    if safe_end > pos:
+                        new_thinking = text[pos:safe_end]
+                        if new_thinking:
+                            yield StreamingThinkingDelta(
+                                thinking=new_thinking, content_index=self._content_index
+                            )
+                        self._last_emitted_pos = safe_end
+                    break
+
+                new_thinking = text[pos:think_end]
+                if new_thinking:
+                    yield StreamingThinkingDelta(
+                        thinking=new_thinking, content_index=self._content_index
+                    )
+                self._in_thinking = False
+                self._content_index += 1
+                pos = think_end + len(_THINK_CLOSE_TAG)
+                self._last_emitted_pos = pos
+
+    def finish(self) -> Iterator[MessageDelta]:
+        remaining = self._utf8_decoder.flush()
+        if remaining:
+            self._accumulated_text += remaining
+
+        if not self._header_emitted:
+            self._header_emitted = True
+            yield StreamingMessageHeader(role="assistant")
+
+        text = self._accumulated_text
+        pos = self._last_emitted_pos
+        if pos < len(text):
+            remaining_text = text[pos:]
+            if self._in_thinking:
+                if remaining_text:
+                    yield StreamingThinkingDelta(
+                        thinking=remaining_text, content_index=self._content_index
+                    )
+            else:
+                if remaining_text:
+                    yield StreamingTextDelta(text=remaining_text, content_index=self._content_index)
+
+        message, _success = self.parse_final_response(self._all_tokens)
+        yield message
 
 
 class Qwen3Renderer(Renderer):
@@ -226,6 +366,19 @@ class Qwen3Renderer(Renderer):
             assistant_message["content"] = content
 
         return assistant_message, True
+
+    def parse_response_streaming(self, response: list[int]) -> Iterator[MessageDelta]:
+        """Parse response tokens with streaming, yielding incremental deltas."""
+        parser = Qwen3StreamingParser(
+            tokenizer=self.tokenizer,
+            end_message_token=self._end_message_token,
+            parse_final_response=self.parse_response,
+        )
+
+        for token in response:
+            yield from parser.feed(token)
+
+        yield from parser.finish()
 
     def to_openai_message(self, message: Message) -> dict:
         """Convert a Message to OpenAI API format with reasoning_content for thinking.

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -132,7 +132,9 @@ class Qwen3StreamingParser:
                     if safe_end > pos:
                         new_text = text[pos:safe_end]
                         if new_text:
-                            yield StreamingTextDelta(text=new_text, content_index=self._content_index)
+                            yield StreamingTextDelta(
+                                text=new_text, content_index=self._content_index
+                            )
                         self._last_emitted_pos = safe_end
                     break
                 if think_start > pos:

--- a/tinker_cookbook/tests/test_renderer_parsing.py
+++ b/tinker_cookbook/tests/test_renderer_parsing.py
@@ -25,6 +25,7 @@ from tinker_cookbook.renderers.base import (
 )
 from tinker_cookbook.renderers.deepseek_v3 import DeepSeekV3DisableThinkingRenderer
 from tinker_cookbook.renderers.kimi_k2 import KimiK2Renderer, _longest_matching_suffix_prefix
+from tinker_cookbook.renderers.qwen3 import Qwen3DisableThinkingRenderer, Qwen3InstructRenderer
 from tinker_cookbook.tests.test_renderers import get_tokenizer
 
 # =============================================================================
@@ -601,13 +602,125 @@ def test_thinking_generation_parse_correspondence(model_name, renderer_cls, rend
 
 
 # =============================================================================
-# Kimi K2 Streaming Parsing Tests
+# Qwen3 Streaming Parsing Tests
 # =============================================================================
 
 
 def _is_message(obj) -> TypeGuard[Message]:
     """Check if object is a Message dict (TypedDict doesn't support isinstance)."""
     return isinstance(obj, dict) and "role" in obj and "content" in obj
+
+
+def test_qwen3_streaming_simple_text():
+    """Test streaming parsing of simple text response."""
+    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    renderer = Qwen3Renderer(tokenizer)
+
+    response_str = "Hello, world!<|im_end|>"
+    response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
+
+    deltas = list(renderer.parse_response_streaming(response_tokens))
+
+    assert isinstance(deltas[0], StreamingMessageHeader)
+    assert deltas[0].role == "assistant"
+    assert _is_message(deltas[-1])
+    assert deltas[-1]["role"] == "assistant"
+
+    text_content = "".join(d.text for d in deltas if isinstance(d, StreamingTextDelta))
+    assert text_content == "Hello, world!"
+
+
+def test_qwen3_streaming_with_thinking():
+    """Test streaming parsing with thinking blocks."""
+    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    renderer = Qwen3Renderer(tokenizer)
+
+    response_str = "<think>Let me reason about this.</think>The answer is 42.<|im_end|>"
+    response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
+
+    deltas = list(renderer.parse_response_streaming(response_tokens))
+
+    assert isinstance(deltas[0], StreamingMessageHeader)
+    assert deltas[0].role == "assistant"
+
+    thinking_content = "".join(d.thinking for d in deltas if isinstance(d, StreamingThinkingDelta))
+    text_content = "".join(d.text for d in deltas if isinstance(d, StreamingTextDelta))
+
+    assert "Let me reason about this." in thinking_content
+    assert "The answer is 42." in text_content
+    assert _is_message(deltas[-1])
+
+
+def test_qwen3_streaming_matches_batch():
+    """Test that streaming parse produces same final message as batch parse."""
+    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    renderer = Qwen3Renderer(tokenizer)
+
+    response_str = "<think>Step 1: Analyze.\nStep 2: Compute.</think>The result is 123.<|im_end|>"
+    response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
+
+    batch_message, batch_success = renderer.parse_response(response_tokens)
+    assert batch_success
+
+    deltas = list(renderer.parse_response_streaming(response_tokens))
+    streaming_message = deltas[-1]
+
+    assert _is_message(streaming_message)
+    assert streaming_message["role"] == batch_message["role"]
+    assert ensure_list(streaming_message["content"]) == ensure_list(batch_message["content"])
+
+
+def test_qwen3_streaming_content_index_increments():
+    """Test that content_index increments when switching content types."""
+    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    renderer = Qwen3Renderer(tokenizer)
+
+    response_str = "<think>thinking</think>text<|im_end|>"
+    response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
+
+    deltas = list(renderer.parse_response_streaming(response_tokens))
+
+    thinking_indices = [d.content_index for d in deltas if isinstance(d, StreamingThinkingDelta)]
+    text_indices = [d.content_index for d in deltas if isinstance(d, StreamingTextDelta)]
+
+    if thinking_indices and text_indices:
+        assert max(text_indices) > min(thinking_indices)
+
+
+def test_qwen3_streaming_empty_response():
+    """Test streaming parsing of empty/minimal response."""
+    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    renderer = Qwen3Renderer(tokenizer)
+
+    response_str = "<|im_end|>"
+    response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
+
+    deltas = list(renderer.parse_response_streaming(response_tokens))
+
+    assert isinstance(deltas[0], StreamingMessageHeader)
+    assert _is_message(deltas[-1])
+
+
+@pytest.mark.parametrize(
+    "renderer_cls",
+    [Qwen3Renderer, Qwen3DisableThinkingRenderer, Qwen3InstructRenderer],
+)
+def test_qwen3_streaming_supported_by_text_variants(renderer_cls):
+    """Streaming should be available across Qwen3 text renderer variants."""
+    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    renderer = renderer_cls(tokenizer)
+
+    response_str = "Variant coverage<|im_end|>"
+    response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
+    deltas = list(renderer.parse_response_streaming(response_tokens))
+
+    assert isinstance(deltas[0], StreamingMessageHeader)
+    assert _is_message(deltas[-1])
+
+
+# =============================================================================
+# Kimi K2 Streaming Parsing Tests
+# =============================================================================
 
 
 def test_kimi_streaming_simple_text():


### PR DESCRIPTION
## Summary
Add streaming response parsing support for Qwen3 so callers can consume incremental deltas while preserving Qwen3-specific `<think>...</think>` behavior.

## What Changed
- Added `Qwen3StreamingParser` in `tinker_cookbook/renderers/qwen3.py`.
- Handles streamed partial chunks across boundaries (including split tags).
- Emits structured deltas for regular assistant text and thinking content in the correct order.
- Finalizes buffered content correctly at end-of-stream.
- Added/updated tests covering parser behavior for incremental token streams and edge cases.
- Applied formatting fixes required by CI pre-commit hooks.

## Validation
- `uv run --with pre-commit pre-commit run --all-files`
- PR checks on GitHub (pre-commit/test/type-check) running against latest commit.