### PR TITLE
feat: thread through `logs` on `MessageEnv` to `MessageStepResult`

### DIFF
--- a/tinker_cookbook/rl/message_env.py
+++ b/tinker_cookbook/rl/message_env.py
@@ -28,6 +28,7 @@ class MessageStepResult:
     episode_done: bool
     next_messages: list[Message]
     metrics: dict[str, float] = field(default_factory=dict)
+    logs: types.Logs = field(default_factory=dict)
     next_stop_condition: StopCondition | None = None
 
 
@@ -109,6 +110,7 @@ class EnvFromMessageEnv(types.Env):
                 next_observation=tinker.ModelInput.empty(),
                 next_stop_condition=self._base_stop_condition,
                 metrics={**msg_step.metrics, "context_overflow": 1.0},
+                logs=msg_step.logs,
             )
 
         return types.StepResult(
@@ -117,4 +119,5 @@ class EnvFromMessageEnv(types.Env):
             next_observation=next_observation,
             next_stop_condition=next_stop_condition,
             metrics=msg_step.metrics,
+            logs=msg_step.logs,
         )

--- a/tinker_cookbook/rl/message_env_test.py
+++ b/tinker_cookbook/rl/message_env_test.py
@@ -315,3 +315,86 @@ class TestStepThreading:
             asyncio.run(env.step([1, 2]))
             mock_to_thread.assert_called_once()
             assert mock_to_thread.call_args[0][0] is renderer.build_generation_prompt
+
+
+class TestLogsPassthrough:
+    """MessageStepResult.logs should be forwarded to StepResult.logs."""
+
+    def test_logs_forwarded_on_success(self):
+        """Logs from MessageEnv are passed through on normal step."""
+        renderer = _make_renderer(gen_prompt_tokens=[1, 2, 3])
+        msg_env = StubMessageEnv(
+            initial_messages=[],
+            step_result=MessageStepResult(
+                reward=0.5,
+                episode_done=False,
+                next_messages=[{"role": "user", "content": "x"}],
+                logs={"assistant": "hello world", "tool_call_0": "name=search"},
+            ),
+        )
+        env = EnvFromMessageEnv(renderer=renderer, message_env=msg_env)
+
+        result = asyncio.run(env.step([1]))
+
+        assert result.logs == {"assistant": "hello world", "tool_call_0": "name=search"}
+
+    def test_logs_forwarded_on_context_overflow(self):
+        """Logs from MessageEnv are preserved even when context overflows."""
+        renderer = _make_renderer(gen_prompt_tokens=list(range(100)))
+        msg_env = StubMessageEnv(
+            initial_messages=[],
+            step_result=MessageStepResult(
+                reward=0.5,
+                episode_done=False,
+                next_messages=[{"role": "user", "content": "x"}],
+                logs={"assistant": "some response", "tool_result_0": "result data"},
+            ),
+        )
+        env = EnvFromMessageEnv(
+            renderer=renderer,
+            message_env=msg_env,
+            max_trajectory_tokens=50,
+        )
+
+        result = asyncio.run(env.step([1]))
+
+        assert result.episode_done is True
+        assert result.metrics["context_overflow"] == 1.0
+        assert result.logs == {"assistant": "some response", "tool_result_0": "result data"}
+
+    def test_no_logs_on_parse_error(self):
+        """Parse errors bypass MessageEnv, so logs are empty."""
+        renderer = _make_renderer(parse_success=False)
+        msg_env = StubMessageEnv(
+            initial_messages=[],
+            step_result=MessageStepResult(
+                reward=1.0,
+                episode_done=False,
+                next_messages=[],
+                logs={"should_not": "appear"},
+            ),
+        )
+        env = EnvFromMessageEnv(
+            renderer=renderer, message_env=msg_env, terminate_on_parse_error=True
+        )
+
+        result = asyncio.run(env.step([1]))
+
+        assert result.logs == {}
+
+    def test_empty_logs_by_default(self):
+        """When MessageEnv doesn't set logs, StepResult.logs defaults to empty."""
+        renderer = _make_renderer(gen_prompt_tokens=[1, 2])
+        msg_env = StubMessageEnv(
+            initial_messages=[],
+            step_result=MessageStepResult(
+                reward=0.5,
+                episode_done=False,
+                next_messages=[{"role": "user", "content": "x"}],
+            ),
+        )
+        env = EnvFromMessageEnv(renderer=renderer, message_env=msg_env)
+
+        result = asyncio.run(env.step([1]))
+
+        assert result.logs == {}


### PR DESCRIPTION
MessageEnv implementations might produce per-step logs (tool calls, tool results) that are useful for trajectory analysis and debugging. Previously these logs had no way to reach the token-level StepResult because MessageStepResult lacked a logs field.

This adds `logs: Logs` to MessageStepResult (default empty dict) and forwards it through all EnvFromMessageEnv return paths:
- Normal step: logs forwarded
- Context overflow: logs forwarded (previously dropped)
- Parse error: logs empty (MessageEnv was never called)