### PR TITLE
Add tinker-debug skill for systematic issue triage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,8 @@
         "./skills/tinker-sft",
         "./skills/tinker-rl",
         "./skills/tinker-preferences",
-        "./skills/tinker-ops"
+        "./skills/tinker-ops",
+        "./skills/tinker-debug"
       ]
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tinker_cookbook/_version.py
 .venv
 uv.lock
 skills-workspace/
+tinker-debug-workspace/

--- a/skills/tinker-debug/SKILL.md
+++ b/skills/tinker-debug/SKILL.md
@@ -1,0 +1,654 @@
+---
+name: tinker-debug
+description: Diagnose training issues with Tinker — slow steps, hanging sessions, output mismatches, error messages, renderer problems, and deployment issues. Use this skill whenever a user reports that training is slow, steps take too long, sessions are hanging, model outputs differ between Tinker and external engines (vLLM, SGLang), they get a confusing error message, training quality is poor (high KL, bad outputs), or they suspect something is wrong. Also trigger when users ask "is this a Tinker issue or my issue?", "is Tinker down?", report unexpected wait times, see output quality regressions, get opaque errors, or want to profile/debug their training or deployment pipeline. This skill walks through systematic triage to determine root cause.
+---
+
+# Tinker Debug
+
+Systematic triage for training and deployment issues. Five triage paths:
+1. **Performance issues** — slow steps, hanging sessions, throughput problems
+2. **Output correctness issues** — mismatches between Tinker sampling and external inference engines
+3. **Service availability** — "is Tinker down?" quick diagnostics
+4. **Renderer issues** — wrong tokens, training quality degradation, prompt mismatches
+5. **Error message decoder** — mapping opaque errors to root causes
+
+Identify which category the user's problem falls into, then follow the appropriate triage.
+
+## How the Tinker SDK works (essential context)
+
+Understanding the SDK's threading model is key to diagnosing most issues. The SDK runs a **background thread** with its own asyncio event loop. All network I/O, heartbeats, and API result polling happen on this thread.
+
+```
+┌─────────────────────┐     ┌──────────────────────────────┐
+│     Main Thread      │     │      SDK Background Thread    │
+│  (user code)         │     │  (asyncio event loop)         │
+│                      │     │                               │
+│  fb = tc.fwd_bwd_   │────>│  HTTP POST /forward_backward  │
+│       async(data)    │     │  → returns request_id         │
+│                      │     │                               │
+│  # prepare next      │     │  Long-poll /retrieve_future   │
+│  # batch here...     │     │  (HTTP 408 = not ready yet)   │
+│                      │     │                               │
+│  result = fb.result()│<────│  Result arrives → resolve     │
+│  # blocks until done │     │                               │
+│                      │     │  Heartbeat every 10s          │
+└─────────────────────┘     └──────────────────────────────┘
+```
+
+When you call `forward_backward_async()`, the SDK:
+1. Submits the request coroutine to the background thread
+2. Returns a future immediately (main thread continues)
+3. Background thread sends HTTP request, starts long-polling for result
+4. Calling `.result()` on the future blocks main thread until the background thread resolves it
+
+**Why this matters for debugging:** The background thread shares the Python GIL with the main thread. If user code holds the GIL for extended periods (heavy numpy/torch computation, CPU-bound data processing, slow serialization), the background thread **cannot**:
+- Send heartbeats (sessions can expire after missed heartbeats)
+- Poll for API results (futures appear to "hang")
+- Submit new requests (pipelining breaks)
+
+This means "my training is slow/hanging" is often caused by the user's own code blocking the SDK's background thread via GIL contention — not a network or server issue.
+
+## Triage order
+
+Work through these steps in order. Most issues are caught in steps 1-3 and never need deep profiling.
+
+### Step 1: Environment check
+
+Bad dependency versions are a silent killer. Check these first because they're fast to verify and cause mysterious slowdowns that look like service issues.
+
+```python
+import sys, pydantic, tinker
+print(f"Python: {sys.version}")
+print(f"pydantic: {pydantic.__version__}")
+print(f"tinker SDK: {tinker.__version__}")
+try:
+    import torch; print(f"torch: {torch.__version__}")
+except ImportError: pass
+try:
+    import numpy; print(f"numpy: {numpy.__version__}")
+except ImportError: pass
+try:
+    import transformers; print(f"transformers: {transformers.__version__}")
+except ImportError: pass
+```
+
+**Known problem versions:**
+- `pydantic >= 2.13.0b1` (beta): Serialization regression makes `model_dump()` extremely slow on large payloads (tokens/tensors). Symptom: SDK thread stalls for minutes on `forward_backward` submission. Fix: pin `pydantic<2.13` or use a stable release.
+- `transformers == 5.3.0`: Incorrect `tokenizer_class` for DeepSeek V2/V3 models (huggingface/transformers#44801, fixed in 5.3.1). Causes tokenizer loading failures. Upgrade or skip this version.
+- `transformers < 5.0`: Bug in `Qwen2VLImageProcessor` that miscounts image tokens for VL models. Fix: upgrade to `>=5.0`.
+- Always check if the user is on the **latest stable** tinker SDK. Suggest `pip install --upgrade tinker`.
+
+If the user has a beta or pre-release of any core dependency, that's the likely culprit. Suggest downgrading before deeper investigation.
+
+### Step 2: Async pipelining check
+
+The single most common performance mistake. If the user's code awaits each API call before submitting the next, the GPU sits idle between steps.
+
+**Ask the user to share their training loop code**, then look for these anti-patterns:
+
+```python
+# BAD: sequential — GPU idle while client prepares next call
+result = tc.forward_backward(data=batch, loss_fn="cross_entropy")  # blocks
+tc.optim_step(adam_params=params)  # blocks
+
+# BAD: async but still sequential
+result = await tc.forward_backward_async(data=batch, loss_fn="cross_entropy")
+await tc.optim_step_async(adam_params=params)
+
+# GOOD: pipelined — submit both before awaiting
+fb_future = tc.forward_backward_async(data=batch, loss_fn="cross_entropy")
+optim_future = tc.optim_step_async(adam_params=params)
+# ... prepare next batch while GPU works ...
+fb_result = fb_future.result()
+optim_result = optim_future.result()
+```
+
+If the user is using the cookbook's `supervised.train` or `rl.train`, pipelining is handled automatically. If they have a custom script, check their loop carefully. If they're struggling with async patterns, suggest switching to the cookbook's training scripts which handle pipelining, checkpointing, and logging out of the box.
+
+**Quick test:** If the user reports "first step is slow but later steps are faster," that's often normal warm-up (model loading, JIT compilation). If *every* step is slow, the issue is likely pipelining or serialization.
+
+### Step 3: Quick timing breakdown
+
+Before reaching for heavy profiling tools, get a rough breakdown of where time goes. The cookbook's built-in tracing does this automatically.
+
+If the user is running the cookbook's train scripts, check the `log_path` output:
+
+```python
+# Read timing metrics from a training run
+import json
+with open("path/to/metrics.jsonl") as f:
+    metrics = [json.loads(line) for line in f]
+
+# Look at timing keys for the last few steps
+for m in metrics[-3:]:
+    timing = {k: v for k, v in m.items() if k.startswith("time/")}
+    print(f"step {m.get('progress/batch')}: {timing}")
+```
+
+**What to look for:**
+- `time/forward_backward` >> `time/optim_step` — Normal, fwd/bwd is heavier
+- `time/get_batch` is large — Data loading is the bottleneck, not Tinker
+- `time/total` >> sum of individual times — There are gaps between operations (pipelining issue)
+- Large `time/forward_backward` on step 0, then normal — Warm-up, not a bug
+
+If the user has a custom script without cookbook tracing, suggest wrapping key sections:
+
+```python
+import time
+
+t0 = time.perf_counter()
+fb_future = tc.forward_backward_async(data=batch, loss_fn="cross_entropy")
+t_submit = time.perf_counter() - t0
+
+t0 = time.perf_counter()
+result = fb_future.result()
+t_wait = time.perf_counter() - t0
+
+print(f"submit: {t_submit:.2f}s, wait: {t_wait:.2f}s")
+```
+
+For a more detailed view, `pyinstrument` with async mode shows exactly where time goes:
+
+```bash
+pip install pyinstrument
+pyinstrument --async-mode=enabled your_script.py
+```
+
+**Interpreting results:**
+- **High submit time** → Client-side bottleneck (serialization, data prep). Go to Step 4.
+- **High wait time** → Either network or server-side. Go to Step 5.
+- **Both reasonable but steps are slow** → Check for gaps between steps (pipelining). Go back to Step 2.
+
+### Step 4: Profile the request lifecycle
+
+The key is to understand where in the request lifecycle time is being spent. Every Tinker API call goes through: **submit → serialize → network send → server compute → long-poll → resolve**. GIL contention can block steps on the SDK background thread silently.
+
+#### Option A: Cookbook tracing (if using cookbook train scripts)
+
+The cookbook automatically produces Gantt charts and Perfetto traces:
+
+```python
+# View the Gantt chart — shows each operation as a timeline bar
+# Open: <log_path>/iteration_000000/timing_gantt.html
+
+# View Perfetto trace (more detail, shows both threads)
+python -m tinker_cookbook.utils.trace <log_path>/trace_events.jsonl -o trace.json
+# Open https://ui.perfetto.dev/ and load trace.json
+```
+
+In the Gantt chart, look for **gaps between bars** — these are periods where neither the main thread nor the SDK is doing useful work. Common patterns:
+- **Long bar for `forward_backward`** with gaps before/after → Pipelining issue
+- **Long bar for `get_batch`** → Data loading bottleneck
+- **Gaps with no bars at all** → GIL contention (background thread blocked)
+
+#### Option B: pyinstrument (for custom scripts)
+
+```bash
+pip install pyinstrument
+pyinstrument --async-mode=enabled your_script.py
+```
+
+The `--async-mode=enabled` flag is critical — without it, time spent in `await` all gets attributed to `epoll.poll` which tells you nothing.
+
+**What to look for:**
+- Time in `pydantic` serialization (`model_dump`, `__repr__`) → Dependency issue (Step 1)
+- Time in `AwaitableConcurrentFuture.result_async` → Waiting for server (network or server-side)
+- Time in data preparation, tokenization, numpy/torch ops → GIL contention risk
+
+#### Option C: Thread stack watchdog (for hung/slow sessions)
+
+When a session is actively slow or hung, use the async task dump + thread stack watchdog to see what both threads are doing in real-time. Read `references/async-task-dump.md` for ready-to-paste diagnostic code.
+
+**Interpreting the output:**
+- SDK thread has pending `_forward_backward_async` tasks → Work submitted, waiting for server
+- SDK thread has pending `_result_async` → Normal long-polling behavior
+- SDK thread stopped logging entirely → **GIL contention** — the background thread can't wake up
+- Main thread stuck in numpy/torch/data code while SDK thread is stalled → GIL is the bottleneck
+
+### Step 5: GIL contention and background thread blocking
+
+This is the most subtle and most common cause of "mysterious" slowdowns. Because the SDK's background thread shares Python's GIL with the main thread, CPU-heavy work in the user's code blocks the SDK from:
+- **Sending heartbeats** → Session may expire (warning: "Session heartbeat failed")
+- **Polling for results** → Futures appear to hang for minutes
+- **Submitting new requests** → Pipelining breaks even when using `_async` variants
+
+**Symptoms of GIL contention:**
+- Steps are slow but server-side traces show the GPU finished quickly
+- Heartbeat warnings in the logs
+- Inconsistent step times (varies with data processing load)
+- `pyinstrument` shows most time in `epoll.poll` (even with async mode) — the event loop couldn't run
+
+**Common GIL-heavy operations in training scripts:**
+- Large numpy array operations (tokenization, data preprocessing)
+- Torch tensor operations on CPU (not GPU — GPU ops release the GIL)
+- Heavy JSON/pydantic serialization
+- File I/O for large datasets
+- `transformers` tokenizer calls on large batches
+
+**Fixes:**
+1. **Move heavy work out of the hot loop**: Preprocess data before training starts
+2. **Use the cookbook's training scripts**: They pipeline data prep with async API calls
+3. **Offload to subprocess**: For sampling-heavy workloads, the SDK supports subprocess isolation via `TINKER_SUBPROCESS_SAMPLING=1`, which gives sampling its own event loop in a separate process (no GIL sharing)
+4. **Break up long CPU operations**: Insert `await asyncio.sleep(0)` or small yields between heavy processing to let the background thread run
+
+**Diagnostic: Is GIL the problem?**
+
+```python
+import threading, time
+
+def gil_monitor(interval=2.0):
+    """Prints when the GIL blocks this thread for too long."""
+    expected = interval
+    while True:
+        t0 = time.monotonic()
+        time.sleep(interval)
+        actual = time.monotonic() - t0
+        jitter = actual - expected
+        if jitter > 0.5:  # >500ms jitter = GIL contention
+            print(f"[GIL monitor] slept {actual:.2f}s instead of {expected:.1f}s "
+                  f"(jitter: {jitter:.2f}s) — likely GIL contention")
+
+threading.Thread(target=gil_monitor, daemon=True).start()
+# ... rest of training script ...
+```
+
+This runs a monitoring thread that detects when `time.sleep()` takes significantly longer than requested — a sign that the GIL was held by another thread.
+
+### Step 6: Network vs. server-side
+
+If GIL is not the issue and the client submits quickly, check whether the wait is network or server:
+
+```python
+import time, tinker
+svc = tinker.ServiceClient()
+t0 = time.perf_counter()
+caps = svc.get_server_capabilities()
+print(f"API round-trip: {time.perf_counter() - t0:.2f}s")
+# >2s suggests network issues; <1s rules out network
+```
+
+If network is fast, share the session ID (`tc.get_info()`) with the Tinker team for server-side investigation.
+
+### Step 7: Escalation
+
+If you've verified that:
+1. Dependencies are on stable, recent versions
+2. The training loop uses proper async pipelining
+3. GIL contention is not the issue
+4. Client-side profiling shows most time in SDK `await` calls
+5. Network round-trip is fast
+
+Then the issue is likely server-side. Help the user file a report with:
+- **Session ID** (from `tc.get_info()`)
+- **Step timing** (from metrics.jsonl or manual timing)
+- **pyinstrument profile** (with `--async-mode=enabled`)
+- **Tinker SDK version** and other dependency versions
+- **What machine they're running on** (cloud instance type, region)
+
+---
+
+## Output correctness triage
+
+When the user reports that their fine-tuned model behaves differently in external inference engines (vLLM, SGLang, TGI) compared to Tinker's sampling client, the problem is almost always in the **weight merge/export** step, not in training.
+
+Tinker's sampling client serves the unmerged LoRA adapter directly on top of the base model — it's the ground truth. If the model produces correct outputs through Tinker sampling but wrong outputs after export, the merge is the first suspect.
+
+### Step 1: Use the cookbook merge, not a custom script
+
+The most common cause of merge issues is users writing their own merge scripts. The cookbook's `weights.build_hf_model()` handles model-specific weight layouts automatically — MoE expert fusion, VL model prefixes, split QKV projections, and more.
+
+```python
+from tinker_cookbook import weights
+
+# Download adapter
+adapter_dir = weights.download(
+    tinker_path="tinker://session-id/sampler_weights/step_N",
+    output_dir="./adapter",
+)
+
+# Merge LoRA into base model (handles all model-specific layouts)
+weights.build_hf_model(
+    base_model="Qwen/Qwen3-8B",
+    adapter_path=adapter_dir,
+    output_path="./merged_model",
+    dtype="bfloat16",
+)
+```
+
+If the user has a custom merge script, strongly recommend switching to the cookbook's implementation first. It handles:
+- **MoE gate_up_proj fusion** — Correctly detects concatenated vs interleaved layouts per model family
+- **VL model prefixes** — Adds `model.language_model.*` prefix for vision-language models
+- **Split QKV projections** — Handles Qwen3.5 fused `in_proj_qkv` with unequal Q/K/V dimensions
+- **Shard-by-shard processing** — Low memory merge for large models
+
+### Step 2: Verify prompt equivalence
+
+Even with correct weights, different inference engines may tokenize or render prompts differently. Verify the model receives identical input:
+
+```python
+# Compare token IDs between Tinker and external engine
+# Tinker side:
+model_input = renderer.build_supervised_example(messages)[0]
+tinker_tokens = [chunk.tokens for chunk in model_input.chunks if hasattr(chunk, 'tokens')]
+
+# External engine side:
+external_tokens = tokenizer.apply_chat_template(messages, tokenize=True)
+
+# Compare
+assert tinker_tokens == external_tokens, "Token mismatch — check chat template and renderer"
+```
+
+For vision models, also verify:
+- Image tokens are in the same positions
+- Image preprocessing (resize, normalization) matches
+- The number of image tokens per image matches
+
+### Step 3: Check for known merge pitfalls
+
+If the user must use a custom merge, the most common issues are:
+- **MoE gate_up_proj fusion convention** — Concatenated (Qwen3.5, Qwen3-VL) vs interleaved (GPT-OSS). Wrong convention silently corrupts weights.
+- **Precision loss** — LoRA merge math must be done in float32, then cast to bfloat16. Direct bfloat16 matmul introduces errors.
+- **Tinker weight naming** — `w1`=gate, `w2`=down, `w3`=up. Swapping `w1`/`w3` is a common bug.
+- **VL model prefix** — Vision-language models add `model.language_model.*` prefix that custom scripts often miss.
+
+For full details (weight layout diagrams, validation scripts, tensor comparison code), read `references/merge-debugging.md`.
+
+### Step 4: Try PEFT adapter as workaround
+
+If merge issues persist, skip the merge entirely and serve the unmerged adapter:
+
+```python
+weights.build_lora_adapter(
+    base_model="Qwen/Qwen3-8B",
+    adapter_path=adapter_dir,
+    output_path="./peft_adapter",
+)
+# Then serve with vLLM: --lora-modules my_adapter=./peft_adapter
+```
+
+This lets the engine apply the LoRA at inference time, sidestepping merge-related precision and layout bugs.
+
+### Step 5: Escalation for correctness issues
+
+If the cookbook merge + correct prompts still produce wrong outputs, gather: model name/size, session ID, merge method, engine version, example input/output comparison, and token IDs confirming prompt equivalence.
+
+---
+
+## Service availability triage
+
+When the user asks "is Tinker down?" or operations hang/fail unexpectedly, run a quick smoke test before deeper investigation. Many users can't distinguish a service outage from a bug in their code.
+
+### Quick smoke test
+
+Help the user run a three-step diagnostic to isolate where things break:
+
+```python
+import time, tinker
+
+svc = tinker.ServiceClient()
+
+# Step 1: API reachable?
+t0 = time.perf_counter()
+try:
+    caps = svc.get_server_capabilities()
+    print(f"API reachable ({time.perf_counter() - t0:.2f}s), {len(caps.models)} models available")
+except Exception as e:
+    print(f"API unreachable: {type(e).__name__}: {e}")
+
+# Step 2: Can we create a training session? (small model for speed)
+try:
+    tc = svc.create_lora_training_client(base_model="meta-llama/Llama-3.2-1B", rank=32)
+    print(f"Training client created: {tc.get_info()}")
+except Exception as e:
+    print(f"Training client failed: {type(e).__name__}: {e}")
+```
+
+**Interpreting:** Step 1 fails → service down or network. Step 1 passes but Step 2 fails → model-specific capacity issue (try smaller model). Both pass but user's script fails → issue is in user's code.
+
+### Common server-side errors
+
+| Error | Meaning |
+|-------|---------|
+| `APIConnectionError` | Service down or network issue |
+| `APITimeoutError` | Service overloaded |
+| HTTP 402 | Billing blocked — check Tinker console |
+| HTTP 429 | Rate limited — reduce concurrency |
+| HTTP 500 | Server bug — gather session ID and report |
+| Client creation hangs | Capacity shortage — SDK may not surface error clearly |
+
+---
+
+## Renderer triage
+
+Renderer issues cause **silent training degradation** — the model trains on wrong tokens, producing poor results without any error messages. This is the most common source of subtle quality bugs.
+
+The renderer converts chat-style messages into model-specific token sequences. If the renderer produces different tokens than the model expects, training teaches the wrong associations. The model may still train (loss goes down) but learn garbage.
+
+### When to suspect a renderer issue
+
+- Training loss decreases but model outputs are poor quality
+- High KL divergence at step 0 (before any training) — indicates the prompt tokens don't match what the model expects
+- Model produces garbled or off-distribution outputs
+- Tool calling works in some models but not others
+- Thinking/reasoning blocks appear or disappear unexpectedly
+
+### Step 1: Verify you're using the right renderer
+
+```python
+from tinker_cookbook import model_info
+
+renderer_name = model_info.get_recommended_renderer_name("Qwen/Qwen3-8B")
+print(f"Recommended renderer: {renderer_name}")
+```
+
+Never hardcode renderer names. Each model family has specific token formats, and using the wrong renderer silently produces incorrect training data.
+
+**Hybrid models (thinking + non-thinking)** are especially tricky. These models support both reasoning (`<think>` blocks) and direct responses. Using the wrong variant causes token-level mismatches:
+
+| Model family | Thinking renderer | Non-thinking renderer | Notes |
+|-------------|-------------------|----------------------|-------|
+| Qwen3 | `qwen3` | `qwen3_disable_thinking` | Default is thinking-enabled. `qwen3_instruct` for instruction-only. |
+| Qwen3.5 | `qwen3_5` | `qwen3_5_disable_thinking` | Hybrid attention; also has VL variants. |
+| DeepSeek V3 | `deepseekv3_thinking` | `deepseekv3` | Default is non-thinking. Thinking adds `<think>` prefill. |
+| Kimi K2.5 | `kimi_k25` | `kimi_k25_disable_thinking` | Vision-capable. |
+| Nemotron3 | `nemotron3` | `nemotron3_disable_thinking` | |
+
+**Common hybrid model mistakes:**
+- Training on data with `<think>` blocks using a `_disable_thinking` renderer → Thinking tokens treated as regular text
+- Using a thinking renderer but testing with `temperature=0` and short `max_tokens` → Model spends all tokens thinking, never produces an answer
+- Comparing against HF template without passing `thinking=True` → Token mismatch that looks like a renderer bug but is a test setup issue
+
+### Step 2: Compare tokens against HuggingFace
+
+The ground truth is the model's HuggingFace tokenizer with `apply_chat_template`. Compare your renderer's output against it:
+
+```python
+from tinker_cookbook.renderers import get_renderer
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.model_info import get_recommended_renderer_name
+
+model_name = "Qwen/Qwen3-8B"
+tokenizer = get_tokenizer(model_name)
+renderer_name = get_recommended_renderer_name(model_name)
+renderer = get_renderer(renderer_name, tokenizer)
+
+# Test conversation
+messages = [
+    {"role": "user", "content": "Hello!"},
+    {"role": "assistant", "content": "Hi there!"},
+]
+
+# Cookbook tokens
+cookbook_mi = renderer.build_generation_prompt(messages)
+cookbook_tokens = cookbook_mi.to_ints()
+
+# HuggingFace tokens
+hf_tokens = tokenizer.apply_chat_template(
+    messages,
+    add_generation_prompt=True,
+    tokenize=True,
+)
+
+if cookbook_tokens == list(hf_tokens):
+    print("MATCH: Renderer tokens match HuggingFace")
+else:
+    print("MISMATCH: Renderer diverges from HuggingFace")
+    # Find first divergence point
+    for i, (a, b) in enumerate(zip(cookbook_tokens, hf_tokens)):
+        if a != b:
+            print(f"  First diff at position {i}: cookbook={a} ({tokenizer.decode([a])!r}) vs HF={b} ({tokenizer.decode([b])!r})")
+            break
+    print(f"  Cookbook length: {len(cookbook_tokens)}, HF length: {len(hf_tokens)}")
+```
+
+**If tokens match:** The renderer is correct. The issue is elsewhere (training config, data quality, etc.).
+
+**If tokens don't match:** Check these common causes:
+- **Thinking mode**: Some models (Qwen3, DeepSeek) need `thinking=True` passed to `apply_chat_template`. The renderer handles this automatically, but make sure you're comparing apples to apples.
+- **System prompt**: Some renderers inject a default system prompt (Kimi K2). If your HF comparison doesn't include one, tokens will diverge.
+- **Tool calling format**: Each model family uses a different tool call format. The renderer must match the model's expected format exactly.
+
+### Step 3: Check thinking mode handling
+
+For models with thinking capabilities (Qwen3, DeepSeek V3, Kimi K2.5, Nemotron3):
+
+- Use the `_disable_thinking` renderer variant if you don't want `<think>` blocks
+- Historical assistant messages may have thinking stripped by default (depends on renderer)
+- If training on thinking data, ensure the renderer preserves `<think>` blocks in the training tokens
+
+### Step 4: Validate tool calling
+
+Tool call formats vary significantly across models. If tool calling quality is poor after training:
+
+1. Check that the renderer's tool format matches what the model was pre-trained on
+2. Verify `parse_response()` correctly extracts tool calls from model output
+3. Compare tool call rendering against HF's `apply_chat_template(..., tools=tool_specs)`
+
+For the full renderer reference (all models, formats, edge cases), read `references/renderer-debugging.md`.
+
+---
+
+## Error message decoder
+
+Tinker errors can be opaque. This section maps common error messages to root causes and fixes.
+
+### SDK / API errors
+
+| Error message | Root cause | Fix |
+|---------------|-----------|-----|
+| `max() iterable argument is empty` | Empty token list in a `Datum` — usually an `EncodedTextChunk` with no tokens | Validate your data: ensure every datum has at least one non-empty chunk with tokens |
+| `Could not convert loss function inputs to array record` | Extra fields in `loss_fn_inputs` that the loss function doesn't expect (e.g., `mask` field not stripped) | Use the cookbook's data helpers which strip extra fields automatically; or remove `mask` from `loss_fn_inputs` before passing to `forward_backward` |
+| `Unknown client error` | Generic catch-all — often means the checkpoint type is wrong | If during sampling: did you pass a `save_state` path instead of `save_weights_for_sampler`? State checkpoints can't be used for sampling. |
+| `prompt tokens + max_tokens > context window` | Prompt too long for the model | Reduce prompt length or `max_tokens`. The error message shows the specific limits. |
+| `Failed after exhausting retries` | Transient server error that didn't recover | Check service availability (smoke test above). If service is up, retry with a fresh session. |
+| `Access blocked` / HTTP 403 | No permission to access the model or checkpoint | Check API key, organization membership, or checkpoint visibility settings |
+| HTTP 402 | Billing issue — account blocked | Add credits at the Tinker console billing page |
+| HTTP 429 | Rate limited — too many concurrent requests | Reduce concurrency (default limit: ~2000 concurrent sampling requests). Add backoff/retry logic. |
+| HTTP 409 on checkpoint save | Checkpoint already exists (retry after transient failure) | The original save succeeded. Check if the checkpoint is already there before retrying. |
+| `session_id is required` with hint about SDK version | Tinker SDK too old | Run `pip install --upgrade tinker` |
+
+### Cookbook errors
+
+| Error message | Root cause | Fix |
+|---------------|-----------|-----|
+| `Unknown model: {name}` | Model name not in cookbook's registry | Check spelling; use `model_info.get_model_attributes()` to list known models |
+| `tokens and weights must be the same length` | Mismatch between token sequence and loss weight array | Check your `datum_from_model_input_weights()` call — usually means `max_length` truncated tokens but not weights |
+| `Expected X tokens, got Y from image` | VLM image token count mismatch — usually a `transformers` version issue | Upgrade `transformers>=5.0` or install `torchvision`. HuggingFace `Qwen2VLImageProcessor` had a bug in older versions. |
+| `RendererError: Unknown renderer` | Invalid renderer name | Use `model_info.get_recommended_renderer_name(model_name)` |
+| `qwen3_vl renderer requires an image_processor` | VL renderer needs image processor | Pass `image_processor` to `get_renderer()`. Load it from `transformers.AutoProcessor`. |
+| `DataFormatError: Each line must contain a 'messages' field` | JSONL data file has wrong format | Each line must be a JSON object with a `messages` key containing a list of message dicts |
+| `StreamingSupervisedDatasetFromHFDataset only supports forward iteration` | Tried to seek backward in streaming dataset | Streaming datasets are forward-only; don't try to restart from an earlier batch |
+
+For the full error reference with additional edge cases, read `references/error-reference.md`.
+
+---
+
+## Decision tree summary
+
+```
+Output differs between Tinker and external engine
+├─ Using custom merge script? → Switch to cookbook weights.build_hf_model()
+├─ Prompts identical? → Compare token IDs and image preprocessing
+├─ MoE model? → Check gate_up_proj fusion convention (concat vs interleave)
+├─ Large model / numerical issues? → Check merge precision (float32), try PEFT adapter
+└─ Cookbook merge + correct prompts + still wrong → Engine-specific issue → Escalate
+├─ Using custom merge script? → Switch to cookbook weights.build_hf_model()
+├─ Prompts identical? → Compare token IDs and image preprocessing
+├─ MoE model? → Check gate_up_proj fusion convention (concat vs interleave)
+├─ Large model / numerical issues? → Check merge precision (float32), try PEFT adapter
+└─ Cookbook merge + correct prompts + still wrong → Engine-specific issue → Escalate
+
+Training is slow
+├─ Check dependency versions (Step 1)
+│  └─ Beta/pre-release pydantic? → Downgrade
+├─ Check async pipelining (Step 2)
+│  └─ Sequential API calls? → Pipeline them
+├─ Get timing breakdown (Step 3)
+│  ├─ High submit time → Profile request lifecycle (Step 4)
+│  │  ├─ Slow serialization → Dependency issue
+│  │  ├─ Slow data loading → Optimize data pipeline
+│  │  └─ SDK thread stalled → GIL contention (Step 5)
+│  └─ High wait time → GIL or network or server
+│     ├─ Heartbeat warnings in logs → GIL contention (Step 5)
+│     ├─ Fast API round-trip → Server-side → Escalate (Step 7)
+│     └─ Slow API round-trip → Network issue
+├─ Inconsistent step times → GIL contention (Step 5)
+└─ First step slow, rest fast → Normal warm-up
+
+Is Tinker down?
+├─ Run smoke test (ServiceClient + create small training client)
+│  ├─ API unreachable → Service down or network issue
+│  ├─ API works but training client fails → Model-specific capacity issue
+│  └─ Everything works → Issue is in user's code
+└─ Check error: HTTP 402 = billing, 429 = rate limit, 500 = server bug
+
+Training quality is poor (high KL, bad outputs)
+├─ KL high at step 0? → Renderer mismatch (tokens don't match model's expected format)
+├─ Compare renderer tokens vs HF apply_chat_template
+│  ├─ Tokens match → Issue is elsewhere (LR, data quality, loss function)
+│  └─ Tokens differ → Wrong renderer or renderer bug
+├─ Tool calling broken? → Check renderer tool format matches model family
+└─ Thinking blocks wrong? → Use correct _disable_thinking variant
+```
+
+## Common resolutions
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Every step takes 5-10min | Missing async pipelining | Use `_async` variants, submit before await |
+| First step slow, rest normal | Model warm-up / JIT | Expected behavior, no fix needed |
+| Steps hang indefinitely | Dependency bug or network | Check pydantic version; try different machine |
+| Slow with large batch_size | Payload serialization | Check pydantic version; reduce batch_size |
+| Works on one machine, not another | Environment difference | Compare `pip freeze` outputs |
+| GPU time looks fine but steps slow | Gaps between submissions | Pipeline: submit next step before awaiting current |
+| Heartbeat warnings + slow steps | GIL contention (CPU work blocking SDK thread) | Preprocess data outside loop; use `TINKER_SUBPROCESS_SAMPLING=1` |
+| Inconsistent step times | GIL contention varies with data batch | Move heavy numpy/torch CPU ops out of hot loop |
+| Session expired unexpectedly | Missed heartbeats (SDK thread blocked) | Reduce GIL-holding operations; use subprocess sampling |
+| Output correct in Tinker, wrong in vLLM/SGLang | Merge bug (usually fused projection layout) | Use cookbook `weights.build_hf_model()` |
+| Model produces invalid/garbled outputs after export | Wrong gate_up_proj convention or precision loss | Check concat vs interleave; merge in float32 |
+| Numerical instability after deploy | Merge precision or engine quantization | Try `build_lora_adapter()` instead of merging |
+| Outputs subtly different but not completely wrong | bfloat16 merge rounding | Merge in float32, cast back after |
+| High KL at step 0 (before any training) | Renderer produces wrong tokens | Compare renderer tokens vs HF `apply_chat_template()` |
+| Training loss drops but outputs are poor | Renderer mismatch or wrong `train_on_what` | Verify renderer; check loss weight masking |
+| `create_lora_training_client` hangs forever | Capacity shortage for that model | Try smaller model; check service availability |
+| `Expected X tokens, got Y from image` | `transformers` version bug in VLM processor | Upgrade to `transformers>=5.0` |
+| `max() iterable argument is empty` | Empty token list in datum | Validate all datums have non-empty chunks |
+| Operations work but sporadically fail/hang | Service under load or transient issues | Add retry logic; gather session IDs for reports |
+
+## Code references
+
+**Key imports for debugging:**
+```python
+from tinker_cookbook import model_info, weights
+from tinker_cookbook.renderers import get_renderer, get_registered_renderer_names
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.utils import trace, ml_log
+import tinker
+```
+
+**Reference files in this skill:**
+- `references/async-task-dump.md` — Ready-to-paste diagnostic for hung sessions
+- `references/serialization-test.md` — Pydantic regression benchmark
+- `references/merge-debugging.md` — Weight layout conventions and fusion formats
+- `references/renderer-debugging.md` — Renderer validation, token comparison, model-specific quirks
+- `references/error-reference.md` — Extended error message decoder with edge cases

--- a/skills/tinker-debug/evals/evals.json
+++ b/skills/tinker-debug/evals/evals.json
@@ -1,0 +1,215 @@
+{
+  "skill_name": "tinker-debug",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "My SFT training steps are taking 300+ seconds each. I'm using Qwen3.5-35B with batch_size=4 and seq_len=8192. The first step took 316 seconds and the second took 324 seconds. Is this a Tinker issue?",
+      "expected_output": "Systematic triage starting with environment check, then async pattern check, then profiling guidance",
+      "files": [],
+      "expectations": [
+        "Asks about or checks dependency versions (especially pydantic, tinker SDK)",
+        "Asks to see the user's training loop code to check async pipelining patterns",
+        "Distinguishes between 'first step slow' (warm-up) vs 'every step slow' (real issue)",
+        "Suggests a timing breakdown approach (submit time vs wait time)",
+        "Does NOT immediately blame the Tinker service — follows client-side triage first",
+        "Mentions pyinstrument with --async-mode=enabled as a profiling option",
+        "Provides actionable next steps rather than just theory"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I'm running the cookbook's supervised train.py and it's been stuck for 45 minutes on the first batch. No error, just hanging. Session ID is abc12345-6789-abcd-ef01-234567890abc.",
+      "expected_output": "Guide to diagnosing a hung session using task dumps and stack traces",
+      "files": [],
+      "expectations": [
+        "Asks about dependency versions as a first check",
+        "Suggests the async task dump diagnostic or stack watchdog to see what's blocking",
+        "Mentions checking if the SDK thread is stalled (serialization, network)",
+        "Mentions the session ID can be shared with Tinker team for server-side investigation",
+        "Suggests a simplified diagnostic if the user can't install aiomonitor",
+        "Explains how to interpret the diagnostic output (main thread stall vs SDK stall vs server wait)"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Training was working fine last week at 30-40sec/step with bs=64. Now the same script is taking 5+ minutes per step. Nothing changed in my code.",
+      "expected_output": "Focus on environment changes — dependency updates, machine differences, network issues",
+      "files": [],
+      "expectations": [
+        "Asks what changed in the environment (pip install, machine change, etc.)",
+        "Suggests comparing pip freeze output between working and broken states",
+        "Specifically checks for pydantic version changes (known regression in beta)",
+        "Suggests the serialization benchmark test to quickly verify",
+        "Considers network connectivity as a factor if environment looks the same",
+        "Does NOT assume it's a Tinker service regression without evidence"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I wrote a custom training script (not using the cookbook). Steps take about 600 seconds. Here's my loop:\n\nfor batch in dataloader:\n    result = tc.forward_backward(data=batch, loss_fn='cross_entropy')\n    tc.optim_step(adam_params=params)\n    print(f'loss: {result.loss}')",
+      "expected_output": "Identify the sequential API call anti-pattern and show the pipelined version",
+      "files": [],
+      "expectations": [
+        "Identifies the synchronous sequential API calls as the primary issue",
+        "Shows the correct pipelined async pattern (submit both, then await)",
+        "Explains WHY pipelining matters (GPU sits idle between sequential calls)",
+        "Shows concrete corrected code using forward_backward_async and optim_step_async",
+        "Mentions that the cookbook's train.py handles pipelining automatically as an alternative",
+        "Suggests additional timing instrumentation to verify the fix helps"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I fine-tuned Qwen3-VL-235B with Tinker and the outputs look correct when I sample through Tinker's sampling client. But after merging the LoRA weights and deploying to vLLM, the model produces invalid tool calls — missing required arguments like coordinates. I verified the input tokens are identical.",
+      "expected_output": "Diagnose as a merge issue, focus on MoE fusion convention and recommend cookbook merge",
+      "files": [],
+      "expectations": [
+        "Identifies this as a weight merge issue, not a training or Tinker service issue",
+        "Recommends using the cookbook's weights.build_hf_model() instead of a custom merge script",
+        "Mentions the MoE gate_up_proj fusion convention (concatenated vs interleaved) as a likely cause",
+        "Explains the w1/w2/w3 to gate/down/up mapping",
+        "Suggests comparing weight tensors between cookbook merge and custom merge to find discrepancies",
+        "Mentions build_lora_adapter() as a workaround that avoids merge entirely",
+        "Does NOT blame the training process or Tinker service since Tinker sampling output is correct"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "After exporting my fine-tuned model, I'm seeing numerical instability — some inputs produce garbled outputs in SGLang but work fine through Tinker. The model is a large MoE model.",
+      "expected_output": "Guide through merge precision checks and PEFT adapter as alternative",
+      "files": [],
+      "expectations": [
+        "Suggests checking merge precision (float32 math, not bfloat16)",
+        "Mentions the PEFT adapter approach (build_lora_adapter) as a way to avoid merge-related precision issues",
+        "Asks whether they used the cookbook merge or a custom script",
+        "Considers engine-side quantization as a potential factor",
+        "Mentions that Tinker serves unmerged LoRA directly, so Tinker output is the ground truth",
+        "Does NOT attribute the issue to training instability since Tinker sampling works"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "My script was working yesterday but today create_lora_training_client just hangs forever. Is Tinker down?",
+      "expected_output": "Guide through service availability smoke test to distinguish outage from client issue",
+      "files": [],
+      "expectations": [
+        "Suggests running a quick smoke test (ServiceClient + get_server_capabilities)",
+        "Provides concrete diagnostic code the user can run immediately",
+        "Explains how to interpret the results (API reachable vs training client creation vs operations)",
+        "Mentions that capacity shortages for specific models can cause hangs without error messages",
+        "Suggests trying a smaller model to test if the service itself is up",
+        "Does NOT just say 'contact support' — gives the user actionable self-diagnosis steps first"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "I'm training Qwen3-8B on my custom dataset but the KL divergence is very high from step 0 (before any training happens). Loss does go down but the model outputs are poor. What's wrong?",
+      "expected_output": "Diagnose as likely renderer mismatch, guide through token comparison",
+      "files": [],
+      "expectations": [
+        "Identifies high step-0 KL as a renderer mismatch signal (tokens don't match model's expected format)",
+        "Asks which renderer they're using and whether it matches the model",
+        "Suggests comparing renderer tokens against HuggingFace apply_chat_template",
+        "Provides the token comparison code or approach",
+        "Mentions thinking mode as a common source of mismatch for Qwen3 (thinking=True vs False)",
+        "Explains WHY loss can decrease even with wrong tokens (model learns the wrong associations)"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "I'm getting 'max() iterable argument is empty' when calling forward_backward. What does this mean?",
+      "expected_output": "Decode the opaque error to its root cause: empty token list in a datum",
+      "files": [],
+      "expectations": [
+        "Maps the error to its root cause: an EncodedTextChunk with an empty token list",
+        "Suggests validating data before sending (check each datum has non-empty chunks)",
+        "Provides concrete validation code or approach",
+        "Does NOT just say 'it's a bug' — explains how the user's data pipeline can produce this",
+        "Suggests checking for edge cases in data preparation (empty messages, truncation to zero tokens)"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "I'm fine-tuning Qwen3-VL-7B with images and getting 'Expected 35 tokens, got 70 from image'. This happens on some images but not others. What's going on?",
+      "expected_output": "Identify as a transformers version bug in Qwen2VLImageProcessor, recommend upgrade",
+      "files": [],
+      "expectations": [
+        "Identifies this as a known bug in HuggingFace's Qwen2VLImageProcessor",
+        "Recommends upgrading transformers to >=5.0 as the fix",
+        "Mentions installing torchvision as an alternative workaround",
+        "Explains that different images produce different token counts, which is why it's intermittent",
+        "Does NOT suggest it's a Tinker bug or a problem with the user's images",
+        "Mentions checking transformers version as a first step"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "My training steps are inconsistent — some take 5 seconds, others take 60+ seconds. I'm also seeing 'Session heartbeat failed' warnings in the logs. I'm doing heavy data preprocessing with numpy between steps.",
+      "expected_output": "Diagnose as GIL contention from numpy blocking the SDK background thread",
+      "files": [],
+      "expectations": [
+        "Identifies GIL contention as the likely cause — numpy holds the GIL, blocking SDK's background thread",
+        "Explains the SDK background thread architecture (heartbeats, result polling share GIL with main thread)",
+        "Connects heartbeat warnings to GIL contention (background thread can't send heartbeats when GIL is held)",
+        "Suggests moving heavy preprocessing outside the training loop or preprocessing data before training",
+        "Mentions TINKER_SUBPROCESS_SAMPLING=1 as a fix for sampling-heavy workloads",
+        "Does NOT blame network or server — the inconsistency pattern + heartbeat warnings are classic GIL symptoms"
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "I saved my checkpoint with tc.save_state(name='my_checkpoint') and now I'm trying to sample from it with svc.create_sampling_client(model_path='tinker://session-id/state/my_checkpoint') but I get 'Unknown client error'. What am I doing wrong?",
+      "expected_output": "Explain the save_state vs save_weights_for_sampler distinction",
+      "files": [],
+      "expectations": [
+        "Explains that save_state() creates a training checkpoint (weights + optimizer), not usable for sampling",
+        "Recommends using save_weights_for_sampler() instead for creating a sampling-compatible checkpoint",
+        "Shows the correct workflow: save_weights_for_sampler() then create_sampling_client()",
+        "Mentions save_weights_and_get_sampling_client() as a convenience method",
+        "Explains WHY the error is opaque ('Unknown client error') rather than a clear message",
+        "Does NOT suggest the checkpoint is corrupted or the service is broken"
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "I'm getting HTTP 409 errors when saving checkpoints. My training script retries failed saves, and the retry always gets a 409. Is there a bug in the checkpoint system?",
+      "expected_output": "Explain that 409 means the original save succeeded despite the apparent failure",
+      "files": [],
+      "expectations": [
+        "Explains that HTTP 409 means the checkpoint already exists — the original save succeeded",
+        "Clarifies that the apparent failure was likely a transient network issue that didn't affect the actual save",
+        "Suggests checking if the checkpoint exists before retrying (idempotent retry logic)",
+        "Does NOT suggest deleting and re-saving the checkpoint",
+        "Provides a concrete approach for handling this (check existence, skip if already saved)"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "I fine-tuned a Kimi K2 model for tool calling but the model's tool calls are malformed after training. During training the loss went down normally. The base model's tool calling works fine.",
+      "expected_output": "Diagnose as renderer tool-calling format mismatch",
+      "files": [],
+      "expectations": [
+        "Suspects a renderer tool-calling format mismatch as the cause",
+        "Explains that different model families have different tool call formats",
+        "Suggests comparing the renderer's tool call format against what the model expects",
+        "Mentions that loss going down doesn't mean the model learned correctly — it can learn wrong token associations",
+        "Suggests checking which renderer is being used and whether it matches Kimi K2's expected format",
+        "Recommends using model_info.get_recommended_renderer_name() to get the correct renderer"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "My RL training script runs evaluations by sampling 500 test problems concurrently with asyncio.gather. It works for the first few evals but then starts getting connection errors and 'Failed after exhausting retries'. What's happening?",
+      "expected_output": "Diagnose as rate limiting from too many concurrent sampling requests",
+      "files": [],
+      "expectations": [
+        "Identifies this as hitting the concurrent sampling request limit (HTTP 429 / rate limiting)",
+        "Explains the approximate limit (~2000 concurrent requests, but can tighten under load)",
+        "Suggests reducing concurrency (smaller batches in asyncio.gather, or use asyncio.Semaphore)",
+        "Explains why it works initially but fails later (server load increases, limits tighten)",
+        "Provides a concrete fix pattern (semaphore-based concurrency limiting)",
+        "Does NOT blame the evaluation code logic — the pattern is correct, just needs throttling"
+      ]
+    }
+  ]
+}

--- a/skills/tinker-debug/references/async-task-dump.md
+++ b/skills/tinker-debug/references/async-task-dump.md
@@ -1,0 +1,256 @@
+# Async Task Dump Diagnostic
+
+Ready-to-paste diagnostic code for investigating hung or slow training sessions. This instruments both the main asyncio event loop and the Tinker SDK's internal event loop to reveal what's blocking.
+
+## What this does
+
+1. **Periodic task dump** — Every second, prints all active asyncio tasks in both the main event loop and the SDK's internal `InternalClientHolder` thread
+2. **Thread stack watchdog** — Every second, prints Python stack traces for the main and SDK threads, so you can see exactly where they're blocked even if it's synchronous code
+3. **aiomonitor** — Opens telnet/web ports for interactive async debugging (optional, requires `pip install aiomonitor`)
+
+## When to use
+
+- A training step has been running for much longer than expected
+- The training loop appears completely hung (no log output)
+- You've confirmed with pyinstrument that time is in `epoll.poll` but need to know what the SDK thread is doing
+
+## Setup
+
+```bash
+pip install aiomonitor
+```
+
+## The diagnostic code
+
+Paste this at the end of the user's script, replacing their `asyncio.run(main(config))` call:
+
+```python
+import asyncio
+
+# ── Configuration ──────────────────────────────────────────────────
+AIOMONITOR_HOST = "127.0.0.1"
+HOLDER_AIOMONITOR = {"port": 20101, "webui_port": 20102, "console_port": 20103}
+MAIN_AIOMONITOR = {"port": 21101, "webui_port": 21102, "console_port": 21103}
+TASK_DUMP_INTERVAL_SEC = 1.0
+
+# ── Periodic async task dump ──────────────────────────────────────
+async def _periodic_dump_tasks(loop, label):
+    import time
+    while True:
+        await asyncio.sleep(TASK_DUMP_INTERVAL_SEC)
+        ts = time.strftime("%Y-%m-%d %H:%M:%S")
+        tasks = asyncio.all_tasks(loop)
+        print(
+            f"\n===== {ts} asyncio task dump [{label}] "
+            f"{len(tasks)} task(s) @ interval={TASK_DUMP_INTERVAL_SEC}s ====="
+        )
+        for t in sorted(tasks, key=lambda x: (x.get_name(), id(x))):
+            coro = t.get_coro()
+            coro_s = repr(coro) if coro is not None else "None"
+            if len(coro_s) > 240:
+                coro_s = coro_s[:237] + "..."
+            if t.cancelled():
+                state = "cancelled"
+            elif t.done():
+                try:
+                    ex = t.exception()
+                except asyncio.CancelledError:
+                    state = "cancelled"
+                else:
+                    state = "done" if ex is None else f"done exc={type(ex).__name__}:{ex}"
+            else:
+                state = "pending"
+            print(f"  {t.get_name()!r}: {state}  {coro_s}")
+        print(f"===== {ts} end [{label}] =====\n", flush=True)
+
+# ── Thread stack watchdog ─────────────────────────────────────────
+_WATCHDOG_INTERVAL_SEC = 1.0
+_watchdog_started = False
+_watchdog_lock = None
+_watchdog_targets = {}
+
+def _watchdog_register_this_thread(label):
+    import threading
+    global _watchdog_lock, _watchdog_targets
+    if _watchdog_lock is None:
+        _watchdog_lock = threading.Lock()
+    t = threading.current_thread()
+    with _watchdog_lock:
+        _watchdog_targets[t.ident] = label
+
+def _ensure_thread_stack_watchdog():
+    import sys, threading, time, traceback
+    global _watchdog_started, _watchdog_lock
+    if _watchdog_lock is None:
+        _watchdog_lock = threading.Lock()
+
+    def watchdog_loop():
+        while True:
+            time.sleep(_WATCHDOG_INTERVAL_SEC)
+            ts = time.strftime("%Y-%m-%d %H:%M:%S")
+            buf = [
+                f"\n{'#' * 72}",
+                f"# {ts} stacks: main + holder threads only",
+                f"{'#' * 72}\n",
+            ]
+            with _watchdog_lock:
+                targets = dict(_watchdog_targets)
+            if not targets:
+                buf.append("(no threads registered yet)\n")
+                print("\n".join(buf), flush=True)
+                continue
+            frames = sys._current_frames()
+            for ident, label in sorted(targets.items(), key=lambda kv: kv[1]):
+                fr = frames.get(ident)
+                if fr is None:
+                    buf.append(f"--- [{label}] ident={ident} (no frame) ---\n")
+                    continue
+                buf.append(f"--- [{label}] ident={ident} ---")
+                buf.append("".join(traceback.format_stack(fr, limit=80)))
+                buf.append("")
+            print("\n".join(buf), flush=True)
+
+    with _watchdog_lock:
+        if _watchdog_started:
+            return
+        _watchdog_started = True
+        threading.Thread(target=watchdog_loop, name="stack-watchdog", daemon=True).start()
+
+# ── Patch SDK internal thread to add monitoring ───────────────────
+def _patch_internal_client_holder_background_thread():
+    import aiomonitor
+    from tinker.lib.internal_client_holder import InternalClientHolderThreadSingleton
+
+    def _background_thread_func_with_monitor(self):
+        assert self._loop is not None
+        _watchdog_register_this_thread("holder")
+        print(
+            f"aiomonitor [holder thread]: telnet {AIOMONITOR_HOST}:{HOLDER_AIOMONITOR['port']}  "
+            f"web http://{AIOMONITOR_HOST}:{HOLDER_AIOMONITOR['webui_port']}  "
+            f"console {AIOMONITOR_HOST}:{HOLDER_AIOMONITOR['console_port']}"
+        )
+        with aiomonitor.start_monitor(self._loop, host=AIOMONITOR_HOST, **HOLDER_AIOMONITOR):
+            self._loop.create_task(
+                _periodic_dump_tasks(self._loop, "holder"),
+                name="periodic-task-dump-holder",
+            )
+            self._loop.run_forever()
+
+    setattr(
+        InternalClientHolderThreadSingleton,
+        "_background_thread_func",
+        _background_thread_func_with_monitor,
+    )
+
+# ── Main runner with monitoring ───────────────────────────────────
+def _run_main_with_aiomonitor(task):
+    import contextlib
+    import aiomonitor
+
+    _watchdog_register_this_thread("main")
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    dump_t = None
+    try:
+        print(
+            f"aiomonitor [main]: telnet {AIOMONITOR_HOST}:{MAIN_AIOMONITOR['port']}  "
+            f"web http://{AIOMONITOR_HOST}:{MAIN_AIOMONITOR['webui_port']}  "
+            f"console {AIOMONITOR_HOST}:{MAIN_AIOMONITOR['console_port']}"
+        )
+        with aiomonitor.start_monitor(loop, host=AIOMONITOR_HOST, **MAIN_AIOMONITOR):
+            dump_t = loop.create_task(
+                _periodic_dump_tasks(loop, "main"),
+                name="periodic-task-dump-main",
+            )
+            loop.run_until_complete(task)
+    finally:
+        if dump_t is not None and not dump_t.done():
+            dump_t.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                loop.run_until_complete(dump_t)
+        with contextlib.suppress(RuntimeError):
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+
+# ── Activate everything ───────────────────────────────────────────
+_ensure_thread_stack_watchdog()
+_patch_internal_client_holder_background_thread()
+
+# Replace: asyncio.run(main(config))
+# With:
+_run_main_with_aiomonitor(main(config))
+```
+
+## Interpreting the output
+
+### Healthy training (no stalls)
+
+You should see both `[main]` and `[holder]` task dumps every second, and the holder thread should cycle through `_forward_backward_async` / `_optim_step_async` / `_result_async` tasks as work is submitted and completed.
+
+### Client-side stall
+
+If the `[main]` thread stops logging for several seconds, but `[holder]` keeps logging, the main thread is blocked on synchronous work. Check the stack watchdog output — it will show exactly where the main thread is stuck (data loading, tokenizer import, etc.).
+
+### SDK serialization stall
+
+If the `[holder]` thread stops logging, the SDK's internal event loop is blocked by synchronous code. The stack watchdog will reveal the exact call — commonly pydantic `model_dump()` or `__repr__` calls during payload serialization.
+
+Example stack trace from a pydantic serialization stall:
+```
+File ".../tinker/_compat.py", line 143, in model_dump
+    return model.model_dump(
+File ".../pydantic/main.py", line 479, in model_dump
+    return self.__pydantic_serializer__.to_python(
+File ".../pydantic/_internal/_serializers.py", line 44, in serialize_sequence_via_list
+    v = handler(item, index)
+```
+
+This indicates a pydantic version issue — see Step 1 in the main skill.
+
+### Server-side wait
+
+If both threads are logging normally and the holder shows pending `_result_async` tasks, the SDK has submitted work and is waiting for the server. Share the session ID and these logs with the Tinker team.
+
+## Simplified version (no aiomonitor)
+
+If the user can't install aiomonitor, use just the stack watchdog:
+
+```python
+import asyncio, sys, threading, time, traceback
+
+_watchdog_targets = {}
+_lock = threading.Lock()
+
+def register_thread(label):
+    with _lock:
+        _watchdog_targets[threading.current_thread().ident] = label
+
+def start_watchdog(interval=1.0):
+    def loop():
+        while True:
+            time.sleep(interval)
+            ts = time.strftime("%H:%M:%S")
+            with _lock:
+                targets = dict(_watchdog_targets)
+            frames = sys._current_frames()
+            for ident, label in targets.items():
+                fr = frames.get(ident)
+                if fr:
+                    stack = "".join(traceback.format_stack(fr, limit=10))
+                    print(f"\n[{ts}] {label}:\n{stack}", flush=True)
+    threading.Thread(target=loop, daemon=True).start()
+
+# Add before any tinker imports:
+register_thread("main")
+start_watchdog()
+
+# Then monkey-patch the holder thread to register itself:
+from tinker.lib.internal_client_holder import InternalClientHolderThreadSingleton
+_orig = InternalClientHolderThreadSingleton._background_thread_func
+def _patched(self):
+    register_thread("holder")
+    _orig(self)
+InternalClientHolderThreadSingleton._background_thread_func = _patched
+
+# ... rest of script ...
+```

--- a/skills/tinker-debug/references/error-reference.md
+++ b/skills/tinker-debug/references/error-reference.md
@@ -1,0 +1,137 @@
+# Error Reference
+
+Extended decoder for Tinker SDK and cookbook error messages. Organized by where the error originates.
+
+## Tinker SDK errors (from the service)
+
+### HTTP 400 — Bad Request
+
+These are validation errors. The request was malformed or had invalid parameters.
+
+| Error detail | Cause | Fix |
+|-------------|-------|-----|
+| `base_model is required` | Missing model name in `create_lora_training_client` | Pass `base_model="org/model-name"` |
+| `lora_config.rank must be positive` | LoRA rank <= 0 | Use a positive rank (typically 32) |
+| `lora_config.rank must be a power of 2` | Rank like 48 or 100 | Use 16, 32, 64, etc. |
+| `At least one of train_unembed, train_mlp, or train_attn must be True` | All training flags disabled | Enable at least one (defaults are all True) |
+| `Prompt length plus max_tokens exceeds the model's context window: {N} + {M} > {limit}` | Input too long | Reduce prompt length or max_tokens. Error shows exact numbers. |
+| `session_id is required. The version of the Tinker SDK you are using is no longer supported.` | SDK too old | `pip install --upgrade tinker` |
+
+### HTTP 402 — Payment Required
+
+Billing account is blocked. Top up at the Tinker console billing page.
+
+### HTTP 403 — Forbidden
+
+| Error detail | Cause | Fix |
+|-------------|-------|-----|
+| `You do not have access to this model` | No permission for the model or checkpoint | Check API key; request access to the model/org |
+| `Invalid session_id` | Session doesn't exist or belongs to another user | Check session ID; create a new session |
+| Generic 403 on checkpoint | Checkpoint is private and user isn't the owner | Request that the checkpoint owner make it public, or get project/org access |
+
+### HTTP 404 — Not Found
+
+Model, session, or checkpoint doesn't exist. Double-check:
+- Model name spelling (e.g., `Qwen/Qwen3-8B` not `qwen3-8b`)
+- Session ID (use `tc.get_info()` to verify)
+- Checkpoint path format (`tinker://session-id/sampler_weights/name`)
+- That you used `save_weights_for_sampler` (not `save_state`) for sampling/download
+
+### HTTP 409 — Conflict
+
+Resource already exists. Most commonly:
+- **Checkpoint save retry**: The first save actually succeeded (network hiccup made it look like it failed). Check if the checkpoint exists before retrying.
+- **Session conflict**: Session already exists with different metadata. Use a different session ID.
+
+### HTTP 429 — Rate Limited
+
+Too many concurrent requests. Default limits:
+- ~2000 concurrent sampling requests per user
+- Tightens under high service load
+
+Fix: Add backoff/retry logic. Reduce concurrency (smaller `num_samples`, fewer parallel `asyncio.gather` calls).
+
+### HTTP 500 — Internal Server Error
+
+Unhandled server-side error. Gather:
+1. Session ID (`tc.get_info()`)
+2. What operation failed
+3. Timestamp
+4. Tinker SDK version
+
+Report to the Tinker team.
+
+### HTTP 504 — Gateway Timeout
+
+`Timeout while publishing request` — the server's internal queue is full or slow. Usually transient. Retry after a few seconds.
+
+## Tinker SDK Python exceptions
+
+| Exception | HTTP code | Retryable? | Notes |
+|-----------|----------|-----------|-------|
+| `tinker.AuthenticationError` | 401/403 | No | Check API key |
+| `tinker.BadRequestError` | 400 | No | Fix the request |
+| `tinker.RateLimitError` | 429 | Yes | Back off and retry |
+| `tinker.APITimeoutError` | timeout | Yes | Increase timeout or retry |
+| `tinker.APIConnectionError` | network | Yes | Check connectivity |
+| `tinker.TinkerError` | varies | Maybe | Catch-all base class |
+
+### Request-level error codes
+
+These appear in `ForwardBackwardResult` or sampling responses:
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| `NonFiniteInTensor` | NaN or Inf in input data | Check your data for invalid values; ensure loss weights don't produce Inf |
+| `PromptTooLong` | Prompt exceeds context window | Reduce input length |
+| `ResourceAlreadyExists` | Duplicate resource | Handle idempotently |
+
+## Cookbook exceptions
+
+### Configuration errors
+
+| Exception | Common triggers |
+|-----------|----------------|
+| `ConfigurationError("Unknown model: {name}")` | Model name not in cookbook registry. Check spelling; use `model_info.get_model_attributes()`. |
+| `ConfigurationError("Log directory already exists")` | Resume from different path, or delete the old log directory |
+
+### Data errors
+
+| Exception | Common triggers |
+|-----------|----------------|
+| `DataFormatError("Each line must contain a 'messages' field")` | JSONL file lines missing `messages` key |
+| `DataValidationError("Cannot seek backward")` | Streaming dataset used with random access |
+| `ValueError("tokens and weights must be the same length")` | `max_length` truncated tokens but not weights. Use `datum_from_model_input_weights()` which handles this. |
+
+### Renderer errors
+
+| Exception | Common triggers |
+|-----------|----------------|
+| `RendererError("Unknown renderer")` | Invalid renderer name. Use `get_recommended_renderer_name()`. |
+| `RendererError("requires an image_processor")` | VL renderer created without image processor |
+| `RendererError("Expected text content, got multimodal content")` | Passed image content to a text-only renderer |
+
+### Weight errors
+
+| Exception | Common triggers |
+|-----------|----------------|
+| `WeightsDownloadError` | Invalid tinker:// path, or checkpoint doesn't exist. Verify with `tinker checkpoint list`. |
+| `WeightsMergeError` | Adapter incompatible with base model. Check model name matches exactly. |
+| `WeightsAdapterError` | Can't convert to PEFT format. Check for empty expert tensors (known issue with some models). |
+
+### Training errors
+
+| Exception | Common triggers |
+|-----------|----------------|
+| `CheckpointError` | Checkpoint save/load failed. Check path format and permissions. |
+| `AllTrajectoriesFailedError` | Every trajectory in a rollout group failed. Check environment code; look at rollout logs. |
+
+## Upstream library errors
+
+| Error | Library | Cause | Fix |
+|-------|---------|-------|-----|
+| `Expected N tokens, got M from image` | `transformers` < 5.0 | Bug in `Qwen2VLImageProcessor` | Upgrade: `pip install 'transformers>=5.0'` |
+| DeepSeek tokenizer loading fails | `transformers` == 5.3.0 | Incorrect `tokenizer_class` on hub (huggingface/transformers#44801) | Upgrade to `transformers>=5.3.1` |
+| `ModuleNotFoundError: pkg_resources` | Python 3.14 | `pkg_resources` removed from stdlib | Downgrade Python or update the offending package |
+| `401 Unauthorized` on tokenizer download | HuggingFace | Gated model (Llama) needs auth | Set `HF_TOKEN` environment variable |
+| Corrupted tokenizer cache | HuggingFace | Cache corruption | Delete `~/.cache/huggingface/hub/models--{org}--{model}/` and retry |

--- a/skills/tinker-debug/references/merge-debugging.md
+++ b/skills/tinker-debug/references/merge-debugging.md
@@ -1,0 +1,176 @@
+# Merge Debugging Reference
+
+Technical reference for debugging weight merge issues between Tinker adapters and HuggingFace models. Read this when the user has output mismatches between Tinker sampling and external inference engines.
+
+## Tinker adapter weight naming
+
+Tinker adapters store LoRA A/B matrices with these naming conventions:
+
+```
+base_model.model.layers.{N}.mlp.gate_proj.lora_A.weight    # w1 = gate
+base_model.model.layers.{N}.mlp.down_proj.lora_A.weight    # w2 = down
+base_model.model.layers.{N}.mlp.up_proj.lora_A.weight      # w3 = up
+base_model.model.layers.{N}.self_attn.q_proj.lora_A.weight
+base_model.model.layers.{N}.self_attn.k_proj.lora_A.weight
+base_model.model.layers.{N}.self_attn.v_proj.lora_A.weight
+base_model.model.layers.{N}.self_attn.o_proj.lora_A.weight
+```
+
+For MoE models, expert weights are 3D tensors: `(num_experts, rank, dim)`.
+
+## MoE expert weight layouts
+
+Different model families fuse gate and up projections differently in HuggingFace format. Getting this wrong is the #1 cause of merge-related output mismatches.
+
+### Separate layout (Qwen3 MoE, DeepSeek, Kimi)
+
+Each expert has individual weight files:
+```
+model.layers.{N}.mlp.experts.{E}.gate_proj.weight   # (out_dim, in_dim)
+model.layers.{N}.mlp.experts.{E}.down_proj.weight
+model.layers.{N}.mlp.experts.{E}.up_proj.weight
+```
+
+Merge is straightforward — apply LoRA delta to each expert independently.
+
+### Fused concatenated layout (Qwen3.5, Qwen3-VL)
+
+Gate and up projections are concatenated into a single tensor:
+```
+model.layers.{N}.mlp.experts.gate_up_proj   # (num_experts, out_dim*2, in_dim) or (num_experts, in_dim, out_dim*2)
+```
+
+The first half (along the fused dimension) is `gate`, the second half is `up`:
+```python
+# Splitting:
+gate = gate_up_proj[..., :out_dim]
+up   = gate_up_proj[..., out_dim:]
+
+# Merging LoRA delta for gate (w1):
+gate_up_proj[..., :out_dim] += lora_B_gate @ lora_A_gate
+
+# Merging LoRA delta for up (w3):
+gate_up_proj[..., out_dim:] += lora_B_up @ lora_A_up
+```
+
+**Important:** The fused dimension can be dim 1 or dim 2 depending on the model:
+- Qwen3-VL: `(num_experts, in_dim, out_dim*2)` — fused on last dim
+- Qwen3.5: `(num_experts, out_dim*2, in_dim)` — fused on middle dim (delta must be transposed)
+
+The cookbook's `_detect_fused_axis()` handles this automatically.
+
+### Fused interleaved layout (GPT-OSS)
+
+Gate and up elements alternate:
+```
+model.layers.{N}.mlp.experts.gate_up_proj
+# Layout: [g0, u0, g1, u1, g2, u2, ...]
+```
+
+```python
+# Splitting:
+gate = gate_up_proj[..., 0::2]   # even indices
+up   = gate_up_proj[..., 1::2]   # odd indices
+
+# Merging LoRA delta for gate:
+gate_up_proj[..., 0::2] += delta_gate
+
+# Merging LoRA delta for up:
+gate_up_proj[..., 1::2] += delta_up
+```
+
+**Using concatenation when the model expects interleaving (or vice versa) silently corrupts the weights.** The model will still generate text, but outputs will be degraded or invalid.
+
+## Vision-language model considerations
+
+VL models add a `model.language_model.*` prefix to language model weights:
+```
+# Standard model:
+model.layers.0.mlp.gate_proj.weight
+
+# VL model:
+model.language_model.layers.0.mlp.gate_proj.weight
+```
+
+The adapter weights don't have this prefix, so the merge code must add it. The cookbook handles this via `has_language_model_prefix` in the merge profile.
+
+## Split QKV projections (Qwen3.5)
+
+Qwen3.5 models with hybrid attention (some layers use linear attention) fuse Q/K/V into a single `in_proj_qkv`:
+```
+model.layers.{N}.self_attn.in_proj_qkv.weight   # (q_dim + k_dim + v_dim, hidden)
+```
+
+Tinker trains separate Q/K/V adapters. During merge, the adapter deltas must be written to the correct row range:
+```python
+q_rows = lora_B_q.shape[0]  # e.g., 4096
+k_rows = lora_B_k.shape[0]  # e.g., 512
+v_rows = lora_B_v.shape[0]  # e.g., 512
+
+# Q delta goes to rows [0 : q_rows]
+# K delta goes to rows [q_rows : q_rows + k_rows]
+# V delta goes to rows [q_rows + k_rows : q_rows + k_rows + v_rows]
+```
+
+## Diagnostic: comparing merge outputs
+
+To verify a merge is correct, compare against Tinker's sampling output on a known input:
+
+```python
+import torch
+from safetensors.torch import load_file
+
+# Load a few expert weights from both merges
+cookbook = load_file("cookbook_merge/model-00003-of-00010.safetensors")
+custom = load_file("custom_merge/model-00003-of-00010.safetensors")
+
+# Focus on MLP expert weights (where fusion bugs manifest)
+for key in sorted(cookbook.keys()):
+    if "experts" in key and "mlp" in key:
+        if key in custom:
+            diff = (cookbook[key].float() - custom[key].float()).abs()
+            if diff.max() > 1e-4:
+                print(f"MISMATCH {key}: max={diff.max():.6f} mean={diff.mean():.6f}")
+            else:
+                print(f"OK       {key}: max={diff.max():.6f}")
+```
+
+If mismatches cluster in `gate_up_proj` weights, the fusion convention is wrong.
+
+## Diagnostic: end-to-end output comparison
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model = AutoModelForCausalLM.from_pretrained("./merged_model", torch_dtype=torch.bfloat16, device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained("./merged_model")
+
+# Use the exact same tokens as Tinker
+input_ids = torch.tensor([tinker_token_ids], device=model.device)
+with torch.no_grad():
+    out = model.generate(input_ids, max_new_tokens=100, temperature=0, do_sample=False)
+
+print(tokenizer.decode(out[0]))
+# Compare with Tinker sampling output
+```
+
+## Using PEFT adapter as a workaround
+
+If merge issues persist and time is critical, serve the unmerged adapter via PEFT:
+
+```python
+from tinker_cookbook import weights
+
+weights.build_lora_adapter(
+    base_model="Qwen/Qwen3-8B",
+    adapter_path="./adapter",
+    output_path="./peft_adapter",
+)
+```
+
+Then serve with vLLM:
+```bash
+vllm serve Qwen/Qwen3-8B --lora-modules my_adapter=./peft_adapter
+```
+
+This avoids merge entirely — the engine applies the LoRA at inference time. It's slightly slower but eliminates merge-related bugs.

--- a/skills/tinker-debug/references/renderer-debugging.md
+++ b/skills/tinker-debug/references/renderer-debugging.md
@@ -1,0 +1,245 @@
+# Renderer Debugging Reference
+
+How to diagnose and fix renderer issues that cause silent training quality degradation.
+
+## How renderers work
+
+A renderer converts a list of chat messages into model-specific token sequences for training and sampling. Each model family (Llama3, Qwen3, DeepSeek, etc.) has its own token format with specific role delimiters, special tokens, and conventions.
+
+Key renderer methods:
+- `build_generation_prompt(messages)` → `ModelInput` (tokens for sampling)
+- `build_supervised_example(messages)` → `(ModelInput, weights)` (tokens + loss mask for training)
+- `parse_response(token_ids)` → `(Message, success)` (decode sampled tokens back to a message)
+
+## Check your transformers version first
+
+Different `transformers` versions have known bugs that affect specific models:
+- `transformers == 5.3.0`: Incorrect `tokenizer_class` for DeepSeek V2/V3 on the hub (huggingface/transformers#44801, fixed in 5.3.1). Causes tokenizer loading to fail or use the wrong tokenizer class.
+- `transformers < 5.0`: Bug in `Qwen2VLImageProcessor` — miscounts image tokens for VL models
+- Always print `transformers.__version__` in your debug output
+
+```python
+import transformers
+print(f"transformers: {transformers.__version__}")
+```
+
+## Full token comparison recipe
+
+This script compares the cookbook renderer against HuggingFace's `apply_chat_template` for a given model and conversation:
+
+```python
+"""
+Renderer parity check — verifies cookbook renderer matches HuggingFace tokenizer.
+Usage: python renderer_check.py
+"""
+from tinker_cookbook.renderers import get_renderer
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.model_info import get_recommended_renderer_name
+
+MODEL_NAME = "Qwen/Qwen3-8B"  # Change this
+
+# Setup
+tokenizer = get_tokenizer(MODEL_NAME)
+renderer_name = get_recommended_renderer_name(MODEL_NAME)
+renderer = get_renderer(renderer_name, tokenizer)
+
+# Test conversations — try several patterns
+test_cases = [
+    # Basic conversation
+    [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "4"},
+    ],
+    # With system message
+    [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+    ],
+    # Multi-turn
+    [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello!"},
+        {"role": "user", "content": "How are you?"},
+    ],
+]
+
+for i, messages in enumerate(test_cases):
+    print(f"\n=== Test case {i + 1} ===")
+
+    # Cookbook tokens
+    cookbook_mi = renderer.build_generation_prompt(messages)
+    cookbook_tokens = cookbook_mi.to_ints()
+
+    # HuggingFace tokens
+    hf_tokens = list(tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+    ))
+
+    if cookbook_tokens == hf_tokens:
+        print(f"PASS: {len(cookbook_tokens)} tokens match")
+    else:
+        print(f"FAIL: cookbook={len(cookbook_tokens)} tokens, HF={len(hf_tokens)} tokens")
+
+        # Find divergence point
+        min_len = min(len(cookbook_tokens), len(hf_tokens))
+        for j in range(min_len):
+            if cookbook_tokens[j] != hf_tokens[j]:
+                ctx_start = max(0, j - 3)
+                print(f"  First diff at position {j}:")
+                print(f"    cookbook[{ctx_start}:{j+3}]: {cookbook_tokens[ctx_start:j+3]}")
+                print(f"    HF[{ctx_start}:{j+3}]:      {hf_tokens[ctx_start:j+3]}")
+                print(f"    cookbook decoded: {tokenizer.decode(cookbook_tokens[max(0,j-5):j+5])!r}")
+                print(f"    HF decoded:      {tokenizer.decode(hf_tokens[max(0,j-5):j+5])!r}")
+                break
+
+        if len(cookbook_tokens) != len(hf_tokens):
+            print(f"  Length diff: cookbook has {len(cookbook_tokens) - len(hf_tokens):+d} tokens")
+```
+
+## Thinking mode
+
+Models with thinking capabilities (Qwen3, DeepSeek V3, Kimi K2.5, Nemotron3) have two renderer variants:
+- **With thinking** (`qwen3`, `deepseekv3_thinking`): Model produces `<think>...</think>` blocks before responding
+- **Without thinking** (`qwen3_disable_thinking`, `deepseekv3`): Thinking is suppressed
+
+Common issues:
+- Training on data with `<think>` blocks using a non-thinking renderer → Thinking tokens get wrong loss weights
+- Using a thinking renderer but passing `thinking=False` to HF template → Token mismatch
+- Historical assistant messages may have thinking stripped by default (`strip_thinking_from_history=True` in Qwen3)
+
+When comparing against HF for thinking models:
+```python
+# For Qwen3 with thinking enabled:
+hf_tokens = tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=True, thinking=True)
+
+# For Qwen3 with thinking disabled:
+hf_tokens = tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=True, thinking=False)
+```
+
+## Tool calling
+
+Each model family has a different tool call format:
+- **Qwen3**: `<tool_call>\n{json}\n</tool_call>` tags
+- **DeepSeek V3**: Special tokens like `<tool_calls_begin>`, `<tool_calls_end>`
+- **Kimi K2**: `## FunctionCall {json}` format
+- **Llama3**: Bare JSON (unreliable parsing — tool calling not well-supported)
+
+When comparing tool-calling conversations against HF:
+```python
+# Must pass tools parameter to HF
+hf_tokens = tokenizer.apply_chat_template(
+    messages,
+    tools=tool_specs,  # List of tool schema dicts
+    add_generation_prompt=True,
+    tokenize=True,
+)
+```
+
+Not all renderers have tool formats that match HF — some intentionally diverge. Check the model's renderer implementation if tool calling quality is poor.
+
+## KL divergence at step 0
+
+If KL divergence is high at the very first training step (before any gradient updates), the renderer is likely producing tokens the model doesn't expect. The model's log-probabilities on the "correct" tokens are low because those tokens don't match its learned distribution.
+
+Diagnosis:
+1. Run the token comparison above
+2. If tokens match HF, the renderer is correct — high step-0 KL may indicate the data distribution is far from the model's pre-training distribution (especially common with gpt-oss models on specialized data)
+3. If tokens don't match, fix the renderer first
+
+## Available renderers
+
+Use `get_recommended_renderer_name()` — never hardcode:
+- **Llama 3.x**: `llama3`
+- **Qwen3**: `qwen3`, `qwen3_disable_thinking`, `qwen3_instruct`, `qwen3_vl`, `qwen3_vl_instruct`
+- **Qwen3.5**: `qwen3_5`, `qwen3_5_disable_thinking`
+- **DeepSeek V3**: `deepseekv3` (no thinking), `deepseekv3_thinking`
+- **Kimi K2**: `kimi_k2`
+- **Kimi K2.5**: `kimi_k25`, `kimi_k25_disable_thinking`
+- **Nemotron3**: `nemotron3`, `nemotron3_disable_thinking`
+- **GPT-OSS**: `gpt_oss_no_sysprompt`, `gpt_oss_low_reasoning`, `gpt_oss_medium_reasoning`, `gpt_oss_high_reasoning`
+- **Generic fallback**: `role_colon`
+
+## Vision model considerations
+
+Vision-language (VL) models add image tokens alongside text tokens, creating additional points of failure.
+
+### Setup
+
+VL renderers require an image processor from the `transformers` library:
+
+```python
+from transformers import AutoProcessor
+from tinker_cookbook.renderers import get_renderer
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+model_name = "Qwen/Qwen3-VL-7B-Instruct"
+tokenizer = get_tokenizer(model_name)
+processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
+
+renderer = get_renderer(
+    "qwen3_vl_instruct",
+    tokenizer,
+    image_processor=processor.image_processor,  # Required for VL renderers
+)
+```
+
+Forgetting `image_processor` raises `RendererError("qwen3_vl renderer requires an image_processor")`.
+
+### VL renderers by model
+
+| Model | Renderer | Notes |
+|-------|----------|-------|
+| Qwen3-VL | `qwen3_vl` | Thinking-enabled VL. For instruct-only: `qwen3_vl_instruct`. |
+| Qwen3.5 (VL variants) | `qwen3_5` | Same renderer handles VL when image_processor provided |
+| Kimi K2.5 | `kimi_k25` | Supports vision natively |
+
+### Common VL issues
+
+**`Expected X tokens, got Y from image`**
+
+This is the most frequently reported VL bug. It's caused by a bug in HuggingFace's `Qwen2VLImageProcessor` in `transformers < 5.0` that miscounts image tokens.
+
+Fix: `pip install 'transformers>=5.0'` (or install `torchvision` as an alternative workaround).
+
+**Image token count mismatch between training and serving**
+
+Different image resolutions produce different numbers of image tokens. The image processor determines this. Ensure:
+- Same `transformers` version during training and serving
+- Same image processor configuration (max resolution, etc.)
+- Images are not re-encoded between training data preparation and actual training
+
+**Token comparison for VL**
+
+When comparing VL renderer output against HuggingFace, you need to include images in the comparison:
+
+```python
+from PIL import Image
+
+messages = [
+    {"role": "user", "content": [
+        {"type": "image", "image": Image.open("test.png")},
+        {"type": "text", "text": "What's in this image?"},
+    ]},
+]
+
+# Cookbook
+cookbook_mi = renderer.build_generation_prompt(messages)
+cookbook_tokens = cookbook_mi.to_ints()
+
+# HuggingFace — use the full processor, not just tokenizer
+hf_inputs = processor.apply_chat_template(
+    messages,
+    add_generation_prompt=True,
+    tokenize=True,
+    return_tensors="pt",
+)
+# Compare input_ids
+```
+
+Note: VL token comparison is more complex because image tokens may be represented differently. Focus on verifying that text tokens surrounding images match and that the total image token count is correct.
+
+**Weight export for VL models**
+
+VL models add a `model.language_model.*` prefix to language model weights. The cookbook's `weights.build_hf_model()` handles this automatically. Custom merge scripts commonly miss this prefix, causing the LoRA adapter to silently not be applied (adapter weight names don't match model weight names).

--- a/skills/tinker-debug/references/serialization-test.md
+++ b/skills/tinker-debug/references/serialization-test.md
@@ -1,0 +1,129 @@
+# Serialization Regression Test
+
+A standalone script to test whether the user's pydantic version causes slow serialization of Tinker SDK payloads. This is the most common "invisible" performance regression — the user's training script works but each step takes minutes instead of seconds.
+
+## When to use
+
+- Step 3 timing shows high submit time (time to submit `forward_backward` call)
+- Step 4 profiling shows time in `pydantic.model_dump()` or `__repr__`
+- User has a non-standard pydantic version (beta, pre-release, or very new)
+
+## The test script
+
+```python
+"""
+Tinker payload serialization benchmark.
+
+Tests whether pydantic model_dump() is fast on typical training payloads.
+Expected: < 0.1s for BS=4, SEQ_LEN=8192.
+If > 1s, the pydantic version likely has a serialization regression.
+
+Usage:
+    python serialization_test.py
+"""
+import sys
+import time
+
+import pydantic
+import torch
+from tinker._compat import model_dump
+from tinker._version import __version__ as tinker_version
+from tinker.types import (
+    Datum,
+    EncodedTextChunk,
+    ForwardBackwardInput,
+    ForwardBackwardRequest,
+    ModelInput,
+)
+
+# ── Print versions ────────────────────────────────────────────────
+print(f"Python:   {sys.version.split()[0]}")
+print(f"pydantic: {pydantic.__version__}")
+print(f"tinker:   {tinker_version}")
+print(f"torch:    {torch.__version__}")
+try:
+    import numpy; print(f"numpy:    {numpy.__version__}")
+except ImportError:
+    print("numpy:    (not installed)")
+print()
+
+# ── Build a realistic payload ─────────────────────────────────────
+BS = 4
+SEQ_LEN = 8192
+VOCAB = 32000
+
+data = []
+for _ in range(BS):
+    tokens = torch.randint(0, VOCAB, (SEQ_LEN,)).tolist()
+    model_input = ModelInput(chunks=[EncodedTextChunk(tokens=tokens)])
+    weights = torch.ones(SEQ_LEN)
+    target_tokens = torch.randint(0, VOCAB, (SEQ_LEN,)).tolist()
+    data.append(
+        Datum(
+            model_input=model_input,
+            loss_fn_inputs={
+                "target_tokens": target_tokens,
+                "weights": weights,
+            },
+        )
+    )
+
+request = ForwardBackwardRequest(
+    forward_backward_input=ForwardBackwardInput(
+        data=data,
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+    ),
+    model_id="tinker://dummy/example",
+    seq_id=1,
+)
+
+# ── Benchmark serialization ──────────────────────────────────────
+t0 = time.perf_counter()
+body = model_dump(request, exclude_unset=True, mode="json")
+dt = time.perf_counter() - t0
+
+print(f"Payload: batch_size={BS}, seq_len={SEQ_LEN}, total_tokens={BS * SEQ_LEN:,}")
+print(f"model_dump() took {dt:.3f}s")
+print()
+
+if dt < 0.1:
+    print("PASS: Serialization is fast.")
+elif dt < 1.0:
+    print("WARNING: Serialization is slower than expected. May cause minor slowdowns.")
+else:
+    print("FAIL: Serialization is very slow. This will cause major training slowdowns.")
+    print(f"  Your pydantic version ({pydantic.__version__}) likely has a regression.")
+    print("  Fix: pip install 'pydantic<2.13'  (or use the latest stable release)")
+```
+
+## Expected output (healthy)
+
+```
+Python:   3.12.9
+pydantic: 2.12.5
+tinker:   0.16.1
+torch:    2.8.0
+numpy:    2.2.5
+
+Payload: batch_size=4, seq_len=8192, total_tokens=32,768
+model_dump() took 0.007s
+
+PASS: Serialization is fast.
+```
+
+## Example output (regression)
+
+```
+Python:   3.12.12
+pydantic: 2.13.0b2
+torch:    2.10.0
+tinker:   0.16.1
+
+Payload: batch_size=4, seq_len=8192, total_tokens=32,768
+model_dump() took 147.231s
+
+FAIL: Serialization is very slow. This will cause major training slowdowns.
+  Your pydantic version (2.13.0b2) likely has a regression.
+  Fix: pip install 'pydantic<2.13'  (or use the latest stable release)
+```


### PR DESCRIPTION
## Summary

- New `tinker-debug` skill covering 5 debugging triage paths, informed by real user support threads and 150+ GitHub issues across tinker-feedback and tinker-cookbook
- Registered in marketplace.json as part of the tinker-cookbook plugin
- 15 eval scenarios with graded expectations

## Installation

If you already have the tinker-cookbook skills installed, the new `tinker-debug` skill will be available automatically after update.

To install the tinker-cookbook skills for the first time, run in Claude Code:

```
/plugin marketplace add thinking-machines-lab/tinker-cookbook
```

Once installed, the skill triggers automatically when you ask about slow training, hanging sessions, error messages, output mismatches, or any debugging question about Tinker.

## Triage paths

| Path | What it covers |
|------|---------------|
| **Performance** | Slow steps, hanging sessions, dependency versions, async pipelining, GIL contention, pyinstrument profiling |
| **Output correctness** | Weight merge bugs (MoE fusion, VL prefix, precision), PEFT adapter workaround |
| **Service availability** | Smoke test to distinguish "Tinker is down" vs "my code is broken" |
| **Renderer validation** | Token comparison against HF `apply_chat_template`, hybrid model (thinking/non-thinking) mapping, VL models |
| **Error decoder** | Opaque error messages mapped to root causes (SDK errors, cookbook exceptions, upstream library bugs) |

### SDK architecture context

The skill includes an explanation of the Tinker SDK's background thread model — how all network I/O, heartbeats, and result polling share Python's GIL with user code. This is the root cause of many "mysterious" slowdowns and is the most impactful section for users with custom training scripts.

## Eval results (with skill vs without)

| Eval | Triage Path | With Skill | Without Skill | Delta |
|------|------------|-----------|--------------|-------|
| 2 | Performance (hung session) | 6/6 (100%) | 1/6 (17%) | **+83%** |
| 4 | Performance (pipelining) | 6/6 (100%) | 4/6 (67%) | +33% |
| 7 | Service availability | 6/6 (100%) | 3/6 (50%) | **+50%** |
| 8 | Renderer (KL) | 6/6 (100%) | 6/6 (100%) | +0% |
| 9 | Error decoder | 5/5 (100%) | 2/5 (40%) | **+60%** |
| **Total** | | **29/29 (100%)** | **16/29 (55%)** | **+45%** |

The skill adds the most value on Tinker-specific internals (SDK thread architecture, async task dumps, known dependency regressions, exact error root causes) that can't be derived from general reasoning. Eval 8 being a tie is expected — when the answer is discoverable from the codebase itself, both paths find it.

## Files

```
skills/tinker-debug/
├── SKILL.md (654 lines) — Main triage guide
├── evals/evals.json — 15 eval scenarios
└── references/
    ├── async-task-dump.md — Diagnostic for hung sessions
    ├── serialization-test.md — Pydantic regression benchmark
    ├── merge-debugging.md — Weight layout conventions
    ├── renderer-debugging.md — Token comparison, VL models, HF version issues
    └── error-reference.md — Extended error decoder
```

## Test plan

- [x] Ran 5 evals with skill — 29/29 expectations passed
- [x] Ran 5 evals without skill as baseline — 16/29 passed
- [x] Verified no customer data in committed files
- [ ] Manual review of SKILL.md for accuracy of SDK architecture description
- [ ] Manual review of error decoder tables for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)