### PR TITLE
Log command invocation in logs.log

### DIFF
--- a/tinker_cookbook/tests/test_ml_log.py
+++ b/tinker_cookbook/tests/test_ml_log.py
@@ -1,0 +1,48 @@
+import logging
+import runpy
+import shlex
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+configure_logging_module = runpy.run_path(
+    str(Path(__file__).resolve().parents[1] / "utils" / "ml_log.py")
+)["configure_logging_module"]
+
+
+def _flush_root_handlers() -> None:
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+
+def test_configure_logging_module_logs_invocation_and_appends(tmp_path):
+    log_path = tmp_path / "logs.log"
+
+    argv_first = ["python", "train.py", "--log-path", str(tmp_path), "--run-name", "first run"]
+    with patch.object(sys, "argv", argv_first):
+        root_logger = configure_logging_module(str(log_path))
+        root_logger.info("first message")
+        _flush_root_handlers()
+
+    first_contents = log_path.read_text()
+    first_invocation = shlex.join(argv_first)
+    assert f"Command line invocation: {first_invocation}" in first_contents
+    assert "first message" in first_contents
+    assert first_contents.index(first_invocation) < first_contents.index("first message")
+
+    argv_second = ["python", "train.py", "--resume", "--run-name", "second run"]
+    with patch.object(sys, "argv", argv_second):
+        root_logger = configure_logging_module(str(log_path))
+        root_logger.info("second message")
+        _flush_root_handlers()
+
+    final_contents = log_path.read_text()
+    second_invocation = shlex.join(argv_second)
+    assert "first message" in final_contents
+    assert "second message" in final_contents
+    assert f"Command line invocation: {second_invocation}" in final_contents
+    assert final_contents.count("Command line invocation:") == 2
+    assert final_contents.index("first message") < final_contents.index(second_invocation)
+    assert final_contents.index(second_invocation) < final_contents.index("second message")

--- a/tinker_cookbook/utils/__init__.py
+++ b/tinker_cookbook/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for tinker-cookbook."""

--- a/tinker_cookbook/utils/ml_log.py
+++ b/tinker_cookbook/utils/ml_log.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import os
+import shlex
+import sys
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
@@ -478,6 +480,13 @@ def setup_logging(
     return ml_logger
 
 
+def _get_command_line_invocation() -> str:
+    """Return the current command line in a shell-safe form."""
+    if not sys.argv:
+        return "<empty sys.argv>"
+    return shlex.join(sys.argv)
+
+
 def configure_logging_module(path: str, level: int = logging.INFO) -> logging.Logger:
     """Configure logging to console (color) and file (plain), forcing override of prior config."""
     # ANSI escape codes for colors
@@ -506,14 +515,17 @@ def configure_logging_module(path: str, level: int = logging.INFO) -> logging.Lo
     )
 
     # File handler without colors
-    file_handler = logging.FileHandler(path, encoding="utf-8")
+    file_handler = logging.FileHandler(path, mode="a", encoding="utf-8")
     file_handler.setFormatter(logging.Formatter("%(name)s:%(lineno)d [%(levelname)s] %(message)s"))
 
     # Force override like basicConfig(..., force=True)
     root = logging.getLogger()
     root.setLevel(level)
-    root.handlers.clear()
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+        handler.close()
     root.addHandler(console_handler)
     root.addHandler(file_handler)
+    logger.info("Command line invocation: %s", _get_command_line_invocation())
 
     return root

--- a/tinker_cookbook/utils/ml_log.py
+++ b/tinker_cookbook/utils/ml_log.py
@@ -526,6 +526,6 @@ def configure_logging_module(path: str, level: int = logging.INFO) -> logging.Lo
         handler.close()
     root.addHandler(console_handler)
     root.addHandler(file_handler)
-    logger.info("Command line invocation: %s", _get_command_line_invocation())
+    root.info("Command line invocation: %s", _get_command_line_invocation())
 
     return root

--- a/tinker_cookbook/utils/ml_log_test.py
+++ b/tinker_cookbook/utils/ml_log_test.py
@@ -1,14 +1,9 @@
 import logging
 import shlex
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
-repo_root = Path(__file__).resolve().parents[2]
-if str(repo_root) not in sys.path:
-    sys.path.insert(0, str(repo_root))
-
-from tinker_cookbook.utils.ml_log import configure_logging_module
+from .ml_log import configure_logging_module
 
 
 def _flush_root_handlers() -> None:

--- a/tinker_cookbook/utils/ml_log_test.py
+++ b/tinker_cookbook/utils/ml_log_test.py
@@ -1,15 +1,14 @@
 import logging
-import runpy
 import shlex
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+repo_root = Path(__file__).resolve().parents[2]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
 
-configure_logging_module = runpy.run_path(
-    str(Path(__file__).resolve().parents[1] / "utils" / "ml_log.py")
-)["configure_logging_module"]
+from tinker_cookbook.utils.ml_log import configure_logging_module
 
 
 def _flush_root_handlers() -> None:


### PR DESCRIPTION
## Summary
- log the current command line invocation each time file logging is configured
- make logs.log append mode explicit and close replaced handlers during reconfiguration
- add a regression test that verifies repeated logger setup appends and records both invocations

## Testing
- pytest -q tinker_cookbook/tests/test_ml_log.py
