### PR TITLE
Add streaming packing module for SFT training

### DIFF
--- a/tinker_cookbook/supervised/__init__.py
+++ b/tinker_cookbook/supervised/__init__.py
@@ -7,6 +7,10 @@ from tinker_cookbook.supervised.data import (
     SupervisedDatasetFromHFDataset,
     conversation_to_datum,
 )
+from tinker_cookbook.supervised.streaming_packing import (
+    StreamingPackedSupervisedDataset,
+    pack_rendered_examples,
+)
 from tinker_cookbook.supervised.types import (
     ChatDatasetBuilder,
     ChatDatasetBuilderCommonConfig,
@@ -25,6 +29,9 @@ __all__ = [
     "StreamingSupervisedDatasetFromHFDataset",
     "SupervisedDatasetFromHFDataset",
     "conversation_to_datum",
+    # Streaming packing (streaming_packing.py)
+    "StreamingPackedSupervisedDataset",
+    "pack_rendered_examples",
     # Helpers (common.py)
     "compute_mean_nll",
     "datum_from_model_input_weights",

--- a/tinker_cookbook/supervised/streaming_packing.py
+++ b/tinker_cookbook/supervised/streaming_packing.py
@@ -1,0 +1,490 @@
+"""
+Streaming packed dataset for supervised fine-tuning.
+
+Renders and packs examples in a background thread so that training can start
+immediately instead of waiting for the entire dataset to be pre-rendered.
+The packing algorithm is the same greedy bin-packing used by
+``tinker_cookbook.recipes.nemotron_cascade.sft_datasets.PackedSupervisedDataset``,
+but rendering happens incrementally in chunks and packed batches are fed to the
+training loop through a bounded queue.
+
+Usage::
+
+    from tinker_cookbook.supervised.streaming_packing import (
+        StreamingPackedSupervisedDataset,
+        pack_rendered_examples,
+    )
+
+    dataset = StreamingPackedSupervisedDataset(
+        examples=my_raw_examples,          # Iterable of raw examples
+        render_fn=my_render_fn,            # Example -> (ModelInput, weights)
+        batch_size=4,
+        max_packed_length=49152,
+        total_examples=len(my_raw_examples),
+    )
+
+    # Satisfies the SupervisedDataset interface — use directly in train.py
+    for batch_idx in range(len(dataset)):
+        batch = dataset.get_batch(batch_idx)
+"""
+
+import logging
+import queue
+import threading
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+from typing import TypeVar
+
+import tinker
+import torch
+
+from tinker_cookbook.supervised.common import datum_from_model_input_weights
+from tinker_cookbook.supervised.types import SupervisedDataset
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# ---------------------------------------------------------------------------
+# Pure packing algorithm
+# ---------------------------------------------------------------------------
+
+
+def pack_rendered_examples(
+    rendered: Iterable[tuple[tinker.ModelInput, torch.Tensor]],
+    max_packed_length: int,
+) -> list[tinker.Datum]:
+    """Pack multiple pre-shift rendered examples into Datums using greedy bin-packing.
+
+    Each rendered example is a ``(ModelInput, weights)`` pair as returned by
+    ``renderer.build_supervised_example``.  This function concatenates multiple
+    examples' tokens and weights into packed sequences up to *max_packed_length*
+    tokens, then applies the standard right-shift via
+    ``datum_from_model_input_weights``.
+
+    Args:
+        rendered: Iterable of ``(ModelInput, weights_tensor)`` pairs.
+        max_packed_length: Maximum number of tokens per packed sequence.
+
+    Returns:
+        List of packed Datums.  Each Datum may contain multiple concatenated
+        examples.
+    """
+    packed_datums: list[tinker.Datum] = []
+    current_tokens: list[int] = []
+    current_weights: list[float] = []
+
+    for model_input, weights in rendered:
+        tokens = list(model_input.to_ints())
+        w = weights.tolist()
+        example_len = len(tokens)
+
+        if example_len == 0:
+            continue
+
+        # If this single example exceeds the limit, pack it alone (truncated).
+        if example_len > max_packed_length:
+            if current_tokens:
+                _flush_packed(current_tokens, current_weights, max_packed_length, packed_datums)
+                current_tokens = []
+                current_weights = []
+            _flush_packed(tokens, w, max_packed_length, packed_datums)
+            continue
+
+        # Would adding this example exceed the limit?
+        if len(current_tokens) + example_len > max_packed_length:
+            _flush_packed(current_tokens, current_weights, max_packed_length, packed_datums)
+            current_tokens = []
+            current_weights = []
+
+        current_tokens.extend(tokens)
+        current_weights.extend(w)
+
+    # Flush remaining.
+    if current_tokens:
+        _flush_packed(current_tokens, current_weights, max_packed_length, packed_datums)
+
+    return packed_datums
+
+
+def _flush_packed(
+    tokens: list[int],
+    weights: list[float],
+    max_packed_length: int,
+    out: list[tinker.Datum],
+) -> None:
+    """Create a Datum from concatenated tokens/weights and append to *out*."""
+    combined_input = tinker.ModelInput.from_ints(tokens[:max_packed_length])
+    combined_weights = torch.tensor(weights[:max_packed_length], dtype=torch.float32)
+    out.append(datum_from_model_input_weights(combined_input, combined_weights, max_packed_length))
+
+
+# ---------------------------------------------------------------------------
+# Incremental packer (packs a stream, yields Datums one at a time)
+# ---------------------------------------------------------------------------
+
+
+def _incremental_pack(
+    rendered_iter: Iterator[tuple[tinker.ModelInput, torch.Tensor]],
+    max_packed_length: int,
+) -> Iterator[tinker.Datum]:
+    """Yield packed Datums one at a time from a stream of rendered examples.
+
+    This is the core of the streaming pipeline: it greedily fills a buffer up to
+    *max_packed_length* tokens, flushes a Datum, and continues.  The caller
+    receives Datums as soon as they are ready rather than waiting for the whole
+    dataset to be rendered.
+
+    Any carry-over from chunk boundaries is handled naturally: leftover examples
+    that did not fit in the previous pack remain in the buffer for the next one.
+    """
+    current_tokens: list[int] = []
+    current_weights: list[float] = []
+
+    for model_input, weights in rendered_iter:
+        tokens = list(model_input.to_ints())
+        w = weights.tolist()
+        example_len = len(tokens)
+
+        if example_len == 0:
+            continue
+
+        # Oversized example: flush current buffer, then emit the oversized one alone.
+        if example_len > max_packed_length:
+            if current_tokens:
+                yield _make_datum(current_tokens, current_weights, max_packed_length)
+                current_tokens = []
+                current_weights = []
+            yield _make_datum(tokens, w, max_packed_length)
+            continue
+
+        # Would this example overflow the current buffer?
+        if len(current_tokens) + example_len > max_packed_length:
+            yield _make_datum(current_tokens, current_weights, max_packed_length)
+            current_tokens = []
+            current_weights = []
+
+        current_tokens.extend(tokens)
+        current_weights.extend(w)
+
+    # Flush any remaining tokens.
+    if current_tokens:
+        yield _make_datum(current_tokens, current_weights, max_packed_length)
+
+
+def _make_datum(
+    tokens: list[int],
+    weights: list[float],
+    max_packed_length: int,
+) -> tinker.Datum:
+    """Build a single Datum from concatenated tokens and weights."""
+    combined_input = tinker.ModelInput.from_ints(tokens[:max_packed_length])
+    combined_weights = torch.tensor(weights[:max_packed_length], dtype=torch.float32)
+    return datum_from_model_input_weights(combined_input, combined_weights, max_packed_length)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel / error wrappers for queue communication
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ErrorSentinel:
+    """Carries an exception from the background thread to the consumer."""
+
+    exception: BaseException
+
+
+# None is used as the end-of-stream sentinel.
+_QueueItem = list[tinker.Datum] | _ErrorSentinel | None
+
+
+# ---------------------------------------------------------------------------
+# StreamingPackedSupervisedDataset
+# ---------------------------------------------------------------------------
+
+
+class StreamingPackedSupervisedDataset(SupervisedDataset):
+    """A streaming, packed supervised dataset that renders in the background.
+
+    Instead of pre-rendering every example before training begins, this class
+    spawns a daemon thread that renders raw examples through a user-supplied
+    ``render_fn``, packs the resulting token sequences using greedy bin-packing,
+    groups packed Datums into batches, and deposits them into a bounded
+    ``queue.Queue``.  The training loop calls ``get_batch(index)`` which pulls
+    the next batch from the queue.
+
+    **Key properties:**
+
+    * Forward-only iteration (like ``StreamingSupervisedDatasetFromHFDataset``).
+    * The background thread starts as soon as the dataset is constructed.
+    * Errors in the background thread are propagated to the main thread on the
+      next ``get_batch`` call.
+    * ``set_epoch`` cleanly stops the current background pipeline and restarts
+      with the new epoch's iterator.
+    * ``__len__`` returns a conservative estimate based on ``total_examples``
+      and average tokens-per-example (updated as rendering progresses).
+
+    Args:
+        examples: An iterable of raw examples.  Must be re-iterable (called
+            again on each epoch) OR a callable returning a fresh iterator.
+        render_fn: Callable that converts a raw example into a
+            ``(ModelInput, weights_tensor)`` pair.
+        batch_size: Number of packed Datums per batch.
+        max_packed_length: Maximum number of tokens per packed sequence.
+        total_examples: Approximate total number of raw examples (used to
+            estimate ``__len__``).
+        queue_size: Maximum number of pre-built batches to buffer.  Larger
+            values decouple render speed from training speed at the cost of
+            memory.
+        avg_example_tokens: Initial estimate of average tokens per raw example.
+            Updated as rendering progresses.  Used to estimate how many packed
+            sequences the dataset will produce.
+    """
+
+    def __init__(
+        self,
+        examples: Iterable[T] | Callable[[], Iterable[T]],
+        render_fn: Callable[[T], tuple[tinker.ModelInput, torch.Tensor]],
+        batch_size: int,
+        max_packed_length: int,
+        total_examples: int,
+        queue_size: int = 64,
+        avg_example_tokens: float = 256.0,
+    ):
+        self._examples_source = examples
+        self._render_fn = render_fn
+        self._batch_size = batch_size
+        self._max_packed_length = max_packed_length
+        self._total_examples = total_examples
+        self._queue_size = queue_size
+
+        # Running statistics for __len__ estimation.
+        self._avg_example_tokens = avg_example_tokens
+        self._total_tokens_seen = 0.0
+        self._total_examples_rendered = 0
+        self._stats_lock = threading.Lock()
+
+        # The batch queue and background thread state.
+        self._queue: queue.Queue[_QueueItem] = queue.Queue(maxsize=queue_size)
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._current_batch_index = -1
+        self._exhausted = False
+
+        # Start the background pipeline.
+        self._start_background()
+
+    # ------------------------------------------------------------------
+    # SupervisedDataset interface
+    # ------------------------------------------------------------------
+
+    def get_batch(self, index: int) -> list[tinker.Datum]:
+        """Return the batch at *index*.
+
+        Only forward sequential access is supported.  If *index* skips ahead,
+        intermediate batches are silently consumed.  Backward seeks raise
+        ``ValueError``.
+
+        Raises ``StopIteration`` when the stream is exhausted.
+        """
+        if self._exhausted:
+            raise StopIteration("Streaming dataset is exhausted")
+
+        if index < self._current_batch_index + 1:
+            raise ValueError(
+                f"StreamingPackedSupervisedDataset only supports forward iteration. "
+                f"Cannot seek backward from batch {self._current_batch_index} to {index}."
+            )
+
+        # Skip forward if needed.
+        batches_to_skip = index - self._current_batch_index - 1
+        for _ in range(batches_to_skip):
+            self._consume_one()
+
+        self._current_batch_index = index
+        return self._consume_one()
+
+    def set_epoch(self, seed: int = 0) -> None:
+        """Stop the current pipeline and restart for a new epoch.
+
+        The *seed* is currently unused for shuffling (the caller is responsible
+        for providing a differently-ordered ``examples`` iterable if shuffling
+        is desired), but the method resets internal state so the dataset can be
+        iterated from the beginning again.
+        """
+        self._stop_background()
+
+        # Reset consumer state.
+        self._current_batch_index = -1
+        self._exhausted = False
+
+        # Create a fresh queue and restart.
+        self._queue = queue.Queue(maxsize=self._queue_size)
+        self._stop_event = threading.Event()
+        self._start_background()
+
+        logger.info("StreamingPackedSupervisedDataset: reset for epoch (seed=%d)", seed)
+
+    def __len__(self) -> int:
+        """Return a conservative estimate of the number of batches.
+
+        The estimate is based on the total number of raw examples, the average
+        tokens per example (updated as rendering progresses), and the packing
+        length.  It may decrease as better statistics become available.
+        """
+        with self._stats_lock:
+            avg_tokens = self._avg_example_tokens
+
+        # Estimate how many packed sequences we will produce.
+        estimated_packed = max(1, int(self._total_examples * avg_tokens / self._max_packed_length))
+        return estimated_packed // self._batch_size
+
+    # ------------------------------------------------------------------
+    # Background pipeline
+    # ------------------------------------------------------------------
+
+    def _start_background(self) -> None:
+        """Spawn the background rendering/packing thread."""
+        self._thread = threading.Thread(
+            target=self._background_worker,
+            name="streaming-packer",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _stop_background(self) -> None:
+        """Signal the background thread to stop and wait for it to finish."""
+        if self._thread is not None and self._thread.is_alive():
+            self._stop_event.set()
+            # Drain the queue so the background thread is not blocked on put().
+            while True:
+                try:
+                    self._queue.get_nowait()
+                except queue.Empty:
+                    break
+            self._thread.join(timeout=10.0)
+            if self._thread.is_alive():
+                logger.warning(
+                    "StreamingPackedSupervisedDataset: background thread did not "
+                    "terminate within timeout"
+                )
+            self._thread = None
+
+    def _get_examples_iter(self) -> Iterable:
+        """Return a fresh iterable over raw examples."""
+        if callable(self._examples_source) and not isinstance(self._examples_source, (list, tuple)):
+            return self._examples_source()
+        return self._examples_source
+
+    def _background_worker(self) -> None:
+        """Render, pack, and enqueue batches until the data is exhausted or stop is requested."""
+        try:
+            examples_iter = self._get_examples_iter()
+            rendered_iter = self._rendering_iterator(examples_iter)
+            packed_iter = _incremental_pack(rendered_iter, self._max_packed_length)
+
+            batch: list[tinker.Datum] = []
+            for datum in packed_iter:
+                if self._stop_event.is_set():
+                    return
+                batch.append(datum)
+                if len(batch) == self._batch_size:
+                    self._put(batch)
+                    batch = []
+
+            # Flush a partial final batch (the training loop handles short batches).
+            if batch and not self._stop_event.is_set():
+                self._put(batch)
+
+            # Signal end-of-stream.
+            if not self._stop_event.is_set():
+                self._put(None)
+
+        except Exception as exc:
+            logger.error(
+                "StreamingPackedSupervisedDataset: background thread error: %s", exc
+            )
+            try:
+                self._queue.put(_ErrorSentinel(exc), timeout=5.0)
+            except queue.Full:
+                pass
+
+    def _rendering_iterator(
+        self, examples: Iterable,
+    ) -> Iterator[tuple[tinker.ModelInput, torch.Tensor]]:
+        """Apply render_fn to each raw example, tracking statistics."""
+        count = 0
+        total_tokens = 0
+        for example in examples:
+            if self._stop_event.is_set():
+                return
+            model_input, weights = self._render_fn(example)
+            n_tokens = model_input.length
+            count += 1
+            total_tokens += n_tokens
+
+            # Update running statistics periodically.
+            if count % 1000 == 0:
+                with self._stats_lock:
+                    self._total_examples_rendered += 1000
+                    self._total_tokens_seen += total_tokens
+                    self._avg_example_tokens = (
+                        self._total_tokens_seen / self._total_examples_rendered
+                    )
+                    total_tokens = 0
+                if count % 50_000 == 0:
+                    logger.info(
+                        "StreamingPackedSupervisedDataset: rendered %d examples "
+                        "(avg %.0f tokens/example)",
+                        self._total_examples_rendered,
+                        self._avg_example_tokens,
+                    )
+
+            yield model_input, weights
+
+        # Final stats update.
+        remainder = count % 1000
+        if remainder > 0:
+            with self._stats_lock:
+                self._total_examples_rendered += remainder
+                self._total_tokens_seen += total_tokens
+                if self._total_examples_rendered > 0:
+                    self._avg_example_tokens = (
+                        self._total_tokens_seen / self._total_examples_rendered
+                    )
+
+        logger.info(
+            "StreamingPackedSupervisedDataset: finished rendering %d examples "
+            "(avg %.0f tokens/example)",
+            self._total_examples_rendered,
+            self._avg_example_tokens,
+        )
+
+    def _put(self, item: _QueueItem) -> None:
+        """Put an item on the queue, respecting the stop event."""
+        while not self._stop_event.is_set():
+            try:
+                self._queue.put(item, timeout=0.5)
+                return
+            except queue.Full:
+                continue
+
+    def _consume_one(self) -> list[tinker.Datum]:
+        """Pull the next batch from the queue.
+
+        Raises ``StopIteration`` if the stream is exhausted, or re-raises any
+        exception that occurred in the background thread.
+        """
+        if self._exhausted:
+            raise StopIteration("Streaming dataset is exhausted")
+
+        item = self._queue.get()
+        if item is None:
+            self._exhausted = True
+            raise StopIteration("Streaming dataset is exhausted")
+        if isinstance(item, _ErrorSentinel):
+            raise RuntimeError(
+                "Background rendering thread failed"
+            ) from item.exception
+        return item

--- a/tinker_cookbook/supervised/streaming_packing_test.py
+++ b/tinker_cookbook/supervised/streaming_packing_test.py
@@ -1,0 +1,447 @@
+"""Tests for streaming_packing.py — pure packing algorithm and streaming dataset."""
+
+import threading
+import time
+
+import pytest
+import tinker
+import torch
+
+from tinker_cookbook.supervised.streaming_packing import (
+    StreamingPackedSupervisedDataset,
+    _incremental_pack,
+    pack_rendered_examples,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rendered(
+    n_tokens: int, n_completion: int
+) -> tuple[tinker.ModelInput, torch.Tensor]:
+    """Create a fake rendered example with *n_tokens* total, last *n_completion* trainable."""
+    tokens = list(range(1, n_tokens + 1))
+    weights = torch.zeros(n_tokens, dtype=torch.float32)
+    weights[-n_completion:] = 1.0
+    return tinker.ModelInput.from_ints(tokens), weights
+
+
+def _simple_render_fn(
+    example: dict,
+) -> tuple[tinker.ModelInput, torch.Tensor]:
+    """A trivial render function for testing: expects {"tokens": [...], "n_completion": int}."""
+    tokens = example["tokens"]
+    n_completion = example["n_completion"]
+    model_input = tinker.ModelInput.from_ints(tokens)
+    weights = torch.zeros(len(tokens), dtype=torch.float32)
+    weights[-n_completion:] = 1.0
+    return model_input, weights
+
+
+# ---------------------------------------------------------------------------
+# Tests for pack_rendered_examples (pure algorithm, relocated from recipe)
+# ---------------------------------------------------------------------------
+
+
+class TestPackRenderedExamples:
+    def test_single_example_packs_correctly(self) -> None:
+        rendered = [_make_rendered(10, 5)]
+        datums = pack_rendered_examples(rendered, max_packed_length=100)
+        assert len(datums) == 1
+        datum = datums[0]
+        # After right-shift: input has 9 tokens, targets/weights have 9 tokens.
+        weights = datum.loss_fn_inputs["weights"]
+        targets = datum.loss_fn_inputs["target_tokens"]
+        assert len(weights.data) == 9
+        assert len(targets.data) == 9
+
+    def test_two_examples_fit_in_one_pack(self) -> None:
+        rendered = [_make_rendered(10, 5), _make_rendered(10, 3)]
+        datums = pack_rendered_examples(rendered, max_packed_length=20)
+        assert len(datums) == 1
+        datum = datums[0]
+        # 20 total tokens -> 19 after right-shift.
+        weights = datum.loss_fn_inputs["weights"]
+        assert len(weights.data) == 19
+
+    def test_examples_split_across_packs(self) -> None:
+        rendered = [_make_rendered(10, 5), _make_rendered(10, 3)]
+        datums = pack_rendered_examples(rendered, max_packed_length=15)
+        assert len(datums) == 2
+
+    def test_exact_fit(self) -> None:
+        rendered = [_make_rendered(8, 4), _make_rendered(8, 4)]
+        datums = pack_rendered_examples(rendered, max_packed_length=16)
+        assert len(datums) == 1
+        weights = datums[0].loss_fn_inputs["weights"]
+        assert len(weights.data) == 15  # 16 - 1 for right-shift
+
+    def test_oversized_example_truncated(self) -> None:
+        rendered = [_make_rendered(20, 10)]
+        datums = pack_rendered_examples(rendered, max_packed_length=10)
+        assert len(datums) == 1
+        weights = datums[0].loss_fn_inputs["weights"]
+        assert len(weights.data) == 9  # truncated to 10, then right-shift -> 9
+
+    def test_empty_examples_skipped(self) -> None:
+        empty = (tinker.ModelInput.from_ints([]), torch.zeros(0, dtype=torch.float32))
+        rendered = [empty, _make_rendered(5, 3), empty]
+        datums = pack_rendered_examples(rendered, max_packed_length=100)
+        assert len(datums) == 1
+
+    def test_weights_preserve_boundaries(self) -> None:
+        """Weights from each example are concatenated, preserving per-token masking."""
+        ex1_input = tinker.ModelInput.from_ints([10, 20, 30, 40])
+        ex1_weights = torch.tensor([0, 0, 1, 1], dtype=torch.float32)
+        ex2_input = tinker.ModelInput.from_ints([50, 60, 70, 80])
+        ex2_weights = torch.tensor([0, 1, 1, 1], dtype=torch.float32)
+
+        datums = pack_rendered_examples(
+            [(ex1_input, ex1_weights), (ex2_input, ex2_weights)],
+            max_packed_length=8,
+        )
+        assert len(datums) == 1
+        # Combined pre-shift weights: [0, 0, 1, 1, 0, 1, 1, 1]
+        # After right-shift (drop first): [0, 1, 1, 0, 1, 1, 1]
+        weights_data = datums[0].loss_fn_inputs["weights"].data
+        assert weights_data == [0, 1, 1, 0, 1, 1, 1]
+
+    def test_many_small_examples(self) -> None:
+        """Many small examples should be efficiently packed."""
+        rendered = [_make_rendered(5, 3) for _ in range(20)]
+        datums = pack_rendered_examples(rendered, max_packed_length=50)
+        assert len(datums) == 2
+        for datum in datums:
+            weights = datum.loss_fn_inputs["weights"]
+            assert len(weights.data) == 49  # 50 - 1 for right-shift
+
+    def test_packing_ratio(self) -> None:
+        """Verify packing efficiency."""
+        rendered = [_make_rendered(100, 50) for _ in range(10)]
+        max_len = 500
+        datums = pack_rendered_examples(rendered, max_packed_length=max_len)
+        assert len(datums) == 2
+        total_tokens = sum(len(d.loss_fn_inputs["weights"].data) for d in datums)
+        assert total_tokens == 998
+
+    def test_accepts_iterator(self) -> None:
+        """pack_rendered_examples should accept any iterable, not just lists."""
+        rendered = iter([_make_rendered(10, 5), _make_rendered(10, 3)])
+        datums = pack_rendered_examples(rendered, max_packed_length=20)
+        assert len(datums) == 1
+
+    def test_empty_input(self) -> None:
+        """Empty iterable produces no datums."""
+        datums = pack_rendered_examples([], max_packed_length=100)
+        assert len(datums) == 0
+
+    def test_all_empty_examples(self) -> None:
+        """All-empty examples produce no datums."""
+        empty = (tinker.ModelInput.from_ints([]), torch.zeros(0, dtype=torch.float32))
+        datums = pack_rendered_examples([empty, empty], max_packed_length=100)
+        assert len(datums) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for _incremental_pack
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalPack:
+    def test_yields_packed_datums(self) -> None:
+        rendered = [_make_rendered(10, 5), _make_rendered(10, 3)]
+        datums = list(_incremental_pack(iter(rendered), max_packed_length=15))
+        assert len(datums) == 2
+
+    def test_carry_over_across_boundary(self) -> None:
+        """When examples span pack boundaries, leftover carries to next pack."""
+        # 3 examples of 10 tokens each, max 25 -> 2 fit in first pack, 1 in second
+        rendered = [_make_rendered(10, 5) for _ in range(3)]
+        datums = list(_incremental_pack(iter(rendered), max_packed_length=25))
+        assert len(datums) == 2
+        # First pack: 20 tokens (2 examples), second pack: 10 tokens (1 example)
+        assert len(datums[0].loss_fn_inputs["weights"].data) == 19  # 20 - 1
+        assert len(datums[1].loss_fn_inputs["weights"].data) == 9  # 10 - 1
+
+    def test_empty_iterator(self) -> None:
+        datums = list(_incremental_pack(iter([]), max_packed_length=100))
+        assert len(datums) == 0
+
+    def test_matches_batch_pack(self) -> None:
+        """Incremental pack should produce the same result as batch pack."""
+        rendered = [_make_rendered(7, 3) for _ in range(15)]
+        batch_datums = pack_rendered_examples(rendered, max_packed_length=50)
+        incremental_datums = list(_incremental_pack(iter(rendered), max_packed_length=50))
+        assert len(batch_datums) == len(incremental_datums)
+        for b, i in zip(batch_datums, incremental_datums):
+            assert b.loss_fn_inputs["weights"].data == i.loss_fn_inputs["weights"].data
+
+
+# ---------------------------------------------------------------------------
+# Tests for StreamingPackedSupervisedDataset
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingPackedSupervisedDataset:
+    def _make_examples(self, n: int, tokens_per: int = 10, completion_per: int = 5) -> list[dict]:
+        return [
+            {"tokens": list(range(1, tokens_per + 1)), "n_completion": completion_per}
+            for _ in range(n)
+        ]
+
+    def test_basic_iteration(self) -> None:
+        """Dataset produces batches that the training loop can consume sequentially."""
+        examples = self._make_examples(20, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=2,
+            max_packed_length=50,
+            total_examples=20,
+        )
+
+        batches = []
+        for i in range(len(ds)):
+            try:
+                batch = ds.get_batch(i)
+                batches.append(batch)
+            except StopIteration:
+                break
+
+        assert len(batches) > 0
+        for batch in batches:
+            assert len(batch) == 2
+            for datum in batch:
+                assert "weights" in datum.loss_fn_inputs
+                assert "target_tokens" in datum.loss_fn_inputs
+
+    def test_forward_only_access(self) -> None:
+        """Backward seek raises ValueError."""
+        examples = self._make_examples(20, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=2,
+            max_packed_length=50,
+            total_examples=20,
+        )
+        ds.get_batch(0)
+        with pytest.raises(ValueError, match="forward iteration"):
+            ds.get_batch(0)
+
+    def test_skip_forward(self) -> None:
+        """Skipping batches should work (intermediate batches consumed silently)."""
+        examples = self._make_examples(100, tokens_per=5)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=50,
+            total_examples=100,
+        )
+        # Skip to batch 2 directly
+        batch = ds.get_batch(2)
+        assert len(batch) == 1
+
+    def test_exhaustion_raises_stop_iteration(self) -> None:
+        """Reading past the end of the dataset raises StopIteration."""
+        examples = self._make_examples(5, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=100,
+            total_examples=5,
+        )
+        # Consume all batches
+        consumed = 0
+        for i in range(100):  # more than enough
+            try:
+                ds.get_batch(i)
+                consumed += 1
+            except StopIteration:
+                break
+        assert consumed > 0
+        # One more should also raise
+        with pytest.raises(StopIteration):
+            ds.get_batch(consumed)
+
+    def test_set_epoch_restarts(self) -> None:
+        """set_epoch should allow iterating from the beginning again."""
+        examples = self._make_examples(10, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=50,
+            total_examples=10,
+        )
+        # Consume some batches
+        batch0_epoch0 = ds.get_batch(0)
+        assert len(batch0_epoch0) > 0
+
+        # Reset
+        ds.set_epoch(seed=1)
+
+        # Should be able to start from 0 again
+        batch0_epoch1 = ds.get_batch(0)
+        assert len(batch0_epoch1) > 0
+
+    def test_callable_examples_source(self) -> None:
+        """When examples is a callable, it should be called each epoch for a fresh iterator."""
+        call_count = 0
+
+        def make_examples():
+            nonlocal call_count
+            call_count += 1
+            return iter(self._make_examples(10, tokens_per=10))
+
+        ds = StreamingPackedSupervisedDataset(
+            examples=make_examples,
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=50,
+            total_examples=10,
+        )
+        ds.get_batch(0)
+        assert call_count == 1
+
+        ds.set_epoch(seed=1)
+        ds.get_batch(0)
+        assert call_count == 2
+
+    def test_error_propagation(self) -> None:
+        """Errors in the render function propagate to the consumer."""
+
+        def bad_render_fn(example: dict) -> tuple[tinker.ModelInput, torch.Tensor]:
+            raise ValueError("render failed")
+
+        examples = self._make_examples(5)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=bad_render_fn,
+            batch_size=1,
+            max_packed_length=100,
+            total_examples=5,
+        )
+        with pytest.raises(RuntimeError, match="Background rendering thread failed"):
+            ds.get_batch(0)
+
+    def test_empty_dataset(self) -> None:
+        """Empty dataset should raise StopIteration on first get_batch."""
+        ds = StreamingPackedSupervisedDataset(
+            examples=[],
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=100,
+            total_examples=0,
+        )
+        with pytest.raises(StopIteration):
+            ds.get_batch(0)
+
+    def test_single_example(self) -> None:
+        """Dataset with a single example should produce one batch."""
+        examples = self._make_examples(1, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=100,
+            total_examples=1,
+        )
+        batch = ds.get_batch(0)
+        assert len(batch) == 1
+
+    def test_oversized_examples(self) -> None:
+        """Examples exceeding max_packed_length should be truncated, not crash."""
+        examples = [{"tokens": list(range(1, 101)), "n_completion": 50}]
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=20,
+            total_examples=1,
+        )
+        batch = ds.get_batch(0)
+        assert len(batch) == 1
+        # Should be truncated to max_packed_length then right-shifted
+        weights = batch[0].loss_fn_inputs["weights"]
+        assert len(weights.data) == 19  # 20 - 1
+
+    def test_len_returns_positive_estimate(self) -> None:
+        """__len__ should return a reasonable positive estimate."""
+        examples = self._make_examples(100, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=2,
+            max_packed_length=50,
+            total_examples=100,
+            avg_example_tokens=10.0,
+        )
+        length = len(ds)
+        assert length > 0
+
+    def test_partial_final_batch(self) -> None:
+        """If the last batch has fewer datums than batch_size, it should still be returned."""
+        # 3 examples of 10 tokens each, max 25 -> 2 packs
+        # With batch_size=3, we cannot fill a full batch, so we get a partial one.
+        examples = self._make_examples(3, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=3,
+            max_packed_length=25,
+            total_examples=3,
+        )
+        # There should be 2 packed sequences, but batch_size is 3, so we get
+        # one partial batch with 2 datums.
+        batch = ds.get_batch(0)
+        assert len(batch) == 2
+
+    def test_chunk_boundary_carry_over(self) -> None:
+        """Verify that examples at chunk boundaries are packed correctly.
+
+        When the last example does not fill a pack, it carries over into the
+        next pack.  This test checks that no tokens are lost.
+        """
+        # 7 examples of 10 tokens, max 30 -> packs of [30, 30, 10]
+        examples = self._make_examples(7, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=1,
+            max_packed_length=30,
+            total_examples=7,
+        )
+        all_datums: list[tinker.Datum] = []
+        for i in range(10):
+            try:
+                batch = ds.get_batch(i)
+                all_datums.extend(batch)
+            except StopIteration:
+                break
+
+        # 7 * 10 = 70 tokens. Packs of 30, 30, 10. Each loses 1 for right-shift.
+        assert len(all_datums) == 3
+        total_weight_tokens = sum(
+            len(d.loss_fn_inputs["weights"].data) for d in all_datums
+        )
+        assert total_weight_tokens == 29 + 29 + 9  # 67
+
+    def test_daemon_thread(self) -> None:
+        """The background thread should be a daemon thread."""
+        examples = self._make_examples(100, tokens_per=10)
+        ds = StreamingPackedSupervisedDataset(
+            examples=examples,
+            render_fn=_simple_render_fn,
+            batch_size=2,
+            max_packed_length=50,
+            total_examples=100,
+        )
+        assert ds._thread is not None
+        assert ds._thread.daemon is True
+        ds._stop_background()


### PR DESCRIPTION
## Summary
- Adds `StreamingPackedSupervisedDataset` to `tinker_cookbook/supervised/streaming_packing.py` — a drop-in replacement for pre-rendered packed datasets that renders and packs in a background thread so training starts immediately
- Relocates the pure `pack_rendered_examples()` bin-packing algorithm from the nemotron cascade recipe into the reusable supervised library
- Adds `_incremental_pack()` streaming variant that yields packed Datums one at a time from an iterator of rendered examples

## Motivation
Pre-rendering 24.5M examples before training takes ~117 hours at ~3500 examples/min. This module overlaps rendering with training — a background daemon thread renders in chunks, packs via greedy bin-packing, and deposits batches into a bounded queue. The training loop consumes batches as they become available.

## Design
- **Three layers**: pure packing (`pack_rendered_examples`) → streaming packer (`_incremental_pack`) → full dataset (`StreamingPackedSupervisedDataset`)
- **`SupervisedDataset` interface**: fully compatible with `train.py` (zero changes needed) — supports `get_batch`, `set_epoch`, `__len__`
- **Thread safety**: `queue.Queue` for communication, `threading.Lock` for stats, `threading.Event` for shutdown
- **Error propagation**: exceptions in background thread wrapped in `_ErrorSentinel` and re-raised on next `get_batch`
- **Forward-only**: matches `StreamingSupervisedDatasetFromHFDataset` semantics
- **Carry-over**: natural across pack boundaries (no token waste at chunk edges)

## Test plan
- [x] 30 unit tests covering pure packing (12), incremental packing (4), and streaming dataset (14)
- [x] Tests verify: packing correctness, boundary carry-over, error propagation, multi-epoch, forward-only enforcement, partial final batches, daemon thread behavior
- [x] `pytest tinker_cookbook/supervised/streaming_packing_test.py` — all 30 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)