### PR TITLE
Add packing algorithm and pre-pack utility for SFT datasets

### DIFF
--- a/tinker_cookbook/supervised/__init__.py
+++ b/tinker_cookbook/supervised/__init__.py
@@ -7,6 +7,14 @@ from tinker_cookbook.supervised.data import (
     SupervisedDatasetFromHFDataset,
     conversation_to_datum,
 )
+from tinker_cookbook.supervised.packing import greedy_pack, make_datum, pack_to_datums
+from tinker_cookbook.supervised.prepack import (
+    PrepackedDatasetBuilder,
+    PrepackedSupervisedDataset,
+    load_packed_datums,
+    render_parallel,
+    save_packed_datums,
+)
 from tinker_cookbook.supervised.types import (
     ChatDatasetBuilder,
     ChatDatasetBuilderCommonConfig,
@@ -25,6 +33,16 @@ __all__ = [
     "StreamingSupervisedDatasetFromHFDataset",
     "SupervisedDatasetFromHFDataset",
     "conversation_to_datum",
+    # Packing algorithm (packing.py)
+    "greedy_pack",
+    "make_datum",
+    "pack_to_datums",
+    # Pre-pack pipeline (prepack.py)
+    "PrepackedDatasetBuilder",
+    "PrepackedSupervisedDataset",
+    "load_packed_datums",
+    "render_parallel",
+    "save_packed_datums",
     # Helpers (common.py)
     "compute_mean_nll",
     "datum_from_model_input_weights",

--- a/tinker_cookbook/supervised/packing.py
+++ b/tinker_cookbook/supervised/packing.py
@@ -1,0 +1,114 @@
+"""
+Canonical bin-packing algorithm for supervised fine-tuning.
+
+This module is the single source of truth for packing multiple tokenized
+examples into fixed-length sequences. The core algorithm (``greedy_pack``)
+operates on plain Python lists and has no dependencies on torch or tinker,
+making it picklable and easy to test. Convenience wrappers build tinker
+``Datum`` objects from the packed output.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import tinker
+import torch
+
+from tinker_cookbook.supervised.common import datum_from_model_input_weights
+
+
+def greedy_pack(
+    items: Iterable[tuple[list[int], list[float]]],
+    max_length: int,
+) -> list[tuple[list[int], list[float]]]:
+    """Greedy first-fit bin-packing on token sequences.
+
+    Iterates over ``(token_ids, weights)`` pairs and concatenates them into
+    bins of at most ``max_length`` tokens. When an item would overflow the
+    current bin, the bin is flushed and a new one is started. Items longer
+    than ``max_length`` are truncated and emitted alone.
+
+    Args:
+        items: An iterable of ``(token_ids, weights)`` pairs. Each pair
+            must have equal length.
+        max_length: Maximum number of tokens per packed sequence.
+
+    Returns:
+        A list of ``(tokens, weights)`` pairs, each with length
+        ``<= max_length``.
+    """
+    packed: list[tuple[list[int], list[float]]] = []
+    current_tokens: list[int] = []
+    current_weights: list[float] = []
+
+    for tokens, weights in items:
+        example_len = len(tokens)
+        if example_len == 0:
+            continue
+
+        # Oversized example: flush buffer, emit alone (truncated).
+        if example_len > max_length:
+            if current_tokens:
+                packed.append((current_tokens, current_weights))
+                current_tokens = []
+                current_weights = []
+            packed.append((tokens[:max_length], weights[:max_length]))
+            continue
+
+        # Would adding this example overflow the current buffer?
+        if len(current_tokens) + example_len > max_length:
+            packed.append((current_tokens, current_weights))
+            current_tokens = []
+            current_weights = []
+
+        current_tokens.extend(tokens)
+        current_weights.extend(weights)
+
+    if current_tokens:
+        packed.append((current_tokens, current_weights))
+
+    return packed
+
+
+def make_datum(tokens: list[int], weights: list[float], max_length: int) -> tinker.Datum:
+    """Convert a packed ``(tokens, weights)`` pair into a training Datum.
+
+    Wraps the tokens in a ``ModelInput``, the weights in a ``torch.Tensor``,
+    and delegates to ``datum_from_model_input_weights`` for the standard
+    next-token input/target split.
+
+    Args:
+        tokens: Token IDs for the packed sequence.
+        weights: Per-token loss weights, same length as *tokens*.
+        max_length: Maximum sequence length (used for padding/truncation
+            inside ``datum_from_model_input_weights``).
+
+    Returns:
+        A ``tinker.Datum`` ready for training.
+    """
+    model_input = tinker.ModelInput.from_ints(tokens[:max_length])
+    weight_tensor = torch.tensor(weights[:max_length], dtype=torch.float32)
+    return datum_from_model_input_weights(model_input, weight_tensor, max_length)
+
+
+def pack_to_datums(
+    items: Iterable[tuple[list[int], list[float]]],
+    max_length: int,
+) -> list[tinker.Datum]:
+    """Pack and convert to Datums in one step.
+
+    Convenience wrapper that calls ``greedy_pack`` followed by ``make_datum``
+    for each resulting bin.
+
+    Args:
+        items: An iterable of ``(token_ids, weights)`` pairs.
+        max_length: Maximum number of tokens per packed sequence.
+
+    Returns:
+        A list of packed ``tinker.Datum`` objects.
+    """
+    return [
+        make_datum(tokens, weights, max_length)
+        for tokens, weights in greedy_pack(items, max_length)
+    ]

--- a/tinker_cookbook/supervised/packing_test.py
+++ b/tinker_cookbook/supervised/packing_test.py
@@ -1,0 +1,150 @@
+"""Tests for the packing algorithm (packing.py)."""
+
+from __future__ import annotations
+
+import tinker
+
+from tinker_cookbook.supervised.packing import greedy_pack, make_datum, pack_to_datums
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(token_ids: list[int], weight_val: float = 1.0) -> tuple[list[int], list[float]]:
+    """Create a (tokens, weights) pair for testing."""
+    return (token_ids, [weight_val] * len(token_ids))
+
+
+# ---------------------------------------------------------------------------
+# greedy_pack
+# ---------------------------------------------------------------------------
+
+
+class TestGreedyPack:
+    def test_empty_input(self):
+        result = greedy_pack([], max_length=100)
+        assert result == []
+
+    def test_single_item_fits(self):
+        items = [_make_item([1, 2, 3, 4, 5])]
+        result = greedy_pack(items, max_length=100)
+        assert len(result) == 1
+        assert result[0][0] == [1, 2, 3, 4, 5]
+
+    def test_two_items_fit_in_one_bin(self):
+        items = [
+            _make_item([1, 2, 3]),
+            _make_item([4, 5, 6]),
+        ]
+        result = greedy_pack(items, max_length=100)
+        assert len(result) == 1
+        assert result[0][0] == [1, 2, 3, 4, 5, 6]
+
+    def test_two_items_overflow_into_two_bins(self):
+        items = [
+            _make_item([1, 2, 3]),
+            _make_item([4, 5, 6]),
+        ]
+        # Max 4 tokens per bin: first item (3) fits, second (3) overflows.
+        result = greedy_pack(items, max_length=4)
+        assert len(result) == 2
+        assert result[0][0] == [1, 2, 3]
+        assert result[1][0] == [4, 5, 6]
+
+    def test_oversized_item_packed_alone_and_truncated(self):
+        items = [
+            _make_item([1, 2]),
+            _make_item(list(range(100))),  # oversized
+            _make_item([3, 4]),
+        ]
+        result = greedy_pack(items, max_length=10)
+        assert len(result) == 3
+        # The oversized item is truncated to max_length.
+        assert len(result[1][0]) == 10
+
+    def test_skips_empty_items(self):
+        items = [
+            _make_item([]),
+            _make_item([1, 2, 3]),
+            _make_item([]),
+        ]
+        result = greedy_pack(items, max_length=100)
+        assert len(result) == 1
+
+    def test_weights_concatenated_correctly(self):
+        items = [
+            ([10, 20], [0.5, 0.5]),
+            ([30, 40], [1.0, 1.0]),
+        ]
+        result = greedy_pack(items, max_length=100)
+        assert len(result) == 1
+        assert result[0][0] == [10, 20, 30, 40]
+        assert result[0][1] == [0.5, 0.5, 1.0, 1.0]
+
+    def test_exact_fit(self):
+        items = [
+            _make_item([1, 2, 3, 4, 5]),
+            _make_item([6, 7, 8, 9, 10]),
+        ]
+        result = greedy_pack(items, max_length=10)
+        assert len(result) == 1
+        assert len(result[0][0]) == 10
+
+    def test_accepts_iterator(self):
+        """greedy_pack works with any Iterable, not just lists."""
+
+        def gen():
+            yield _make_item([1, 2])
+            yield _make_item([3, 4])
+
+        result = greedy_pack(gen(), max_length=100)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# make_datum
+# ---------------------------------------------------------------------------
+
+
+class TestMakeDatum:
+    def test_returns_datum(self):
+        datum = make_datum([1, 2, 3, 4], [1.0, 1.0, 1.0, 1.0], max_length=100)
+        assert isinstance(datum, tinker.Datum)
+        assert datum.model_input.length > 0
+
+    def test_truncation(self):
+        tokens = list(range(20))
+        weights = [1.0] * 20
+        datum = make_datum(tokens, weights, max_length=10)
+        # After make_datum, the model_input length should be <= max_length.
+        # (datum_from_model_input_weights does input/target split, so actual
+        # model_input length is max_length - 1.)
+        assert datum.model_input.length <= 10
+
+
+# ---------------------------------------------------------------------------
+# pack_to_datums
+# ---------------------------------------------------------------------------
+
+
+class TestPackToDatums:
+    def test_convenience_wrapper(self):
+        items = [
+            _make_item([10, 20, 30, 40]),
+            _make_item([50, 60, 70, 80]),
+        ]
+        datums = pack_to_datums(items, max_length=100)
+        assert len(datums) >= 1
+        assert all(isinstance(d, tinker.Datum) for d in datums)
+
+    def test_empty_input(self):
+        assert pack_to_datums([], max_length=100) == []
+
+    def test_multiple_bins(self):
+        items = [_make_item([i, i + 1]) for i in range(10)]
+        datums = pack_to_datums(items, max_length=5)
+        # Each item is 2 tokens. At max 5, we fit 2 items per bin (4 tokens).
+        # 10 items -> 5 bins.
+        assert len(datums) == 5

--- a/tinker_cookbook/supervised/prepack.py
+++ b/tinker_cookbook/supervised/prepack.py
@@ -1,0 +1,454 @@
+"""
+Offline pre-packing pipeline for supervised fine-tuning datasets.
+
+Pre-renders and packs a JSONL dataset of conversations into sharded files of
+packed Datums. The heavy tokenization work is done once upfront using multiple
+CPU cores, and the packed output can be loaded instantly for repeated training
+runs.
+
+**CLI usage**::
+
+    python -m tinker_cookbook.supervised.prepack \\
+        source_file=/data/sft.jsonl \\
+        output_dir=/data/packed \\
+        model_name=nvidia/Nemotron-3-8B \\
+        renderer_name=nemotron3_disable_thinking \\
+        max_packed_length=49152 \\
+        num_workers=64
+
+**Programmatic usage**::
+
+    from tinker_cookbook.supervised.prepack import PrepackedSupervisedDataset
+
+    dataset = PrepackedSupervisedDataset(
+        packed_dir="/data/packed",
+        batch_size=4,
+    )
+    # Satisfies SupervisedDataset -- use directly in train.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import multiprocessing
+import random
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import chz
+import tinker
+
+from tinker_cookbook.renderers import TrainOnWhat
+from tinker_cookbook.supervised.packing import pack_to_datums
+from tinker_cookbook.supervised.types import SupervisedDataset, SupervisedDatasetBuilder
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SHARD_SIZE = 10_000
+"""Number of packed Datums per shard file."""
+
+_METADATA_FILENAME = "metadata.json"
+
+
+# ---------------------------------------------------------------------------
+# Save / load helpers
+# ---------------------------------------------------------------------------
+
+
+def save_packed_datums(
+    datums: list[tinker.Datum],
+    output_dir: str | Path,
+    metadata: dict,
+    shard_size: int = _DEFAULT_SHARD_SIZE,
+) -> None:
+    """Write packed Datums to sharded JSONL files plus a metadata file.
+
+    Args:
+        datums: The packed Datum objects to persist.
+        output_dir: Directory to write into (created if needed).
+        metadata: Provenance dict to write as ``metadata.json``.
+        shard_size: Maximum number of Datums per shard file.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    shard_idx = 0
+    for start in range(0, len(datums), shard_size):
+        shard_datums = datums[start : start + shard_size]
+        shard_path = output_dir / f"shard_{shard_idx:06d}.jsonl"
+        with open(shard_path, "w") as f:
+            for datum in shard_datums:
+                f.write(datum.model_dump_json() + "\n")
+        shard_idx += 1
+
+    # Write metadata last (signals successful completion).
+    metadata_out = {
+        **metadata,
+        "num_datums": len(datums),
+        "num_shards": shard_idx,
+        "shard_size": shard_size,
+    }
+    with open(output_dir / _METADATA_FILENAME, "w") as f:
+        json.dump(metadata_out, f, indent=2)
+
+    logger.info(
+        "Saved %d packed Datums in %d shards to %s", len(datums), shard_idx, output_dir
+    )
+
+
+def load_packed_datums(packed_dir: str | Path) -> tuple[list[tinker.Datum], dict]:
+    """Load all packed Datums and metadata from a pre-packed directory.
+
+    Args:
+        packed_dir: Path to directory created by ``save_packed_datums``.
+
+    Returns:
+        Tuple of (list of Datums, metadata dict).
+
+    Raises:
+        FileNotFoundError: If the metadata file is missing.
+    """
+    packed_dir = Path(packed_dir)
+    metadata_path = packed_dir / _METADATA_FILENAME
+    if not metadata_path.exists():
+        raise FileNotFoundError(
+            f"No metadata file found at {metadata_path}. "
+            f"Is this a valid pre-packed directory?"
+        )
+
+    with open(metadata_path) as f:
+        metadata = json.load(f)
+
+    num_shards: int = metadata["num_shards"]
+    datums: list[tinker.Datum] = []
+    for shard_idx in range(num_shards):
+        shard_path = packed_dir / f"shard_{shard_idx:06d}.jsonl"
+        with open(shard_path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    datums.append(tinker.Datum.model_validate_json(line))
+
+    expected = metadata.get("num_datums", len(datums))
+    if len(datums) != expected:
+        logger.warning(
+            "Expected %d Datums from metadata but loaded %d", expected, len(datums)
+        )
+
+    return datums, metadata
+
+
+# ---------------------------------------------------------------------------
+# PrepackedSupervisedDataset
+# ---------------------------------------------------------------------------
+
+
+class PrepackedSupervisedDataset(SupervisedDataset):
+    """A ``SupervisedDataset`` backed by pre-packed Datums on disk.
+
+    All Datums are loaded into memory at construction time (they are already
+    compressed by packing, so this is memory-efficient). The dataset supports:
+
+    * Exact ``__len__`` (known at load time).
+    * Random-access ``get_batch``.
+    * Epoch shuffling via ``set_epoch`` (shuffles pack order with a seed).
+
+    This class can be used directly with the standard training loop in
+    ``tinker_cookbook.supervised.train``.
+
+    Args:
+        packed_dir: Path to a directory created by ``save_packed_datums`` or
+            the CLI tool.
+        batch_size: Number of packed Datums per training batch.
+    """
+
+    def __init__(self, packed_dir: str | Path, batch_size: int):
+        self._datums, self._metadata = load_packed_datums(packed_dir)
+        self._batch_size = batch_size
+        # Maintain a shuffled index list for epoch-aware access.
+        self._indices: list[int] = list(range(len(self._datums)))
+        if len(self._datums) == 0:
+            logger.warning("PrepackedSupervisedDataset: loaded 0 Datums from %s", packed_dir)
+
+    def get_batch(self, index: int) -> list[tinker.Datum]:
+        """Return the batch at the given index.
+
+        Args:
+            index: Zero-based batch index.
+
+        Returns:
+            A list of ``batch_size`` packed Datums (or fewer for the last batch).
+        """
+        start = index * self._batch_size
+        end = min(start + self._batch_size, len(self._indices))
+        return [self._datums[self._indices[i]] for i in range(start, end)]
+
+    def set_epoch(self, seed: int = 0) -> None:
+        """Shuffle the pack order for a new epoch.
+
+        The shuffle is deterministic for a given seed.
+
+        Args:
+            seed: Random seed for reproducible shuffling.
+        """
+        rng = random.Random(seed)
+        self._indices = list(range(len(self._datums)))
+        rng.shuffle(self._indices)
+
+    def __len__(self) -> int:
+        """Return the number of complete batches."""
+        return len(self._datums) // self._batch_size
+
+    @property
+    def metadata(self) -> dict:
+        """Return the metadata dict loaded from disk."""
+        return self._metadata
+
+
+# ---------------------------------------------------------------------------
+# PrepackedDatasetBuilder
+# ---------------------------------------------------------------------------
+
+
+@chz.chz
+class PrepackedDatasetBuilder(SupervisedDatasetBuilder):
+    """Builder that loads a pre-packed dataset directory for training.
+
+    This integrates with the ``chz`` config system so that pre-packed
+    datasets can be used directly in training configs::
+
+        chz.nested_entrypoint(train, allow_hyphens=True)
+        # dataset_builder=PrepackedDatasetBuilder packed_dir=/data/packed batch_size=4
+    """
+
+    packed_dir: str
+    batch_size: int
+
+    def __call__(self) -> tuple[SupervisedDataset, SupervisedDataset | None]:
+        return PrepackedSupervisedDataset(self.packed_dir, self.batch_size), None
+
+
+# ---------------------------------------------------------------------------
+# Parallel rendering
+# ---------------------------------------------------------------------------
+
+_worker_renderer = None
+_worker_train_on_what = None
+
+
+def _worker_init(renderer_name: str, model_name: str, train_on_what_str: str) -> None:
+    """Per-worker initializer: creates a renderer once per process."""
+    global _worker_renderer, _worker_train_on_what
+    from tinker_cookbook.renderers import get_renderer
+    from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+    tokenizer = get_tokenizer(model_name)
+    _worker_renderer = get_renderer(renderer_name, tokenizer)
+    _worker_train_on_what = TrainOnWhat(train_on_what_str)
+
+
+def _render_one(messages: list[dict]) -> tuple[list[int], list[float]] | None:
+    """Render a single conversation to (token_ids, weights).
+
+    Returns ``None`` if the conversation produces no tokens (e.g. empty).
+    """
+    assert _worker_renderer is not None, "Worker not initialized"
+    assert _worker_train_on_what is not None, "Worker not initialized"
+    try:
+        model_input, weights = _worker_renderer.build_supervised_example(
+            messages, train_on_what=_worker_train_on_what
+        )
+        tokens = list(model_input.to_ints())
+        if len(tokens) == 0:
+            return None
+        return tokens, weights.tolist()
+    except Exception:
+        logger.warning("Failed to render a conversation, skipping", exc_info=True)
+        return None
+
+
+def render_parallel(
+    conversations: list[list[dict]],
+    renderer_name: str,
+    model_name: str,
+    train_on_what: str = "all_assistant_messages",
+    num_workers: int = 8,
+    imap_chunksize: int = 500,
+) -> list[tuple[list[int], list[float]]]:
+    """Render conversations to ``(token_ids, weights)`` pairs using multiple processes.
+
+    This is a reusable building block extracted from the CLI pipeline. It can
+    be called independently to render a dataset without packing or saving.
+
+    Args:
+        conversations: List of conversation message lists.
+        renderer_name: Name of the renderer to use.
+        model_name: Model name (for tokenizer lookup).
+        train_on_what: Which messages to train on (default: all assistant).
+        num_workers: Number of parallel worker processes. Use 1 for
+            single-process mode (useful for debugging).
+        imap_chunksize: Chunk size for ``pool.imap_unordered``.
+
+    Returns:
+        A list of ``(token_ids, weights)`` tuples for successfully rendered
+        conversations.
+    """
+    from tqdm import tqdm
+
+    rendered: list[tuple[list[int], list[float]]] = []
+
+    if num_workers <= 1:
+        # Single-process fallback (useful for debugging).
+        _worker_init(renderer_name, model_name, train_on_what)
+        for msgs in tqdm(conversations, desc="Rendering"):
+            result = _render_one(msgs)
+            if result is not None:
+                rendered.append(result)
+    else:
+        with multiprocessing.Pool(
+            processes=num_workers,
+            initializer=_worker_init,
+            initargs=(renderer_name, model_name, train_on_what),
+        ) as pool:
+            for result in tqdm(
+                pool.imap_unordered(_render_one, conversations, chunksize=imap_chunksize),
+                total=len(conversations),
+                desc="Rendering",
+            ):
+                if result is not None:
+                    rendered.append(result)
+
+    return rendered
+
+
+# ---------------------------------------------------------------------------
+# CLI: pre-pack a JSONL dataset
+# ---------------------------------------------------------------------------
+
+
+@chz.chz
+class PrepackConfig:
+    """Configuration for the pre-packing CLI."""
+
+    source_file: str
+    output_dir: str
+    model_name: str
+    renderer_name: str
+    max_packed_length: int = 49152
+    train_on_what: str = "all_assistant_messages"
+    num_workers: int = 8
+    shuffle_seed: int = 42
+    shard_size: int = _DEFAULT_SHARD_SIZE
+    imap_chunksize: int = 500
+
+
+def prepack(
+    config: PrepackConfig,
+    render_fn: Callable[[list[list[dict]]], list[tuple[list[int], list[float]]]] | None = None,
+) -> None:
+    """Run the full pre-pack pipeline: load, render in parallel, pack, save.
+
+    Args:
+        config: CLI configuration object.
+        render_fn: Optional custom rendering function. When provided, it is
+            called with the list of conversations and must return a list of
+            ``(token_ids, weights)`` tuples. When ``None`` (the default), the
+            built-in renderer-based parallel rendering is used.
+    """
+    # 1. Load raw conversations.
+    logger.info("Loading conversations from %s", config.source_file)
+    conversations: list[list[dict]] = []
+    with open(config.source_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            if "messages" not in data:
+                raise ValueError(
+                    f"Each JSONL line must have a 'messages' field. Got keys: {list(data.keys())}"
+                )
+            conversations.append(data["messages"])
+
+    if len(conversations) == 0:
+        logger.warning("Source file is empty, nothing to pack.")
+        save_packed_datums(
+            [],
+            config.output_dir,
+            metadata=_build_metadata(config, num_raw=0, num_rendered=0),
+        )
+        return
+
+    logger.info("Loaded %d conversations", len(conversations))
+
+    # 2. Shuffle with seed.
+    rng = random.Random(config.shuffle_seed)
+    rng.shuffle(conversations)
+
+    # 3. Render.
+    logger.info(
+        "Rendering %d conversations using %d workers...",
+        len(conversations),
+        config.num_workers,
+    )
+    t0 = time.monotonic()
+
+    if render_fn is not None:
+        rendered = render_fn(conversations)
+    else:
+        rendered = render_parallel(
+            conversations,
+            renderer_name=config.renderer_name,
+            model_name=config.model_name,
+            train_on_what=config.train_on_what,
+            num_workers=config.num_workers,
+            imap_chunksize=config.imap_chunksize,
+        )
+
+    elapsed = time.monotonic() - t0
+    logger.info(
+        "Rendered %d/%d examples in %.1fs (%.0f examples/s)",
+        len(rendered),
+        len(conversations),
+        elapsed,
+        len(rendered) / max(elapsed, 0.001),
+    )
+
+    # 4. Pack rendered examples.
+    logger.info("Packing into sequences of up to %d tokens...", config.max_packed_length)
+    packed_datums = pack_to_datums(rendered, config.max_packed_length)
+    logger.info("Packed into %d sequences", len(packed_datums))
+
+    # 5. Save to sharded JSONL + metadata.
+    metadata = _build_metadata(
+        config, num_raw=len(conversations), num_rendered=len(rendered)
+    )
+    save_packed_datums(
+        packed_datums, config.output_dir, metadata=metadata, shard_size=config.shard_size
+    )
+
+
+def _build_metadata(config: PrepackConfig, num_raw: int, num_rendered: int) -> dict:
+    """Build the provenance metadata dict."""
+    return {
+        "source_file": config.source_file,
+        "model_name": config.model_name,
+        "renderer_name": config.renderer_name,
+        "max_packed_length": config.max_packed_length,
+        "train_on_what": config.train_on_what,
+        "shuffle_seed": config.shuffle_seed,
+        "num_workers": config.num_workers,
+        "num_raw_conversations": num_raw,
+        "num_rendered_examples": num_rendered,
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    chz.nested_entrypoint(prepack, allow_hyphens=True)

--- a/tinker_cookbook/supervised/prepack_test.py
+++ b/tinker_cookbook/supervised/prepack_test.py
@@ -1,0 +1,330 @@
+"""Tests for the pre-packing pipeline (prepack.py): dataset, serialization, CLI."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import tinker
+
+from tinker_cookbook.supervised.packing import pack_to_datums
+from tinker_cookbook.supervised.prepack import (
+    PrepackConfig,
+    PrepackedDatasetBuilder,
+    PrepackedSupervisedDataset,
+    load_packed_datums,
+    prepack,
+    render_parallel,
+    save_packed_datums,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(token_ids: list[int], weight_val: float = 1.0) -> tuple[list[int], list[float]]:
+    """Create a (tokens, weights) pair for testing."""
+    return (token_ids, [weight_val] * len(token_ids))
+
+
+def _make_jsonl(conversations: list[list[dict]], path: Path) -> None:
+    """Write conversations to a JSONL file."""
+    with open(path, "w") as f:
+        for msgs in conversations:
+            f.write(json.dumps({"messages": msgs}) + "\n")
+
+
+def _simple_conversations(n: int) -> list[list[dict]]:
+    """Create n simple user/assistant conversations."""
+    return [
+        [
+            {"role": "user", "content": f"Question {i}"},
+            {"role": "assistant", "content": f"Answer {i}"},
+        ]
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Save / load roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoad:
+    def test_roundtrip(self):
+        """Datums survive a save/load cycle."""
+        items = [
+            _make_item([10, 20, 30, 40]),
+            _make_item([50, 60, 70, 80]),
+        ]
+        datums = pack_to_datums(items, max_length=100)
+        assert len(datums) > 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            metadata = {"source_file": "test.jsonl", "max_packed_length": 100}
+            save_packed_datums(datums, tmpdir, metadata=metadata, shard_size=1)
+
+            loaded_datums, loaded_metadata = load_packed_datums(tmpdir)
+
+            assert len(loaded_datums) == len(datums)
+            assert loaded_metadata["source_file"] == "test.jsonl"
+            assert loaded_metadata["num_datums"] == len(datums)
+            assert loaded_metadata["num_shards"] >= 1
+
+            # Verify content matches.
+            for orig, loaded in zip(datums, loaded_datums, strict=True):
+                assert list(orig.model_input.to_ints()) == list(loaded.model_input.to_ints())
+
+    def test_roundtrip_empty(self):
+        """Empty dataset roundtrips correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums([], tmpdir, metadata={"empty": True})
+            loaded, meta = load_packed_datums(tmpdir)
+            assert loaded == []
+            assert meta["num_datums"] == 0
+
+    def test_missing_metadata_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(FileNotFoundError, match="metadata"):
+                load_packed_datums(tmpdir)
+
+    def test_multiple_shards(self):
+        """Many Datums are spread across multiple shard files."""
+        items = [_make_item(list(range(i, i + 5))) for i in range(20)]
+        datums = pack_to_datums(items, max_length=12)
+        assert len(datums) > 3, f"Expected >3 datums but got {len(datums)}"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums(datums, tmpdir, metadata={}, shard_size=3)
+            shard_files = list(Path(tmpdir).glob("shard_*.jsonl"))
+            assert len(shard_files) > 1
+
+            loaded, meta = load_packed_datums(tmpdir)
+            assert len(loaded) == len(datums)
+
+
+# ---------------------------------------------------------------------------
+# PrepackedSupervisedDataset
+# ---------------------------------------------------------------------------
+
+
+class TestPrepackedSupervisedDataset:
+    def test_len_exact(self):
+        """__len__ returns num_datums // batch_size."""
+        items = [_make_item([i, i + 1]) for i in range(10)]
+        datums = pack_to_datums(items, max_length=5)
+        # Each item is 2 tokens. At max 5, we get 2 items per pack (4 tokens).
+        # 10 items -> 5 packs.
+        assert len(datums) == 5
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums(datums, tmpdir, metadata={})
+            ds = PrepackedSupervisedDataset(tmpdir, batch_size=2)
+            assert len(ds) == 2  # 5 // 2 = 2
+
+    def test_get_batch(self):
+        items = [_make_item([i, i + 1]) for i in range(10)]
+        datums = pack_to_datums(items, max_length=5)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums(datums, tmpdir, metadata={})
+            ds = PrepackedSupervisedDataset(tmpdir, batch_size=2)
+            batch = ds.get_batch(0)
+            assert len(batch) == 2
+            assert all(isinstance(d, tinker.Datum) for d in batch)
+
+    def test_get_batch_random_access(self):
+        items = [_make_item([i, i + 1]) for i in range(10)]
+        datums = pack_to_datums(items, max_length=5)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums(datums, tmpdir, metadata={})
+            ds = PrepackedSupervisedDataset(tmpdir, batch_size=2)
+            # Access batches in any order.
+            b1 = ds.get_batch(1)
+            b0 = ds.get_batch(0)
+            assert len(b0) == 2
+            assert len(b1) == 2
+            # They should be different batches.
+            assert list(b0[0].model_input.to_ints()) != list(b1[0].model_input.to_ints())
+
+    def test_set_epoch_shuffles_deterministically(self):
+        items = [_make_item([i * 10, i * 10 + 1]) for i in range(20)]
+        datums = pack_to_datums(items, max_length=5)
+        assert len(datums) >= 4
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums(datums, tmpdir, metadata={})
+            ds = PrepackedSupervisedDataset(tmpdir, batch_size=2)
+
+            # Epoch 0
+            ds.set_epoch(seed=0)
+            batch_e0 = ds.get_batch(0)
+
+            # Epoch 1 should differ
+            ds.set_epoch(seed=1)
+            batch_e1 = ds.get_batch(0)
+
+            # Same seed should produce same order
+            ds.set_epoch(seed=0)
+            batch_e0_again = ds.get_batch(0)
+
+            e0_tokens = [list(d.model_input.to_ints()) for d in batch_e0]
+            e1_tokens = [list(d.model_input.to_ints()) for d in batch_e1]
+            e0_again_tokens = [list(d.model_input.to_ints()) for d in batch_e0_again]
+
+            assert e0_tokens == e0_again_tokens, "Same seed should produce same order"
+            # With enough datums, different seeds should produce different orders
+            # (extremely unlikely to be the same by chance).
+            assert e0_tokens != e1_tokens, "Different seeds should produce different orders"
+
+    def test_empty_dataset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums([], tmpdir, metadata={})
+            ds = PrepackedSupervisedDataset(tmpdir, batch_size=4)
+            assert len(ds) == 0
+
+
+# ---------------------------------------------------------------------------
+# PrepackedDatasetBuilder
+# ---------------------------------------------------------------------------
+
+
+class TestPrepackedDatasetBuilder:
+    def test_builder_returns_dataset(self):
+        items = [_make_item([i, i + 1]) for i in range(10)]
+        datums = pack_to_datums(items, max_length=5)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_packed_datums(datums, tmpdir, metadata={})
+            builder = PrepackedDatasetBuilder(packed_dir=tmpdir, batch_size=2)
+            train_ds, eval_ds = builder()
+            assert isinstance(train_ds, PrepackedSupervisedDataset)
+            assert eval_ds is None
+            assert len(train_ds) == 2
+
+
+# ---------------------------------------------------------------------------
+# Parallel rendering (integration test with mock renderer)
+# ---------------------------------------------------------------------------
+
+
+class TestParallelRendering:
+    @patch("tinker_cookbook.supervised.prepack._worker_init")
+    @patch("tinker_cookbook.supervised.prepack._render_one")
+    def test_single_worker_rendering(self, mock_render, mock_init):
+        """Single-worker mode processes all conversations."""
+        mock_render.return_value = ([1, 2, 3], [1.0, 1.0, 1.0])
+
+        conversations = _simple_conversations(5)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source.jsonl"
+            _make_jsonl(conversations, source)
+
+            config = PrepackConfig(
+                source_file=str(source),
+                output_dir=str(Path(tmpdir) / "packed"),
+                model_name="test-model",
+                renderer_name="test-renderer",
+                max_packed_length=100,
+                num_workers=1,
+            )
+
+            prepack(config)
+
+            # Should have called render for each conversation
+            assert mock_render.call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Custom render_fn
+# ---------------------------------------------------------------------------
+
+
+class TestCustomRenderFn:
+    def test_prepack_with_custom_render_fn(self):
+        """prepack() accepts a custom render_fn instead of using the renderer."""
+        conversations = _simple_conversations(5)
+
+        def custom_render(convos: list[list[dict]]) -> list[tuple[list[int], list[float]]]:
+            return [([1, 2, 3], [1.0, 1.0, 1.0]) for _ in convos]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source.jsonl"
+            _make_jsonl(conversations, source)
+
+            config = PrepackConfig(
+                source_file=str(source),
+                output_dir=str(Path(tmpdir) / "packed"),
+                model_name="unused",
+                renderer_name="unused",
+                max_packed_length=100,
+                num_workers=1,
+            )
+
+            prepack(config, render_fn=custom_render)
+
+            datums, metadata = load_packed_datums(Path(tmpdir) / "packed")
+            assert len(datums) > 0
+            assert metadata["num_raw_conversations"] == 5
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CLI test (uses a real renderer)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    @pytest.fixture
+    def sample_data_dir(self, tmp_path: Path) -> Path:
+        """Create a temp directory with a small JSONL file."""
+        conversations = _simple_conversations(10)
+        source = tmp_path / "data.jsonl"
+        _make_jsonl(conversations, source)
+        return tmp_path
+
+    def test_end_to_end_with_role_colon(self, sample_data_dir: Path):
+        """Full pipeline: load -> render -> pack -> save -> load."""
+        output_dir = sample_data_dir / "packed"
+        source_file = sample_data_dir / "data.jsonl"
+
+        config = PrepackConfig(
+            source_file=str(source_file),
+            output_dir=str(output_dir),
+            model_name="Qwen/Qwen3-0.6B",
+            renderer_name="role_colon",
+            # Small max_packed_length to force multiple packed sequences.
+            max_packed_length=40,
+            num_workers=2,
+            train_on_what="all_assistant_messages",
+            shard_size=5,
+            imap_chunksize=2,
+        )
+
+        prepack(config)
+
+        # Verify output structure.
+        assert (output_dir / "metadata.json").exists()
+        shard_files = list(output_dir.glob("shard_*.jsonl"))
+        assert len(shard_files) > 0
+
+        # Load and verify.
+        datums, metadata = load_packed_datums(output_dir)
+        assert len(datums) > 0
+        assert metadata["num_raw_conversations"] == 10
+        assert metadata["renderer_name"] == "role_colon"
+
+        # Use as a dataset.
+        batch_size = min(2, len(datums))
+        ds = PrepackedSupervisedDataset(output_dir, batch_size=batch_size)
+        assert len(ds) >= 1
+        batch = ds.get_batch(0)
+        assert len(batch) == batch_size
+        for datum in batch:
+            assert isinstance(datum, tinker.Datum)
+            assert datum.model_input.length > 0


### PR DESCRIPTION
## Summary
Adds two new modules for efficient SFT dataset preparation:

- **`tinker_cookbook/supervised/packing.py`** — Pure bin-packing algorithm (`greedy_pack`, `make_datum`, `pack_to_datums`). Works on plain Python lists, no torch/tinker in the core loop. Reusable by any code that needs sequence packing.

- **`tinker_cookbook/supervised/prepack.py`** — Offline pre-packing pipeline:
  - `render_parallel()` — parallel rendering across CPU cores via `multiprocessing.Pool`
  - `save_packed_datums()` / `load_packed_datums()` — sharded JSONL serialization
  - `PrepackedSupervisedDataset` — dataset with exact `__len__`, random-access `get_batch`, deterministic `set_epoch`
  - `PrepackedDatasetBuilder` — `@chz.chz` builder for training config integration
  - CLI: `python -m tinker_cookbook.supervised.prepack source_file=... output_dir=... num_workers=64`

## Motivation
Rendering 24.5M SFT examples takes ~117 hours on a single core. Pre-pack once with parallel CPU rendering, save to disk, reuse across runs. Exact step count enables proper cosine LR scheduling.

## Design
Clean separation of concerns:
- `packing.py` — pure algorithm, no IO, no multiprocessing, fully testable
- `prepack.py` — pipeline (rendering, serialization, dataset, CLI)
- `PrepackedDatasetBuilder` integrates with `chz` training configs
- `render_parallel()` is a standalone reusable function, accepts custom `render_fn`
- Workers return plain `(list[int], list[float])` tuples across process boundaries

## Test plan
- [x] 14 packing algorithm tests (greedy_pack, make_datum, pack_to_datums)
- [x] 13 pipeline tests (save/load, dataset, builder, parallel rendering, CLI e2e)
- [x] All 27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)