### PR TITLE
fix: use math.ceil for batch count to not ignore remainder

### DIFF
--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -4,6 +4,7 @@ Uses existing modules but with a simple, flat training loop.
 """
 
 import logging
+import math
 import time
 
 import chz
@@ -55,7 +56,7 @@ def main(config: Config):
     assert isinstance(dataset, datasets.DatasetDict)
     train_dataset = dataset["train"]
 
-    n_train_batches = len(train_dataset) // config.batch_size
+    n_train_batches = math.ceil(len(train_dataset) / config.batch_size)
     logger.info(f"Train batches: {n_train_batches}")
 
     # Setup training client


### PR DESCRIPTION
Issue #381: Use math.ceil instead of floor division (//) to not
silently ignore the last few rows when batch_size does not divide evenly.

Happy to make any changes if needed!