### PR TITLE
Increase smoke test timeouts for VLM classifier

### DIFF
--- a/.github/workflows/smoke-test-recipes.yaml
+++ b/.github/workflows/smoke-test-recipes.yaml
@@ -32,7 +32,7 @@ jobs:
   smoke-test:
     needs: discover
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     strategy:
       fail-fast: false

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,7 @@ import time
 import pytest
 
 # Timeout for each recipe (seconds). Override with SMOKE_TEST_TIMEOUT env var.
-DEFAULT_TIMEOUT = int(os.environ.get("SMOKE_TEST_TIMEOUT", "900"))
+DEFAULT_TIMEOUT = int(os.environ.get("SMOKE_TEST_TIMEOUT", "1800"))
 
 # Default number of training steps for smoke tests.
 DEFAULT_MAX_STEPS = 2


### PR DESCRIPTION
## Summary
- Bump Python `DEFAULT_TIMEOUT` from 900s to 1800s (30 min) in `tests/helpers.py`
- Bump workflow `timeout-minutes` from 20 to 35 in `smoke-test-recipes.yaml`

The VLM classifier recipe takes ~13 min per step (mostly eval with image processing), so 2 steps exceed the previous 15-min Python timeout. See [failed run](https://github.com/thinking-machines-lab/tinker-cookbook/actions/runs/23082205295).

## Test plan
- [x] Re-run the `smoke-test-recipes` workflow and verify `test_recipe_vlm_classifier` passes (all tests passed here https://github.com/YujiaBao/tinker-cookbook/actions/runs/23092951720)

🤖 Generated with [Claude Code](https://claude.com/claude-code)