### PR TITLE
Fix YAML parsing errors in nightly and publish-pypi workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,7 +32,8 @@ jobs:
         run: uv build
 
       - name: smoke test
-        run: uv run python -c "import tinker_cookbook; print(f'Version: {tinker_cookbook.__version__}')"
+        run: |
+          uv run python -c "import tinker_cookbook; print(f'Version: {tinker_cookbook.__version__}')"
 
       - name: get version
         id: version
@@ -54,20 +55,23 @@ jobs:
 
       - name: create nightly release
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          REPO="${{ github.repository }}"
+          SHORT_SHA="${GITHUB_SHA::8}"
+          {
+            echo "Automated nightly build from \`main\` at $(date -u '+%Y-%m-%d %H:%M UTC')."
+            echo ""
+            echo "**Version:** \`${VERSION}\`"
+            echo "**Commit:** [\`${SHORT_SHA}\`](https://github.com/${REPO}/commit/${GITHUB_SHA})"
+            echo ""
+            echo "### Install"
+            echo "\`\`\`bash"
+            echo "pip install 'tinker_cookbook @ https://github.com/${REPO}/releases/download/nightly/tinker_cookbook-${VERSION}-py3-none-any.whl'"
+            echo "\`\`\`"
+          } > /tmp/release-notes.md
           gh release create nightly dist/* \
             --prerelease \
-            --title "Nightly Build (${{ steps.version.outputs.version }})" \
-            --notes "$(cat <<EOF
-Automated nightly build from \`main\` at $(date -u '+%Y-%m-%d %H:%M UTC').
-
-**Version:** \`${{ steps.version.outputs.version }}\`
-**Commit:** [\`${GITHUB_SHA::8}\`](https://github.com/${{ github.repository }}/commit/${GITHUB_SHA})
-
-### Install
-\`\`\`bash
-pip install 'tinker_cookbook @ https://github.com/${{ github.repository }}/releases/download/nightly/tinker_cookbook-${{ steps.version.outputs.version }}-py3-none-any.whl'
-\`\`\`
-EOF
-          )"
+            --title "Nightly Build (${VERSION})" \
+            --notes-file /tmp/release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -53,7 +53,8 @@ jobs:
           fi
 
       - name: run smoke test
-        run: uv run python -c "import tinker_cookbook; print(f'Version: {tinker_cookbook.__version__}')"
+        run: |
+          uv run python -c "import tinker_cookbook; print(f'Version: {tinker_cookbook.__version__}')"
 
       - name: publish
         run: uv publish --token="$PYPI_TOKEN"


### PR DESCRIPTION
## Summary
- Inline `run:` values containing Python f-string braces (`{tinker_cookbook.__version__}`) were parsed as YAML flow mappings, causing both workflows to fail before any job ran.
- The heredoc body in nightly.yaml's release notes step had zero indentation, which prematurely terminated the YAML block scalar.
- Switched affected `run:` lines to block scalar (`run: |`) syntax and replaced the heredoc with echo statements writing to a temp file + `--notes-file`.

## Test plan
- [ ] Verify nightly and publish-pypi workflows no longer show "workflow file issue" failures on push to main
- [ ] Manually trigger nightly workflow via `workflow_dispatch` to confirm it runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)