### PR TITLE
Fix get_recommended_renderer returning kimi_k2 for Kimi-K2.5

### DIFF
--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -135,7 +135,12 @@ def get_recommended_renderer_names(model_name: str) -> list[str]:
     elif attributes.organization == "openai":
         return ["gpt_oss_no_sysprompt", "gpt_oss_medium_reasoning"]
     elif attributes.organization == "moonshotai":
-        return ["kimi_k2"]
+        if attributes.version_str == "K2.5":
+            return ["kimi_k25", "kimi_k25_disable_thinking"]
+        elif attributes.version_str == "K2":
+            return ["kimi_k2"]
+        else:
+            raise ValueError(f"Unknown model: {model_name}")
     else:
         raise ValueError(f"Unknown model: {model_name}")
 


### PR DESCRIPTION
## Summary
- Branch on `version_str` for moonshotai models so `Kimi-K2.5` returns `["kimi_k25", "kimi_k25_disable_thinking"]` instead of `["kimi_k2"]`
- Adds explicit `raise ValueError` for unknown future moonshot versions

Closes #407

## Test plan
- [x] Verified `moonshotai/Kimi-K2-Thinking` → `["kimi_k2"]`
- [x] Verified `moonshotai/Kimi-K2.5` → `["kimi_k25", "kimi_k25_disable_thinking"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)