### PR TITLE
Fix Kimi-K2-Thinking tokenizer failing with newer transformers

### DIFF
--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -93,7 +93,7 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
     kwargs: dict[str, Any] = {}
     if model_name == "moonshotai/Kimi-K2-Thinking":
         kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "612681931a8c906ddb349f8ad0f582cb552189cd"
+        kwargs["revision"] = "a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55"
     elif model_name == "moonshotai/Kimi-K2.5":
         kwargs["trust_remote_code"] = True
         kwargs["revision"] = "2426b45b6af0da48d0dcce71bbce6225e5c73adc"


### PR DESCRIPTION
## Summary

Fixes #378.

- The pinned HuggingFace revision (`612681931a`) for `moonshotai/Kimi-K2-Thinking` used a custom `tokenization_kimi.py` that imported `bytes_to_unicode` from `transformers.models.gpt2.tokenization_gpt2`. This import path was removed in newer versions of the `transformers` library, causing an `ImportError`.
- Moonshot fixed this upstream by moving the import to `transformers.convert_slow_tokenizer` (which works in both old and new `transformers` versions).
- This PR updates the pinned revision from the older `612681931a8c906ddb349f8ad0f582cb552189cd` to the latest `a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55`, which includes this fix. The tokenizer vocabulary and behavior are unchanged.

## Test plan

- [x] Verified tokenizer loads correctly with the new revision (`vocab_size=163840`, encode/decode round-trips)
- [x] `pytest tinker_cookbook/tests/test_renderers.py` — 139 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)