### PR TITLE
feat: populate diagnostic logs in `AgentToolMessageEnv`

### DIFF
--- a/tinker_cookbook/tool_use/agent_tool_message_env.py
+++ b/tinker_cookbook/tool_use/agent_tool_message_env.py
@@ -7,7 +7,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
 from tinker_cookbook.renderers import Renderer
-from tinker_cookbook.renderers.base import Message, ToolCall
+from tinker_cookbook.renderers.base import Message, ToolCall, get_text_content
+from tinker_cookbook.rl import types
 from tinker_cookbook.rl.message_env import EnvFromMessageEnv, MessageEnv, MessageStepResult
 from tinker_cookbook.tool_use.tools import handle_tool_call
 from tinker_cookbook.tool_use.types import Tool
@@ -77,14 +78,26 @@ class AgentToolMessageEnv(MessageEnv):
         """
         self._turn_count += 1
         metrics: dict[str, float] = {}
+        logs: types.Logs = {}
 
         # Append the message to history
         self.history.append(message)
 
+        # Log assistant content (handles both str and multimodal content)
+        assistant_text = get_text_content(message)
+        if assistant_text:
+            logs["assistant_content"] = assistant_text
+
         # Extract and execute tool calls if present
         tool_calls: list[ToolCall] = list(message.get("tool_calls") or [])
         if tool_calls:
-            await self._handle_tool_calls(tool_calls)
+            for i, tc in enumerate(tool_calls):
+                logs[f"tool_call_{i}"] = f"{tc.function.name}({tc.function.arguments})"
+
+            tool_result_messages = await self._handle_tool_calls(tool_calls)
+
+            for i, msg in enumerate(tool_result_messages):
+                logs[f"tool_result_{i}"] = get_text_content(msg)
 
         # Determine if episode is done
         no_tool_calls = len(tool_calls) == 0
@@ -106,6 +119,7 @@ class AgentToolMessageEnv(MessageEnv):
             episode_done=done,
             next_messages=self.history,
             metrics=metrics,
+            logs=logs,
         )
 
 

--- a/tinker_cookbook/tool_use/agent_tool_message_env_test.py
+++ b/tinker_cookbook/tool_use/agent_tool_message_env_test.py
@@ -1,0 +1,174 @@
+"""Tests for AgentToolMessageEnv log population."""
+
+import asyncio
+from typing import Any
+
+from tinker_cookbook.renderers.base import Message, ToolCall, ToolSpec
+from tinker_cookbook.tool_use.agent_tool_message_env import AgentToolMessageEnv
+from tinker_cookbook.tool_use.tools import simple_tool_result
+from tinker_cookbook.tool_use.types import ToolInput, ToolResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop_reward(history: list[Message]) -> tuple[float, dict[str, float]]:
+    return 1.0, {}
+
+
+class StubTool:
+    """Minimal Tool implementation for testing."""
+
+    def __init__(self, name: str, response: str, should_stop: bool = False):
+        self._name = name
+        self._response = response
+        self._should_stop = should_stop
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Stub tool: {self._name}"
+
+    @property
+    def parameters_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def run(self, input: ToolInput) -> ToolResult:
+        return simple_tool_result(
+            self._response,
+            call_id=input.call_id or "",
+            name=self._name,
+            should_stop=self._should_stop,
+        )
+
+    def to_spec(self) -> ToolSpec:
+        return {
+            "name": self._name,
+            "description": self.description,
+            "parameters": self.parameters_schema,
+        }
+
+
+def _make_tool_call(name: str, arguments: str = "{}", call_id: str = "call_1") -> ToolCall:
+    return ToolCall(id=call_id, function=ToolCall.FunctionBody(name=name, arguments=arguments))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStepLogs:
+    """AgentToolMessageEnv.step() should populate logs with diagnostic info."""
+
+    def test_logs_assistant_content(self):
+        """Logs include assistant_content when message has text content."""
+        env = AgentToolMessageEnv(
+            tools=[],
+            initial_messages=[{"role": "user", "content": "hi"}],
+            max_turns=5,
+            reward_fn=_noop_reward,
+        )
+        asyncio.run(env.initial_observation())
+
+        result = asyncio.run(env.step({"role": "assistant", "content": "Hello world"}))
+
+        assert result.logs["assistant_content"] == "Hello world"
+
+    def test_logs_empty_when_no_content(self):
+        """Logs omit assistant_content when message has empty content."""
+        env = AgentToolMessageEnv(
+            tools=[],
+            initial_messages=[{"role": "user", "content": "hi"}],
+            max_turns=5,
+            reward_fn=_noop_reward,
+        )
+        asyncio.run(env.initial_observation())
+
+        result = asyncio.run(env.step({"role": "assistant", "content": ""}))
+
+        assert "assistant_content" not in result.logs
+
+    def test_logs_multimodal_content(self):
+        """Logs extract text from multimodal content via get_text_content."""
+        env = AgentToolMessageEnv(
+            tools=[],
+            initial_messages=[{"role": "user", "content": "hi"}],
+            max_turns=5,
+            reward_fn=_noop_reward,
+        )
+        asyncio.run(env.initial_observation())
+
+        result = asyncio.run(
+            env.step(
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "extracted text"}],
+                }
+            )
+        )
+
+        assert result.logs["assistant_content"] == "extracted text"
+
+    def test_logs_tool_calls_and_results(self):
+        """Logs include tool call names/args and tool result content."""
+        search_tool = StubTool("search", '{"results": ["a", "b"]}')
+        env = AgentToolMessageEnv(
+            tools=[search_tool],
+            initial_messages=[{"role": "user", "content": "find stuff"}],
+            max_turns=5,
+            reward_fn=_noop_reward,
+        )
+        asyncio.run(env.initial_observation())
+
+        tc = _make_tool_call("search", '{"query": "weather"}')
+        result = asyncio.run(
+            env.step({"role": "assistant", "content": "Let me search.", "tool_calls": [tc]})
+        )
+
+        assert result.logs["assistant_content"] == "Let me search."
+        assert result.logs["tool_call_0"] == 'search({"query": "weather"})'
+        assert result.logs["tool_result_0"] == '{"results": ["a", "b"]}'
+
+    def test_logs_multiple_tool_calls(self):
+        """Logs index multiple tool calls and results separately."""
+        search_tool = StubTool("search", "search result")
+        calc_tool = StubTool("calc", "42")
+        env = AgentToolMessageEnv(
+            tools=[search_tool, calc_tool],
+            initial_messages=[{"role": "user", "content": "hi"}],
+            max_turns=5,
+            reward_fn=_noop_reward,
+        )
+        asyncio.run(env.initial_observation())
+
+        tc1 = _make_tool_call("search", '{"q": "x"}', call_id="call_1")
+        tc2 = _make_tool_call("calc", '{"expr": "1+1"}', call_id="call_2")
+        result = asyncio.run(
+            env.step({"role": "assistant", "content": "Doing both.", "tool_calls": [tc1, tc2]})
+        )
+
+        assert result.logs["tool_call_0"] == 'search({"q": "x"})'
+        assert result.logs["tool_call_1"] == 'calc({"expr": "1+1"})'
+        assert result.logs["tool_result_0"] == "search result"
+        assert result.logs["tool_result_1"] == "42"
+
+    def test_logs_no_tool_calls(self):
+        """When there are no tool calls, only assistant_content is logged."""
+        env = AgentToolMessageEnv(
+            tools=[],
+            initial_messages=[{"role": "user", "content": "hi"}],
+            max_turns=5,
+            reward_fn=_noop_reward,
+        )
+        asyncio.run(env.initial_observation())
+
+        result = asyncio.run(env.step({"role": "assistant", "content": "Just text."}))
+
+        assert result.logs == {"assistant_content": "Just text."}
+        assert "tool_call_0" not in result.logs
+        assert "tool_result_0" not in result.logs


### PR DESCRIPTION
## Motivation

`AgentToolMessageEnv` is the primary environment for tool-use RL training (used by search_tool, harbor_rl, and code_rl recipes). #518 added the `logs` field to `MessageStepResult` and threaded it through `EnvFromMessageEnv`, but no `MessageEnv` implementation was populating it — so `StepResult.logs` was always empty for tool-use trajectories.

Without per-step logs, debugging tool-use RL training requires reconstructing what happened from token-level data. This PR populates the logs so that each step records what the model said, which tools it called, and what they returned — visible in logtree HTML reports and JSONL exports.

## Changes

`AgentToolMessageEnv.step()` now populates `MessageStepResult.logs` with per-step diagnostic info:
- `assistant_content`: model's text response (via `get_text_content` — handles both string and multimodal content)
- `tool_call_{i}`: formatted as `name(arguments)` for each tool call
- `tool_result_{i}`: content from each tool result message

Example logs for a step with two tool calls:
```python
{
    "assistant_content": "Let me search and calculate.",
    "tool_call_0": 'search({"query": "weather"})',
    "tool_call_1": 'calc({"expr": "1+1"})',
    "tool_result_0": '{"results": ["sunny"]}',
    "tool_result_1": "2",
}
```

## Design decisions

- **Flat key naming** (`tool_call_0`, `tool_result_0`) over nested structures — keeps logs greppable, JSONL-friendly, and compatible with the existing `Logs = dict[str, str | int | float]` type without any type changes.
- **`get_text_content()`** for text extraction — the same helper used across the codebase (problem_env, preference_envs, eval, deepcoder, etc.). Properly handles both `str` and `list[ContentPart]` content, stripping thinking blocks from reasoning models.
- **Omit `assistant_content` when empty** rather than logging an empty string — keeps logs sparse and meaningful.

## Backward compatibility

- `MessageStepResult.logs` defaults to `{}`, so this is purely additive — existing code that doesn't read logs is unaffected.
- All 3 recipes using `AgentToolMessageEnv` (`search_tool`, `harbor_rl`, `code_rl`) only pass config to the builder; none read `MessageStepResult.logs`.
- Downstream consumers (`_log_transition_logs`, `write_rollout_summaries_jsonl`) iterate generically over log keys — new keys are displayed/serialized automatically.
- No key conflicts with other envs that populate logs (e.g., `GuessNumberEnv` uses `"guess"`, `"feedback"`, `"target"`).
- All log values are `str`, matching the `Logs` type alias.

## Test plan
- [x] `test_logs_assistant_content` — text content is logged
- [x] `test_logs_empty_when_no_content` — empty content is omitted
- [x] `test_logs_multimodal_content` — `list[ContentPart]` is properly extracted
- [x] `test_logs_tool_calls_and_results` — tool call names/args and results are logged
- [x] `test_logs_multiple_tool_calls` — multiple tool calls indexed correctly
- [x] `test_logs_no_tool_calls` — only `assistant_content` when no tools
- [x] pyright and ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)