### PR TITLE
Migrate core modules from os.path to pathlib.Path

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -2,8 +2,8 @@ import asyncio
 import dataclasses
 import json
 import logging
-import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal
 
 import tinker
@@ -252,14 +252,14 @@ async def check_renderer_name_for_checkpoint_async(
 
 @scope
 def load_checkpoints_file(log_dir: str) -> list[CheckpointRecord]:
-    checkpoint_path = os.path.join(log_dir, CHECKPOINTS_BASE_NAME)
-    if not os.path.exists(checkpoint_path):
+    checkpoint_path = Path(log_dir) / CHECKPOINTS_BASE_NAME
+    if not checkpoint_path.exists():
         logger.info(f"No checkpoints found at {checkpoint_path}")
         return []
 
     logger.info(f"Reading checkpoints from {checkpoint_path}")
-    update_scope_context({"checkpoint_path": checkpoint_path})
-    return [CheckpointRecord.from_dict(d) for d in read_jsonl(checkpoint_path)]
+    update_scope_context({"checkpoint_path": str(checkpoint_path)})
+    return [CheckpointRecord.from_dict(d) for d in read_jsonl(str(checkpoint_path))]
 
 
 @scope
@@ -326,7 +326,7 @@ async def save_checkpoint_async(
     logger.info(f"Saved checkpoints: {paths}")
 
     record = CheckpointRecord.from_dict({"name": name, **loop_state, **paths})
-    with open(os.path.join(log_path, "checkpoints.jsonl"), "a") as f:
+    with open(Path(log_path) / "checkpoints.jsonl", "a") as f:
         f.write(json.dumps(record.to_dict()) + "\n")
 
     return paths

--- a/tinker_cookbook/checkpoint_utils_test.py
+++ b/tinker_cookbook/checkpoint_utils_test.py
@@ -1,0 +1,82 @@
+"""Tests for checkpoint_utils path handling."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from tinker_cookbook.checkpoint_utils import (
+    CheckpointRecord,
+    load_checkpoints_file,
+    get_last_checkpoint,
+)
+
+
+def _write_checkpoints_jsonl(log_dir: str, records: list[dict]) -> None:
+    path = Path(log_dir) / "checkpoints.jsonl"
+    with open(path, "w") as f:
+        for record in records:
+            f.write(json.dumps(record) + "\n")
+
+
+def test_load_checkpoints_file_missing_dir():
+    """load_checkpoints_file returns [] when the directory doesn't exist."""
+    result = load_checkpoints_file("/tmp/nonexistent_dir_abc123")
+    assert result == []
+
+
+def test_load_checkpoints_file_missing_file():
+    """load_checkpoints_file returns [] when checkpoints.jsonl is absent."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = load_checkpoints_file(tmpdir)
+        assert result == []
+
+
+def test_load_checkpoints_file_reads_records():
+    """load_checkpoints_file reads and deserializes checkpoint records."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_checkpoints_jsonl(
+            tmpdir,
+            [
+                {"name": "000005", "batch": 5, "state_path": "tinker://state/5"},
+                {"name": "000010", "batch": 10, "state_path": "tinker://state/10"},
+            ],
+        )
+        result = load_checkpoints_file(tmpdir)
+        assert len(result) == 2
+        assert isinstance(result[0], CheckpointRecord)
+        assert result[0].name == "000005"
+        assert result[1].batch == 10
+
+
+def test_get_last_checkpoint_returns_last():
+    """get_last_checkpoint returns the last record with the required key."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_checkpoints_jsonl(
+            tmpdir,
+            [
+                {"name": "000005", "batch": 5, "state_path": "tinker://state/5"},
+                {"name": "000010", "batch": 10, "sampler_path": "tinker://sampler/10"},
+                {"name": "000015", "batch": 15, "state_path": "tinker://state/15"},
+            ],
+        )
+        result = get_last_checkpoint(tmpdir, required_key="state_path")
+        assert result is not None
+        assert result.name == "000015"
+
+
+def test_get_last_checkpoint_returns_none_when_empty():
+    """get_last_checkpoint returns None when no checkpoints exist."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = get_last_checkpoint(tmpdir)
+        assert result is None
+
+
+def test_get_last_checkpoint_returns_none_when_key_missing():
+    """get_last_checkpoint returns None when no record has the required key."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_checkpoints_jsonl(
+            tmpdir,
+            [{"name": "000005", "batch": 5, "sampler_path": "tinker://sampler/5"}],
+        )
+        result = get_last_checkpoint(tmpdir, required_key="state_path")
+        assert result is None

--- a/tinker_cookbook/cli_utils.py
+++ b/tinker_cookbook/cli_utils.py
@@ -1,6 +1,6 @@
 import logging
-import os
 import shutil
+from pathlib import Path
 from typing import Literal
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def check_log_dir(log_dir: str, behavior_if_exists: LogdirBehavior):
     Returns:
         None
     """
-    if os.path.exists(log_dir):
+    if Path(log_dir).exists():
         if behavior_if_exists == "delete":
             logger.info(
                 f"Log directory {log_dir} already exists. Will delete it and start logging there."

--- a/tinker_cookbook/cli_utils_test.py
+++ b/tinker_cookbook/cli_utils_test.py
@@ -1,0 +1,39 @@
+"""Tests for cli_utils path handling."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tinker_cookbook.cli_utils import check_log_dir
+
+
+def test_check_log_dir_nonexistent_is_noop():
+    """check_log_dir does nothing when the directory doesn't exist."""
+    check_log_dir("/tmp/nonexistent_dir_abc123", "raise")
+
+
+def test_check_log_dir_resume_keeps_directory():
+    """check_log_dir with 'resume' leaves the directory intact."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        marker = Path(tmpdir) / "keep_me.txt"
+        marker.write_text("hello")
+        check_log_dir(tmpdir, "resume")
+        assert marker.exists()
+
+
+def test_check_log_dir_delete_removes_directory():
+    """check_log_dir with 'delete' removes the directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = Path(tmpdir) / "subdir"
+        target.mkdir()
+        (target / "file.txt").write_text("hello")
+        check_log_dir(str(target), "delete")
+        assert not target.exists()
+
+
+def test_check_log_dir_raise_raises():
+    """check_log_dir with 'raise' raises ValueError when directory exists."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="already exists"):
+            check_log_dir(tmpdir, "raise")

--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -5,8 +5,8 @@ https://thinkingmachines.ai/blog/on-policy-distillation
 
 import asyncio
 import logging
-import os
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Sequence, cast
 
 import chz
@@ -155,7 +155,7 @@ class Config:
     wandb_project: str | None = None
     wandb_name: str | None = None
 
-    log_path: str = chz.field(munger=lambda _, s: os.path.expanduser(s))
+    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
     base_url: str | None = None
     enable_trace: bool = False
 
@@ -371,7 +371,7 @@ async def main(
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.set_name("main")
-        trace_events_path = os.path.join(cfg.log_path, "trace_events.jsonl")
+        trace_events_path = str(Path(cfg.log_path) / "trace_events.jsonl")
         logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_path}")
         logger.info(
             f"Run `python tinker_cookbook/utils/trace.py {trace_events_path} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"

--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -4,8 +4,8 @@ Direct Preference Optimization (DPO) training
 
 import asyncio
 import logging
-import os
 import time
+from pathlib import Path
 from typing import cast
 
 import chz
@@ -30,7 +30,7 @@ class Config:
     """Configuration for Direct Preference Optimization (DPO) training."""
 
     # Required parameters
-    log_path: str = chz.field(munger=lambda _, s: os.path.expanduser(s))
+    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
     model_name: str
     dataset_builder: ChatDatasetBuilder
     load_checkpoint_path: str | None = None

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import asyncio
 import io
 import logging
-import os
 import re
 import time
+from pathlib import Path
 from concurrent.futures import Executor
 from contextlib import contextmanager
 from typing import Any, Callable, Coroutine, Iterable, Iterator, List, Sequence, TypeVar
@@ -160,8 +160,8 @@ def _get_logtree_scope(
         yield
         return
 
-    logtree_path = os.path.join(log_path, f"{f_name}.html")
-    logtree_json_path = os.path.join(log_path, f"{f_name}_logtree.json")
+    logtree_path = str(Path(log_path) / f"{f_name}.html")
+    logtree_json_path = str(Path(log_path) / f"{f_name}_logtree.json")
     trace = None
     try:
         with logtree.init_trace(scope_name, path=logtree_path) as trace:
@@ -349,7 +349,7 @@ class Config:
     # Maximum number of generated tokens per rollout trajectory.
     max_tokens: int
     # Directory for checkpoints, logs, and traces.
-    log_path: str = chz.field(munger=lambda _, s: os.path.expanduser(s))
+    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
     # Evaluation cadence in training iterations (0 = disabled).
     eval_every: int = 20
     # Checkpoint cadence in training iterations (0 = disabled).
@@ -1300,7 +1300,7 @@ async def main(
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.set_name("main")
-        trace_events_path = os.path.join(cfg.log_path, "trace_events.jsonl")
+        trace_events_path = str(Path(cfg.log_path) / "trace_events.jsonl")
         logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_path}")
         logger.info(
             f"Run `python tinker_cookbook/utils/trace.py {trace_events_path} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -9,9 +9,9 @@ refer to `tinker_cookbook/recipes/sl_loop.py`.
 
 import asyncio
 import logging
-import os
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 import chz
 import tinker
@@ -42,7 +42,7 @@ class Config:
     """Configuration for supervised fine-tuning."""
 
     # Required parameters
-    log_path: str = chz.field(munger=lambda _, s: os.path.expanduser(s))
+    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
     model_name: str
     load_checkpoint_path: str | None = None
     renderer_name: str | None = None
@@ -187,12 +187,12 @@ async def main(config: Config):
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.set_name("main")
-        trace_events_path = os.path.join(config.log_path, "trace_events.jsonl")
+        trace_events_path = str(Path(config.log_path) / "trace_events.jsonl")
         logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_path}")
         logger.info(
             f"Run `python tinker_cookbook/utils/trace.py {trace_events_path} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
         )
-        trace_init(output_file=os.path.join(config.log_path, "trace_events.jsonl"))
+        trace_init(output_file=trace_events_path)
 
     service_client = tinker.ServiceClient(base_url=config.base_url)
 


### PR DESCRIPTION
## Motivation
The codebase has a mix of `os.path` and `pathlib.Path` usage. Newer modules (e.g., `weights/`, `rl/rollout_logging.py`, `utils/`) already use `pathlib`, but core training modules still use `os.path`. This PR standardizes on `pathlib.Path` for improved readability, fewer imports, and consistency across the codebase.

## What's in this PR (Phase 1 — core modules)
- Replace `os.path.join`, `os.path.exists`, and `os.path.expanduser` with `pathlib.Path` equivalents in 6 core modules:
  - `checkpoint_utils.py`, `cli_utils.py`
  - `supervised/train.py`, `rl/train.py`
  - `preference/train_dpo.py`, `distillation/train_on_policy.py`
- Add unit tests for `checkpoint_utils` and `cli_utils` path handling (10 new tests)
- All `import os` removed from these files since `os` is no longer referenced

## What's next
- **Phase 2**: Recipes (`vlm_classifier/`, `rubric/`, `prompt_distillation/`, `distillation/`, `preference/rlhf/`)

## Test plan
- [x] 10 new unit tests pass (`checkpoint_utils_test.py`, `cli_utils_test.py`)
- [x] 395 existing unit tests pass
- [x] Smoke tests pass (`test_sl`, `test_dpo`)
- [x] ruff format, ruff check, pyright all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)