### PR TITLE
Make CheckpointRecord backward-compatible with external checkpoint formats

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -18,26 +18,43 @@ logger = logging.getLogger(__name__)
 RENDERER_NAME_METADATA_KEY = "renderer_name"
 
 
+_MISSING = object()  # sentinel for distinguishing "not set" from None
+
+
 @dataclass
 class CheckpointRecord:
     """A single checkpoint record stored in ``checkpoints.jsonl``.
 
-    Known fields are exposed as typed attributes. Any additional user-supplied
-    metadata from ``loop_state`` is preserved in :attr:`extra` so that custom
-    keys round-trip through save/load without loss.
+    Known fields are exposed as typed attributes.  ``batch`` is optional so
+    that checkpoint files written by older code (or external tools that use
+    different progress counters) can still be loaded.
+
+    Any additional user-supplied metadata from ``loop_state`` is preserved in
+    :attr:`extra` so that custom keys round-trip through save/load without
+    loss.
     """
 
     name: str
-    batch: int
+    batch: int | None = None
     epoch: int | None = None
     final: bool | None = None
     state_path: str | None = None
     sampler_path: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        # Defensive: if extra accidentally contains a known key (e.g. via
+        # direct construction), drop it so to_dict() never double-writes.
+        overlap = set(self.extra) & _CHECKPOINT_RECORD_KNOWN_KEYS
+        if overlap:
+            logger.warning("CheckpointRecord: dropping known keys from extra: %s", overlap)
+            self.extra = {k: v for k, v in self.extra.items() if k not in overlap}
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a dict for JSON storage. Omits ``None`` optional fields."""
-        d: dict[str, Any] = {"name": self.name, "batch": self.batch}
+        d: dict[str, Any] = {"name": self.name}
+        if self.batch is not None:
+            d["batch"] = self.batch
         if self.epoch is not None:
             d["epoch"] = self.epoch
         if self.final is not None:
@@ -51,10 +68,14 @@ class CheckpointRecord:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "CheckpointRecord":
-        """Deserialize from a JSON-parsed dict."""
+        """Deserialize from a JSON-parsed dict.
+
+        Unknown keys are preserved in :attr:`extra` so that downstream
+        metadata (e.g. ``step``) round-trips without loss.
+        """
         return cls(
             name=d["name"],
-            batch=d["batch"],
+            batch=d.get("batch"),
             epoch=d.get("epoch"),
             final=d.get("final"),
             state_path=d.get("state_path"),
@@ -67,6 +88,22 @@ class CheckpointRecord:
         if key in _CHECKPOINT_RECORD_KNOWN_KEYS:
             return getattr(self, key) is not None
         return key in self.extra
+
+    def get(self, key: str, default: Any = _MISSING) -> Any:
+        """Get a field value by name, falling back to extra, then *default*.
+
+        This provides uniform access regardless of whether a key is a known
+        attribute or user-supplied metadata stored in :attr:`extra`.
+
+        For known fields, returns the attribute value (which may be ``None``
+        if the field is optional and unset).  Returns *default* only when the
+        key is not a known field **and** is absent from :attr:`extra`.
+        """
+        if key in _CHECKPOINT_RECORD_KNOWN_KEYS:
+            return getattr(self, key)
+        if default is _MISSING:
+            return self.extra.get(key)
+        return self.extra.get(key, default)
 
 
 # Derived from the dataclass fields so it stays in sync automatically.
@@ -304,8 +341,8 @@ async def save_checkpoint_async(
         training_client: Training client to save from.
         name: Name for the checkpoint (used in the tinker:// path).
         log_path: Directory containing ``checkpoints.jsonl``.
-        loop_state: Training loop state (must include ``batch``; may include
-            ``epoch``, ``final``, and any additional user metadata).
+        loop_state: Training loop state. May include ``batch``, ``step``,
+            ``epoch``, ``final``, and any additional user metadata.
         kind: Which checkpoint types to save.
         ttl_seconds: Server-side retention. ``None`` keeps the checkpoint indefinitely.
 

--- a/tinker_cookbook/checkpoint_utils_test.py
+++ b/tinker_cookbook/checkpoint_utils_test.py
@@ -80,3 +80,81 @@ def test_get_last_checkpoint_returns_none_when_key_missing():
         )
         result = get_last_checkpoint(tmpdir, required_key="state_path")
         assert result is None
+
+
+def test_load_checkpoints_file_without_batch():
+    """Entries without 'batch' should deserialize without error (backward compat)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_checkpoints_jsonl(
+            tmpdir,
+            [
+                {"name": "000000", "step": 0},
+                {"name": "000010", "step": 10, "state_path": "tinker://state/10"},
+            ],
+        )
+        result = load_checkpoints_file(tmpdir)
+        assert len(result) == 2
+        assert result[0].batch is None
+        assert result[0].extra["step"] == 0
+        assert result[1].state_path == "tinker://state/10"
+
+
+def test_checkpoint_record_extra_round_trips():
+    """Unknown keys land in extra and survive to_dict/from_dict round-trip."""
+    record = CheckpointRecord.from_dict(
+        {"name": "000005", "batch": 5, "step": 5, "custom_key": "val"}
+    )
+    assert record.extra == {"step": 5, "custom_key": "val"}
+    d = record.to_dict()
+    assert d["step"] == 5
+    assert d["custom_key"] == "val"
+    restored = CheckpointRecord.from_dict(d)
+    assert restored.extra == {"step": 5, "custom_key": "val"}
+
+
+def test_checkpoint_record_name_only():
+    """A minimal entry with only 'name' should deserialize (batch None)."""
+    record = CheckpointRecord.from_dict({"name": "000000"})
+    assert record.name == "000000"
+    assert record.batch is None
+
+
+def test_checkpoint_record_get_known_field():
+    """get() returns known field values, including None for unset optional fields."""
+    record = CheckpointRecord(name="test", batch=5, state_path="tinker://state/5")
+    assert record.get("batch") == 5
+    assert record.get("state_path") == "tinker://state/5"
+    # Known fields always return the attribute value, even when None.
+    # This distinguishes "field exists but is unset" from "key is unknown".
+    assert record.get("epoch") is None
+    assert record.get("epoch", -1) is None
+
+
+def test_checkpoint_record_get_extra_field():
+    """get() falls through to extra for unknown keys."""
+    record = CheckpointRecord(name="test", extra={"step": 10, "custom": "val"})
+    assert record.get("step") == 10
+    assert record.get("custom") == "val"
+    assert record.get("missing") is None
+    assert record.get("missing", "default") == "default"
+
+
+def test_checkpoint_record_has_extra_field():
+    """has() works for both known fields and extra keys."""
+    record = CheckpointRecord(name="test", batch=5, extra={"step": 10})
+    assert record.has("batch")
+    assert not record.has("epoch")
+    assert record.has("step")
+    assert not record.has("missing")
+
+
+def test_checkpoint_record_extra_overlap_with_known_keys():
+    """Known keys in extra are dropped defensively to prevent to_dict() conflicts."""
+    record = CheckpointRecord(name="test", batch=5, extra={"batch": 99, "custom": "val"})
+    # "batch" should be stripped from extra; the attribute value (5) wins
+    assert record.batch == 5
+    assert "batch" not in record.extra
+    assert record.extra == {"custom": "val"}
+    # to_dict() should have batch=5, not 99
+    d = record.to_dict()
+    assert d["batch"] == 5


### PR DESCRIPTION
## Summary
- Make `CheckpointRecord.batch` optional (`int | None = None`) so checkpoint files written without `batch` can be loaded
- Add `get(key, default)` accessor for uniform access across known fields and `extra`
- Add `__post_init__` guard to prevent `extra` from clobbering known fields in `to_dict()`

## Motivation

The `CheckpointRecord` introduced in #450 required `batch` as a mandatory field. This breaks any external tooling or older checkpoint files that use a different progress counter (e.g. `step`) or write minimal entries (e.g. `{"name": "000000", "step": 0}`).

**Before (crashes):**
```python
# Entry written by external tool: {"name": "000000", "step": 0}
checkpoint_utils.load_checkpoints_file(log_dir)
# => KeyError: 'batch'  (from_dict requires d["batch"])

# Accessing fields uniformly:
record = get_last_checkpoint(log_dir)
record["state_path"]   # => TypeError: CheckpointRecord is not subscriptable
record.get("step")     # => AttributeError: no attribute 'get'
```

**After (works):**
```python
# Entry without batch loads fine, "step" preserved in extra
records = checkpoint_utils.load_checkpoints_file(log_dir)
records[0].batch       # => None
records[0].get("step") # => 0  (from extra)

# Uniform accessor works for both known fields and extra
record.get("state_path")          # => "tinker://..."  (known field)
record.get("step")                # => 10  (from extra)
record.get("missing", "default")  # => "default"
```

## Test plan
- [x] All 6 existing tests pass unchanged
- [x] New: entries without `batch` deserialize correctly
- [x] New: unknown keys round-trip through `extra` via `to_dict()`/`from_dict()`
- [x] New: `get()` on known fields, extra keys, and missing keys with defaults
- [x] New: `has()` on known fields and extra keys
- [x] New: `__post_init__` strips known-key overlap from `extra`
- [x] ruff format + ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)