### PR TITLE
Add strip_thinking_from_history to KimiK2.5 renderer

### DIFF
--- a/tinker_cookbook/renderers/kimi_k25.py
+++ b/tinker_cookbook/renderers/kimi_k25.py
@@ -35,8 +35,13 @@ class KimiK25Renderer(KimiK2Renderer):
 
     image_processor: ImageProcessor | None
 
-    def __init__(self, tokenizer: Tokenizer, image_processor: ImageProcessor | None = None):
-        super().__init__(tokenizer)
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        image_processor: ImageProcessor | None = None,
+        strip_thinking_from_history: bool = True,
+    ):
+        super().__init__(tokenizer, strip_thinking_from_history=strip_thinking_from_history)
         self.image_processor = image_processor
 
     def _encode_multipart_content(self, content: list[ContentPart]) -> list[tinker.ModelInputChunk]:

--- a/tinker_cookbook/tests/test_renderers.py
+++ b/tinker_cookbook/tests/test_renderers.py
@@ -49,6 +49,7 @@ from tinker_cookbook.renderers import (
 )
 from tinker_cookbook.renderers.base import ensure_list, ensure_text
 from tinker_cookbook.renderers.kimi_k2 import KimiK2Renderer
+from tinker_cookbook.renderers.kimi_k25 import KimiK25Renderer
 from tinker_cookbook.tests.conversation_generator import generate_conversation
 from tinker_cookbook.tokenizer_utils import (
     get_registered_tokenizer_names,
@@ -712,6 +713,8 @@ def test_tool_call_supervised_rendering(model_name: str):
     [
         ("Qwen/Qwen3-8B", Qwen3Renderer),
         ("deepseek-ai/DeepSeek-V3.1", DeepSeekV3ThinkingRenderer),
+        ("moonshotai/Kimi-K2-Thinking", KimiK2Renderer),
+        ("moonshotai/Kimi-K2.5", KimiK25Renderer),
     ],
 )
 def test_strip_thinking_from_history_default(model_name: str, renderer_class):
@@ -739,6 +742,8 @@ def test_strip_thinking_from_history_default(model_name: str, renderer_class):
     [
         ("Qwen/Qwen3-8B", Qwen3Renderer),
         ("deepseek-ai/DeepSeek-V3.1", DeepSeekV3ThinkingRenderer),
+        ("moonshotai/Kimi-K2-Thinking", KimiK2Renderer),
+        ("moonshotai/Kimi-K2.5", KimiK25Renderer),
     ],
 )
 def test_strip_thinking_from_history_false(model_name: str, renderer_class):


### PR DESCRIPTION
## Summary
- Forward `strip_thinking_from_history` through `KimiK25Renderer.__init__` to its K2 parent so users can control thinking-block stripping on K2.5
- Add K2 and K2.5 to the parametrized `test_strip_thinking_from_history_default` and `test_strip_thinking_from_history_false` tests in `test_renderers.py`