### PR TITLE
Handle checkpoint save 409 conflicts with idempotent local recovery fix checkpoint conflict

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -326,6 +326,72 @@ def get_last_checkpoint(log_dir: str, required_key: str = "state_path") -> Check
         return None
 
 
+def _find_last_checkpoint_by_name(log_dir: str, name: str) -> CheckpointRecord | None:
+    """Return the most recent checkpoint record with the given name."""
+    checkpoints = load_checkpoints_file(log_dir)
+    for checkpoint in reversed(checkpoints):
+        if checkpoint.name == name:
+            return checkpoint
+    return None
+
+
+def _recover_path_from_conflict(
+    *,
+    log_path: str,
+    checkpoint_name: str,
+    path_key: Literal["state_path", "sampler_path"],
+) -> str | None:
+    """Recover existing checkpoint path from local records after a 409 conflict."""
+    existing = _find_last_checkpoint_by_name(log_path, checkpoint_name)
+    if existing is None:
+        return None
+    recovered_path = existing.get(path_key)
+    if isinstance(recovered_path, str):
+        return recovered_path
+    return None
+
+
+async def _save_one_kind_with_conflict_recovery(
+    *,
+    training_client: tinker.TrainingClient,
+    checkpoint_name: str,
+    ttl_seconds: int | None,
+    log_path: str,
+    kind: Literal["state", "sampler"],
+) -> tuple[str, bool]:
+    """Save one checkpoint kind and recover idempotently from name conflicts."""
+    try:
+        if kind == "state":
+            response = await (
+                await training_client.save_state_async(checkpoint_name, ttl_seconds=ttl_seconds)
+            ).result_async()
+        else:
+            response = await (
+                await training_client.save_weights_for_sampler_async(
+                    checkpoint_name, ttl_seconds=ttl_seconds
+                )
+            ).result_async()
+        return response.path, False
+    except tinker.ConflictError:
+        path_key: Literal["state_path", "sampler_path"] = (
+            "state_path" if kind == "state" else "sampler_path"
+        )
+        recovered_path = _recover_path_from_conflict(
+            log_path=log_path,
+            checkpoint_name=checkpoint_name,
+            path_key=path_key,
+        )
+        if recovered_path is None:
+            raise
+        logger.warning(
+            "Checkpoint save conflict for %s '%s'; reusing existing %s from checkpoints.jsonl",
+            kind,
+            checkpoint_name,
+            path_key,
+        )
+        return recovered_path, True
+
+
 @trace.scope
 async def save_checkpoint_async(
     training_client: tinker.TrainingClient,
@@ -349,22 +415,44 @@ async def save_checkpoint_async(
     Returns:
         Dict mapping ``"state_path"`` and/or ``"sampler_path"`` to tinker:// paths.
     """
-    futures = {}
-    if kind in ["state", "both"]:
-        futures["state"] = await training_client.save_state_async(name, ttl_seconds=ttl_seconds)
-    if kind in ["sampler", "both"]:
-        futures["sampler"] = await training_client.save_weights_for_sampler_async(
-            name, ttl_seconds=ttl_seconds
-        )
+    paths: dict[str, str] = {}
+    recovered_from_conflict = False
 
-    results = {k: await v.result_async() for k, v in futures.items()}
-    paths = {k + "_path": v.path for k, v in results.items()}
+    if kind in ["state", "both"]:
+        state_path, state_recovered = await _save_one_kind_with_conflict_recovery(
+            training_client=training_client,
+            checkpoint_name=name,
+            ttl_seconds=ttl_seconds,
+            log_path=log_path,
+            kind="state",
+        )
+        paths["state_path"] = state_path
+        recovered_from_conflict = recovered_from_conflict or state_recovered
+
+    if kind in ["sampler", "both"]:
+        sampler_path, sampler_recovered = await _save_one_kind_with_conflict_recovery(
+            training_client=training_client,
+            checkpoint_name=name,
+            ttl_seconds=ttl_seconds,
+            log_path=log_path,
+            kind="sampler",
+        )
+        paths["sampler_path"] = sampler_path
+        recovered_from_conflict = recovered_from_conflict or sampler_recovered
+
     trace.update_scope_context(paths)
     logger.info(f"Saved checkpoints: {paths}")
 
     record = CheckpointRecord.from_dict({"name": name, **loop_state, **paths})
-    with open(Path(log_path) / "checkpoints.jsonl", "a") as f:
-        f.write(json.dumps(record.to_dict()) + "\n")
+    existing = _find_last_checkpoint_by_name(log_path, name)
+    if recovered_from_conflict and existing is not None and existing.to_dict() == record.to_dict():
+        logger.info(
+            "Skipping duplicate checkpoints.jsonl append for conflict-recovered checkpoint '%s'",
+            name,
+        )
+    else:
+        with open(Path(log_path) / "checkpoints.jsonl", "a") as f:
+            f.write(json.dumps(record.to_dict()) + "\n")
 
     return paths
 

--- a/tinker_cookbook/checkpoint_utils_test.py
+++ b/tinker_cookbook/checkpoint_utils_test.py
@@ -1,13 +1,16 @@
 """Tests for checkpoint_utils path handling."""
 
+import asyncio
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from tinker_cookbook.checkpoint_utils import (
     CheckpointRecord,
     get_last_checkpoint,
     load_checkpoints_file,
+    save_checkpoint_async,
 )
 
 
@@ -158,3 +161,101 @@ def test_checkpoint_record_extra_overlap_with_known_keys():
     # to_dict() should have batch=5, not 99
     d = record.to_dict()
     assert d["batch"] == 5
+
+
+class _FakeResponse:
+    def __init__(self, path: str):
+        self.path = path
+
+
+class _FakeFuture:
+    def __init__(self, response: _FakeResponse | None = None, error: Exception | None = None):
+        self._response = response
+        self._error = error
+
+    async def result_async(self):
+        if self._error is not None:
+            raise self._error
+        assert self._response is not None
+        return self._response
+
+
+class _FakeTrainingClient:
+    def __init__(
+        self,
+        *,
+        state_future: _FakeFuture | None = None,
+        sampler_future: _FakeFuture | None = None,
+    ):
+        self._state_future = state_future or _FakeFuture(_FakeResponse("tinker://state/new"))
+        self._sampler_future = sampler_future or _FakeFuture(_FakeResponse("tinker://sampler/new"))
+
+    async def save_state_async(self, name: str, ttl_seconds: int | None = None):
+        del name, ttl_seconds
+        return self._state_future
+
+    async def save_weights_for_sampler_async(self, name: str, ttl_seconds: int | None = None):
+        del name, ttl_seconds
+        return self._sampler_future
+
+
+def test_save_checkpoint_async_recovers_conflict_from_existing_state_record():
+    class FakeConflictError(Exception):
+        pass
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_checkpoints_jsonl(
+            tmpdir,
+            [
+                {
+                    "name": "000010",
+                    "batch": 10,
+                    "state_path": "tinker://state/existing",
+                }
+            ],
+        )
+        training_client = _FakeTrainingClient(
+            state_future=_FakeFuture(error=FakeConflictError("checkpoint already exists"))
+        )
+
+        with patch("tinker_cookbook.checkpoint_utils.tinker.ConflictError", FakeConflictError):
+            paths = asyncio.run(
+                save_checkpoint_async(
+                    training_client=training_client,  # type: ignore[arg-type]
+                    name="000010",
+                    log_path=tmpdir,
+                    loop_state={"batch": 10},
+                    kind="state",
+                )
+            )
+
+        assert paths == {"state_path": "tinker://state/existing"}
+        records = load_checkpoints_file(tmpdir)
+        assert len(records) == 1
+
+
+def test_save_checkpoint_async_conflict_without_local_record_raises():
+    class FakeConflictError(Exception):
+        pass
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        training_client = _FakeTrainingClient(
+            state_future=_FakeFuture(error=FakeConflictError("checkpoint already exists"))
+        )
+
+        with patch("tinker_cookbook.checkpoint_utils.tinker.ConflictError", FakeConflictError):
+            try:
+                asyncio.run(
+                    save_checkpoint_async(
+                        training_client=training_client,  # type: ignore[arg-type]
+                        name="000010",
+                        log_path=tmpdir,
+                        loop_state={"batch": 10},
+                        kind="state",
+                    )
+                )
+                raised = None
+            except Exception as e:  # pragma: no cover - checked below
+                raised = e
+
+        assert isinstance(raised, FakeConflictError)


### PR DESCRIPTION
This PR makes checkpoint saving resilient to 409 Conflict errors when a checkpoint with the same name already exists (issue #401). Instead of failing immediately, save_checkpoint_async now attempts idempotent recovery from local checkpoints.jsonl.

  ## What changed

- Updated tinker_cookbook/checkpoint_utils.py:
- Added conflict-aware save path for each checkpoint kind (state, sampler).
- On tinker.ConflictError, recover the existing checkpoint path from the most recent matching name in local checkpoints.jsonl.
- Preserve current behavior (re-raise) if no recoverable local record exists.
- Avoid duplicate checkpoints.jsonl entries when conflict recovery resolves to an identical record.
- Added tests in tinker_cookbook/checkpoint_utils_test.py:
   - test_save_checkpoint_async_recovers_conflict_from_existing_state_record
   - test_save_checkpoint_async_conflict_without_local_record_raises

  ## Why

  Training can be interrupted/retried around checkpoint boundaries. Reusing checkpoint names should be safe and idempotent when local metadata already confirms the checkpoint path.
  This improves robustness of resume/retry flows across training loops that share checkpoint_utils.save_checkpoint_async.

  ## Validation

- uv run pytest -q tinker_cookbook/checkpoint_utils_test.py
- uv run ruff check tinker_cookbook/checkpoint_utils.py tinker_cookbook/checkpoint_utils_test.py

Both pass locally.

## Scope / compatibility

- No public function signatures changed.
- Default behavior is unchanged except for conflict recovery in idempotent cases.
- If recovery is not possible, errors still propagate.