### PR TITLE
feat: widen `Logs` type alias to `dict[str, Any]`

### DIFF
--- a/tests/downstream_compat/test_rl_types.py
+++ b/tests/downstream_compat/test_rl_types.py
@@ -38,7 +38,7 @@ class TestTypeAliases:
         assert isinstance(val, dict)
 
     def test_logs_is_dict(self):
-        val: Logs = {"msg": "ok", "step": 1}
+        val: Logs = {"msg": "ok", "step": 1, "nested": {"a": [1, 2]}}
         assert isinstance(val, dict)
 
     def test_observation_alias_exists(self):

--- a/tinker_cookbook/rl/rollout_logging_test.py
+++ b/tinker_cookbook/rl/rollout_logging_test.py
@@ -7,7 +7,7 @@ import tinker
 
 from tinker_cookbook.completers import TokensWithLogprobs
 from tinker_cookbook.rl.rollout_logging import write_rollout_summaries_jsonl
-from tinker_cookbook.rl.types import Logs, Metrics, Trajectory, TrajectoryGroup, Transition
+from tinker_cookbook.rl.types import Metrics, Trajectory, TrajectoryGroup, Transition
 
 
 def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
@@ -17,7 +17,7 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         reward=cast(float, np.float32(0.25)),
         episode_done=True,
         metrics=cast(Metrics, {"score": np.float32(1.5)}),
-        logs=cast(Logs, {"rank": np.int64(2)}),
+        logs={"rank": np.int64(2)},
     )
     trajectory = Trajectory(transitions=[transition], final_ob=tinker.ModelInput.from_ints([1] * 8))
     trajectory_group = TrajectoryGroup(

--- a/tinker_cookbook/rl/types.py
+++ b/tinker_cookbook/rl/types.py
@@ -5,7 +5,7 @@ Basic interfaces and types for reinforcement learning.
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import chz
 import tinker
@@ -17,7 +17,7 @@ Action: TypeAlias = list[int]
 Observation: TypeAlias = tinker.ModelInput
 Logprobs: TypeAlias = list[float]
 Metrics: TypeAlias = dict[str, float | int]
-Logs: TypeAlias = dict[str, str | int | float]
+Logs: TypeAlias = dict[str, Any]
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Widen `Logs` type alias from `dict[str, str | int | float]` to `dict[str, Any]` to support structured diagnostic data (e.g. tool calls, nested objects)
- All downstream consumers (`_log_transition_logs`, `_json_safe`, JSONL export) already handle arbitrary types — the narrow type was an artificial constraint
- Remove `cast(Logs, ...)` workaround in rollout_logging_test now that the type accepts Any

## Test plan
- [x] `pytest tinker_cookbook/rl/rollout_logging_test.py` — numpy scalar in logs works without cast
- [x] `pytest tests/downstream_compat/test_rl_types.py` — Logs accepts nested/structured values
- [x] `pytest tinker_cookbook/rl/message_env_test.py` — no regressions in MessageEnv log threading
- [x] pyright and ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)