### PR TITLE
Add test_lifecycle to weights-e2e workflow and pass TINKER_API_KEY

### DIFF
--- a/.github/workflows/weights.yaml
+++ b/.github/workflows/weights.yaml
@@ -9,7 +9,7 @@ jobs:
   e2e:
     if: github.repository == 'thinking-machines-lab/tinker-cookbook'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -27,12 +27,16 @@ jobs:
           - test_strategy_consistency
           - test_quantized
           - test_quantized_equivalence
+          - test_lifecycle
         transformers-version: ["4.57.6", "5.2.0"]
         exclude:
           # Qwen3.5 requires transformers >= 5.0
           - test: test_export_qwen3_5
             transformers-version: "4.57.6"
           - test: test_adapter_qwen3_5
+            transformers-version: "4.57.6"
+          # Lifecycle test doesn't depend on transformers version
+          - test: test_lifecycle
             transformers-version: "4.57.6"
 
     name: ${{ matrix.test }} (transformers ${{ matrix.transformers-version }})
@@ -56,3 +60,4 @@ jobs:
         run: uv run pytest tests/weights/${{ matrix.test }}.py -v --timeout=120
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          TINKER_API_KEY: ${{ secrets.TINKER_API_KEY }}

--- a/tests/weights/test_lifecycle.py
+++ b/tests/weights/test_lifecycle.py
@@ -26,6 +26,7 @@ from tinker_cookbook.weights import build_hf_model, download
 
 
 @pytest.mark.integration
+@pytest.mark.timeout(900)
 class TestFullLifecycle:
     """Train 1 step → save → download → build merged HF model."""
 


### PR DESCRIPTION
## Summary
- Pass `TINKER_API_KEY` secret to the weights-e2e workflow — fixes the CI failure where `tests/conftest.py` was rejecting runs with `CI=true` but no API key
- Add `test_lifecycle` (train → save → download → build) to the workflow matrix, excluded from the `4.57.6` transformers variant since it doesn't test transformers compat
- Bump `test_lifecycle` pytest timeout to 15min and workflow job timeout to 20min
- `test_download` is skipped since `test_lifecycle` already covers the download path

## Test plan
- [x] Verified all weights-e2e jobs pass on fork: https://github.com/YujiaBao/tinker-cookbook/actions/runs/23516477350

🤖 Generated with [Claude Code](https://claude.com/claude-code)