### PR TITLE
Fix LoRA merging for Qwen3.5 dense models

### DIFF
--- a/tinker_cookbook/weights/_merge.py
+++ b/tinker_cookbook/weights/_merge.py
@@ -371,7 +371,9 @@ def plan_merge_ops(
                     k = adapter_weights[pfx + ".in_proj_k.lora_B.weight"].shape[0]
                     start = {"q": 0, "k": q, "v": q + k}[qkv_role]
                     ops.setdefault(fused_key, []).append(
-                        MergeOp(target_key=fused_key, lora_A=lora_A, lora_B=lora_B, slice_start=start)
+                        MergeOp(
+                            target_key=fused_key, lora_A=lora_A, lora_B=lora_B, slice_start=start
+                        )
                     )
                     continue
             _plan_non_expert_op(target_key, lora_A, lora_B, n, profile, model_state_keys, ops)

--- a/tinker_cookbook/weights/merge_test.py
+++ b/tinker_cookbook/weights/merge_test.py
@@ -790,8 +790,7 @@ class TestQwen35QkvFusion:
         # All three should land on in_proj_qkv, not on separate split keys
         assert "model.layers.0.linear_attn.in_proj_qkv.weight" in ops
         assert not any(
-            k.endswith((".in_proj_q.weight", ".in_proj_k.weight", ".in_proj_v.weight"))
-            for k in ops
+            k.endswith((".in_proj_q.weight", ".in_proj_k.weight", ".in_proj_v.weight")) for k in ops
         )
         assert len(ops["model.layers.0.linear_attn.in_proj_qkv.weight"]) == 3
 
@@ -806,7 +805,7 @@ class TestQwen35QkvFusion:
         ops = plan_merge_ops(adapter_weights, adapter_config, model_state_keys, profile)
         merge_ops = ops["model.layers.0.linear_attn.in_proj_qkv.weight"]
 
-        starts = sorted(op.slice_start for op in merge_ops)
+        starts = sorted(op.slice_start for op in merge_ops if op.slice_start is not None)
         assert starts == [0, self.Q_OUT, self.Q_OUT + self.K_OUT]
 
     def test_correct_delta_applied_to_each_slice(self):


### PR DESCRIPTION
## Problem

`build_hf_model()` crashes with `WeightsMergeError` on Qwen3.5 models due to two issues:

1. **Split vs fused QKV** — Tinker trains separate `in_proj_q/k/v` LoRA weights, but HF stores a single fused `in_proj_qkv` (Q‖K‖V, unequal dims: Q=K=2048, V=4096 for 4B).
2. **`unembed_tokens` remap** — Qwen3.5 has `vision_config`, so HF uses `model.language_model.*` keys. `lm_head` is weight-tied and absent from safetensors

## Changes (`_merge.py`)

- `MergeOp.slice_start` — new field for row-slice targeting within a fused weight.
- `plan_merge_ops` — intercepts `in_proj_q/k/v`, redirects to `in_proj_qkv` with offsets from sibling `lora_B` shapes; reorders vision remaps so prefix applies before `unembed_tokens → embed_tokens`.
- `apply_merge_op` — applies delta to `target[start:end]` when `slice_start` is set.
- `validate_merge_op_shapes` — accepts sliced ops (checks bounds, not full-tensor equality).

## Tests

New tests in `TestQwen35QkvFusion` covering offset correctness, value correctness, non-overlap, unequal dims, and vision prefix path. All tests pass.

## Verified on

`Qwen/Qwen3.5-4B` and `Qwen/Qwen3.5-27B`