### PR TITLE
Exclude xmux/ and chat_app/ from package wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["tinker_cookbook"]
-exclude = ["*_test.py"]
+exclude = ["*_test.py", "tinker_cookbook/xmux/", "tinker_cookbook/chat_app/"]
 
 [tool.pytest.ini_options]
 testpaths = ["tinker_cookbook", "tests"]
@@ -100,6 +100,8 @@ exclude = [
 include = ["tinker_cookbook"]
 exclude = [
     ".venv",
+    "tinker_cookbook/xmux/",
+    "tinker_cookbook/chat_app/",
     # Vendored from HuggingFace, kept identical to upstream
     "kimi-k2.5-hf-tokenizer/tool_declaration_ts.py",
 ]


### PR DESCRIPTION
## Summary
- Exclude `tinker_cookbook/xmux/` (TMUX experiment launcher) and `tinker_cookbook/chat_app/` (chat CLI) from the wheel build
- Exclude both from pyright checking
- These are standalone developer tools not imported by any library code or recipes

## Test plan
- [x] All CI checks pass (pre-commit, pyright, pytest)
- [ ] `pip install` of the wheel no longer includes xmux/ or chat_app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)