### PR TITLE
Keep final SFT and RL checkpoints indefinitely

### DIFF
--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -245,7 +245,7 @@ def main(config: Config):
         log_path=config.log_path,
         kind="both",
         loop_state={"batch": n_train_batches},
-        ttl_seconds=config.ttl_seconds,
+        ttl_seconds=None,
     )
     ml_logger.close()
     logger.info("Training completed")

--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -150,7 +150,7 @@ def main(config: Config):
         log_path=config.log_path,
         kind="both",
         loop_state={"batch": n_train_batches},
-        ttl_seconds=config.ttl_seconds,
+        ttl_seconds=None,
     )
 
     ml_logger.close()

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -364,8 +364,8 @@ class Config:
     # -------------------------------------------------------------------------
     # Checkpoint retention and logging detail (advanced)
     # -------------------------------------------------------------------------
-    # TTL for checkpoints in seconds, i.e. how long checkpoints should live
-    # before expiry (None = no expiry).
+    # Periodic checkpoints use this TTL; the final checkpoint is kept indefinitely.
+    # None disables expiry entirely.
     ttl_seconds: int | None = 604800  # 7 days
     num_groups_to_log: int = 4  # Number of groups to log per iteration (0 = disable logging)
 
@@ -1266,7 +1266,7 @@ async def main(
             log_path=cfg.log_path,
             kind="both",
             loop_state={"batch": num_batches},
-            ttl_seconds=cfg.ttl_seconds,
+            ttl_seconds=None,
         )
     else:
         logger.info("Training was already complete; nothing to do")

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -65,6 +65,7 @@ class Config:
     save_every: int = 20
     eval_every: int = 10
     infrequent_eval_every: int = 100
+    # Periodic checkpoints use this TTL; the final checkpoint is kept indefinitely.
     ttl_seconds: int | None = 604800  # 7 days
 
     # Adam optimizer parameters
@@ -374,7 +375,7 @@ async def main(config: Config):
             log_path=config.log_path,
             kind="both",
             loop_state={"epoch": config.num_epochs, "batch": n_batches},
-            ttl_seconds=config.ttl_seconds,
+            ttl_seconds=None,
         )
     else:
         logger.info("Training was already complete; nothing to do")


### PR DESCRIPTION
## Summary
- keep the final `/final` checkpoint in supervised training indefinitely
- keep the final `/final` checkpoint in RL training indefinitely
- align the simple SFT/RL recipe loops with the same final checkpoint retention behavior

## Testing
- python -m py_compile tinker_cookbook/supervised/train.py tinker_cookbook/rl/train.py tinker_cookbook/recipes/sl_loop.py tinker_cookbook/recipes/rl_loop.py