### PR TITLE
Skip inspect_ai tests when not installed

### DIFF
--- a/tests/test_inspect_eval.py
+++ b/tests/test_inspect_eval.py
@@ -14,6 +14,9 @@ Test matrix:
 import asyncio
 
 import pytest
+
+pytest.importorskip("inspect_ai")
+
 import tinker
 from inspect_ai.model import ChatMessage as InspectAIChatMessage
 from inspect_ai.model import ChatMessageUser as InspectAIChatMessageUser

--- a/tinker_cookbook/eval/inspect_utils_test.py
+++ b/tinker_cookbook/eval/inspect_utils_test.py
@@ -1,5 +1,9 @@
 """Tests for inspect_utils conversion functions."""
 
+import pytest
+
+pytest.importorskip("inspect_ai")
+
 from inspect_ai.model import ChatMessage as InspectAIChatMessage
 from inspect_ai.model import ChatMessageAssistant as InspectAIChatMessageAssistant
 from inspect_ai.model import ChatMessageUser as InspectAIChatMessageUser


### PR DESCRIPTION
## Summary
- `inspect_ai` is an optional dependency (under `[inspect]` extra), but test files importing it have no guard
- Added `pytest.importorskip("inspect_ai")` to both `tinker_cookbook/eval/inspect_utils_test.py` and `tests/test_inspect_eval.py` so they are skipped gracefully instead of crashing at collection time

## Test plan
- [x] Run `pytest tinker_cookbook/eval/inspect_utils_test.py` without `inspect_ai` installed — should show SKIPPED
- [x] Run `pytest tinker_cookbook/eval/inspect_utils_test.py` with `inspect_ai` installed — tests should pass as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)