### PR TITLE
Add docs on how to integrate tinker-cookbook with litellm

### DIFF
--- a/docs/compatible-apis/litellm.mdx
+++ b/docs/compatible-apis/litellm.mdx
@@ -101,21 +101,24 @@ class TinkerCookbookLLM(CustomLLM):
         renderer = _get_renderer(base_model)
         sampling_client = _get_sampling_client(base_model)
 
-        # Render messages -> token IDs
-        tinker_msgs = _to_tinker_messages(messages)
+        # Inject tool declarations into the prompt
+        tools = optional_params.get("tools")
+        if tools:
+            tool_specs = [t["function"] for t in tools if "function" in t]
+            match tinker_msgs:
+                case [{"role": "system", "content": system_prompt}, *rest]:
+                    pass
+                case rest:
+                    system_prompt = ""
+            tinker_msgs = renderer.create_conversation_prefix_with_tools(tool_specs, system_prompt) + rest
+
         model_input = renderer.build_generation_prompt(tinker_msgs)
         input_tokens: list[int] = model_input.to_ints()
 
         # Build sampling params from optional_params
-        sampling_params = SamplingParams(
-            max_tokens=optional_params.get("max_tokens", 8192),
-        )
-        if "temperature" in optional_params:
-            sampling_params.temperature = optional_params["temperature"]
-        if "top_p" in optional_params:
-            sampling_params.top_p = optional_params["top_p"]
-        if "top_k" in optional_params:
-            sampling_params.top_k = optional_params["top_k"]
+	sampling_params = SamplingParams(
+	    **{k: v for k, v in optional_params.items() if k in SamplingParams.model_fields}
+	)
 
         # Call Tinker sampling API
         result = await sampling_client.sample_async(


### PR DESCRIPTION
I learned this from https://medium.com/@yugez/tuning-any-ai-agent-with-tinker-agent-lightning-part-1-1d8c9a397f0e

This example makes it easy to convert agentic harnesses / programs that use litellm into token in / token out format, so they can target the Tinker API and the tokens can be used for training.

If we want to merge this, we should do a few things to clean it up:

- [x] Fix https://github.com/thinking-machines-lab/tinker-cookbook/issues/407 and remove the hard coded kimi_k25 renderer
- [ ] Remove the hard-coded max_tokens
- [ ] Make sure the docs render properly
- [ ] Possibly add a test so this integration won't break in the future

This already runs successfully with a tool heavy agentic harness. It can be improved a little by e.g. translating tinker's `tinker.BadRequestError` into litellm's ContextWindowExceededError.