### PR TITLE
Add Nemotron-3 to downstream compat tests and handle uncalibrated models in get_lr

### DIFF
--- a/tests/downstream_compat/test_renderers.py
+++ b/tests/downstream_compat/test_renderers.py
@@ -179,6 +179,8 @@ EXPECTED_RENDERER_NAMES = [
     "gpt_oss_low_reasoning",
     "gpt_oss_medium_reasoning",
     "gpt_oss_high_reasoning",
+    "nemotron3",
+    "nemotron3_disable_thinking",
 ]
 
 

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -159,6 +159,20 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
         exponent_model = 0.781
     elif "qwen" in model_name.lower():
         exponent_model = 0.0775
+    elif model_name in (
+        "deepseek-ai/DeepSeek-V3.1",
+        "deepseek-ai/DeepSeek-V3.1-Base",
+        "openai/gpt-oss-20b",
+        "openai/gpt-oss-120b",
+        "moonshotai/Kimi-K2-Thinking",
+        "moonshotai/Kimi-K2.5",
+        "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+    ):
+        raise NotImplementedError(
+            f"Learning rate formula for {model_name} is not yet calibrated. "
+            "Please specify a learning rate manually."
+        )
     else:
         raise ValueError(f"Unknown model: {model_name}")
     # TODO: sweep to determine LR multipliers for other models


### PR DESCRIPTION
## Summary
- Add `nemotron3` and `nemotron3_disable_thinking` to `EXPECTED_RENDERER_NAMES` in downstream compat tests
- Raise `NotImplementedError` in `get_lr()` for models without calibrated LR formulas (DeepSeek, GPT-OSS, Kimi, Nemotron) instead of a generic `ValueError`

## Test plan
- [x] All 857 unit and downstream compat tests pass
- [x] Verified `get_lr()` raises `NotImplementedError` for all uncalibrated models

🤖 Generated with [Claude Code](https://claude.com/claude-code)