### PR TITLE
Warn when renderer is not recommended for the model

### DIFF
--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -14,7 +14,7 @@ import tinker
 import torch
 from tinker.types import LossFnType
 
-from tinker_cookbook import checkpoint_utils
+from tinker_cookbook import checkpoint_utils, model_info
 from tinker_cookbook.display import colorize_example
 from tinker_cookbook.distillation.datasets import (
     CompositeDataset,
@@ -401,6 +401,7 @@ async def main(
     if wandb_link := ml_logger.get_logger_url():
         user_metadata["wandb_link"] = wandb_link
     checkpoint_utils.add_renderer_name_to_user_metadata(user_metadata, cfg.renderer_name)
+    model_info.warn_if_renderer_not_recommended(cfg.model_name, cfg.renderer_name)
 
     if resume_info:
         # Resuming interrupted training - load optimizer state for proper continuation

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -2,10 +2,15 @@
 This module associates model names with metadata, which helps  training code choose good defaults.
 """
 
+from __future__ import annotations
+
+import logging
 from dataclasses import dataclass
 from functools import cache
 
 from tinker_cookbook.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
 
 # Common renderer tuples, defined once to reduce repetition.
 # Tuples (not lists) because these are shared across ModelAttributes instances
@@ -156,3 +161,29 @@ def get_recommended_renderer_name(model_name: str) -> str:
     Return the most recommended renderer for the model.
     """
     return get_recommended_renderer_names(model_name)[0]
+
+
+def warn_if_renderer_not_recommended(model_name: str, renderer_name: str | None) -> None:
+    """
+    Log a warning if ``renderer_name`` is not in the recommended list for ``model_name``.
+
+    Silently returns if ``renderer_name`` is None (caller is using the default) or if
+    ``model_name`` is not in the model registry.
+    """
+    if renderer_name is None:
+        return
+    try:
+        recommended = get_recommended_renderer_names(model_name)
+    except (ConfigurationError, KeyError, ValueError):
+        # Unknown model — nothing to validate against.
+        return
+    if renderer_name not in recommended:
+        logger.warning(
+            "Renderer %r is not recommended for model %r. "
+            "Recommended renderer(s): %s. "
+            "Using an incompatible renderer can silently degrade training quality "
+            "(e.g., prefilling tokens the model was never trained on).",
+            renderer_name,
+            model_name,
+            ", ".join(repr(r) for r in recommended),
+        )

--- a/tinker_cookbook/model_info_test.py
+++ b/tinker_cookbook/model_info_test.py
@@ -1,0 +1,45 @@
+import logging
+
+import pytest
+
+from tinker_cookbook.model_info import warn_if_renderer_not_recommended
+
+
+class TestWarnIfRendererNotRecommended:
+    def test_no_warning_when_renderer_is_none(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            warn_if_renderer_not_recommended("Qwen/Qwen3-4B-Instruct-2507", None)
+        assert caplog.text == ""
+
+    def test_no_warning_when_renderer_is_recommended(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            warn_if_renderer_not_recommended("Qwen/Qwen3-4B-Instruct-2507", "qwen3_instruct")
+        assert caplog.text == ""
+
+    def test_warning_when_renderer_not_recommended(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            warn_if_renderer_not_recommended(
+                "Qwen/Qwen3-4B-Instruct-2507", "qwen3_disable_thinking"
+            )
+        assert "not recommended" in caplog.text
+        assert "qwen3_disable_thinking" in caplog.text
+        assert "qwen3_instruct" in caplog.text
+
+    def test_no_warning_for_unknown_model(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING):
+            warn_if_renderer_not_recommended("unknown/model", "qwen3")
+        assert caplog.text == ""
+
+    def test_warning_for_thinking_renderer_on_thinking_model_alt(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """qwen3_disable_thinking is valid for Qwen3-8B (a thinking model)."""
+        with caplog.at_level(logging.WARNING):
+            warn_if_renderer_not_recommended("Qwen/Qwen3-8B", "qwen3_disable_thinking")
+        assert caplog.text == ""
+
+    def test_warning_for_wrong_family(self, caplog: pytest.LogCaptureFixture):
+        """llama3 renderer is not recommended for a Qwen model."""
+        with caplog.at_level(logging.WARNING):
+            warn_if_renderer_not_recommended("Qwen/Qwen3-8B", "llama3")
+        assert "not recommended" in caplog.text

--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -12,7 +12,7 @@ import tinker
 import torch
 import torch.nn.functional as F
 
-from tinker_cookbook import checkpoint_utils
+from tinker_cookbook import checkpoint_utils, model_info
 from tinker_cookbook.eval.evaluators import Evaluator, EvaluatorBuilder
 from tinker_cookbook.supervised.train import run_evals
 from tinker_cookbook.supervised.types import ChatDatasetBuilder, SupervisedDataset
@@ -373,6 +373,7 @@ def main(config: Config):
     if wandb_link := ml_logger.get_logger_url():
         user_metadata["wandb_link"] = wandb_link
     checkpoint_utils.add_renderer_name_to_user_metadata(user_metadata, config.renderer_name)
+    model_info.warn_if_renderer_not_recommended(config.model_name, config.renderer_name)
     training_client, reference_client = create_dpo_clients(config, resume_info, user_metadata)
     tokenizer = get_tokenizer(config.model_name)
 

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -23,7 +23,7 @@ import torch
 from tinker.types import LossFnType
 from tqdm import tqdm
 
-from tinker_cookbook import checkpoint_utils
+from tinker_cookbook import checkpoint_utils, model_info
 from tinker_cookbook.display import colorize_example
 from tinker_cookbook.eval.evaluators import SamplingClientEvaluator, SamplingClientEvaluatorBuilder
 from tinker_cookbook.exceptions import ConfigurationError
@@ -1414,6 +1414,7 @@ async def main(
     if wandb_link := ml_logger.get_logger_url():
         user_metadata["wandb_link"] = wandb_link
     checkpoint_utils.add_renderer_name_to_user_metadata(user_metadata, cfg.renderer_name)
+    model_info.warn_if_renderer_not_recommended(cfg.model_name, cfg.renderer_name)
 
     if resume_info:
         # Resuming interrupted training - load optimizer state for proper continuation

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -16,7 +16,7 @@ import chz
 import tinker
 from tinker.lib.public_interfaces import APIFuture
 
-from tinker_cookbook import checkpoint_utils
+from tinker_cookbook import checkpoint_utils, model_info
 from tinker_cookbook.display import colorize_example
 from tinker_cookbook.eval.evaluators import (
     Evaluator,
@@ -198,6 +198,7 @@ async def main(config: Config):
     if wandb_link := ml_logger.get_logger_url():
         user_metadata["wandb_link"] = wandb_link
     checkpoint_utils.add_renderer_name_to_user_metadata(user_metadata, config.renderer_name)
+    model_info.warn_if_renderer_not_recommended(config.model_name, config.renderer_name)
 
     if resume_info:
         # Resuming interrupted training - load optimizer state for proper continuation


### PR DESCRIPTION
## Summary
- Add `warn_if_renderer_not_recommended()` to `model_info.py` that logs a warning when a user-specified renderer is not in the model's recommended list
- Call it at training startup in all 4 entry points: SL, RL, DPO, and distillation
- Add unit tests covering recommended, non-recommended, unknown model, and cross-family cases

Motivated by a user passing `renderer_name=qwen3_disable_thinking` to `Qwen3-4B-Instruct-2507` (a non-thinking model), which prefills `<think>\n\n</think>\n\n` tokens the model was never trained on, silently collapsing advantages to 0.

## Test plan
- [x] 6 new unit tests in `model_info_test.py` all pass
- [x] Existing `test_model_info.py` downstream compat tests still pass
- [x] Verify warning appears in training logs when using a mismatched renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)