### PR TITLE
Migrate recipe modules from os.path to pathlib.Path

### DIFF
--- a/tinker_cookbook/eval/inspect_evaluators.py
+++ b/tinker_cookbook/eval/inspect_evaluators.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 from typing import Optional
 
 import chz
@@ -114,7 +114,7 @@ class InspectEvaluator(SamplingClientEvaluator):
             # the inspect evaluation can still fail if e.g. the parser returns an error for
             # a given sample.
             fail_on_error=False,
-            log_dir=self.config.log_dir or os.path.expanduser("~/inspect-logs"),
+            log_dir=self.config.log_dir or str(Path("~/inspect-logs").expanduser()),
             max_connections=self.config.max_connections,
             log_level=self.config.log_level,
             log_realtime=False,

--- a/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
+++ b/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
@@ -15,8 +15,8 @@ Example usage:
 
 import asyncio
 import logging
-import os
 from datetime import datetime
+from pathlib import Path
 from typing import cast
 
 import chz
@@ -138,7 +138,7 @@ def cli_main(cli_config: CLIConfig):
     # Create log path if not specified
     if cli_config.log_path is not None:
         log_path = cli_config.log_path
-        run_name = os.path.basename(log_path)
+        run_name = Path(log_path).name
     else:
         model_name = cli_config.model_name.replace("/", "-")
         run_name = (

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -27,8 +27,8 @@ Example usage:
 
 import asyncio
 import logging
-import os
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import chz
@@ -123,7 +123,7 @@ async def cli_main(cli_config: CLIConfig):
     if cli_config.wandb_name is not None:
         wandb_name = cli_config.wandb_name
     else:
-        wandb_name = os.path.basename(log_path)
+        wandb_name = Path(log_path).name
 
     # Create dataset builder
     dataset_builder = PromptOnlyDatasetBuilder(

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation_harbor_multi_turn.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation_harbor_multi_turn.py
@@ -27,8 +27,8 @@ Example usage:
 
 import asyncio
 import logging
-import os
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import chz
@@ -120,9 +120,9 @@ async def cli_main(cli_config: CLIConfig):
             f"{cli_config.learning_rate}lr-{cli_config.groups_per_batch}batch-"
             f"{datetime.now().strftime('%Y-%m-%d-%H-%M')}"
         )
-        log_path = os.path.expanduser(f"~/tinker-examples/distillation/{run_name}")
+        log_path = str(Path(f"~/tinker-examples/distillation/{run_name}").expanduser())
 
-    wandb_name = cli_config.wandb_name or os.path.basename(log_path)
+    wandb_name = cli_config.wandb_name or Path(log_path).name
 
     # Load harbor tasks
     tasks = load_terminal_bench_tasks()

--- a/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
@@ -19,8 +19,8 @@ Example usage:
 
 import asyncio
 import logging
-import os
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import chz
@@ -116,7 +116,7 @@ async def cli_main(cli_config: CLIConfig):
     if cli_config.wandb_name is not None:
         wandb_name = cli_config.wandb_name
     else:
-        wandb_name = os.path.basename(log_path)
+        wandb_name = Path(log_path).name
 
     # Create DeepMath dataset builder
     deepmath_builder = PromptOnlyDatasetBuilder(

--- a/tinker_cookbook/recipes/preference/rlhf/rlhf_pipeline.py
+++ b/tinker_cookbook/recipes/preference/rlhf/rlhf_pipeline.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-import os
+from pathlib import Path
 
 import chz
 from tinker_cookbook import checkpoint_utils, model_info
@@ -240,10 +240,10 @@ async def train_rl(
 
 
 def cli_main(cli_config: CLIConfig):
-    log_path_root = f"/tmp/tinker-examples/rlhf-{cli_config.short_name}"
-    sft_log_path = os.path.join(log_path_root, "sft")
-    rm_log_path = os.path.join(log_path_root, "rm")
-    rl_log_path = os.path.join(log_path_root, "rl")
+    log_path_root = Path(f"/tmp/tinker-examples/rlhf-{cli_config.short_name}")
+    sft_log_path = str(log_path_root / "sft")
+    rm_log_path = str(log_path_root / "rm")
+    rl_log_path = str(log_path_root / "rl")
     if cli_config.run_sft:
         sft_stage(
             sft_log_path,

--- a/tinker_cookbook/recipes/prompt_distillation/create_data.py
+++ b/tinker_cookbook/recipes/prompt_distillation/create_data.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
-import os
 import re
+from pathlib import Path
 from typing import Any
 
 import chz
@@ -155,14 +155,15 @@ async def create_data_async(cfg: Config, sampling_client: Any, tokenizer: Any, r
 
 def main(cfg: Config):
     # check if the output file exists
-    if os.path.exists(cfg.output_file):
+    output_path = Path(cfg.output_file)
+    if output_path.exists():
         print(f"Output file {cfg.output_file} already exists")
         return
-    elif not os.path.exists(os.path.dirname(cfg.output_file)):
+    elif not output_path.parent.exists():
         # check if the output directory exists
-        print(f"Output directory {os.path.dirname(cfg.output_file)} does not exist")
-        print(f"Creating directory {os.path.dirname(cfg.output_file)}")
-        os.makedirs(os.path.dirname(cfg.output_file), exist_ok=True)
+        print(f"Output directory {output_path.parent} does not exist")
+        print(f"Creating directory {output_path.parent}")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Setup clients synchronously
     sampling_client, tokenizer, renderer = setup_clients()

--- a/tinker_cookbook/recipes/prompt_distillation/train.py
+++ b/tinker_cookbook/recipes/prompt_distillation/train.py
@@ -3,8 +3,8 @@ CLI for prompt distillation training.
 """
 
 import asyncio
-import os
 from datetime import datetime
+from pathlib import Path
 
 import chz
 from tinker_cookbook import checkpoint_utils, cli_utils
@@ -70,7 +70,7 @@ def cli_main(cli_config: CLIConfig):
         wandb_name = run_name
 
     # make sure the data file exists
-    if not os.path.exists(cli_config.file_path):
+    if not Path(cli_config.file_path).exists():
         raise FileNotFoundError(f"Data file not found: {cli_config.file_path}")
 
     cli_utils.check_log_dir(log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists)

--- a/tinker_cookbook/recipes/rubric/data.py
+++ b/tinker_cookbook/recipes/rubric/data.py
@@ -1,6 +1,6 @@
 import json
-import os
 import re
+from pathlib import Path
 from dataclasses import dataclass
 from typing import Any, Sequence, TypeAlias
 
@@ -150,7 +150,7 @@ class RubricDatapointListBuilderFromJsonl(RubricDatapointListBuilder):
     jsonl_path: str
 
     def __call__(self) -> Sequence[RubricBasedDatapoint]:
-        if not os.path.exists(self.jsonl_path):
+        if not Path(self.jsonl_path).exists():
             raise FileNotFoundError(
                 f"Data file not found: {self.jsonl_path}\n"
                 f"Please generate the example data first by running:\n"

--- a/tinker_cookbook/recipes/rubric/generate_data.py
+++ b/tinker_cookbook/recipes/rubric/generate_data.py
@@ -1,6 +1,7 @@
-from tinker_cookbook.recipes.rubric.data import RubricBasedDatapoint, Rubric
 import random
-import os
+from pathlib import Path
+
+from tinker_cookbook.recipes.rubric.data import RubricBasedDatapoint, Rubric
 
 
 def generate_one(rng: random.Random) -> RubricBasedDatapoint:
@@ -23,15 +24,16 @@ def generate_dataset(
     total_datapoints = num_train + num_test
     datapoints = [generate_one(rng) for _ in range(total_datapoints)]
 
+    write_path = Path(write_dir)
     train_datapoints = datapoints[:num_train]
-    train_jsonl_path = os.path.join(write_dir, "example_rubric_train.jsonl")
+    train_jsonl_path = str(write_path / "example_rubric_train.jsonl")
     with open(train_jsonl_path, "w") as f:
         for datapoint in train_datapoints:
             f.write(datapoint.to_json() + "\n")
     print(f"Generated {len(train_datapoints)} train datapoints in {train_jsonl_path}")
 
     test_datapoints = datapoints[num_train:]
-    test_jsonl_path = os.path.join(write_dir, "example_rubric_test.jsonl")
+    test_jsonl_path = str(write_path / "example_rubric_test.jsonl")
     with open(test_jsonl_path, "w") as f:
         for datapoint in test_datapoints:
             f.write(datapoint.to_json() + "\n")

--- a/tinker_cookbook/recipes/vlm_classifier/eval_sweep.py
+++ b/tinker_cookbook/recipes/vlm_classifier/eval_sweep.py
@@ -21,8 +21,8 @@ python -m tinker_cookbook.recipes.vlm_classifier.eval_sweep \
 import asyncio
 import json
 import logging
-import os
 import re
+from pathlib import Path
 from typing import Any
 
 import chz
@@ -147,8 +147,8 @@ async def evaluate_experiment(
     Evaluate a single few-shot image classifier experiment.
     """
 
-    experiment_path = os.path.join(eval_config.experiment_dir, experiment_name)
-    assert os.path.isdir(experiment_path), f"Experiment directory does not exist: {experiment_path}"
+    experiment_path = Path(eval_config.experiment_dir) / experiment_name
+    assert experiment_path.is_dir(), f"Experiment directory does not exist: {experiment_path}"
 
     # Load checkpoint: use early stopping step if provided, otherwise use last checkpoint
     early_stop_step = (
@@ -157,9 +157,10 @@ async def evaluate_experiment(
         else None
     )
 
+    experiment_path_str = str(experiment_path)
     if early_stop_step is not None:
         checkpoint = get_checkpoint_at_step(
-            experiment_path, early_stop_step, required_key="sampler_path"
+            experiment_path_str, early_stop_step, required_key="sampler_path"
         )
         assert checkpoint is not None, (
             f"No checkpoint at step {early_stop_step} with sampler_path found in {experiment_path}"
@@ -168,7 +169,7 @@ async def evaluate_experiment(
             f"Using early stopping checkpoint at step {early_stop_step} for {experiment_name}"
         )
     else:
-        checkpoint = get_last_checkpoint(experiment_path, required_key="sampler_path")
+        checkpoint = get_last_checkpoint(experiment_path_str, required_key="sampler_path")
         assert checkpoint is not None, f"No checkpoint with sampler_path found in {experiment_path}"
 
     # Parse hyperparameters (including dataset) from directory name
@@ -239,17 +240,12 @@ def run_eval_sweep(eval_config: EvalConfig):
 
     logging.basicConfig(level=logging.INFO)
 
-    if not os.path.isdir(eval_config.experiment_dir):
+    experiment_dir = Path(eval_config.experiment_dir)
+    if not experiment_dir.is_dir():
         raise ValueError(f"Experiment directory does not exist: {eval_config.experiment_dir}")
 
     # Find all experiment subdirectories
-    experiment_names = sorted(
-        [
-            d
-            for d in os.listdir(eval_config.experiment_dir)
-            if os.path.isdir(os.path.join(eval_config.experiment_dir, d))
-        ]
-    )
+    experiment_names = sorted(d.name for d in experiment_dir.iterdir() if d.is_dir())
 
     logger.info(
         f"Found {len(experiment_names)} experiment directories in {eval_config.experiment_dir}"
@@ -262,7 +258,7 @@ def run_eval_sweep(eval_config: EvalConfig):
     )
 
     # Save results to output file
-    os.makedirs(os.path.dirname(os.path.abspath(eval_config.output_file)), exist_ok=True)
+    Path(eval_config.output_file).resolve().parent.mkdir(parents=True, exist_ok=True)
     with open(eval_config.output_file, "w") as f:
         json.dump(classifier_results_json, f, indent=2)
 

--- a/tinker_cookbook/recipes/vlm_classifier/sweep.py
+++ b/tinker_cookbook/recipes/vlm_classifier/sweep.py
@@ -10,8 +10,8 @@ python -m tinker_cookbook.recipes.vlm_classifier.sweep experiment_dir=./sweep mo
 
 """
 
-import os
 import asyncio
+from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from itertools import product
@@ -95,7 +95,7 @@ def run_experiment(experiment_config: ExperimentConfig):
     )
     experiment_name = f"{experiment_config.dataset}-{model_name}-{experiment_config.lora_rank}rank-{experiment_config.learning_rate}lr-{experiment_config.batch_size}batch{shot_suffix}-{date_and_time}"
 
-    experiment_path = os.path.join(experiment_config.experiment_dir, experiment_name)
+    experiment_path = str(Path(experiment_config.experiment_dir) / experiment_name)
     cli_utils.check_log_dir(experiment_path, behavior_if_exists="delete")
 
     dataset_builder = get_dataset_builder(

--- a/tinker_cookbook/recipes/vlm_classifier/train.py
+++ b/tinker_cookbook/recipes/vlm_classifier/train.py
@@ -10,9 +10,8 @@ python -m tinker_cookbook.recipes.vlm_classifier.train experiment_dir=./vlm_clas
 
 """
 
-import os
-
 import asyncio
+from pathlib import Path
 from datetime import datetime
 from typing import Literal
 
@@ -99,7 +98,7 @@ def run_experiment(experiment_config: ExperimentConfig):
     )
     experiment_name = f"{experiment_config.dataset}-{model_name}-{experiment_config.lora_rank}rank-{experiment_config.learning_rate}lr-{experiment_config.batch_size}batch{shot_suffix}-{date_and_time}"
 
-    experiment_path = os.path.join(experiment_config.experiment_dir, experiment_name)
+    experiment_path = str(Path(experiment_config.experiment_dir) / experiment_name)
     cli_utils.check_log_dir(
         experiment_path, behavior_if_exists=experiment_config.behavior_if_log_dir_exists
     )


### PR DESCRIPTION
## Motivation
Phase 2 of the os.path → pathlib.Path migration (follows #466). Standardizes
recipe modules and eval/inspect_evaluators on pathlib for consistency with the
core modules migrated in phase 1.

## What's in this PR (Phase 2 — recipes & eval)
- Replace `os.path.join`, `os.path.exists`, `os.path.isdir`, `os.path.basename`,
  `os.path.expanduser`, `os.path.dirname`, `os.makedirs`, and `os.listdir` with
  pathlib equivalents across 13 files:
  - `recipes/vlm_classifier/` (eval_sweep, sweep, train)
  - `recipes/rubric/` (data, generate_data)
  - `recipes/prompt_distillation/` (create_data, train)
  - `recipes/distillation/` (on_policy, off_policy_reasoning, multi_teacher, harbor_multi_turn)
  - `recipes/preference/rlhf/rlhf_pipeline.py`
  - `eval/inspect_evaluators.py`

## What's next
- **Phase 3**: `xmux/` subsystem (shell command construction with `shlex.quote`)

## Test plan
- [x] 419 unit tests pass
- [x] ruff check, ruff format, pyright all clean (no new errors)
- [x] Smoke tests pass (test_supervised, test_dpo)
- [x] Recipe e2e tests pass: chat_sl, dpo, off_policy_reasoning, on_policy_distillation, on_policy_multi_teacher, rlhf_pipeline, vlm_classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)