### PR TITLE
Add Nemotron-3 adapter serving, vLLM e2e tests, and weights README

### DIFF
--- a/tests/weights/vllm_serving/README.md
+++ b/tests/weights/vllm_serving/README.md
@@ -52,7 +52,7 @@ CUDA_VISIBLE_DEVICES=4   /tmp/vllm-test-env/bin/python -m pytest tests/weights/v
 | GPT-OSS-20B | `test_gpt_oss.py` | Conversion only | mxfp4+LoRA not supported in vLLM |
 | Kimi-K2 | `test_kimi.py` | Placeholder | Model too large for routine testing |
 | DeepSeek V3/V3.1 | `test_deepseek.py` | Placeholder | Intentionally unsupported |
-| Nemotron-3 | `test_nemotron.py` | Placeholder | Adapter conversion not yet implemented |
+| Nemotron-3-Nano-30B-A3B | `test_nemotron.py` | Tested | `backbone.*` → `model.*` remap, TP=2 |
 
 ## Adding a new model
 

--- a/tests/weights/vllm_serving/test_nemotron.py
+++ b/tests/weights/vllm_serving/test_nemotron.py
@@ -1,8 +1,96 @@
 """vLLM serving tests for Nemotron-3.
 
-Nemotron-3 (model_type=nemotron_h) adapter conversion is not yet supported
-due to the non-standard 'backbone.*' weight prefix. The unsupported error
-is verified by unit tests in tinker_cookbook/weights/adapter_test.py.
+Nemotron-3 uses 'backbone.*' weight prefix in HF checkpoints, but vLLM
+remaps to 'model.*' internally via WeightsMapper. The adapter conversion
+applies the same remap so PEFT keys match vLLM's parameter names.
 
-Add vLLM serving tests here when Nemotron adapter conversion is implemented.
+Nemotron-3 is a hybrid Mamba+Attention MoE architecture.
 """
+
+from __future__ import annotations
+
+import pytest
+import torch
+from vllm import LLM
+from vllm.lora.request import LoRARequest
+
+from tests.weights.vllm_serving.conftest import (
+    LORA_RANK,
+    PROMPT,
+    convert_and_load,
+    generate,
+    load_hf_config_dict,
+    save_tinker_adapter,
+)
+
+MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+
+
+class TestNemotron3:
+    """Nemotron-3-Nano-30B-A3B: hybrid Mamba+Attention MoE with backbone.* prefix."""
+
+    @pytest.fixture(scope="class")
+    def llm(self):
+        return LLM(
+            model=MODEL,
+            enable_lora=True,
+            max_lora_rank=LORA_RANK,
+            max_loras=1,
+            max_model_len=256,
+            enforce_eager=True,
+            gpu_memory_utilization=0.5,
+            tensor_parallel_size=2,
+            trust_remote_code=True,
+        )
+
+    def test_attention_adapter(self, llm, tmp_path):
+        """Create q_proj adapter for an attention layer, verify backbone→model remap."""
+        config = load_hf_config_dict(MODEL)
+        hidden = config["hidden_size"]
+        num_heads = config["num_attention_heads"]
+        head_dim = config.get("head_dim", hidden // num_heads)
+        q_dim = num_heads * head_dim
+
+        # Find an attention layer. Nemotron-3 uses hybrid_override_pattern:
+        # M=Mamba, E=MoE, *=Attention
+        pattern = config.get("hybrid_override_pattern", "")
+        attn_idx = None
+        for i, ch in enumerate(pattern):
+            if ch == "*":
+                attn_idx = i
+                break
+        if attn_idx is None:
+            pytest.skip("No attention layer found in Nemotron config")
+
+        # Tinker adapter uses backbone.* prefix (matching HF checkpoint)
+        prefix = f"base_model.model.backbone.layers.{attn_idx}.mixer"
+        weights = {
+            f"{prefix}.q_proj.lora_A.weight": torch.randn(LORA_RANK, hidden) * 0.01,
+            f"{prefix}.q_proj.lora_B.weight": torch.randn(q_dim, LORA_RANK) * 0.01,
+        }
+
+        adapter_path = tmp_path / "tinker_adapter"
+        peft_path = tmp_path / "peft_adapter"
+        save_tinker_adapter(adapter_path, weights)
+        peft_weights, peft_config = convert_and_load(MODEL, adapter_path, peft_path)
+
+        # PEFT keys should use model.* (vLLM's internal names), not backbone.*
+        assert not any("backbone" in k for k in peft_weights), (
+            "PEFT keys should not contain 'backbone'"
+        )
+        assert any("model.layers" in k for k in peft_weights), (
+            "PEFT keys should use 'model.layers' prefix"
+        )
+        assert "q_proj" in peft_config["target_modules"]
+
+        print(f"\n  PEFT keys: {sorted(peft_weights.keys())}")
+        print(f"  target_modules: {peft_config['target_modules']}")
+
+        base_text = generate(llm, PROMPT)
+        assert len(base_text) > 0
+        print(f"  Base: {base_text!r}")
+
+        lora_req = LoRARequest("nemotron3", 1, str(peft_path))
+        lora_text = generate(llm, PROMPT, lora_request=lora_req)
+        assert len(lora_text) > 0
+        print(f"  LoRA: {lora_text!r}")

--- a/tinker_cookbook/weights/README.md
+++ b/tinker_cookbook/weights/README.md
@@ -1,0 +1,98 @@
+# Weights: Merge & Adapter Serving Support
+
+Two build paths for trained LoRA adapters:
+
+- **`build_hf_model`** — merge LoRA into full HF model weights (for direct deployment)
+- **`build_lora_adapter`** — convert to PEFT format for serving with vLLM / SGLang (lightweight, hot-swappable)
+
+## Model Support Matrix
+
+| Model Family | Merge | Adapter | Transformers | Notes |
+|---|:---:|:---:|---|---|
+| **Qwen3 dense** (4B–32B) | ✅ | ✅ | 4.x, 5.x | Standard attention LoRA |
+| **Qwen3 MoE** (30B-A3B) | ✅ | ✅ | 4.x, 5.x | Fused gate_up_proj experts; vLLM MoE LoRA experimental |
+| **Qwen3-VL MoE** (30B-A3B) | ✅ | ✅ | 4.x, 5.x | Vision prefix (`model.language_model.*`) + fused experts |
+| **Qwen3.5 dense** (4B, 27B) | ✅ | ✅ | 5.x only | Split QKV (`in_proj_q/k/v`); tied embeddings |
+| **Qwen3.5 MoE** (35B-A3B, 397B-A17B) | ✅ | ✅ | 5.x only | Split QKV + fused experts; vLLM MoE LoRA experimental |
+| **GPT-OSS** (20B, 120B) | ✅ | ✅ | 4.x, 5.x | `.attn` → `.self_attn` remap; interleaved expert layout |
+| **Kimi-K2** | ✅ | ✅ | 4.x, 5.x | DeepSeek architecture, separate experts; ~1TB bf16 |
+| **Kimi-K2.5** | ✅ | ✅ | 4.x, 5.x | VL model (`kimi_k25`); vLLM LoRA not yet supported |
+| **DeepSeek V3 / V3.1** | ✅ | ❌ | 4.x (custom code), 5.x (native) | vLLM/SGLang don't support DeepSeek LoRA |
+| **Nemotron-3** (Nano 30B, Super 120B) | ✅ | ✅ | 4.x, 5.x | `backbone.*` weight prefix (handled automatically) |
+
+### Legend
+
+- **Merge** = `build_hf_model` support
+- **Adapter** = `build_lora_adapter` support (PEFT format for vLLM/SGLang serving)
+- **Transformers** = supported `transformers` library versions
+
+## Architecture Details
+
+### Expert Weight Layouts
+
+MoE models store expert weights in different layouts. The merge/adapter code handles all three:
+
+| Layout | Models | Structure |
+|---|---|---|
+| **Separate** | DeepSeek, Kimi-K2, Qwen3 MoE (transformers 4.x) | Individual `experts.{i}.gate_proj.weight` per expert |
+| **Fused concatenated** | Qwen3 MoE (transformers 5.x), Qwen3.5 MoE, Qwen3-VL MoE | Single `experts.gate_up_proj` with `[gate \| up]` layout |
+| **Fused interleaved** | GPT-OSS | Single `experts.gate_up_proj` with `[g0, u0, g1, u1, ...]` layout |
+
+### Qwen3.5 Split QKV
+
+Qwen3.5 linear attention layers use a fused `in_proj_qkv` weight, but Tinker trains separate `in_proj_q/k/v` LoRA adapters (which may have unequal dimensions). The merge path fuses them back; the adapter path keeps them split (vLLM handles this via `packed_modules_mapping`).
+
+### Key Remapping
+
+| Remap | Applies to | Why |
+|---|---|---|
+| `base_model.model.` prefix strip | All models | Tinker adapter prefix → HF parameter names |
+| `unembed_tokens` → `lm_head` (or `embed_tokens`) | All models | Tinker naming → HF naming; tied embeddings use `embed_tokens` |
+| `model.*` → `model.language_model.*` | Vision models | Vision models nest language model under `language_model` |
+| `.attn` → `.self_attn` | GPT-OSS | Tinker internal naming → HF naming |
+| `w1/w2/w3` → `gate_proj/down_proj/up_proj` | MoE expert keys | Tinker expert naming → HF naming |
+
+## Unsupported Models — Adapter Serving
+
+### DeepSeek V3/V3.1 (`model_type=deepseek_v3`)
+
+**Status:** Blocked — raises `WeightsAdapterError`.
+
+**Reason:** vLLM and SGLang do not support LoRA inference for the DeepSeek V3 architecture. Use `build_hf_model` to merge the adapter into a full model instead.
+
+**Unblock when:** vLLM adds DeepSeek V3 LoRA support.
+
+### ~~Nemotron-3 (`model_type=nemotron_h`)~~ — Resolved
+
+Nemotron HF checkpoints use `backbone.*` instead of `model.*` as the weight prefix. vLLM remaps `backbone.*` → `model.*` internally via `WeightsMapper`. The adapter conversion applies the same remap via `_SERVING_PREFIX_REMAPS` so PEFT keys match vLLM's internal parameter names.
+
+## vLLM Serving Compatibility
+
+Adapter serving has been verified end-to-end with vLLM 0.18:
+
+| Model | vLLM LoRA | Status |
+|---|---|---|
+| Qwen3-8B (dense) | Full support | ✅ Verified |
+| Qwen3-30B-A3B (MoE) | Experimental | ✅ Verified (requires all 3 expert projections) |
+| Qwen3.5-4B (split QKV) | Full support | ✅ Verified (split in_proj_q/k/v works) |
+| GPT-OSS-20B | Full support | ⚠️ Conversion verified; serving blocked by mxfp4+LoRA incompatibility |
+| Kimi-K2 | Supported (DeepSeekV2) | ⚠️ Conversion verified; model too large (~1TB) for routine e2e testing |
+| Kimi-K2.5 | Not supported | ⚠️ Conversion verified; vLLM 0.18 lacks LoRA for `KimiK25ForConditionalGeneration` |
+| DeepSeek V3/V3.1 | Not supported | ❌ Adapter conversion blocked |
+| Nemotron-3 (30B-A3B) | Full support (vLLM) | ✅ Verified (`backbone.*` → `model.*` remap) |
+
+See `tests/weights/vllm_serving/` for the serving test suite.
+
+## Testing
+
+```bash
+# Unit tests (no network, no API key)
+pytest tinker_cookbook/weights/ -v
+
+# E2E tests (downloads HF configs, no API key)
+pytest tests/weights/ -v
+
+# vLLM serving tests (requires GPU + isolated venv)
+bash tests/weights/vllm_serving/setup_env.sh
+/tmp/vllm-test-env/bin/python -m pytest tests/weights/vllm_serving/ -v -s
+```

--- a/tinker_cookbook/weights/_adapter.py
+++ b/tinker_cookbook/weights/_adapter.py
@@ -56,11 +56,17 @@ _UNSUPPORTED_MODEL_TYPES: dict[str, str] = {
         "serving in vLLM or SGLang. "
         "Use build_hf_model to merge the adapter into a full HF model instead."
     ),
-    "nemotron_h": (
-        "Nemotron-3 (model_type='nemotron_h') adapter conversion is not yet supported "
-        "(non-standard 'backbone.*' weight prefix needs investigation). "
-        "Use build_hf_model to merge the adapter into a full HF model instead."
-    ),
+}
+
+# Serving frameworks (vLLM, SGLang) may rename weight prefixes when loading
+# HF checkpoints. For example, vLLM's NemotronH WeightsMapper converts
+# "backbone.*" → "model.*". PEFT adapter keys must match the serving
+# framework's internal parameter names, not the original HF checkpoint names.
+#
+# Map from model_type → list of (old, new) prefix replacements to apply to
+# PEFT output keys.
+_SERVING_PREFIX_REMAPS: dict[str, tuple[tuple[str, str], ...]] = {
+    "nemotron_h": (("backbone.", "model."),),
 }
 
 # Expert remapping: Tinker internal names → HuggingFace parameter names.
@@ -143,6 +149,11 @@ def build_lora_adapter(
         # Core conversion: remap keys, expand experts, produce PEFT tensors.
         peft_weights, target_modules = _convert_adapter(adapter_weights, model_state_keys, profile)
 
+        # Apply serving-framework prefix remaps (e.g., backbone.* → model.* for Nemotron).
+        model_type = config_dict.get("model_type", "")
+        if model_type in _SERVING_PREFIX_REMAPS:
+            peft_weights = _apply_serving_prefix_remaps(peft_weights, model_type)
+
         # Write output.
         peft_config = _build_peft_config(adapter_config, base_model, target_modules)
         _write_peft_adapter(out, peft_weights, peft_config)
@@ -168,6 +179,27 @@ def _check_model_support(config_dict: dict) -> None:
     model_type = config_dict.get("model_type", "")
     if model_type in _UNSUPPORTED_MODEL_TYPES:
         raise WeightsAdapterError(_UNSUPPORTED_MODEL_TYPES[model_type])
+
+
+def _apply_serving_prefix_remaps(
+    peft_weights: dict[str, torch.Tensor],
+    model_type: str,
+) -> dict[str, torch.Tensor]:
+    """Remap PEFT key prefixes so they match the serving framework's internal names.
+
+    Some models use non-standard prefixes in their HF checkpoints (e.g.,
+    Nemotron uses ``backbone.*`` instead of ``model.*``). Serving frameworks
+    like vLLM remap these at load time, so PEFT adapter keys must match the
+    remapped names, not the original HF checkpoint names.
+    """
+    remaps = _SERVING_PREFIX_REMAPS[model_type]
+    remapped: dict[str, torch.Tensor] = {}
+    for key, tensor in peft_weights.items():
+        new_key = key
+        for old, new in remaps:
+            new_key = new_key.replace(old, new)
+        remapped[new_key] = tensor
+    return remapped
 
 
 def _warn_experimental_moe(profile: MergeProfile) -> None:

--- a/tinker_cookbook/weights/adapter_test.py
+++ b/tinker_cookbook/weights/adapter_test.py
@@ -520,7 +520,13 @@ class TestUnsupportedModels:
                 output_path=str(output_dir),
             )
 
-    def test_nemotron_raises_error(self, tmp_path: Path) -> None:
+    def test_nemotron_backbone_prefix_remapped(self, tmp_path: Path) -> None:
+        """Nemotron HF checkpoints use 'backbone.*' but vLLM remaps to 'model.*'.
+
+        The adapter conversion must produce PEFT keys with 'model.*' prefix
+        (matching vLLM's internal parameter names) not 'backbone.*' (the HF
+        checkpoint prefix).
+        """
         model_dir = tmp_path / "model"
         adapter_dir = tmp_path / "adapter"
         output_dir = tmp_path / "output"
@@ -542,12 +548,21 @@ class TestUnsupportedModels:
             },
         )
 
-        with pytest.raises(WeightsAdapterError, match="Nemotron"):
-            build_lora_adapter(
-                base_model=str(model_dir),
-                adapter_path=str(adapter_dir),
-                output_path=str(output_dir),
-            )
+        build_lora_adapter(
+            base_model=str(model_dir),
+            adapter_path=str(adapter_dir),
+            output_path=str(output_dir),
+        )
+
+        peft_weights, peft_config = _load_peft_output(output_dir)
+
+        # PEFT keys should use model.* (vLLM's internal names), not backbone.*
+        assert "base_model.model.model.layers.0.mixer.q_proj.lora_A.weight" in peft_weights
+        assert "base_model.model.model.layers.0.mixer.q_proj.lora_B.weight" in peft_weights
+        assert not any("backbone" in k for k in peft_weights), (
+            "PEFT keys should not contain 'backbone' — vLLM remaps to 'model'"
+        )
+        assert "q_proj" in peft_config["target_modules"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Unblock `build_lora_adapter` for Nemotron-3 (`model_type=nemotron_h`)
- Add vLLM adapter serving e2e tests for all supported model families
- Add `tinker_cookbook/weights/README.md` documenting the full model support matrix

## Nemotron-3 adapter serving

Nemotron HF checkpoints use `backbone.*` weight prefix, but vLLM remaps to `model.*` internally via `WeightsMapper`. PEFT adapter keys must match the serving framework's internal names.

Added `_SERVING_PREFIX_REMAPS` in `_adapter.py` — a dict mapping `model_type → prefix remaps` applied to PEFT output keys after conversion. Extensible to future models with similar HF↔serving prefix mismatches.

Verified e2e with Nemotron-3-Nano-30B-A3B on vLLM 0.18 (TP=2).

## vLLM serving tests (`tests/weights/vllm_serving/`)

Per-model-family e2e tests verifying adapters from `build_lora_adapter` can be loaded and served by vLLM. Requires GPU + isolated venv (vLLM pins conflicting torch/transformers).

| Model | Result |
|---|---|
| Qwen3-8B (dense) | Pass |
| Qwen3-30B-A3B (MoE, TP=2) | Pass |
| Qwen3.5-4B (full_attention) | Pass |
| Qwen3.5-4B (split in_proj_q/k/v) | Pass |
| GPT-OSS-20B | Conversion pass (mxfp4+LoRA not supported in vLLM) |
| Nemotron-3-Nano-30B-A3B (TP=2) | Pass |

Setup: `bash tests/weights/vllm_serving/setup_env.sh`
`conftest.py` skips collection when vLLM/GPU unavailable — normal test suite unaffected.

## Weights README

`tinker_cookbook/weights/README.md` documenting:
- Model support matrix (merge vs adapter × model family × transformers version)
- Expert weight layouts, split QKV, key remapping details
- vLLM serving compatibility
- Unsupported models and reasons

## Test plan

- [x] 16 adapter unit tests pass (including new Nemotron `backbone.*` → `model.*` remap test)
- [x] All 173 weights unit tests pass
- [x] vLLM e2e: Nemotron-3-Nano-30B-A3B adapter loads and generates (TP=2)
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)