### PR TITLE
Add SFT resume smoke test

### DIFF
--- a/tests/test_recipe_chat_sl.py
+++ b/tests/test_recipe_chat_sl.py
@@ -2,10 +2,32 @@ import pytest
 
 from tests.helpers import run_recipe
 
+MODULE = "tinker_cookbook.recipes.chat_sl.train"
+LOG_PATH = "/tmp/tinker-smoke-test/chat_sl_resume"
+
 
 @pytest.mark.integration
 def test_chat_sl():
+    """Train SFT from scratch for 2 steps, saving a checkpoint at step 1."""
     run_recipe(
-        "tinker_cookbook.recipes.chat_sl.train",
-        ["behavior_if_log_dir_exists=delete"],
+        MODULE,
+        [
+            "behavior_if_log_dir_exists=delete",
+            f"log_path={LOG_PATH}",
+            "save_every=1",
+        ],
+    )
+
+
+@pytest.mark.integration
+def test_chat_sl_resume():
+    """Resume SFT training from the checkpoint saved by test_chat_sl."""
+    run_recipe(
+        MODULE,
+        [
+            "behavior_if_log_dir_exists=resume",
+            f"log_path={LOG_PATH}",
+            "save_every=1",
+        ],
+        max_steps=4,
     )


### PR DESCRIPTION
## Summary
- Add a resume test to `test_recipe_chat_sl.py` that exercises the checkpoint resume path
- `test_chat_sl` trains from scratch for 2 steps with `save_every=1`, saving a checkpoint at step 1
- `test_chat_sl_resume` resumes from that checkpoint with `max_steps=4`, training steps 2-3
- Follow-up to #446 and #447 which fixed checkpoint loading in OnPoDI and DPO

## Test plan
- [x] Tests collected successfully (`pytest --collect-only`)
- [x] Unit tests pass (348 passed)
- [x] Smoke test passes in CI (requires `TINKER_API_KEY`) See https://github.com/YujiaBao/tinker-cookbook/actions/runs/23072236308/job/67025151407 -> note the vlm classifier ci test failed there, but it is independent to the changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)