### PR TITLE
Add pytest markers for test categorization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,10 @@ exclude = ["*_test.py"]
 testpaths = ["tinker_cookbook", "tests"]
 python_files = ["*_test.py", "test_*.py"]
 norecursedirs = ["tinker_cookbook/scripts"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: marks tests requiring TINKER_API_KEY and network access",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/smoke_tests.py
+++ b/tests/smoke_tests.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import cast
 
 import datasets
+import pytest
 import tinker
 from tinker_cookbook import renderers
 from tinker_cookbook.recipes.math_rl import arithmetic_env
@@ -14,6 +15,7 @@ from tinker_cookbook.supervised.data import (
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
 
+@pytest.mark.integration
 def test_supervised():
     batch_size = 64
     model_name = "meta-llama/Llama-3.1-8B-Instruct"
@@ -44,6 +46,7 @@ def test_supervised():
     asyncio.run(supervised_train.main(cfg))
 
 
+@pytest.mark.integration
 async def test_rl():
     model_name = "meta-llama/Llama-3.1-8B-Instruct"
     lora_rank = 32
@@ -71,6 +74,7 @@ async def test_rl():
     await rl_train.main(cfg)
 
 
+@pytest.mark.integration
 def test_rl_async():
     model_name = "Qwen/Qwen2.5-VL-7B-Instruct"
     lora_rank = 32
@@ -102,6 +106,7 @@ def test_rl_async():
     asyncio.run(rl_train.main(cfg))
 
 
+@pytest.mark.integration
 def test_rl_sync_stream_minibatch():
     model_name = "Qwen/Qwen2.5-VL-7B-Instruct"
     lora_rank = 32

--- a/tests/test_recipe_chat_sl.py
+++ b/tests/test_recipe_chat_sl.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_chat_sl():
     run_recipe(
         "tinker_cookbook.recipes.chat_sl.train",

--- a/tests/test_recipe_dpo.py
+++ b/tests/test_recipe_dpo.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_dpo():
     run_recipe(
         "tinker_cookbook.recipes.preference.dpo.train",

--- a/tests/test_recipe_guess_number.py
+++ b/tests/test_recipe_guess_number.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_guess_number():
     run_recipe(
         "tinker_cookbook.recipes.multiplayer_rl.guess_number.train",

--- a/tests/test_recipe_off_policy_reasoning.py
+++ b/tests/test_recipe_off_policy_reasoning.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_off_policy_reasoning():
     run_recipe(
         "tinker_cookbook.recipes.distillation.off_policy_reasoning",

--- a/tests/test_recipe_on_policy_distillation.py
+++ b/tests/test_recipe_on_policy_distillation.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_on_policy_distillation():
     run_recipe(
         "tinker_cookbook.recipes.distillation.on_policy_distillation",

--- a/tests/test_recipe_on_policy_multi_teacher.py
+++ b/tests/test_recipe_on_policy_multi_teacher.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_on_policy_multi_teacher():
     run_recipe(
         "tinker_cookbook.recipes.distillation.on_policy_multi_teacher",

--- a/tests/test_recipe_rlhf_pipeline.py
+++ b/tests/test_recipe_rlhf_pipeline.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_rlhf_pipeline():
     run_recipe(
         "tinker_cookbook.recipes.preference.rlhf.rlhf_pipeline",

--- a/tests/test_recipe_shorter.py
+++ b/tests/test_recipe_shorter.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_shorter():
     run_recipe(
         "tinker_cookbook.recipes.preference.shorter.train",

--- a/tests/test_recipe_text_arena.py
+++ b/tests/test_recipe_text_arena.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_text_arena():
     run_recipe(
         "tinker_cookbook.recipes.multiplayer_rl.text_arena.train",

--- a/tests/test_recipe_twenty_questions.py
+++ b/tests/test_recipe_twenty_questions.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_twenty_questions():
     run_recipe(
         "tinker_cookbook.recipes.multiplayer_rl.twenty_questions.train",

--- a/tests/test_recipe_vlm_classifier.py
+++ b/tests/test_recipe_vlm_classifier.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import run_recipe
 
 
+@pytest.mark.integration
 def test_vlm_classifier():
     run_recipe(
         "tinker_cookbook.recipes.vlm_classifier.train",


### PR DESCRIPTION
## Summary
- Define `slow` and `integration` pytest markers in pyproject.toml
- Mark all test functions in `tests/` (smoke tests + recipe tests) with `@pytest.mark.integration`
- Enables running subsets: `pytest -m "not integration"` for fast local testing

## Test plan
- [x] `pytest tinker_cookbook/` still runs all unit tests
- [x] `pytest tests/ -m integration` collects all integration tests
- [x] No `PytestUnknownMarkWarning` warnings
- [x] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)