### PR TITLE
Add Nemotron-3 models to docs and Claude skills

### DIFF
--- a/.claude/skills/models/SKILL.md
+++ b/.claude/skills/models/SKILL.md
@@ -28,6 +28,7 @@ Help the user choose the right model for their task.
 | `Qwen/Qwen3-32B` | Hybrid | Dense | Medium |
 | `Qwen/Qwen3-8B` | Hybrid | Dense | Small |
 | `Qwen/Qwen3-8B-Base` | Base | Dense | Small |
+| `Qwen/Qwen3-4B-Instruct-2507` | Instruction | Dense | Compact |
 | `Qwen/Qwen3-VL-235B-A22B-Instruct` | Vision | MoE | Large |
 | `Qwen/Qwen3-VL-30B-A3B-Instruct` | Vision | MoE | Medium |
 
@@ -40,6 +41,12 @@ Help the user choose the right model for their task.
 | `meta-llama/Llama-3.1-8B-Instruct` | Instruction | Dense | Small |
 | `meta-llama/Llama-3.2-3B` | Base | Dense | Compact |
 | `meta-llama/Llama-3.2-1B` | Base | Dense | Compact |
+
+### Nemotron family
+| Model | Type | Arch | Size |
+|-------|------|------|------|
+| `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` | Hybrid | MoE | Large |
+| `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` | Hybrid | MoE | Medium |
 
 ### Other families
 | Model | Type | Arch | Size |

--- a/.claude/skills/renderers/SKILL.md
+++ b/.claude/skills/renderers/SKILL.md
@@ -28,7 +28,7 @@ tokenizer = get_tokenizer(model_name)
 renderer = get_renderer(renderer_name, tokenizer)
 ```
 
-**Available renderers:** `llama3`, `qwen3`, `deepseekv3`, `kimi_k2`, `kimi_k25`, `role_colon`, and more. See `tinker_cookbook/renderers/__init__.py` for the full registry.
+**Available renderers:** `llama3`, `qwen3`, `deepseekv3`, `kimi_k2`, `kimi_k25`, `nemotron3`, `nemotron3_disable_thinking`, `role_colon`, and more. See `tinker_cookbook/renderers/__init__.py` for the full registry.
 
 ## Key renderer methods
 

--- a/docs/model-lineup.mdx
+++ b/docs/model-lineup.mdx
@@ -41,6 +41,8 @@ export const models = [
   { name: "meta-llama/Llama-3.1-8B-Instruct", type: "Instruction", arch: "Dense", size: "Small" },
   { name: "meta-llama/Llama-3.2-3B", type: "Base", arch: "Dense", size: "Compact" },
   { name: "meta-llama/Llama-3.2-1B", type: "Base", arch: "Dense", size: "Compact" },
+  { name: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", type: "Hybrid", arch: "MoE", size: "Large" },
+  { name: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", type: "Hybrid", arch: "MoE", size: "Medium" },
   { name: "moonshotai/Kimi-K2-Thinking", type: "Reasoning", arch: "MoE", size: "Large" },
   { name: "moonshotai/Kimi-K2.5", type: "Reasoning + Vision", arch: "MoE", size: "Large" },
 ]


### PR DESCRIPTION
## Summary
- Add NVIDIA Nemotron-3 Super (120B) and Nano (30B) to `docs/model-lineup.mdx`
- Add Nemotron family section to the models Claude skill
- Add `nemotron3` and `nemotron3_disable_thinking` renderers to the renderers Claude skill
- Add missing `Qwen3-4B-Instruct-2507` to the models Claude skill

## Test plan
- [ ] Verify model-lineup.mdx renders correctly on docs site
- [ ] Verify models skill lists all current models
- [ ] Verify renderers skill lists all current renderers

🤖 Generated with [Claude Code](https://claude.com/claude-code)