### PR TITLE
Make `save_checkpoint_async` more async with asyncio.gather on results

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -254,7 +254,9 @@ async def save_checkpoint_async(
             name, ttl_seconds=ttl_seconds
         )
 
-    results = {k: await v.result_async() for k, v in futures.items()}
+    keys = list(futures.keys())
+    vals = await asyncio.gather(*(futures[k].result_async() for k in keys))
+    results = dict(zip(keys, vals))
     paths = {k + "_path": v.path for k, v in results.items()}
     update_scope_context(paths)
     logger.info(f"Saved checkpoints: {paths}")


### PR DESCRIPTION
Use asyncio.gather to await checkpoint result_async() calls concurrently (previous loop awaited sequentially), i.e.,

Before, have to wait for sampler and state results non-concurrently:
https://github.com/thinking-machines-lab/tinker-cookbook/blob/98c775bbe671fa61ce99dbf12ea0f355716e9c9f/tinker_cookbook/checkpoint_utils.py#L249-L257

Now: results loaded concurrently
```python
keys = list(futures.keys())
vals = await asyncio.gather(*(futures[k].result_async() for k in keys))
results = dict(zip(keys, vals))
```

Or more concisely:
```python
results = await asyncio.gather(*(v.result_async() for v in futures.values()))
results = dict(zip(futures.keys(), results))
```