### PR TITLE
Move test_tool_calling_e2e.py from scripts/ to tests/

### DIFF
--- a/tests/test_tool_calling_e2e.py
+++ b/tests/test_tool_calling_e2e.py
@@ -8,7 +8,7 @@ that tool calls are correctly rendered, generated, and parsed.
 NOT a unit test - requires API access and queries real models.
 
 Usage:
-    uv run python tinker_cookbook/scripts/test_tool_calling_e2e.py [--model MODEL_NAME]
+    uv run python tests/test_tool_calling_e2e.py [--model MODEL_NAME]
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- Move `tinker_cookbook/scripts/test_tool_calling_e2e.py` to `tests/test_tool_calling_e2e.py`
- This is an end-to-end test, not a script — it belongs with other integration tests
- Updated docstring path reference; no import changes needed

## Test plan
- [x] All CI checks pass (pre-commit, pyright, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)