### PR TITLE
Fix gate_up_proj interleave index always 0 in merge script

### DIFF
--- a/tinker_cookbook/scripts/merge_tinker_adapter_to_hf_model.py
+++ b/tinker_cookbook/scripts/merge_tinker_adapter_to_hf_model.py
@@ -119,11 +119,16 @@ def merge_adapter_weights(
                     apply_merged_weight(model_state_dict[target_key_exp], merged_lora[exp_idx])
             else:
                 # Single/fused weight and shared w13, shape is <num_experts, in_dim, out_dim>
-                if target_key.endswith((".gate_proj.weight", ".up_proj.weight")):
-                    target_key = target_key.replace(".gate_proj.weight", ".gate_up_proj").replace(
-                        ".up_proj.weight", ".gate_up_proj"
-                    )
-                    idx = 0 if target_key.endswith(".gate_up_proj") else 1
+                if target_key.endswith(".gate_proj.weight"):
+                    idx = 0
+                    target_key = target_key.replace(".gate_proj.weight", ".gate_up_proj")
+                elif target_key.endswith(".up_proj.weight"):
+                    idx = 1
+                    target_key = target_key.replace(".up_proj.weight", ".gate_up_proj")
+                else:
+                    idx = None
+
+                if idx is not None:
                     if is_gpt_oss:
                         # gpt-oss has interleaved w13
                         target = model_state_dict[target_key][:, :, idx::2]


### PR DESCRIPTION
## Summary
- Fix bug where `idx` for selecting gate vs up slots in fused `gate_up_proj` was always 0, causing `up_proj` LoRA deltas to overwrite gate slots instead of up slots
- Affects **6 models** across 3 architecture families: GPT-OSS (interleaved layout), Qwen3.5 MoE, and Qwen3-VL MoE (concatenated layout)
- Determine `idx` from original key name before renaming to `.gate_up_proj`

Closes #457

## Affected models

| Model | Layout | How broken |
|---|---|---|
| gpt-oss-20b, gpt-oss-120b | Interleaved `[g0,u0,g1,u1,...]` | up delta → even indices (gate slots) instead of odd (up slots) |
| Qwen3.5-35B-A3B, Qwen3.5-397B-A17B | Concatenated `[gate \| up]` | up delta → first half (gate) instead of second half (up) |
| Qwen3-VL-30B-A3B, Qwen3-VL-235B-A22B | Concatenated `[gate \| up]` | Same as Qwen3.5 |

Not affected: Qwen3 MoE (separate per-expert weights), DeepSeek-V3.1, Kimi-K2/K2.5, all Llama, all dense Qwen — these never enter the fused experts code path. See full impact analysis in PR comments.

## Test plan
- [x] E2E test with tiny GPT-OSS model (from_config, save/load roundtrip) confirms gate/up deltas land in correct interleaved slots (3/3 pass)
- [x] Verified e2e tests fail on original buggy code (2/3 fail) and pass with fix (3/3 pass)
- [x] Existing 369 unit tests pass with no regressions

**Note:** Unit tests and e2e tests for the merge script are not included in this PR since `tinker_cookbook/scripts/` is currently excluded from pytest discovery and has no test infrastructure. These will be added in a follow-up that integrates the merge logic into the cookbook module with proper test coverage.

## Follow-up
- Integrate the merge script into the cookbook module with unit tests and smoke tests to guardrail weight merging going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)