### PR TITLE
Fix TinkerMessageCompleter dropping tool_calls

### DIFF
--- a/tinker_cookbook/completers.py
+++ b/tinker_cookbook/completers.py
@@ -117,4 +117,7 @@ class TinkerMessageCompleter(MessageCompleter):
         # Decode the response
         parsed_message, _success = self.renderer.parse_response(response.sequences[0].tokens)
 
-        return {"role": "assistant", "content": parsed_message["content"]}
+        result: renderers.Message = {"role": "assistant", "content": parsed_message["content"]}
+        if "tool_calls" in parsed_message:
+            result["tool_calls"] = parsed_message["tool_calls"]
+        return result


### PR DESCRIPTION
## Summary
- `TinkerMessageCompleter.__call__` was constructing the return `Message` with only `role` and `content`, silently dropping `tool_calls` from the parsed response.
- Now preserves `tool_calls` when present in the output of `renderer.parse_response`.

## Test plan
- [ ] Verify tool-calling RL envs / evals that use `TinkerMessageCompleter` now receive tool calls in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)