### PR TITLE
Add rollout error resilience for RL training

### DIFF
--- a/.claude/skills/grpo/SKILL.md
+++ b/.claude/skills/grpo/SKILL.md
@@ -54,6 +54,7 @@ Implement the `Env` protocol from `tinker_cookbook/rl/types.py`. Key points:
 - `learning_rate`: Typically 1e-5 to 4e-5 for RL
 - `kl_penalty_coef`: KL penalty against reference model (0.0 = no penalty)
 - `temperature`: Sampling temperature (default 1.0)
+- `rollout_error_tolerance`: Tolerance for rollout errors (`False` = crash on any error, `True` = retry failed trajectories with default budget, `RetryOnFailure(max_retries=5)` = custom retry budget). Error counts logged as `rollout_errors/*` metrics.
 
 ### Loss Functions
 - `importance_sampling` — Default, on-policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Agents often struggle with the nested type hierarchy. Key resources:
 - Renderers: `tinker_cookbook/renderers/`
 - Completers: `tinker_cookbook/completers.py`
 - RL types: `tinker_cookbook/rl/types.py`
+- Rollout strategies: `tinker_cookbook/rl/rollout_strategy.py` (FailFast, RetryOnFailure)
 - Logging: `tinker_cookbook/utils/logtree.py`, `tinker_cookbook/rl/rollouts.py`
 - Recipes: `tinker_cookbook/recipes/`
 

--- a/tinker_cookbook/__init__.py
+++ b/tinker_cookbook/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
         __version__ = "0.0.0.dev0+unknown"
 
 from tinker_cookbook.exceptions import (
+    AllTrajectoriesFailedError,
     CheckpointError,
     ConfigurationError,
     DataError,
@@ -27,6 +28,7 @@ from tinker_cookbook.exceptions import (
 
 __all__ = [
     "__version__",
+    "AllTrajectoriesFailedError",
     "CheckpointError",
     "ConfigurationError",
     "DataError",

--- a/tinker_cookbook/exceptions.py
+++ b/tinker_cookbook/exceptions.py
@@ -40,6 +40,7 @@ __all__ = [
     "RendererError",
     "TrainingError",
     "CheckpointError",
+    "AllTrajectoriesFailedError",
     "WeightsError",
     "WeightsDownloadError",
     "WeightsMergeError",
@@ -139,6 +140,14 @@ class CheckpointError(TrainingError):
 
     Raised when a checkpoint file is missing, corrupted, or when the
     save/load operation fails.
+    """
+
+
+class AllTrajectoriesFailedError(TrainingError):
+    """All trajectories in a rollout group failed.
+
+    Caught internally by the rollout pipeline to skip the affected group
+    rather than crash the training run.
     """
 
 

--- a/tinker_cookbook/recipes/code_rl/train.py
+++ b/tinker_cookbook/recipes/code_rl/train.py
@@ -6,6 +6,7 @@ import chz
 
 from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.recipes.code_rl.code_env import DeepcoderDatasetBuilder
+from tinker_cookbook.rl.rollout_strategy import RetryOnFailure
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
 from tinker_cookbook.sandbox import SandboxBackend
 
@@ -54,6 +55,10 @@ class CLIConfig:
     sandbox_backend: SandboxBackend = SandboxBackend.SANDBOXFUSION
 
     max_steps: int | None = None
+
+    # Maximum number of times to retry a failed trajectory rollout (container crash,
+    # sandbox flake, etc.). None (default) = crash on any error. 0+ = retry budget.
+    rollout_max_retries: int | None = None
 
 
 async def cli_main(cli_config: CLIConfig) -> None:
@@ -113,6 +118,9 @@ async def cli_main(cli_config: CLIConfig) -> None:
         if cli_config.max_steps_off_policy is not None
         else None,
         max_steps=cli_config.max_steps,
+        rollout_error_tolerance=RetryOnFailure(max_retries=cli_config.rollout_max_retries)
+        if cli_config.rollout_max_retries is not None
+        else False,
     )
 
     cli_utils.check_log_dir(log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists)

--- a/tinker_cookbook/rl/metric_util.py
+++ b/tinker_cookbook/rl/metric_util.py
@@ -1,5 +1,6 @@
 import asyncio
 import itertools
+import logging
 from collections import defaultdict
 
 import numpy as np
@@ -7,11 +8,14 @@ import tinker
 
 from tinker_cookbook.completers import TinkerTokenCompleter, TokenCompleter
 from tinker_cookbook.eval.evaluators import SamplingClientEvaluator
+from tinker_cookbook.exceptions import AllTrajectoriesFailedError
 from tinker_cookbook.rl.rollout_logging import (
     RolloutSummaryExportConfig,
     write_rollout_summaries_jsonl,
 )
+from tinker_cookbook.rl.rollout_strategy import RolloutStrategy
 from tinker_cookbook.rl.rollouts import (
+    RolloutErrorCounter,
     do_group_rollout,
     do_group_rollout_and_filter_constant_reward,
     get_rollout_executor,
@@ -19,6 +23,8 @@ from tinker_cookbook.rl.rollouts import (
 from tinker_cookbook.rl.types import EnvGroupBuilder, RLDataset, TrajectoryGroup
 from tinker_cookbook.utils import logtree
 from tinker_cookbook.utils.misc_utils import all_same, dict_mean
+
+logger = logging.getLogger(__name__)
 
 
 def _compute_by_group_metrics(trajectory_groups_P: list[TrajectoryGroup], good_thresh: float = 0.5):
@@ -117,11 +123,13 @@ class RLTestSetEvaluator(SamplingClientEvaluator):
         max_tokens: int,
         name: str = "test",
         num_groups_to_log: int = 4,
+        strategy: RolloutStrategy | None = None,
     ):
         self.env_group_builders_P = dataset_to_env_group_builders(dataset)
         self.max_tokens = max_tokens
         self.name = name
         self.num_groups_to_log = num_groups_to_log
+        self.strategy = strategy
 
     async def eval_token_completer(
         self,
@@ -129,33 +137,34 @@ class RLTestSetEvaluator(SamplingClientEvaluator):
         *,
         rollout_summary_export: RolloutSummaryExportConfig | None = None,
     ) -> dict[str, float]:
-        async def run_group_rollout(builder, i):
-            enable_logging = i < self.num_groups_to_log
-            with logtree.optional_enable_logging(enable=enable_logging):
-                return await do_group_rollout(builder, policy)
+        async def run_group_rollout(
+            builder: EnvGroupBuilder, group_idx: int
+        ) -> TrajectoryGroup | None:
+            enable_logging = group_idx < self.num_groups_to_log
+            try:
+                with logtree.optional_enable_logging(enable=enable_logging):
+                    result = await do_group_rollout(
+                        builder,
+                        policy,
+                        strategy=self.strategy,
+                    )
+            except AllTrajectoriesFailedError as e:
+                logger.warning(f"Eval: {e}")
+                result = None
+            except Exception as e:
+                if self.strategy is None or not self.strategy.catches_group_errors:
+                    raise
+                logger.warning(f"Eval rollout error ({type(e).__name__}): {e}")
+                result = None
+            return result
 
-        trajectory_groups_P = await asyncio.gather(
-            *[run_group_rollout(builder, i) for i, builder in enumerate(self.env_group_builders_P)]
+        results = await asyncio.gather(
+            *[
+                run_group_rollout(builder, group_idx)
+                for group_idx, builder in enumerate(self.env_group_builders_P)
+            ]
         )
-        taglist_P = [builder.logging_tags() for builder in self.env_group_builders_P]
-        if rollout_summary_export is not None:
-            sampling_client_steps_P = (
-                [rollout_summary_export.sampling_client_step] * len(trajectory_groups_P)
-                if rollout_summary_export.sampling_client_step is not None
-                else None
-            )
-            write_rollout_summaries_jsonl(
-                rollout_summary_export.path,
-                split=rollout_summary_export.split,
-                iteration=rollout_summary_export.iteration,
-                trajectory_groups_P=trajectory_groups_P,
-                taglist_P=taglist_P,
-                sampling_client_steps_P=sampling_client_steps_P,
-            )
-        metrics = compute_trajectory_metrics(trajectory_groups_P, taglist_P)
-
-        metrics = {f"{self.name}/{k}": v for k, v in metrics.items()}
-        return metrics
+        return self._collect_eval_metrics(results, rollout_summary_export)
 
     async def __call__(
         self,
@@ -191,15 +200,29 @@ class RLTestSetEvaluator(SamplingClientEvaluator):
                     temperature=1.0,
                     do_remove_constant_reward_groups=False,
                     enable_logging=i < self.num_groups_to_log,
+                    strategy=self.strategy,
                 )
                 for i, builder in enumerate(self.env_group_builders_P)
             ]
         )
-        # remove_constant_reward_groups=False so None results shouldn't occur,
-        # but filter for type safety
-        trajectory_groups_P = [r for r in results if r is not None]
+        return self._collect_eval_metrics(results, rollout_summary_export)
 
-        taglist_P = [builder.logging_tags() for builder in self.env_group_builders_P]
+    def _collect_eval_metrics(
+        self,
+        results: list[TrajectoryGroup | None],
+        rollout_summary_export: RolloutSummaryExportConfig | None,
+    ) -> dict[str, float]:
+        """Shared logic for collecting metrics from eval rollout results."""
+        error_counter = RolloutErrorCounter()
+        for result in results:
+            error_counter.ingest(result)
+
+        trajectory_groups_P = [r for r in results if r is not None]
+        taglist_P = [
+            builder.logging_tags()
+            for builder, r in zip(self.env_group_builders_P, results)
+            if r is not None
+        ]
         if rollout_summary_export is not None:
             sampling_client_steps_P = (
                 [rollout_summary_export.sampling_client_step] * len(trajectory_groups_P)
@@ -215,5 +238,6 @@ class RLTestSetEvaluator(SamplingClientEvaluator):
                 sampling_client_steps_P=sampling_client_steps_P,
             )
         metrics = compute_trajectory_metrics(trajectory_groups_P, taglist_P)
+        metrics.update(error_counter.get_metrics())
         metrics = {f"{self.name}/{k}": v for k, v in metrics.items()}
         return metrics

--- a/tinker_cookbook/rl/rollout_error_resilience_test.py
+++ b/tinker_cookbook/rl/rollout_error_resilience_test.py
@@ -1,0 +1,409 @@
+"""Tests for rollout error resilience: strategy abstraction, retry, error tracking, and pickling."""
+
+from __future__ import annotations
+
+import asyncio
+import pickle
+from unittest.mock import MagicMock, patch
+
+import pytest
+import tinker
+
+from tinker_cookbook.completers import TokenCompleter, TokensWithLogprobs
+from tinker_cookbook.exceptions import AllTrajectoriesFailedError, ConfigurationError
+from tinker_cookbook.rl.rollout_strategy import (
+    FailFast,
+    RetryOnFailure,
+    rollout_strategy_from_config,
+)
+from tinker_cookbook.rl.rollouts import (
+    RolloutErrorCounter,
+    _do_group_rollout_and_filter_constant_reward_impl,
+    do_group_rollout,
+)
+from tinker_cookbook.rl.types import (
+    Env,
+    EnvGroupBuilder,
+    RolloutError,
+    StepResult,
+    Trajectory,
+    TrajectoryGroup,
+    Transition,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trajectory() -> Trajectory:
+    """Create a minimal valid Trajectory."""
+    return Trajectory(
+        transitions=[
+            Transition(
+                ob=tinker.ModelInput.from_ints([1, 2, 3]),
+                ac=TokensWithLogprobs(tokens=[4, 5], maybe_logprobs=[0.1, 0.2]),
+                reward=1.0,
+                episode_done=True,
+            )
+        ],
+        final_ob=tinker.ModelInput.from_ints([]),
+    )
+
+
+class _FakePolicy(TokenCompleter):
+    """Policy that returns a fixed result, optionally failing on specific call indices."""
+
+    def __init__(self, fail_indices: set[int] | None = None, error: BaseException | None = None):
+        self._call_count = 0
+        self.fail_indices = fail_indices or set()
+        self.error = error or RuntimeError("fake error")
+
+    async def __call__(self, model_input, stop):
+        idx = self._call_count
+        self._call_count += 1
+        if idx in self.fail_indices:
+            raise self.error
+        return TokensWithLogprobs(tokens=[4, 5], maybe_logprobs=[0.1, 0.2])
+
+
+class _FakeEnv(Env):
+    async def initial_observation(self):
+        return tinker.ModelInput.from_ints([1, 2, 3]), [0]
+
+    async def step(self, action):
+        return StepResult(
+            reward=1.0,
+            episode_done=True,
+            next_observation=tinker.ModelInput.from_ints([]),
+            next_stop_condition=[0],
+        )
+
+
+class _FakeEnvGroupBuilder(EnvGroupBuilder):
+    def __init__(self, n_envs: int = 4):
+        self.n_envs = n_envs
+        self.make_envs_call_count = 0
+
+    async def make_envs(self):
+        self.make_envs_call_count += 1
+        return [_FakeEnv() for _ in range(self.n_envs)]
+
+
+# ---------------------------------------------------------------------------
+# rollout_strategy_from_config tests
+# ---------------------------------------------------------------------------
+
+
+class TestRolloutStrategyFromConfig:
+    def test_false_returns_fail_fast(self):
+        strategy = rollout_strategy_from_config(False)
+        assert isinstance(strategy, FailFast)
+        assert not strategy.catches_group_errors
+
+    def test_true_returns_retry_on_failure(self):
+        strategy = rollout_strategy_from_config(True)
+        assert isinstance(strategy, RetryOnFailure)
+        assert strategy.max_retries == 3
+        assert strategy.catches_group_errors
+
+    def test_strategy_instance_passed_through(self):
+        strategy = RetryOnFailure(max_retries=5)
+        assert rollout_strategy_from_config(strategy) is strategy
+
+    def test_fail_fast_instance_passed_through(self):
+        strategy = FailFast()
+        assert rollout_strategy_from_config(strategy) is strategy
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ConfigurationError):
+            rollout_strategy_from_config(0.5)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Strategy pickling tests
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyPickle:
+    def test_fail_fast_pickleable(self):
+        strategy = FailFast()
+        restored = pickle.loads(pickle.dumps(strategy))
+        assert isinstance(restored, FailFast)
+
+    def test_retry_on_failure_pickleable(self):
+        strategy = RetryOnFailure(max_retries=5)
+        restored = pickle.loads(pickle.dumps(strategy))
+        assert isinstance(restored, RetryOnFailure)
+        assert restored.max_retries == 5
+
+
+# ---------------------------------------------------------------------------
+# RolloutError and TrajectoryGroup tests
+# ---------------------------------------------------------------------------
+
+
+class TestRolloutError:
+    def test_pickleable(self):
+        err = RolloutError(error_type="BadRequestError", error_message="context overflow")
+        restored = pickle.loads(pickle.dumps(err))
+        assert restored.error_type == "BadRequestError"
+        assert restored.error_message == "context overflow"
+
+
+class TestTrajectoryGroupErrors:
+    def test_default_no_errors(self):
+        tg = TrajectoryGroup([_make_trajectory()], [1.0], [{}])
+        assert tg.rollout_errors == []
+
+    def test_with_errors(self):
+        errors = [RolloutError("BadRequestError", "too long")]
+        tg = TrajectoryGroup([_make_trajectory()], [1.0], [{}], rollout_errors=errors)
+        assert len(tg.rollout_errors) == 1
+
+    def test_pickleable_with_errors(self):
+        errors = [RolloutError("BadRequestError", "too long")]
+        tg = TrajectoryGroup([_make_trajectory()], [1.0], [{}], rollout_errors=errors)
+        restored = pickle.loads(pickle.dumps(tg))
+        assert len(restored.rollout_errors) == 1
+
+    def test_get_total_rewards_unaffected(self):
+        errors = [RolloutError("Err", "msg")]
+        tg = TrajectoryGroup(
+            [_make_trajectory(), _make_trajectory()],
+            [0.5, 0.3],
+            [{}, {}],
+            rollout_errors=errors,
+        )
+        rewards = tg.get_total_rewards()
+        assert rewards[0] == pytest.approx(1.5)
+        assert rewards[1] == pytest.approx(1.3)
+
+
+# ---------------------------------------------------------------------------
+# RolloutErrorCounter tests
+# ---------------------------------------------------------------------------
+
+
+class TestRolloutErrorCounter:
+    def test_ingest_successful_group(self):
+        counter = RolloutErrorCounter()
+        tg = TrajectoryGroup([_make_trajectory()], [1.0], [{}])
+        counter.ingest(tg)
+        assert counter.get_metrics() == {}
+
+    def test_ingest_none_increments_groups_skipped(self):
+        counter = RolloutErrorCounter()
+        counter.ingest(None)
+        counter.ingest(None)
+        metrics = counter.get_metrics()
+        assert metrics["rollout_errors/groups_skipped"] == 2.0
+
+    def test_ingest_group_with_errors(self):
+        counter = RolloutErrorCounter()
+        errors = [
+            RolloutError("BadRequestError", "msg1"),
+            RolloutError("BadRequestError", "msg2"),
+            RolloutError("TimeoutError", "msg3"),
+        ]
+        tg = TrajectoryGroup([_make_trajectory()], [1.0], [{}], rollout_errors=errors)
+        counter.ingest(tg)
+        metrics = counter.get_metrics()
+        assert metrics["rollout_errors/BadRequestError"] == 2.0
+        assert metrics["rollout_errors/TimeoutError"] == 1.0
+        assert metrics["rollout_errors/total"] == 3.0
+
+    def test_cumulative_across_ingests(self):
+        counter = RolloutErrorCounter()
+        tg1 = TrajectoryGroup(
+            [_make_trajectory()],
+            [1.0],
+            [{}],
+            rollout_errors=[RolloutError("BadRequestError", "a")],
+        )
+        counter.ingest(tg1)
+        counter.ingest(None)
+        metrics = counter.get_metrics()
+        assert metrics["rollout_errors/BadRequestError"] == 1.0
+        assert metrics["rollout_errors/groups_skipped"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# FailFast strategy tests (via do_group_rollout)
+# ---------------------------------------------------------------------------
+
+
+class TestFailFastStrategy:
+    def test_default_strategy_raises_on_error(self):
+        """Without strategy (FailFast default), errors propagate."""
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        policy = _FakePolicy(fail_indices={1})
+        with pytest.raises(RuntimeError, match="fake error"):
+            asyncio.run(do_group_rollout(builder, policy))
+
+    def test_success_returns_all_trajectories(self):
+        builder = _FakeEnvGroupBuilder(n_envs=3)
+        policy = _FakePolicy()
+        tg = asyncio.run(do_group_rollout(builder, policy))
+        assert len(tg.trajectories_G) == 3
+        assert tg.rollout_errors == []
+
+    def test_cancelled_error_propagates(self):
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        policy = _FakePolicy(fail_indices={0}, error=asyncio.CancelledError())
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(do_group_rollout(builder, policy))
+
+
+# ---------------------------------------------------------------------------
+# RetryOnFailure strategy tests (via do_group_rollout)
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnFailureStrategy:
+    def test_no_errors_returns_all_trajectories(self):
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        policy = _FakePolicy()
+        tg = asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=3)))
+        assert len(tg.trajectories_G) == 2
+        assert tg.rollout_errors == []
+
+    def test_retry_recovers_from_transient_failure(self):
+        """One trajectory fails initially, retry succeeds."""
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        # Call index 1 fails, but retry (index 2) succeeds
+        policy = _FakePolicy(fail_indices={1})
+        tg = asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=3)))
+        # Original success + retry success = 2 trajectories
+        assert len(tg.trajectories_G) == 2
+        assert len(tg.rollout_errors) == 1
+        assert tg.rollout_errors[0].error_type == "RuntimeError"
+
+    def test_retry_creates_fresh_envs(self):
+        """Retry calls make_envs again to get a fresh environment."""
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        policy = _FakePolicy(fail_indices={1})  # one failure triggers one retry
+        asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=3)))
+        # Initial make_envs + 1 retry make_envs
+        assert builder.make_envs_call_count == 2
+
+    def test_all_fail_raises_after_retries(self):
+        """All trajectories fail and retries exhausted -> re-raises last error."""
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        # All calls fail (indices 0,1 initial + 2,3,4 retries = 5 total calls)
+        policy = _FakePolicy(fail_indices={0, 1, 2, 3, 4})
+        with pytest.raises(RuntimeError, match="fake error"):
+            asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=3)))
+
+    def test_budget_exhausted_cancels_and_raises(self):
+        """When retry budget runs out, cancel remaining tasks and re-raise."""
+        builder = _FakeEnvGroupBuilder(n_envs=4)
+        # Indices 0,1 succeed; 2 fails, retry at 4 fails; 3 fails, retry at 5 fails
+        # Budget is 2 — first retry succeeds at index 4? No: indices 2,3 fail, retries at 4,5 also fail
+        # After 2 retries exhausted, next failure re-raises
+        policy = _FakePolicy(fail_indices={2, 3, 4, 5})
+        with pytest.raises(RuntimeError, match="fake error"):
+            asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=2)))
+
+    def test_zero_retries_raises_on_any_failure(self):
+        """max_retries=0 means no retries — any failure crashes the group."""
+        builder = _FakeEnvGroupBuilder(n_envs=4)
+        policy = _FakePolicy(fail_indices={2})
+        with pytest.raises(RuntimeError, match="fake error"):
+            asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=0)))
+
+    def test_cancelled_error_not_swallowed(self):
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        policy = _FakePolicy(fail_indices={0}, error=asyncio.CancelledError())
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=3)))
+
+    def test_keyboard_interrupt_not_swallowed(self):
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        policy = _FakePolicy(fail_indices={0}, error=KeyboardInterrupt())
+        with pytest.raises(KeyboardInterrupt):
+            asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=3)))
+
+    def test_make_envs_failure_during_retry_propagates(self):
+        """If make_envs() fails during retry, the error propagates."""
+
+        call_count = 0
+
+        class _FailOnSecondMakeEnvs(EnvGroupBuilder):
+            async def make_envs(self):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 1:
+                    raise RuntimeError("container pool exhausted")
+                return [_FakeEnv() for _ in range(2)]
+
+        builder = _FailOnSecondMakeEnvs()
+        policy = _FakePolicy(fail_indices={1})  # triggers a retry
+        with pytest.raises(RuntimeError, match="container pool exhausted"):
+            asyncio.run(do_group_rollout(builder, policy, strategy=RetryOnFailure(max_retries=3)))
+
+
+# ---------------------------------------------------------------------------
+# _do_group_rollout_and_filter_constant_reward_impl tests
+# ---------------------------------------------------------------------------
+
+
+class TestImplErrorHandling:
+    def test_fail_fast_propagates_error(self):
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        sampling_client = MagicMock(spec=tinker.SamplingClient)
+        with (
+            patch(
+                "tinker_cookbook.rl.rollouts.do_group_rollout",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            asyncio.run(
+                _do_group_rollout_and_filter_constant_reward_impl(
+                    sampling_client,
+                    builder,
+                    max_tokens=100,
+                    temperature=1.0,
+                    do_remove_constant_reward_groups=False,
+                    strategy=FailFast(),
+                )
+            )
+
+    def test_retry_strategy_returns_none_on_group_error(self):
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        sampling_client = MagicMock(spec=tinker.SamplingClient)
+        with patch(
+            "tinker_cookbook.rl.rollouts.do_group_rollout",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = asyncio.run(
+                _do_group_rollout_and_filter_constant_reward_impl(
+                    sampling_client,
+                    builder,
+                    max_tokens=100,
+                    temperature=1.0,
+                    do_remove_constant_reward_groups=False,
+                    strategy=RetryOnFailure(max_retries=3),
+                )
+            )
+        assert result is None
+
+    def test_all_trajectories_failed_returns_none(self):
+        builder = _FakeEnvGroupBuilder(n_envs=2)
+        sampling_client = MagicMock(spec=tinker.SamplingClient)
+        with patch(
+            "tinker_cookbook.rl.rollouts.do_group_rollout",
+            side_effect=AllTrajectoriesFailedError("all failed"),
+        ):
+            result = asyncio.run(
+                _do_group_rollout_and_filter_constant_reward_impl(
+                    sampling_client,
+                    builder,
+                    max_tokens=100,
+                    temperature=1.0,
+                    do_remove_constant_reward_groups=False,
+                    strategy=RetryOnFailure(max_retries=3),
+                )
+            )
+        assert result is None

--- a/tinker_cookbook/rl/rollout_strategy.py
+++ b/tinker_cookbook/rl/rollout_strategy.py
@@ -1,0 +1,220 @@
+"""Pluggable strategies for collecting trajectories within a rollout group.
+
+A :class:`RolloutStrategy` decides *how* to run N single-rollout coroutines
+in parallel — whether to fail fast, retry on failure, etc.  It owns the full
+trajectory collection lifecycle including env creation (via
+``EnvGroupBuilder.make_envs()``), so strategies like retry can create fresh
+envs as needed.
+
+Group reward computation and logging remain in
+:func:`~tinker_cookbook.rl.rollouts.do_group_rollout`.
+
+Implementations must be pickleable (frozen dataclasses with primitive fields)
+because they are bundled into ``_RolloutTask`` for cross-process dispatch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from tinker_cookbook.completers import TokenCompleter
+from tinker_cookbook.exceptions import ConfigurationError
+from tinker_cookbook.rl.types import Env, EnvGroupBuilder, RolloutError, Trajectory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RolloutResult:
+    """Output of a :class:`RolloutStrategy`."""
+
+    trajectories: list[Trajectory]
+    envs: Sequence[Env]
+    errors: list[RolloutError]
+
+
+class RolloutStrategy(ABC):
+    """Controls how trajectories are collected from a group of environments.
+
+    Subclasses implement :meth:`execute` which receives the
+    :class:`EnvGroupBuilder` and a policy, creates envs, runs rollouts,
+    and returns the surviving trajectories plus any error info.
+
+    Implementations must be pickleable — use ``@dataclass(frozen=True)``
+    with only primitive fields.
+    """
+
+    @property
+    def catches_group_errors(self) -> bool:
+        """If True, group-level errors (``make_envs``, ``compute_group_rewards``)
+        are caught and the group is skipped.  If False, they propagate."""
+        return False
+
+    @abstractmethod
+    async def execute(
+        self,
+        env_group_builder: EnvGroupBuilder,
+        policy: TokenCompleter,
+    ) -> RolloutResult:
+        """Create envs, run rollouts, and return results.
+
+        May raise on unrecoverable errors (e.g. retry budget exhausted).
+        The caller (:func:`do_group_rollout`) handles group-level error
+        recovery based on :attr:`catches_group_errors`.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class FailFast(RolloutStrategy):
+    """Default strategy: any trajectory error crashes the group.
+
+    Produces identical behaviour to the original ``asyncio.gather(...)``
+    path — no error tolerance, no overhead.
+    """
+
+    async def execute(
+        self,
+        env_group_builder: EnvGroupBuilder,
+        policy: TokenCompleter,
+    ) -> RolloutResult:
+        from tinker_cookbook.rl.rollouts import do_single_rollout
+
+        envs = await env_group_builder.make_envs()
+        trajectories: list[Trajectory] = list(
+            await asyncio.gather(*[do_single_rollout(policy, env) for env in envs])
+        )
+        return RolloutResult(trajectories=trajectories, envs=envs, errors=[])
+
+
+@dataclass(frozen=True)
+class RetryOnFailure(RolloutStrategy):
+    """Retry failed trajectories with fresh environments.
+
+    When a trajectory fails (container crash, sandbox flake, transient error),
+    a fresh env is created via ``make_envs()`` and the rollout is retried.
+    This continues until either all trajectories succeed or the retry budget
+    is exhausted.
+
+    If the retry budget is exhausted and a failure still occurs, the remaining
+    in-flight tasks are cancelled and the exception is re-raised. This avoids
+    partial-group bias from training on an incomplete set of trajectories.
+
+    Uses ``asyncio.wait(FIRST_COMPLETED)`` so retries start as soon as a
+    failure is detected, without waiting for other in-flight rollouts.
+
+    Args:
+        max_retries: Total retry budget across all trajectories in the group.
+            For example, with ``max_retries=3`` and a group of 8 envs, up to
+            3 individual trajectory failures will be retried.
+    """
+
+    max_retries: int = 3
+
+    @property
+    def catches_group_errors(self) -> bool:
+        return True
+
+    async def execute(
+        self,
+        env_group_builder: EnvGroupBuilder,
+        policy: TokenCompleter,
+    ) -> RolloutResult:
+        from tinker_cookbook.rl.rollouts import do_single_rollout
+
+        envs = await env_group_builder.make_envs()
+
+        # Map task -> env for tracking
+        task_to_env: dict[asyncio.Task[Trajectory], Env] = {}
+        for env in envs:
+            task = asyncio.create_task(do_single_rollout(policy, env))
+            task_to_env[task] = env
+
+        trajectories: list[Trajectory] = []
+        surviving_envs: list[Env] = []
+        errors: list[RolloutError] = []
+        retries_remaining = self.max_retries
+        pending: set[asyncio.Task[Trajectory]] = set(task_to_env.keys())
+
+        while pending:
+            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                try:
+                    traj = task.result()
+                    trajectories.append(traj)
+                    surviving_envs.append(task_to_env[task])
+                except (asyncio.CancelledError, KeyboardInterrupt):
+                    # Never swallow cancellation — cancel remaining and propagate
+                    for t in pending:
+                        t.cancel()
+                    await asyncio.gather(*pending, return_exceptions=True)
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "Trajectory failed (%s): %s (retries_remaining=%d)",
+                        type(exc).__name__,
+                        exc,
+                        retries_remaining,
+                    )
+                    errors.append(
+                        RolloutError(
+                            error_type=type(exc).__name__,
+                            error_message=str(exc),
+                        )
+                    )
+                    if retries_remaining > 0:
+                        retries_remaining -= 1
+                        # Create a fresh env for retry.
+                        # Note: make_envs() creates a full group but we only need one.
+                        # The extras are cheap Python objects for most envs; for sandbox
+                        # envs the unused containers get GC'd.
+                        new_envs = await env_group_builder.make_envs()
+                        new_env = new_envs[0]
+                        new_task = asyncio.create_task(do_single_rollout(policy, new_env))
+                        task_to_env[new_task] = new_env
+                        pending.add(new_task)
+                    else:
+                        # Budget exhausted — cancel remaining and re-raise.
+                        # This avoids partial-group bias from training on an
+                        # incomplete group of trajectories.
+                        logger.error(
+                            "Retry budget exhausted (%d retries), cancelling remaining tasks",
+                            self.max_retries,
+                        )
+                        for t in pending:
+                            t.cancel()
+                        await asyncio.gather(*pending, return_exceptions=True)
+                        raise exc
+
+        return RolloutResult(
+            trajectories=trajectories,
+            envs=surviving_envs,
+            errors=errors,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config mapping
+# ---------------------------------------------------------------------------
+
+
+def rollout_strategy_from_config(
+    rollout_error_tolerance: bool | RolloutStrategy,
+) -> RolloutStrategy:
+    """Convert a ``Config.rollout_error_tolerance`` value to a :class:`RolloutStrategy`.
+
+    - ``False`` -> :class:`FailFast` (crash on any error, the default)
+    - ``True``  -> :class:`RetryOnFailure` with default ``max_retries=3``
+    - A :class:`RolloutStrategy` instance -> passed through as-is
+    """
+    if isinstance(rollout_error_tolerance, RolloutStrategy):
+        return rollout_error_tolerance
+    if rollout_error_tolerance is False:
+        return FailFast()
+    if rollout_error_tolerance is True:
+        return RetryOnFailure()
+    raise ConfigurationError(f"Invalid rollout_error_tolerance value: {rollout_error_tolerance!r}")

--- a/tinker_cookbook/rl/rollouts.py
+++ b/tinker_cookbook/rl/rollouts.py
@@ -1,14 +1,17 @@
 import asyncio
+import logging
 import numbers
-from collections.abc import Sequence
+from collections import Counter
 from concurrent.futures import Executor
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import tinker
 
 from tinker_cookbook.completers import TinkerTokenCompleter, TokenCompleter
+from tinker_cookbook.exceptions import AllTrajectoriesFailedError
+from tinker_cookbook.rl.rollout_strategy import FailFast, RolloutStrategy
 from tinker_cookbook.rl.types import (
     Env,
     EnvGroupBuilder,
@@ -18,6 +21,39 @@ from tinker_cookbook.rl.types import (
 )
 from tinker_cookbook.utils import logtree, trace
 from tinker_cookbook.utils.misc_utils import all_same
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RolloutErrorCounter:
+    """Accumulates rollout error counts from :class:`TrajectoryGroup` results.
+
+    Lives in the main event loop only — never crosses thread/process boundaries.
+    Error information reaches the counter via :attr:`TrajectoryGroup.rollout_errors`,
+    which is embedded in the return value (pickleable, safe for any executor).
+    """
+
+    _counts: Counter[str] = field(default_factory=Counter)
+    _groups_skipped: int = 0
+
+    def ingest(self, result: TrajectoryGroup | None) -> None:
+        """Absorb error info from a single rollout result."""
+        if result is None:
+            self._groups_skipped += 1
+            return
+        for err in result.rollout_errors:
+            self._counts[err.error_type] += 1
+
+    def get_metrics(self, prefix: str = "rollout_errors") -> dict[str, float]:
+        """Return cumulative error metrics (monotonically increasing)."""
+        out: dict[str, float] = {}
+        if self._counts or self._groups_skipped > 0:
+            for k, v in self._counts.items():
+                out[f"{prefix}/{k}"] = float(v)
+            out[f"{prefix}/total"] = float(sum(self._counts.values()))
+            out[f"{prefix}/groups_skipped"] = float(self._groups_skipped)
+        return out
 
 
 def _log_transition_logs(logs: dict[str, Any]) -> None:
@@ -106,25 +142,38 @@ async def do_single_rollout(policy: TokenCompleter, env: Env) -> Trajectory:
 
 @logtree.scope_header_decorator("Group Rollout")
 async def do_group_rollout(
-    env_group_builder: EnvGroupBuilder, policy: TokenCompleter
+    env_group_builder: EnvGroupBuilder,
+    policy: TokenCompleter,
+    strategy: RolloutStrategy | None = None,
 ) -> TrajectoryGroup:
-    envs_G: Sequence[Env] = await env_group_builder.make_envs()
-    trajectories_G = await asyncio.gather(*[do_single_rollout(policy, env) for env in envs_G])
+    """Run rollouts for all environments in a group and compute group rewards.
+
+    Args:
+        strategy: Controls how trajectories are collected (error handling,
+            retries, etc.).  Defaults to :class:`FailFast` which preserves
+            the original fail-on-any-error behaviour.
+    """
+    if strategy is None:
+        strategy = FailFast()
+
+    result = await strategy.execute(env_group_builder, policy)
 
     async with trace.scope_span("compute_group_rewards"):
         rewards_and_metrics_G = await env_group_builder.compute_group_rewards(
-            trajectories_G, envs_G
+            result.trajectories, result.envs
         )
     rewards_G, metrics_G = zip(*rewards_and_metrics_G, strict=True)
 
     with logtree.scope_header("Trajectory Details"):
         for traj_idx, (traj, final_reward) in enumerate(
-            zip(trajectories_G, rewards_G, strict=True)
+            zip(result.trajectories, rewards_G, strict=True)
         ):
             with logtree.scope_header(f"Trajectory {traj_idx} Episode"):
                 _log_single_trajectory_details(traj, final_reward)
 
-    return TrajectoryGroup(trajectories_G, list(rewards_G), list(metrics_G))
+    return TrajectoryGroup(
+        result.trajectories, list(rewards_G), list(metrics_G), rollout_errors=result.errors
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +213,7 @@ class _RolloutTask:
     temperature: float
     remove_constant_reward_groups: bool
     enable_logging: bool
+    strategy: RolloutStrategy = field(default_factory=FailFast)
 
 
 def _run_rollout_sync(task: _RolloutTask) -> TrajectoryGroup | None:
@@ -180,6 +230,7 @@ def _run_rollout_sync(task: _RolloutTask) -> TrajectoryGroup | None:
             task.temperature,
             task.remove_constant_reward_groups,
             task.enable_logging,
+            strategy=task.strategy,
         )
     )
 
@@ -192,6 +243,7 @@ async def do_group_rollout_and_filter_constant_reward(
     temperature: float,
     do_remove_constant_reward_groups: bool,
     enable_logging: bool = True,
+    strategy: RolloutStrategy | None = None,
 ) -> TrajectoryGroup | None:
     """Run a group rollout, optionally dispatching to an external executor.
 
@@ -199,7 +251,14 @@ async def do_group_rollout_and_filter_constant_reward(
     bundled into a pickleable ``_RolloutTask`` and dispatched via
     ``loop.run_in_executor()``. Otherwise, runs as an asyncio coroutine
     in the current process (zero overhead).
+
+    Args:
+        strategy: Controls how trajectories are collected within the group
+            (error handling, retries, etc.).  Defaults to :class:`FailFast`.
     """
+    if strategy is None:
+        strategy = FailFast()
+
     executor = get_rollout_executor()
     if executor is not None:
         task = _RolloutTask(
@@ -209,6 +268,7 @@ async def do_group_rollout_and_filter_constant_reward(
             temperature=temperature,
             remove_constant_reward_groups=do_remove_constant_reward_groups,
             enable_logging=enable_logging,
+            strategy=strategy,
         )
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(executor, _run_rollout_sync, task)
@@ -220,6 +280,7 @@ async def do_group_rollout_and_filter_constant_reward(
         temperature,
         do_remove_constant_reward_groups,
         enable_logging,
+        strategy=strategy,
     )
 
 
@@ -230,14 +291,31 @@ async def _do_group_rollout_and_filter_constant_reward_impl(
     temperature: float,
     do_remove_constant_reward_groups: bool,
     enable_logging: bool = True,
+    strategy: RolloutStrategy | None = None,
 ) -> TrajectoryGroup | None:
+    if strategy is None:
+        strategy = FailFast()
+
     policy = TinkerTokenCompleter(sampling_client, max_tokens=max_tokens, temperature=temperature)
 
-    with logtree.optional_enable_logging(enable_logging):
-        trajectory_group = await do_group_rollout(env_group_builder, policy)
+    try:
+        with logtree.optional_enable_logging(enable_logging):
+            trajectory_group = await do_group_rollout(
+                env_group_builder,
+                policy,
+                strategy=strategy,
+            )
+    except AllTrajectoriesFailedError as e:
+        # All retries exhausted — already logged per-trajectory inside the strategy
+        logger.warning(str(e))
+        return None
+    except Exception as e:
+        if not strategy.catches_group_errors:
+            raise
+        logger.warning(f"Rollout error ({type(e).__name__}), skipping group: {e}")
+        return None
 
     # Remove if all trajectories have the same reward
     if do_remove_constant_reward_groups and all_same(trajectory_group.get_total_rewards()):
         return None
-    else:
-        return trajectory_group
+    return trajectory_group

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -45,7 +45,12 @@ from tinker_cookbook.rl.rollout_logging import (
     rollout_summaries_jsonl_path,
     write_rollout_summaries_jsonl_from_groups,
 )
+from tinker_cookbook.rl.rollout_strategy import (
+    RolloutStrategy,
+    rollout_strategy_from_config,
+)
 from tinker_cookbook.rl.rollouts import (
+    RolloutErrorCounter,
     do_group_rollout,  # noqa: F401 — re-exported for verifiers monkey-patching
     do_group_rollout_and_filter_constant_reward,
     set_rollout_executor,
@@ -401,6 +406,11 @@ class Config:
     compute_post_kl: bool = False
     # Remove groups where all trajectories have identical reward.
     remove_constant_reward_groups: bool = False
+    # Tolerance for errors during rollouts (container crashes, sandbox flakes, etc.).
+    # False (default): crash on any error (FailFast).
+    # True: retry failed trajectories with default budget (RetryOnFailure(max_retries=3)).
+    # RolloutStrategy instance: custom strategy (e.g. RetryOnFailure(max_retries=5)).
+    rollout_error_tolerance: bool | RolloutStrategy = False
     # Emit async trace events for debugging/profiling.
     enable_trace: bool = False
     # Save a Gantt chart HTML every N iterations (0 = disabled). Requires plotly.
@@ -508,6 +518,8 @@ async def do_sync_training_with_stream_minibatch(
     dataset: RLDataset,
     ml_logger: ml_log.Logger,
     tokenizer: Tokenizer,
+    error_counter: RolloutErrorCounter | None = None,
+    strategy: RolloutStrategy | None = None,
 ):
     """
     Implements fully synchronous on-policy training with minibatch streaming.
@@ -560,8 +572,12 @@ async def do_sync_training_with_stream_minibatch(
                     temperature=cfg.temperature,
                     do_remove_constant_reward_groups=cfg.remove_constant_reward_groups,
                     enable_logging=enable_logging,
+                    strategy=strategy,
                 )
                 metrics["time/trajectory_group_worker_loop/total"] = time.time() - t_start
+                # Ingest error info (safe: same event loop thread)
+                if error_counter is not None:
+                    error_counter.ingest(trajectory_group)
                 if trajectory_group is not None:
                     trajectory_groups_queue.put_nowait(
                         WrappedTrajectoryGroup(
@@ -616,6 +632,8 @@ async def do_sync_training_with_stream_minibatch(
 
         # Log metrics
         metrics.update(full_batch_metrics)
+        if error_counter is not None:
+            metrics.update(error_counter.get_metrics())
         metrics["time/total"] = time.time() - t_start
         ml_logger.log_metrics(metrics, step=i_batch)
 
@@ -673,6 +691,8 @@ async def do_async_training(
     dataset: RLDataset,
     ml_logger: ml_log.Logger,
     tokenizer: Tokenizer,
+    error_counter: RolloutErrorCounter | None = None,
+    strategy: RolloutStrategy | None = None,
 ):
     """Implements async off-policy training, capped at K steps off policy."""
     assert cfg.async_config is not None
@@ -751,7 +771,11 @@ async def do_async_training(
                 max_tokens=cfg.max_tokens,
                 temperature=cfg.temperature,
                 do_remove_constant_reward_groups=cfg.remove_constant_reward_groups,
+                strategy=strategy,
             )
+            # Ingest error info (safe: same event loop thread)
+            if error_counter is not None:
+                error_counter.ingest(trajectory_group)
             if trajectory_group is None:
                 trajectory_groups_queue.put_nowait(None)
             else:
@@ -925,6 +949,8 @@ async def do_async_training(
 
             # Log metrics
             metrics.update(train_step_metrics)
+            if error_counter is not None:
+                metrics.update(error_counter.get_metrics())
             metrics["time/training_loop/total"] = time.time() - t_start
             ml_logger.log_metrics(metrics, step=i_batch)
             i_batch += 1
@@ -1274,6 +1300,8 @@ async def do_sync_training(
     dataset: RLDataset,
     ml_logger: ml_log.Logger,
     tokenizer: Tokenizer,
+    error_counter: RolloutErrorCounter | None = None,
+    strategy: RolloutStrategy | None = None,
 ):
     """Implements fully synchronous on-policy training"""
     # Initial sampling client
@@ -1282,7 +1310,7 @@ async def do_sync_training(
     )
 
     for i_batch in range(start_batch, end_batch):
-        metrics = {
+        metrics: dict[str, Any] = {
             "progress/batch": i_batch,
             "optim/lr": cfg.learning_rate,
             "progress/done_frac": (i_batch + 1) / num_batches,
@@ -1308,7 +1336,7 @@ async def do_sync_training(
             ):
                 # Note: do_remove_constant_reward_groups=False here because we remove
                 # constant reward groups after all rollouts are collected (below)
-                trajectory_groups_P = await gather_with_progress(
+                results_P = await gather_with_progress(
                     (
                         do_group_rollout_and_filter_constant_reward(
                             sampling_client,
@@ -1317,46 +1345,67 @@ async def do_sync_training(
                             temperature=cfg.temperature,
                             do_remove_constant_reward_groups=False,
                             enable_logging=i < cfg.num_groups_to_log,
+                            strategy=strategy,
                         )
                         for i, builder in enumerate(env_group_builders_P)
                     ),
                     desc=f"Sampling batch {i_batch}",
                 )
 
-            _maybe_export_rollout_summary_jsonl(
-                cfg=cfg,
-                file_prefix=f"train_iteration_{i_batch:06d}",
-                split="train",
-                iteration=i_batch,
-                groups_P=[
-                    RolloutSummaryGroup(
-                        trajectory_group=trajectory_group,
-                        tags=env_group_builder.logging_tags(),
-                        sampling_client_step=i_batch,
-                    )
-                    for env_group_builder, trajectory_group in safezip(
-                        env_group_builders_P, trajectory_groups_P
-                    )
-                ],
-            )
+            # Ingest error info from results
+            if error_counter is not None:
+                for result in results_P:
+                    error_counter.ingest(result)
 
-            if cfg.remove_constant_reward_groups:
-                trajectory_groups_P = remove_constant_reward_groups(trajectory_groups_P)
+            # Filter out None results (from errored or fully-failed groups)
+            successful = [
+                (builder, tg)
+                for builder, tg in safezip(env_group_builders_P, results_P)
+                if tg is not None
+            ]
+            batch_skipped = not successful
+            if batch_skipped:
+                logger.warning(f"Batch {i_batch}: all groups failed or filtered, skipping batch")
+            else:
+                env_group_builders_P = [s[0] for s in successful]
+                trajectory_groups_P: list[TrajectoryGroup] = [s[1] for s in successful]
 
-            # Train step
-            sampling_client, train_step_metrics = await do_train_step_and_get_sampling_client(
-                cfg,
-                i_batch,
-                training_client,
-                kl_reference_client,
-                tokenizer,
-                env_group_builders_P,
-                trajectory_groups_P,
-            )
+                _maybe_export_rollout_summary_jsonl(
+                    cfg=cfg,
+                    file_prefix=f"train_iteration_{i_batch:06d}",
+                    split="train",
+                    iteration=i_batch,
+                    groups_P=[
+                        RolloutSummaryGroup(
+                            trajectory_group=trajectory_group,
+                            tags=env_group_builder.logging_tags(),
+                            sampling_client_step=i_batch,
+                        )
+                        for env_group_builder, trajectory_group in safezip(
+                            env_group_builders_P, trajectory_groups_P
+                        )
+                    ],
+                )
 
-            metrics.update(train_step_metrics)
+                if cfg.remove_constant_reward_groups:
+                    trajectory_groups_P = remove_constant_reward_groups(trajectory_groups_P)
+
+                # Train step
+                sampling_client, train_step_metrics = await do_train_step_and_get_sampling_client(
+                    cfg,
+                    i_batch,
+                    training_client,
+                    kl_reference_client,
+                    tokenizer,
+                    env_group_builders_P,
+                    trajectory_groups_P,
+                )
+
+                metrics.update(train_step_metrics)
 
         metrics.update(window.get_timing_metrics())
+        if error_counter is not None:
+            metrics.update(error_counter.get_metrics())
         window.write_spans_jsonl(Path(cfg.log_path) / "timing_spans.jsonl", step=i_batch)
         if cfg.span_chart_every > 0 and i_batch % cfg.span_chart_every == 0:
             trace.save_gantt_chart_html(
@@ -1445,9 +1494,19 @@ async def main(
 
     # Create dataset from thunk
     dataset, maybe_test_dataset = await cfg.dataset_builder()
+    # Build rollout strategy and error counter from config
+    strategy = rollout_strategy_from_config(cfg.rollout_error_tolerance)
+    error_counter = RolloutErrorCounter() if strategy.catches_group_errors else None
+
     evaluators = [evaluator() for evaluator in cfg.evaluator_builders]
     if maybe_test_dataset is not None:
-        evaluators.append(RLTestSetEvaluator(maybe_test_dataset, max_tokens=cfg.max_tokens))
+        evaluators.append(
+            RLTestSetEvaluator(
+                maybe_test_dataset,
+                max_tokens=cfg.max_tokens,
+                strategy=strategy,
+            )
+        )
 
     num_batches = len(dataset)
     end_batch = min(cfg.max_steps, num_batches) if cfg.max_steps is not None else num_batches
@@ -1484,6 +1543,8 @@ async def main(
         dataset=dataset,
         ml_logger=ml_logger,
         tokenizer=tokenizer,
+        error_counter=error_counter,
+        strategy=strategy,
     )
 
     # Save final checkpoint

--- a/tinker_cookbook/rl/types.py
+++ b/tinker_cookbook/rl/types.py
@@ -82,6 +82,21 @@ class Trajectory:
     final_ob: Observation
 
 
+@dataclass(frozen=True)
+class RolloutError:
+    """A captured error from a failed trajectory rollout.
+
+    Stored on :class:`TrajectoryGroup` so error information flows through
+    return values (including across process boundaries via pickle) without
+    requiring shared mutable state.
+    """
+
+    error_type: str
+    """The exception class name, e.g. ``'BadRequestError'``."""
+    error_message: str
+    """``str(exception)`` — the human-readable error description."""
+
+
 class EnvGroupBuilder(ABC):
     """
     Builds a group of environments. The group will be used in the following way:
@@ -146,6 +161,10 @@ class TrajectoryGroup:
     trajectories_G: list[Trajectory]
     final_rewards_G: list[float]  # computed by the EnvGroupBuilder, looking at whole group
     metrics_G: list[Metrics]
+
+    # Error tracking — populated by do_group_rollout when using error-tolerant strategies.
+    # Empty list means no trajectory errors occurred.
+    rollout_errors: list[RolloutError] = field(default_factory=list)
 
     def get_total_rewards(self) -> list[float]:
         """


### PR DESCRIPTION
## Problem

During RL training, per-trajectory errors (container crashes, sandbox flakes, transient API failures) crash the entire training run. There's no error tolerance or retry mechanism in the rollout pipeline.

## Solution

A pluggable `RolloutStrategy` abstraction that controls how trajectories are collected within a group, with a built-in retry strategy for env-level failures.

### Design Rationale

Per joschu's feedback: skipping failed trajectories causes bias that is hard to reason about in RL training. Instead, **failed trajectories should be retried with fresh environments**. When the retry budget is exhausted, the group fails entirely (cancel remaining + re-raise) to avoid partial-group bias from training on an incomplete set of trajectories. Context overflow issues should be handled at the env level (separate concern, not in scope here).

Per kennyyu's suggestion: the rollout collection logic should be a pluggable strategy interface, since there are many possible approaches (retry, over-provisioning, variance-based collection, etc.).

### Config

```python
# Tolerance for errors during rollouts (container crashes, sandbox flakes, etc.).
# False (default): crash on any error (FailFast).
# True: retry failed trajectories with default budget (RetryOnFailure(max_retries=3)).
# RolloutStrategy instance: custom strategy (e.g. RetryOnFailure(max_retries=5)).
rollout_error_tolerance: bool | RolloutStrategy = False
```

### RolloutStrategy

Pluggable strategy for trajectory collection (`rl/rollout_strategy.py`):

```python
class RolloutStrategy(ABC):
    @property
    def catches_group_errors(self) -> bool: ...
    @abstractmethod
    async def execute(self, env_group_builder, policy) -> RolloutResult: ...
```

The strategy owns the full trajectory collection lifecycle including env creation (via `make_envs()`), so strategies like retry can create fresh envs as needed. Group reward computation and logging remain in `do_group_rollout`.

**Built-in strategies:**
- `FailFast` — original `asyncio.gather(...)` behavior, any error crashes
- `RetryOnFailure(max_retries=3)` — retry failed trajectories with fresh environments using `asyncio.wait(FIRST_COMPLETED)`. Retries start immediately when a failure is detected. When retry budget is exhausted, cancels remaining tasks and re-raises to avoid partial-group bias.

### Error Tracking

- `TrajectoryGroup.rollout_errors: list[RolloutError]` — carries error info through return values (pickle-safe, works across ProcessPoolExecutor/Ray)
- `RolloutErrorCounter` — aggregates in the main event loop only, no shared mutable state
- Cumulative metrics per batch: `rollout_errors/total`, `rollout_errors/{ErrorType}`, `rollout_errors/groups_skipped`

## Scope

This PR handles **env-level failures** (container crashes, sandbox flakes, transient errors) where retrying the trajectory with a fresh environment is appropriate.

**Not in scope:** Context overflow from `prompt + max_tokens > context_window`. Per joschu's feedback, this should be handled at the env level by terminating the episode before exceeding the context limit — not by catching the error after the fact. That fix belongs in a separate PR.

## Files Changed

| File | Changes |
|------|---------|
| `tinker_cookbook/rl/rollout_strategy.py` | **New.** `RolloutStrategy` ABC, `FailFast`, `RetryOnFailure`, config mapping. |
| `tinker_cookbook/rl/types.py` | `RolloutError` dataclass, `rollout_errors` field on `TrajectoryGroup`. |
| `tinker_cookbook/rl/rollouts.py` | `do_group_rollout` delegates to strategy. `RolloutErrorCounter`. |
| `tinker_cookbook/rl/train.py` | Config: `rollout_error_tolerance`. Strategy + counter threaded to all 3 training modes. |
| `tinker_cookbook/rl/metric_util.py` | `RLTestSetEvaluator` accepts strategy, uses `RolloutErrorCounter`. |
| `tinker_cookbook/exceptions.py` | `AllTrajectoriesFailedError` as `TrainingError` subclass. |
| `tinker_cookbook/__init__.py` | Re-export. |
| `tinker_cookbook/recipes/code_rl/train.py` | `rollout_max_retries` CLI field. |
| `tinker_cookbook/rl/rollout_error_resilience_test.py` | **New.** 31 tests. |

## Backward Compatibility

All changes are backward compatible — default behavior is identical to pre-PR:

- `rollout_error_tolerance=False` (default) produces `FailFast` which executes the exact same `asyncio.gather(*[do_single_rollout(...)])` code path as before
- All function signatures add optional params with defaults (`strategy=None`, `error_counter=None`)
- `TrajectoryGroup.rollout_errors` field has `default_factory=list` — existing positional construction unaffected
- `Config` new field has default `False` — all 5 recipes use keyword construction, unaffected
- Distillation module calls `do_group_rollout_and_filter_constant_reward` and `RLTestSetEvaluator` without new kwargs — defaults apply
- Verifiers recipe monkey-patch pattern is pre-existing and unaffected

## Distributed / Multiprocess Safety

- `FailFast` and `RetryOnFailure` are `@dataclass(frozen=True)` with primitive fields — trivially pickleable for `ProcessPoolExecutor`/Ray dispatch via `_RolloutTask`
- `RetryOnFailure` uses `asyncio.create_task` + `asyncio.wait(FIRST_COMPLETED)` which works in the fresh event loop created by `asyncio.run()` in worker processes
- `RolloutErrorCounter` lives only in the main event loop — error info flows back via `TrajectoryGroup.rollout_errors` (pickle-safe return values)
- All three training modes (sync, async, stream minibatch) correctly handle `None` results from error tolerance

## Test plan

- [x] 31 new unit tests (strategies, retry behavior, budget exhaustion, cancellation, pickling, config mapping, error counter, make_envs failure)
- [x] All existing tests pass (758 unit)
- [x] pyright clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
