### PR TITLE
Allow older transformers version CI to fail without blocking PRs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,33 +10,6 @@ permissions:
   contents: write  # needed to create/delete releases
 
 jobs:
-  test-older-transformers:
-    runs-on: ubuntu-latest
-    name: test-older-transformers (transformers 4.57.6)
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: install-uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: venv
-        run: uv venv && uv sync --all-extras
-
-      - name: pin transformers
-        run: uv pip install transformers==4.57.6
-
-      - name: pytest (unit)
-        run: uv run pytest tinker_cookbook/
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-
-      - name: pyright
-        run: uv run pyright tinker_cookbook
-
   build-and-release:
     runs-on: ubuntu-latest
     # Only run if: manually triggered, or smoke tests passed on schedule

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -9,6 +9,17 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        include:
+          - transformers-version: "5.2.0"
+            allow-failure: false
+          - transformers-version: "4.57.6"
+            allow-failure: true
+
+    name: type-check (transformers ${{ matrix.transformers-version }})
+    continue-on-error: ${{ matrix.allow-failure }}
+
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -20,6 +31,9 @@ jobs:
 
       - name: venv
         run: uv venv && uv sync --all-extras
+
+      - name: pin transformers
+        run: uv pip install transformers==${{ matrix.transformers-version }}
 
       - name: pyright
         run: uv run pyright tinker_cookbook

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,6 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        include:
+          - transformers-version: "5.2.0"
+            allow-failure: false
+          - transformers-version: "4.57.6"
+            allow-failure: true
+
+    name: test (transformers ${{ matrix.transformers-version }})
+    continue-on-error: ${{ matrix.allow-failure }}
+
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -21,6 +32,9 @@ jobs:
 
       - name: venv
         run: uv venv && uv sync --all-extras
+
+      - name: pin transformers
+        run: uv pip install transformers==${{ matrix.transformers-version }}
 
       - name: pytest (unit)
         run: uv run pytest tinker_cookbook/


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` for transformers 4.57.6 matrix entries in pytest and pyright workflows
- The latest version (5.2.0) remains a hard failure
- Older version test results are still visible in workflow logs for debugging

## Motivation
We support `transformers>=4.57.6,<5.3.0`, but development targets the latest version. Older version failures shouldn't block PRs — developers would have to manually install/uninstall different transformers versions locally to debug issues that are often just stale API differences. With `continue-on-error`, the older version job still runs and surfaces failures clearly in the workflow UI, but doesn't block the PR or show a red X at the top level.

## Test plan
- [ ] Verify PR CI shows green overall even if the 4.57.6 job fails
- [ ] Verify 5.2.0 job failure still blocks (shows red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)