### PR TITLE
Remove unused `name` parameter from `save_weights_and_get_sampling_client` calls

### DIFF
--- a/.claude/skills/checkpoints/SKILL.md
+++ b/.claude/skills/checkpoints/SKILL.md
@@ -27,8 +27,11 @@ tc.save_state(name="step_100", ttl_seconds=None)
 # Save sampler weights (for sampling/export)
 tc.save_weights_for_sampler(name="step_100_sampler", ttl_seconds=None)
 
-# Save both + get a SamplingClient
-sc = tc.save_weights_and_get_sampling_client(name="step_100")
+# Get an ephemeral SamplingClient for the current weights (not persistently saved)
+# This is optimized for fast weight transfer in training loops.
+# For persistent saves, use save_weights_for_sampler(name=...) +
+# service_client.create_sampling_client(model_path=...)
+sc = tc.save_weights_and_get_sampling_client()
 ```
 
 `ttl_seconds=None` means indefinite retention. Set a TTL for intermediate checkpoints to avoid storage bloat.

--- a/.claude/skills/tinker-sdk/SKILL.md
+++ b/.claude/skills/tinker-sdk/SKILL.md
@@ -74,8 +74,10 @@ tc.optim_step(adam_params=AdamParams(learning_rate=2e-4))
 tc.save_state(name="step_100", ttl_seconds=None)                # Full state (resumable)
 tc.save_weights_for_sampler(name="step_100_sampler", ttl_seconds=None)  # Sampler-only
 
-# Save + get SamplingClient in one call
-sc = tc.save_weights_and_get_sampling_client(name="step_100")
+# Save + get SamplingClient in one call (ephemeral, not persistently saved)
+# NOTE: This does NOT persist the checkpoint. For persistent saves, use
+# save_weights_for_sampler(name=...) + service_client.create_sampling_client(model_path=...)
+sc = tc.save_weights_and_get_sampling_client()
 
 # Load checkpoint
 tc.load_state(path="tinker://...")
@@ -113,7 +115,7 @@ optim_result = optim_future.result()
 ```python
 from tinker import SamplingParams
 
-sc = tc.save_weights_and_get_sampling_client(name="step_100")
+sc = tc.save_weights_and_get_sampling_client()
 
 response = sc.sample(
     prompt=model_input,

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ training_client.optim_step(...)
 training_client.save_state(...)
 training_client.load_state(...)
 
-sampling_client = training_client.save_weights_and_get_sampling_client(name="my_model")
+sampling_client = training_client.save_weights_and_get_sampling_client()
 sampling_client.sample(...)
 ```
 

--- a/docs/api-reference/trainingclient.md
+++ b/docs/api-reference/trainingclient.md
@@ -26,7 +26,7 @@ fwdbwd_future = training_client.forward_backward(training_data, "cross_entropy")
 optim_future = training_client.optim_step(types.AdamParams(learning_rate=1e-4))
 fwdbwd_result = fwdbwd_future.result()  # Wait for gradients
 optim_result = optim_future.result()    # Wait for parameter update
-sampling_client = training_client.save_weights_and_get_sampling_client("my-model")
+sampling_client = training_client.save_weights_and_get_sampling_client()
 ```
 
 #### `forward`
@@ -451,14 +451,14 @@ Async version of create_sampling_client.
 
 ```python
 def save_weights_and_get_sampling_client(
-        name: str | None = None,
         retry_config: RetryConfig | None = None) -> SamplingClient
 ```
 
-Save current weights and create a SamplingClient for inference.
+Save current weights and create a SamplingClient for inference. This creates an **ephemeral** checkpoint optimized for fast weight transfer in training loops. The checkpoint is not persistently saved and cannot be retrieved later.
+
+To create a persistent, named checkpoint, use `save_weights_for_sampler(name=...)` followed by `service_client.create_sampling_client(model_path=...)`.
 
 Args:
-- `name`: Optional name for the saved weights (currently ignored for ephemeral saves)
 - `retry_config`: Optional configuration for retrying failed requests
 
 Returns:
@@ -479,7 +479,6 @@ result = sampling_client.sample(prompt, 1, params).result()
 
 ```python
 async def save_weights_and_get_sampling_client_async(
-        name: str | None = None,
         retry_config: RetryConfig | None = None) -> SamplingClient
 ```
 

--- a/docs/save-load.mdx
+++ b/docs/save-load.mdx
@@ -32,7 +32,7 @@ sampling_client = service_client.create_sampling_client(model_path=sampling_path
 **Shortcut:** Combine these steps with:
 
 ```python
-sampling_client = training_client.save_weights_and_get_sampling_client(name="0000")
+sampling_client = training_client.save_weights_and_get_sampling_client()
 ```
 
 ### Example: Saving to resume training

--- a/docs/training-sampling.mdx
+++ b/docs/training-sampling.mdx
@@ -171,7 +171,7 @@ Now we can test our model by sampling from it. In this case, we'll translate the
 
 ```python
 # First, create a sampling client. We need to transfer weights
-sampling_client = training_client.save_weights_and_get_sampling_client(name='pig-latin-model')
+sampling_client = training_client.save_weights_and_get_sampling_client()
 
 # Now, we can sample from the model.
 prompt = types.ModelInput.from_ints(tokenizer.encode("English: coffee break\nPig Latin:"))

--- a/tests/third_party/test_litellm.py
+++ b/tests/third_party/test_litellm.py
@@ -137,7 +137,7 @@ async def test_set_client_with_finetuned_checkpoint(tinker_provider) -> None:
     training_client = service.create_lora_training_client(base_model=BASE_MODEL, rank=8)
 
     # Save weights and get a sampling client for the checkpoint
-    checkpoint_sampler = training_client.save_weights_and_get_sampling_client(name="litellm_test")
+    checkpoint_sampler = training_client.save_weights_and_get_sampling_client()
 
     # Inject via set_client — base_model is derived from the sampling client
     tinker_provider.set_client(checkpoint_sampler)

--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -122,7 +122,7 @@ def create_dpo_clients(
             base_model=config.model_name, rank=config.lora_rank, user_metadata=user_metadata
         )
     # Create a sampling client for the reference model from the training client
-    reference_client = training_client.save_weights_and_get_sampling_client("reference")
+    reference_client = training_client.save_weights_and_get_sampling_client()
     return training_client, reference_client
 
 

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -133,9 +133,7 @@ async def run_evals(
             nonlocal sampling_client
             if sampling_client is None:
                 # Snapshot the current pre-step weights and create a new sampling client.
-                sampling_client = await training_client.save_weights_and_get_sampling_client_async(
-                    f"evals_step_{step}"
-                )
+                sampling_client = await training_client.save_weights_and_get_sampling_client_async()
             return await evaluator(sampling_client)
         else:
             raise ConfigurationError(f"Unknown evaluator type: {type(evaluator)}")


### PR DESCRIPTION
## Summary

- Remove the `name` argument from all `save_weights_and_get_sampling_client()` call sites — the SDK silently ignores it, so passing it gave users the false impression that checkpoints were being persistently saved.
- Update API reference docs to clarify this method creates **ephemeral** checkpoints optimized for fast weight transfer, and point users to `save_weights_for_sampler(name=...)` + `create_sampling_client(model_path=...)` for persistent saves.
- Update skill files with the same clarification.

Relates to #153.

## Test plan

- [x] Unit tests pass (815 passed)
- [ ] Verify docs render correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)