### PR TITLE
Add version lower bounds and exclude compromised litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,23 +9,23 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "aiohttp",
-    "anyio",
-    "blobfile",
-    "chz",
-    "cloudpickle",
+    "aiohttp>=3.9.0",
+    "anyio>=4.0.0",
+    "blobfile>=3.0.0",
+    "chz>=0.4.0",
+    "cloudpickle>=3.0.0",
     "datasets>=2.14.0",
-    "huggingface_hub",
+    "huggingface_hub>=0.20.0",
     "numpy>=1.24.0",
-    "pillow",
-    "pydantic",
-    "rich",
-    "safetensors",
-    "termcolor",
+    "pillow>=10.0.0",
+    "pydantic>=2.0.0",
+    "rich>=13.0.0",
+    "safetensors>=0.4.0",
+    "termcolor>=2.0.0",
     "tiktoken>=0.12.0", # Required for Kimi tokenizer
     "tinker>=0.9.0",
     "torch>=2.0",
-    "tqdm",
+    "tqdm>=4.60.0",
     "transformers>=4.57.6,<=5.3.0",
 ]
 
@@ -36,31 +36,31 @@ Documentation = "https://tinker-docs.thinkingmachines.ai/"
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "pytest-asyncio",
-    "pytest-timeout",
-    "ruff",
-    "pyright",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-timeout>=2.0.0",
+    "ruff>=0.4.0",
+    "pyright>=1.1.300",
 ]
 math-rl = [
-    "math-verify",
-    "pylatexenc",
-    "sympy",
+    "math-verify>=0.5.0",
+    "pylatexenc>=2.0",
+    "sympy>=1.12.0",
 ]
 modal = [
-    "modal",
+    "modal>=1.0.0",
 ]
 multiplayer-rl = [
     "textarena>=0.7.4",
 ]
 vector-search = [
-    "chromadb",
-    "google-genai",
-    "huggingface_hub",
+    "chromadb>=1.0.0",
+    "google-genai>=1.0.0",
+    "huggingface_hub>=0.20.0",
 ]
 wandb = [
-    "wandb",
-    "plotly",
+    "wandb>=0.16.0",
+    "plotly>=5.0.0",
 ]
 neptune-scale = [
     "neptune-scale>=0.27.0",
@@ -70,14 +70,14 @@ trackio = [
 ]
 verifiers = [
     "verifiers>=0.1.9,<0.1.10",
-    "openai",
+    "openai>=1.0.0",
 ]
 inspect = [
-    "inspect-ai",
+    "inspect-ai>=0.3.100",
     "inspect-evals>=0.3.106",
 ]
 litellm = [
-    "litellm",
+    "litellm>=1.80.0,!=1.82.7,!=1.82.8",
 ]
 all = [
     "tinker_cookbook[math-rl]",


### PR DESCRIPTION
## Summary
- Add `>=` lower bounds to all previously unpinned dependencies in `pyproject.toml` to prevent pulling ancient or incompatible versions.
- Exclude litellm 1.82.7 and 1.82.8 (`!=1.82.7,!=1.82.8`) which were compromised via a supply chain attack (TeamPCP account takeover through the Trivy breach). These versions contain a credential-stealing payload.

## Test plan
- [x] Unit tests pass (824 passed, 78 skipped, 0 failures)
- [x] `uv sync` resolves correctly with the new bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)