### PR TITLE
Add Nemotron-3-Super vLLM test and update model docs

### DIFF
--- a/tests/weights/vllm_serving/README.md
+++ b/tests/weights/vllm_serving/README.md
@@ -50,9 +50,11 @@ CUDA_VISIBLE_DEVICES=4   /tmp/vllm-test-env/bin/python -m pytest tests/weights/v
 | Qwen3-30B-A3B (MoE) | `test_qwen3.py` | Tested | Expert expansion, TP=2 |
 | Qwen3.5-4B (split QKV) | `test_qwen3_5.py` | Tested | Split in_proj_q/k/v + full_attention |
 | GPT-OSS-20B | `test_gpt_oss.py` | Conversion only | mxfp4+LoRA not supported in vLLM |
-| Kimi-K2 | `test_kimi.py` | Placeholder | Model too large for routine testing |
+| Kimi-K2 | `test_kimi.py` | Placeholder | ~1TB bf16, too large; vLLM LoRA supported via DeepSeekV2 |
+| Kimi-K2.5 | `test_kimi.py` | Placeholder | vLLM 0.18 lacks LoRA for KimiK25ForConditionalGeneration |
 | DeepSeek V3/V3.1 | `test_deepseek.py` | Placeholder | Intentionally unsupported |
 | Nemotron-3-Nano-30B-A3B | `test_nemotron.py` | Tested | `backbone.*` → `model.*` remap, TP=2 |
+| Nemotron-3-Super-120B-A12B | `test_nemotron.py` | Tested | `backbone.*` → `model.*` remap, TP=4 |
 
 ## Adding a new model
 

--- a/tests/weights/vllm_serving/test_kimi.py
+++ b/tests/weights/vllm_serving/test_kimi.py
@@ -1,7 +1,17 @@
-"""vLLM serving tests for Kimi-K2: DeepSeek architecture with per-expert expansion.
+"""vLLM serving tests for Kimi-K2 / K2.5.
 
-Kimi-K2 (~236B parameters) is too large for routine local testing.
-The adapter conversion correctness is verified by unit tests in
-tests/weights/test_adapter_kimi.py. Add vLLM serving tests here
-when a smaller Kimi model is available or infra supports it.
+Kimi-K2 (model_type=kimi_k2, architecture=DeepseekV3ForCausalLM):
+  - Adapter conversion supported (separate per-expert expansion)
+  - vLLM LoRA supported via DeepseekV2ForCausalLM (SupportsLoRA)
+  - ~1TB in bf16 — too large for routine e2e testing on 8xH200
+  - Conversion correctness verified by tests/weights/test_adapter_kimi.py
+
+Kimi-K2.5 (model_type=kimi_k25, architecture=KimiK25ForConditionalGeneration):
+  - Adapter conversion supported
+  - vLLM 0.18 does NOT implement SupportsLoRA for KimiK25ForConditionalGeneration
+  - 595 GB in bf16 — fits on 8xH200 but no LoRA support to test
+
+Add vLLM serving tests here when either:
+  - A smaller Kimi-K2 variant is available, or
+  - vLLM adds LoRA support for KimiK25ForConditionalGeneration
 """

--- a/tests/weights/vllm_serving/test_nemotron.py
+++ b/tests/weights/vllm_serving/test_nemotron.py
@@ -5,6 +5,10 @@ remaps to 'model.*' internally via WeightsMapper. The adapter conversion
 applies the same remap so PEFT keys match vLLM's parameter names.
 
 Nemotron-3 is a hybrid Mamba+Attention MoE architecture.
+
+Run individual variants:
+    CUDA_VISIBLE_DEVICES=0,1 .../python -m pytest .../test_nemotron.py::TestNemotron3Nano -v -s
+    CUDA_VISIBLE_DEVICES=0,1,2,3 .../python -m pytest .../test_nemotron.py::TestNemotron3Super -v -s
 """
 
 from __future__ import annotations
@@ -23,16 +27,54 @@ from tests.weights.vllm_serving.conftest import (
     save_tinker_adapter,
 )
 
-MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+
+def _make_nemotron_adapter(model: str) -> tuple[dict, dict[str, torch.Tensor]]:
+    """Create a synthetic Tinker adapter for a Nemotron attention layer.
+
+    Returns (config_dict, adapter_weights).
+    """
+    config = load_hf_config_dict(model)
+    hidden = config["hidden_size"]
+    num_heads = config["num_attention_heads"]
+    head_dim = config.get("head_dim", hidden // num_heads)
+    q_dim = num_heads * head_dim
+
+    # Find an attention layer. Nemotron-3 uses hybrid_override_pattern:
+    # M=Mamba, E=MoE, *=Attention
+    pattern = config.get("hybrid_override_pattern", "")
+    attn_idx = next((i for i, ch in enumerate(pattern) if ch == "*"), None)
+    if attn_idx is None:
+        pytest.skip("No attention layer found in Nemotron config")
+
+    # Tinker adapter uses backbone.* prefix (matching HF checkpoint)
+    prefix = f"base_model.model.backbone.layers.{attn_idx}.mixer"
+    weights = {
+        f"{prefix}.q_proj.lora_A.weight": torch.randn(LORA_RANK, hidden) * 0.01,
+        f"{prefix}.q_proj.lora_B.weight": torch.randn(q_dim, LORA_RANK) * 0.01,
+    }
+    return config, weights
 
 
-class TestNemotron3:
-    """Nemotron-3-Nano-30B-A3B: hybrid Mamba+Attention MoE with backbone.* prefix."""
+def _verify_nemotron_peft_keys(peft_weights: dict[str, torch.Tensor], peft_config: dict) -> None:
+    """Assert PEFT keys use model.* (not backbone.*) and target_modules is correct."""
+    assert not any("backbone" in k for k in peft_weights), (
+        "PEFT keys should not contain 'backbone' — vLLM remaps to 'model'"
+    )
+    assert any("model.layers" in k for k in peft_weights), (
+        "PEFT keys should use 'model.layers' prefix"
+    )
+    assert "q_proj" in peft_config["target_modules"]
+
+
+class TestNemotron3Nano:
+    """Nemotron-3-Nano-30B-A3B: 30B MoE (3B active), TP=2."""
+
+    MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
 
     @pytest.fixture(scope="class")
     def llm(self):
         return LLM(
-            model=MODEL,
+            model=self.MODEL,
             enable_lora=True,
             max_lora_rank=LORA_RANK,
             max_loras=1,
@@ -44,53 +86,65 @@ class TestNemotron3:
         )
 
     def test_attention_adapter(self, llm, tmp_path):
-        """Create q_proj adapter for an attention layer, verify backbone→model remap."""
-        config = load_hf_config_dict(MODEL)
-        hidden = config["hidden_size"]
-        num_heads = config["num_attention_heads"]
-        head_dim = config.get("head_dim", hidden // num_heads)
-        q_dim = num_heads * head_dim
-
-        # Find an attention layer. Nemotron-3 uses hybrid_override_pattern:
-        # M=Mamba, E=MoE, *=Attention
-        pattern = config.get("hybrid_override_pattern", "")
-        attn_idx = None
-        for i, ch in enumerate(pattern):
-            if ch == "*":
-                attn_idx = i
-                break
-        if attn_idx is None:
-            pytest.skip("No attention layer found in Nemotron config")
-
-        # Tinker adapter uses backbone.* prefix (matching HF checkpoint)
-        prefix = f"base_model.model.backbone.layers.{attn_idx}.mixer"
-        weights = {
-            f"{prefix}.q_proj.lora_A.weight": torch.randn(LORA_RANK, hidden) * 0.01,
-            f"{prefix}.q_proj.lora_B.weight": torch.randn(q_dim, LORA_RANK) * 0.01,
-        }
+        """Verify backbone→model remap and vLLM serving for Nano variant."""
+        _, adapter_weights = _make_nemotron_adapter(self.MODEL)
 
         adapter_path = tmp_path / "tinker_adapter"
         peft_path = tmp_path / "peft_adapter"
-        save_tinker_adapter(adapter_path, weights)
-        peft_weights, peft_config = convert_and_load(MODEL, adapter_path, peft_path)
+        save_tinker_adapter(adapter_path, adapter_weights)
+        peft_weights, peft_config = convert_and_load(self.MODEL, adapter_path, peft_path)
 
-        # PEFT keys should use model.* (vLLM's internal names), not backbone.*
-        assert not any("backbone" in k for k in peft_weights), (
-            "PEFT keys should not contain 'backbone'"
-        )
-        assert any("model.layers" in k for k in peft_weights), (
-            "PEFT keys should use 'model.layers' prefix"
-        )
-        assert "q_proj" in peft_config["target_modules"]
-
-        print(f"\n  PEFT keys: {sorted(peft_weights.keys())}")
-        print(f"  target_modules: {peft_config['target_modules']}")
+        _verify_nemotron_peft_keys(peft_weights, peft_config)
 
         base_text = generate(llm, PROMPT)
         assert len(base_text) > 0
-        print(f"  Base: {base_text!r}")
 
-        lora_req = LoRARequest("nemotron3", 1, str(peft_path))
+        lora_req = LoRARequest("nemotron3_nano", 1, str(peft_path))
         lora_text = generate(llm, PROMPT, lora_request=lora_req)
         assert len(lora_text) > 0
+
+        print(f"\n  PEFT keys: {sorted(peft_weights.keys())}")
+        print(f"  Base: {base_text!r}")
+        print(f"  LoRA: {lora_text!r}")
+
+
+class TestNemotron3Super:
+    """Nemotron-3-Super-120B-A12B: 120B MoE (12B active), TP=4."""
+
+    MODEL = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
+
+    @pytest.fixture(scope="class")
+    def llm(self):
+        return LLM(
+            model=self.MODEL,
+            enable_lora=True,
+            max_lora_rank=LORA_RANK,
+            max_loras=1,
+            max_model_len=256,
+            enforce_eager=True,
+            gpu_memory_utilization=0.5,
+            tensor_parallel_size=4,
+            trust_remote_code=True,
+        )
+
+    def test_attention_adapter(self, llm, tmp_path):
+        """Verify backbone→model remap and vLLM serving for Super variant."""
+        _, adapter_weights = _make_nemotron_adapter(self.MODEL)
+
+        adapter_path = tmp_path / "tinker_adapter"
+        peft_path = tmp_path / "peft_adapter"
+        save_tinker_adapter(adapter_path, adapter_weights)
+        peft_weights, peft_config = convert_and_load(self.MODEL, adapter_path, peft_path)
+
+        _verify_nemotron_peft_keys(peft_weights, peft_config)
+
+        base_text = generate(llm, PROMPT)
+        assert len(base_text) > 0
+
+        lora_req = LoRARequest("nemotron3_super", 1, str(peft_path))
+        lora_text = generate(llm, PROMPT, lora_request=lora_req)
+        assert len(lora_text) > 0
+
+        print(f"\n  PEFT keys: {sorted(peft_weights.keys())}")
+        print(f"  Base: {base_text!r}")
         print(f"  LoRA: {lora_text!r}")

--- a/tinker_cookbook/weights/README.md
+++ b/tinker_cookbook/weights/README.md
@@ -79,7 +79,8 @@ Adapter serving has been verified end-to-end with vLLM 0.18:
 | Kimi-K2 | Supported (DeepSeekV2) | ⚠️ Conversion verified; model too large (~1TB) for routine e2e testing |
 | Kimi-K2.5 | Not supported | ⚠️ Conversion verified; vLLM 0.18 lacks LoRA for `KimiK25ForConditionalGeneration` |
 | DeepSeek V3/V3.1 | Not supported | ❌ Adapter conversion blocked |
-| Nemotron-3 (30B-A3B) | Full support (vLLM) | ✅ Verified (`backbone.*` → `model.*` remap) |
+| Nemotron-3-Nano (30B-A3B) | Full support (vLLM) | ✅ Verified (`backbone.*` → `model.*` remap, TP=2) |
+| Nemotron-3-Super (120B-A12B) | Full support (vLLM) | ✅ Verified (`backbone.*` → `model.*` remap, TP=4) |
 
 See `tests/weights/vllm_serving/` for the serving test suite.
 


### PR DESCRIPTION
## Summary

- Add Nemotron-3-Super-120B-A12B vLLM serving test (verified on 8xH200, TP=4)
- Update weights README and vLLM serving README with full model status
- Document Kimi-K2/K2.5 infra constraints

## Changes

**`tests/weights/vllm_serving/test_nemotron.py`** — Refactored into `TestNemotron3Nano` (TP=2) and `TestNemotron3Super` (TP=4) with shared helper. Both verified passing.

**`tests/weights/vllm_serving/test_kimi.py`** — Updated placeholder with detailed findings: K2 too large (~1TB), K2.5 lacks vLLM LoRA support.

**`tinker_cookbook/weights/README.md`** — Added Nemotron-3-Super verified status, Kimi-K2/K2.5 details.

**`tests/weights/vllm_serving/README.md`** — Updated model status table.

## Test plan

- [x] Nemotron-3-Nano-30B-A3B e2e pass (TP=2, vLLM 0.18)
- [x] Nemotron-3-Super-120B-A12B e2e pass (TP=4, vLLM 0.18)
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)