### PR TITLE
fix: prevent pytest from collecting manual tool-calling E2E script

### DIFF
--- a/tinker_cookbook/scripts/test_tool_calling_e2e.py
+++ b/tinker_cookbook/scripts/test_tool_calling_e2e.py
@@ -16,6 +16,10 @@ import asyncio
 
 import tinker
 
+# This is a manual E2E runner (not a pytest module), even though its filename
+# starts with "test_" for discoverability by humans.
+__test__ = False
+
 from tinker_cookbook.renderers import (
     Message,
     ToolSpec,
@@ -108,7 +112,7 @@ def print_result(
     print(f"\nRaw response (first 500 chars):\n{raw_response[:500]}")
 
 
-async def test_model(
+async def run_model_test(
     service_client: tinker.ServiceClient,
     model_name: str,
     renderer_name: str,
@@ -197,7 +201,7 @@ async def main():
     results = []
     for config in configs:
         try:
-            success, message, raw_response = await test_model(
+            success, message, raw_response = await run_model_test(
                 service_client=service_client,
                 model_name=config["model_name"],
                 renderer_name=config["renderer_name"],


### PR DESCRIPTION
## What changed
- Marked `tinker_cookbook/scripts/test_tool_calling_e2e.py` as non-test code by adding `__test__ = False`.
- Renamed the helper coroutine `test_model` to `run_model_test` to avoid test-style naming in a manual E2E runner.

## Why
- `pytest` discovers files/functions by naming conventions. Because this manual script is named `test_*.py` and contained `async def test_model(...)`, it was auto-collected during normal test runs.
- That function expects runtime objects (for example `service_client`) that are not pytest fixtures, so the suite failed before reaching actual unit tests.

## Insight / Why this matters
- **Root cause:** pytest discovery is pattern-based, not intent-based. A script under `scripts/` can still be collected if its filename/function names look like tests.
- **Why this is easy to miss:** the file docstring already says “NOT a unit test,” which is correct for humans but not enforced for tooling.
- **Practical impact:** prevents false-negative CI/local failures and keeps contributor test feedback focused on real regressions.
- **Tradeoff:** this change only affects test discovery behavior; it does not alter E2E runtime logic, model calls, or parser behavior.

## Testing
- Reproduced previous failure with:
  - `scripts/clone_and_test.sh thinking-machines-lab/tinker-cookbook`
  - Before this change: pytest failed with `fixture 'service_client' not found` from `tinker_cookbook/scripts/test_tool_calling_e2e.py`.
- Validated fix with the same command:
  - `scripts/clone_and_test.sh thinking-machines-lab/tinker-cookbook`
  - Result after change: `235 passed, 28 skipped`.
