### PR TITLE
Introduce ActionExtra TypedDict for Env.step extensibility

### DIFF
--- a/.claude/skills/environments/SKILL.md
+++ b/.claude/skills/environments/SKILL.md
@@ -22,7 +22,7 @@ Read these for details:
 ### Env (single-use, no reset)
 
 ```python
-from tinker_cookbook.rl.types import Env, Observation, Action, StepResult, StopCondition
+from tinker_cookbook.rl.types import ActionExtra, Env, Observation, Action, StepResult, StopCondition
 
 class MyEnv(Env):
     async def initial_observation(self) -> tuple[Observation, StopCondition]:
@@ -31,7 +31,7 @@ class MyEnv(Env):
         stop = renderer.get_stop_sequences()
         return model_input, stop
 
-    async def step(self, action: Action) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Process model output and return next observation + reward."""
         # action is TokensWithLogprobs (tokens + logprobs)
         return StepResult(

--- a/docs/rl/rl-envs.mdx
+++ b/docs/rl/rl-envs.mdx
@@ -14,7 +14,7 @@ class Env:
     async def initial_observation(self) -> tuple[Observation, StopCondition]:
         raise NotImplementedError
 
-    async def step(self, action: Action) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         raise NotImplementedError
 ```
 

--- a/tests/downstream_compat/test_rl_types.py
+++ b/tests/downstream_compat/test_rl_types.py
@@ -10,6 +10,7 @@ from dataclasses import fields
 from tinker_cookbook.completers import TokensWithLogprobs
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     Logs,
@@ -43,6 +44,25 @@ class TestTypeAliases:
 
     def test_observation_alias_exists(self):
         assert Observation is not None
+
+
+# ---------------------------------------------------------------------------
+# ActionExtra
+# ---------------------------------------------------------------------------
+
+
+class TestActionExtra:
+    def test_is_typed_dict(self):
+        extra = ActionExtra(stop_reason="stop")
+        assert isinstance(extra, dict)
+
+    def test_all_fields_optional(self):
+        extra: ActionExtra = {}
+        assert isinstance(extra, dict)
+
+    def test_stop_reason_key(self):
+        extra = ActionExtra(stop_reason="length")
+        assert extra["stop_reason"] == "length"
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +140,7 @@ class TestEnv:
     def test_step_signature(self):
         from tests.downstream_compat.sig_helpers import assert_params
 
-        assert_params(Env.step, ["action", "stop_reason", "kwargs"])
+        assert_params(Env.step, ["action", "extra"])
 
 
 # ---------------------------------------------------------------------------

--- a/tinker_cookbook/distillation/datasets.py
+++ b/tinker_cookbook/distillation/datasets.py
@@ -9,7 +9,7 @@ a teacher model. The environment provides no correctness or format rewards.
 import math
 from collections.abc import Sequence
 from functools import partial
-from typing import Any, Literal
+from typing import Literal
 
 import chz
 import tinker
@@ -20,6 +20,7 @@ from tinker_cookbook.exceptions import ConfigurationError, DataError
 from tinker_cookbook.rl.problem_env import ProblemEnv, ProblemGroupBuilder, logger
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     EnvGroupBuilder,
     RLDataset,
     RLDatasetBuilder,
@@ -109,7 +110,7 @@ class PromptOnlyEnv(ProblemEnv):
         """No reference answer needed for distillation."""
         return ""
 
-    async def step(self, action: Action, **kwargs: Any) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Return zero reward always."""
         message, parse_success = self.renderer.parse_response(action)
         return StepResult(

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
@@ -2,7 +2,6 @@ import random
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
 
 import chz
 from tinker import ModelInput
@@ -13,6 +12,7 @@ from tinker_cookbook.completers import (
 from tinker_cookbook.renderers import Message, Renderer, ensure_text, get_renderer
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     RLDataset,
@@ -69,7 +69,7 @@ class GuessNumberEnv(Env):
         except ValueError:
             return RETURN_ON_FAIL
 
-    async def step(self, action: Action, **kwargs: Any) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         # step 1: parse the action tokens into a message
         # this step is specific to our library, but usually templated, so you can just copy it.
         (action_message, _parse_success) = self.renderer.parse_response(action)

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/env.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import chz
 import tinker
@@ -22,6 +22,7 @@ from tinker_cookbook.completers import StopCondition, TinkerMessageCompleter
 from tinker_cookbook.renderers import Message, Renderer, get_renderer, get_text_content
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     Observation,
@@ -138,7 +139,7 @@ class TwoPlayerEnv(Env):
         opponent_action_content = get_text_content(opponent_response)
         await self.coordinator.make_move(opponent_player_id, opponent_action_content)
 
-    async def step(self, action: Action, **kwargs: Any) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Take a step in the environment."""
         if self.coordinator.game_done:
             return self.get_done_step()

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
@@ -4,7 +4,6 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import chz
 import tinker
@@ -20,6 +19,7 @@ from tinker_cookbook.model_info import get_recommended_renderer_name
 from tinker_cookbook.renderers import Message, Renderer, get_renderer, get_text_content
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     RLDataset,
@@ -96,7 +96,7 @@ class TwentyQuestionsEnv(Env):
         )
         return 1.0 if content_contains_answer else 0.0
 
-    async def step(self, action: Action, **kwargs: Any) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """
         In one step,
         1. The environment accepts an action from the player (a message containin a question or a guess).

--- a/tinker_cookbook/recipes/rubric/env.py
+++ b/tinker_cookbook/recipes/rubric/env.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
 
 import chz
 import tinker
@@ -20,6 +19,7 @@ from tinker_cookbook.recipes.rubric.data import (
 from tinker_cookbook.renderers import Renderer, get_renderer
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     RLDataset,
@@ -88,7 +88,7 @@ class RubricGradedEnv(Env):
             print(colored(f"Extracted Score: {score}", "magenta") + "\n")
         return score, grader_response_content
 
-    async def step(self, action: Action, **kwargs: Any) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         with logtree.scope_header("Prompt"):
             logtree.log_formatter(ConversationFormatter(messages=self.convo))
 

--- a/tinker_cookbook/rl/__init__.py
+++ b/tinker_cookbook/rl/__init__.py
@@ -3,6 +3,7 @@
 from tinker_cookbook.rl.rollout_strategy import FailFast, RetryOnFailure, RolloutStrategy
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     Logs,
@@ -20,6 +21,7 @@ from tinker_cookbook.rl.types import (
 __all__ = [
     # Core protocol and types (types.py)
     "Action",
+    "ActionExtra",
     "Env",
     "EnvGroupBuilder",
     "Logs",

--- a/tinker_cookbook/rl/message_env.py
+++ b/tinker_cookbook/rl/message_env.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
 
 import tinker
 
@@ -106,11 +105,12 @@ class EnvFromMessageEnv(types.Env):
         return model_input, self._base_stop_condition
 
     async def step(
-        self, action: types.Action, *, stop_reason: tinker.StopReason = "stop", **kwargs: Any
+        self, action: types.Action, *, extra: types.ActionExtra | None = None
     ) -> types.StepResult:
         """Parse tokens to a message, delegate to MessageEnv, and render response."""
         # If the model hit max_tokens without producing a stop sequence, terminate
         # the episode early. Previous turns' logprobs are preserved in the trajectory.
+        stop_reason = (extra or {}).get("stop_reason", "stop")
         if stop_reason == "length":
             return types.StepResult(
                 reward=self.context_overflow_reward,

--- a/tinker_cookbook/rl/message_env_test.py
+++ b/tinker_cookbook/rl/message_env_test.py
@@ -508,7 +508,7 @@ class TestMaxTokensReached:
         )
         env = EnvFromMessageEnv(renderer=renderer, message_env=msg_env)
 
-        result = asyncio.run(env.step([1, 2, 3], stop_reason="length"))
+        result = asyncio.run(env.step([1, 2, 3], extra={"stop_reason": "length"}))
 
         assert result.episode_done is True
         assert result.reward == -0.1  # default context_overflow_reward
@@ -530,7 +530,7 @@ class TestMaxTokensReached:
             context_overflow_reward=-0.5,
         )
 
-        result = asyncio.run(env.step([1], stop_reason="length"))
+        result = asyncio.run(env.step([1], extra={"stop_reason": "length"}))
 
         assert result.reward == -0.5
         assert result.metrics["max_tokens_reached"] == 1.0

--- a/tinker_cookbook/rl/preference_envs.py
+++ b/tinker_cookbook/rl/preference_envs.py
@@ -2,7 +2,6 @@ import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
 
 import chz
 import tinker
@@ -20,6 +19,7 @@ from tinker_cookbook.preference.types import (
 )
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     Metrics,
@@ -53,7 +53,7 @@ class PreferenceEnv(Env):
     async def initial_observation(self) -> tuple[Observation, StopCondition]:
         return self.policy_renderer.build_generation_prompt(self.convo_prefix), self.stop_condition
 
-    async def step(self, action: Action, **kwargs: Any) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Compute the reward for a given action.
 
         Args:

--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -2,7 +2,6 @@ import logging
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any
 
 import tinker
 
@@ -10,6 +9,7 @@ from tinker_cookbook import renderers
 from tinker_cookbook.completers import StopCondition
 from tinker_cookbook.rl.types import (
     Action,
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     Metrics,
@@ -61,7 +61,7 @@ class ProblemEnv(Env):
         ]
         return self.renderer.build_generation_prompt(convo), self.stop_condition
 
-    async def step(self, action: Action, **kwargs: Any) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         convo = self.convo_prefix + [{"role": "user", "content": self.get_question()}]
         message, parse_success = self.renderer.parse_response(action)
         content = renderers.get_text_content(message)

--- a/tinker_cookbook/rl/rollout_error_resilience_test.py
+++ b/tinker_cookbook/rl/rollout_error_resilience_test.py
@@ -71,7 +71,7 @@ class _FakeEnv(Env):
     async def initial_observation(self):
         return tinker.ModelInput.from_ints([1, 2, 3]), [0]
 
-    async def step(self, action, **kwargs):
+    async def step(self, action, *, extra=None):
         return StepResult(
             reward=1.0,
             episode_done=True,

--- a/tinker_cookbook/rl/rollouts.py
+++ b/tinker_cookbook/rl/rollouts.py
@@ -13,6 +13,7 @@ from tinker_cookbook.completers import TinkerTokenCompleter, TokenCompleter
 from tinker_cookbook.exceptions import AllTrajectoriesFailedError
 from tinker_cookbook.rl.rollout_strategy import FailFast, RolloutStrategy
 from tinker_cookbook.rl.types import (
+    ActionExtra,
     Env,
     EnvGroupBuilder,
     Trajectory,
@@ -124,7 +125,8 @@ async def do_single_rollout(policy: TokenCompleter, env: Env) -> Trajectory:
             ac_with_logprobs = await policy(ob, stop_condition)
         async with trace.scope_span("env_step"):
             step_result = await env.step(
-                ac_with_logprobs.tokens, stop_reason=ac_with_logprobs.stop_reason
+                ac_with_logprobs.tokens,
+                extra=ActionExtra(stop_reason=ac_with_logprobs.stop_reason),
             )
         transition = Transition(
             ob=ob,

--- a/tinker_cookbook/rl/types.py
+++ b/tinker_cookbook/rl/types.py
@@ -5,10 +5,11 @@ Basic interfaces and types for reinforcement learning.
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 import chz
 import tinker
+from typing_extensions import TypedDict
 
 from tinker_cookbook.completers import StopCondition, TokensWithLogprobs
 from tinker_cookbook.utils.misc_utils import safezip
@@ -56,6 +57,19 @@ class Transition:
     """Diagnostic info for display/debugging tools (not aggregated like metrics)."""
 
 
+class ActionExtra(TypedDict, total=False):
+    """Extra metadata passed alongside an action to :meth:`Env.step`.
+
+    All fields are optional so that callers and env implementations can
+    ignore keys they don't care about.  Values must be picklable (the
+    rollout executor may serialise them across process boundaries).
+    """
+
+    stop_reason: tinker.StopReason
+    """Why sampling stopped — ``"stop"`` (hit a stop sequence) or ``"length"``
+    (hit *max_tokens* without a stop sequence)."""
+
+
 class Env(ABC):
     """
     Stateful environment that a single agent interacts with.
@@ -67,9 +81,7 @@ class Env(ABC):
         pass
 
     @abstractmethod
-    async def step(
-        self, action: Action, *, stop_reason: tinker.StopReason = "stop", **kwargs: Any
-    ) -> StepResult:
+    async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         pass
 
 


### PR DESCRIPTION
## Summary
- Introduce `ActionExtra(TypedDict, total=False)` as a typed extensibility mechanism for `Env.step()`, replacing `stop_reason` as a keyword arg and dropping `**kwargs: Any`
- `stop_reason` is now an optional key in `ActionExtra`, accessed via `(extra or {}).get("stop_reason", "stop")`
- Update all Env implementations, rollout loop, tests, docs, and downstream compat assertions

## Design rationale
PR #506 added `stop_reason` directly to the `Env.step()` signature. The concern was that adding more fields this way grows the protocol surface and makes the interface brittle — each new piece of metadata means a new keyword arg on every Env implementation.

Instead, we introduce `ActionExtra`, a `TypedDict` with `total=False`:
- **Typed, not arbitrary**: Unlike `**kwargs`, all fields are explicitly declared with types, so consumers get autocomplete and type checking
- **Extensible**: New metadata (beyond `stop_reason`) can be added as optional keys without changing any Env implementation signatures
- **Ignorable**: Envs that don't care about extra metadata simply accept `extra: ActionExtra | None = None` and never read it — unknown keys are naturally ignored by dict access patterns
- **Picklable**: `ActionExtra` is a plain dict at runtime, inherently picklable for distributed rollout execution

## Graceful degradation

The `extra` dict is designed so that missing keys never cause errors — they just fall back to safe defaults:

- **`EnvFromMessageEnv`** reads `stop_reason` via `(extra or {}).get("stop_reason", "stop")`. If `extra` is `None` or `stop_reason` is absent, it defaults to `"stop"` and proceeds with normal parsing. If the tokens were actually truncated (i.e., `stop_reason` should have been `"length"`), `parse_response` will likely fail, which is caught by the existing parse error path (`failed_parse_reward`, default -1.0). This is actually a harsher penalty than the context overflow path (-0.1), so the training signal remains correct.

- **Single-turn envs** (ProblemEnv, recipe envs) don't read `extra` at all. If tokens are truncated, their existing format/correctness scoring handles it naturally (e.g., `correct_format = float(parse_success)` in ProblemEnv gives 0 reward for garbled output).

The key invariant: **not having `stop_reason` in `extra` never causes an error** — it just means the env treats the action as a normal completion, and any truncation-induced parse failure is caught by existing error handling.

## Test plan
- [x] All 842 unit tests pass
- [x] All 202 downstream compat tests pass (including new `TestActionExtra` assertions)
- [x] `message_env_test.py` updated to pass `extra={"stop_reason": "length"}`
- [x] ruff format + ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)