### PR TITLE
Add curated public API surface to core subpackages

### DIFF
--- a/tinker_cookbook/distillation/__init__.py
+++ b/tinker_cookbook/distillation/__init__.py
@@ -1,0 +1,27 @@
+"""On-policy distillation training.
+
+Provides dataset configuration and the training loop for distilling
+from a teacher model into a student model using on-policy rollouts.
+
+Example::
+
+    from tinker_cookbook.distillation import Config, DistillationDatasetConfig
+"""
+
+from tinker_cookbook.distillation.datasets import (
+    CompositeDataset,
+    DistillationDatasetConfig,
+    PromptOnlyDatasetBuilder,
+    TeacherConfig,
+)
+from tinker_cookbook.distillation.train_on_policy import Config
+
+__all__ = [
+    # Training config and entry point
+    "Config",
+    # Dataset configuration
+    "DistillationDatasetConfig",
+    "TeacherConfig",
+    "CompositeDataset",
+    "PromptOnlyDatasetBuilder",
+]

--- a/tinker_cookbook/eval/__init__.py
+++ b/tinker_cookbook/eval/__init__.py
@@ -1,0 +1,31 @@
+"""Evaluation interfaces for training loops.
+
+Provides evaluator base classes that integrate with the supervised and RL
+training loops, plus the Inspect AI integration.
+
+Example::
+
+    from tinker_cookbook.eval import (
+        SamplingClientEvaluator,
+        TrainingClientEvaluator,
+        EvaluatorBuilder,
+    )
+"""
+
+from tinker_cookbook.eval.evaluators import (
+    Evaluator,
+    EvaluatorBuilder,
+    SamplingClientEvaluator,
+    SamplingClientEvaluatorBuilder,
+    TrainingClientEvaluator,
+)
+
+__all__ = [
+    # Evaluator base classes
+    "TrainingClientEvaluator",
+    "SamplingClientEvaluator",
+    # Type aliases
+    "Evaluator",
+    "EvaluatorBuilder",
+    "SamplingClientEvaluatorBuilder",
+]

--- a/tinker_cookbook/preference/__init__.py
+++ b/tinker_cookbook/preference/__init__.py
@@ -1,0 +1,45 @@
+"""Preference learning: Direct Preference Optimization (DPO) and RLHF.
+
+Provides preference data types, comparison renderers, preference models,
+and the DPO training entry point.
+
+Example::
+
+    from tinker_cookbook.preference import Comparison, LabeledComparison
+    from tinker_cookbook.preference import Config  # DPO training config
+"""
+
+from tinker_cookbook.preference.preference_datasets import (
+    ChatDatasetBuilderFromComparisons,
+    ComparisonDatasetBuilder,
+)
+from tinker_cookbook.preference.train_dpo import Config
+from tinker_cookbook.preference.types import (
+    Comparison,
+    ComparisonRenderer,
+    ComparisonRendererFromChatRenderer,
+    LabeledComparison,
+    PreferenceModel,
+    PreferenceModelBuilder,
+    PreferenceModelBuilderFromChatRenderer,
+    PreferenceModelFromChatRenderer,
+)
+
+__all__ = [
+    # Core preference types
+    "Comparison",
+    "LabeledComparison",
+    # Comparison rendering
+    "ComparisonRenderer",
+    "ComparisonRendererFromChatRenderer",
+    # Preference models
+    "PreferenceModel",
+    "PreferenceModelBuilder",
+    "PreferenceModelFromChatRenderer",
+    "PreferenceModelBuilderFromChatRenderer",
+    # Dataset builders
+    "ComparisonDatasetBuilder",
+    "ChatDatasetBuilderFromComparisons",
+    # DPO training config and entry point
+    "Config",
+]

--- a/tinker_cookbook/rl/__init__.py
+++ b/tinker_cookbook/rl/__init__.py
@@ -1,0 +1,65 @@
+"""Reinforcement learning training and environment abstractions.
+
+Provides the Env protocol, environment builders, dataset types, and the
+RL training loop entry point.
+
+Example::
+
+    from tinker_cookbook.rl import Env, StepResult, EnvGroupBuilder, RLDataset
+"""
+
+from tinker_cookbook.rl.data_processing import (
+    assemble_training_data,
+    compute_advantages,
+    trajectory_to_data,
+)
+from tinker_cookbook.rl.message_env import EnvFromMessageEnv, MessageEnv, MessageStepResult
+from tinker_cookbook.rl.problem_env import ProblemEnv, ProblemGroupBuilder
+from tinker_cookbook.rl.train import Config
+from tinker_cookbook.rl.types import (
+    Action,
+    Env,
+    EnvGroupBuilder,
+    Logprobs,
+    Logs,
+    Metrics,
+    Observation,
+    RLDataset,
+    RLDatasetBuilder,
+    StepResult,
+    Trajectory,
+    TrajectoryGroup,
+    Transition,
+)
+
+__all__ = [
+    # Core types and type aliases
+    "Action",
+    "Observation",
+    "Logprobs",
+    "Metrics",
+    "Logs",
+    # Environment protocol
+    "Env",
+    "StepResult",
+    "Transition",
+    "Trajectory",
+    "TrajectoryGroup",
+    # Environment builders
+    "EnvGroupBuilder",
+    "ProblemEnv",
+    "ProblemGroupBuilder",
+    # Message-level environment abstractions
+    "MessageEnv",
+    "MessageStepResult",
+    "EnvFromMessageEnv",
+    # Dataset types
+    "RLDataset",
+    "RLDatasetBuilder",
+    # Training config and entry point
+    "Config",
+    # Data processing utilities
+    "compute_advantages",
+    "assemble_training_data",
+    "trajectory_to_data",
+]

--- a/tinker_cookbook/supervised/__init__.py
+++ b/tinker_cookbook/supervised/__init__.py
@@ -1,0 +1,49 @@
+"""Supervised fine-tuning (SFT) training and data utilities.
+
+Provides dataset builders for constructing supervised training data from
+chat conversations or HuggingFace datasets, plus the training loop entry point.
+
+Example::
+
+    from tinker_cookbook.supervised import (
+        ChatDatasetBuilder,
+        SupervisedDatasetBuilder,
+        conversation_to_datum,
+    )
+"""
+
+from tinker_cookbook.supervised.common import (
+    compute_mean_nll,
+    datum_from_model_input_weights,
+)
+from tinker_cookbook.supervised.data import (
+    FromConversationFileBuilder,
+    StreamingSupervisedDatasetFromHFDataset,
+    SupervisedDatasetFromHFDataset,
+    conversation_to_datum,
+)
+from tinker_cookbook.supervised.train import Config
+from tinker_cookbook.supervised.types import (
+    ChatDatasetBuilder,
+    ChatDatasetBuilderCommonConfig,
+    SupervisedDataset,
+    SupervisedDatasetBuilder,
+)
+
+__all__ = [
+    # Core types
+    "SupervisedDataset",
+    "SupervisedDatasetBuilder",
+    "ChatDatasetBuilder",
+    "ChatDatasetBuilderCommonConfig",
+    # Training config and entry point
+    "Config",
+    # Dataset implementations
+    "SupervisedDatasetFromHFDataset",
+    "StreamingSupervisedDatasetFromHFDataset",
+    "FromConversationFileBuilder",
+    # Data utilities
+    "conversation_to_datum",
+    "datum_from_model_input_weights",
+    "compute_mean_nll",
+]

--- a/tinker_cookbook/utils/__init__.py
+++ b/tinker_cookbook/utils/__init__.py
@@ -1,1 +1,38 @@
-"""Utility helpers for tinker-cookbook."""
+"""Utility helpers for tinker-cookbook.
+
+Provides logging, tracing, and general-purpose utilities used across
+training loops and evaluation code.
+
+Submodules:
+    - ``ml_log``: Metrics logging (JSON, W&B, console)
+    - ``logtree``: Structured HTML report generation
+    - ``trace``: Performance tracing and Gantt chart visualization
+    - ``misc_utils``: Small helpers (safezip, timed, dict_mean, etc.)
+    - ``lr_scheduling``: Learning rate schedule utilities
+"""
+
+from tinker_cookbook.utils import logtree, ml_log, trace
+from tinker_cookbook.utils.misc_utils import (
+    all_same,
+    concat_lists,
+    dict_mean,
+    not_none,
+    safezip,
+    split_list,
+    timed,
+)
+
+__all__ = [
+    # Submodules (commonly imported as `from tinker_cookbook.utils import ml_log`)
+    "ml_log",
+    "logtree",
+    "trace",
+    # Misc utilities
+    "safezip",
+    "timed",
+    "dict_mean",
+    "all_same",
+    "split_list",
+    "concat_lists",
+    "not_none",
+]


### PR DESCRIPTION
## Summary

Populate the previously empty `__init__.py` files in six core subpackages with explicit imports and `__all__` declarations, giving users clean top-level import paths while maintaining full backward compatibility.

### Subpackages and exports

- **`supervised/`** — `SupervisedDataset`, `SupervisedDatasetBuilder`, `ChatDatasetBuilder`, `Config`, `conversation_to_datum`, `datum_from_model_input_weights`, `compute_mean_nll`
- **`rl/`** — `Env`, `StepResult`, `Transition`, `Trajectory`, `EnvGroupBuilder`, `MessageEnv`, `RLDataset`, `RLDatasetBuilder`, `Config`, `compute_advantages`, plus type aliases
- **`preference/`** — `Comparison`, `LabeledComparison`, `ComparisonRenderer`, `PreferenceModel`, `ComparisonDatasetBuilder`, `Config`
- **`eval/`** — `TrainingClientEvaluator`, `SamplingClientEvaluator`, `Evaluator`, `EvaluatorBuilder`
- **`distillation/`** — `Config`, `DistillationDatasetConfig`, `TeacherConfig`, `CompositeDataset`, `PromptOnlyDatasetBuilder`
- **`utils/`** — `ml_log`, `logtree`, `trace` submodules; `safezip`, `timed`, `dict_mean`, `not_none`

### Design

- Follows the pattern established by `renderers/__init__.py` and `weights/__init__.py`
- Every file declares `__all__` for explicit API boundaries
- All existing deep imports (e.g., `from tinker_cookbook.rl.types import Env`) continue to work — this is purely additive

## Test plan

- [x] `pytest tinker_cookbook/` — 495 passed, 39 skipped
- [x] `pytest tests/downstream_compat/` — 187 passed
- [x] `pyright tinker_cookbook` — 0 errors
- [ ] Verify `from tinker_cookbook.<subpackage> import <name>` works for each exported symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)