### PR TITLE
Fix stream minibatch test to use renamed CLIConfig field

### DIFF
--- a/tests/recipes/test_recipe_math_rl.py
+++ b/tests/recipes/test_recipe_math_rl.py
@@ -43,7 +43,8 @@ def test_math_rl_stream_minibatch():
             "groups_per_batch=8",
             "group_size=4",
             "max_tokens=5",
-            "stream_minibatch=true",
+            "stream_minibatch_config.groups_per_batch=8",
+            "stream_minibatch_config.num_minibatches=2",
             "behavior_if_log_dir_exists=delete",
         ],
     )


### PR DESCRIPTION
## Summary
- Fix `test_math_rl_stream_minibatch` nightly CI failure caused by stale CLI argument name
- Commit `5a23578` renamed `stream_minibatch: bool` to `stream_minibatch_config: StreamMinibatchConfig | None` in `CLIConfig` but didn't update the test
- Update test to use chz nested config syntax (`stream_minibatch_config.groups_per_batch=8`, `stream_minibatch_config.num_minibatches=2`)

## Test plan
- [x] Nightly CI `test_recipe_math_rl` job passes: https://github.com/YujiaBao/tinker-cookbook/actions/runs/23311149054

🤖 Generated with [Claude Code](https://claude.com/claude-code)