### PR TITLE
Shorten skill names for better slash command UX

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   },
   "plugins": [
     {
-      "name": "tinker-cookbook",
+      "name": "tinker",
       "description": "Skills for fine-tuning language models with the Tinker API — setup, models, SFT, RL, DPO, distillation, checkpoints, weights, and more.",
       "source": "./",
       "strict": false,
@@ -20,15 +20,7 @@
         "./skills/tinker-rl",
         "./skills/tinker-preferences",
         "./skills/tinker-ops",
-        "./skills/tinker-debug"
-      ]
-    },
-    {
-      "name": "tinker-dev",
-      "description": "Development skills for contributing to the tinker-cookbook repo — testing, CI, code style, and recipe scaffolding.",
-      "source": "./",
-      "strict": false,
-      "skills": [
+        "./skills/tinker-debug",
         "./skills/tinker-dev"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -88,13 +88,25 @@ Tinker cookbook includes several utilities. Here's a quick overview:
 
 ## Claude Code Skills
 
-Tinker Cookbook ships with [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) that teach Claude how to use the Tinker API — SFT, RL, DPO, renderers, environments, and more. Install them globally so Claude can help you in any project:
+Tinker Cookbook ships with [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) that teach Claude how to use the Tinker API. Install them so Claude can help you write training code in any project:
 
 ```
 /plugin marketplace add thinking-machines-lab/tinker-cookbook
 ```
 
-Once installed, use `/tinker-sft`, `/tinker-grpo`, `/tinker-setup`, etc. in Claude Code. Skills update automatically from the repo.
+Then install the **tinker** plugin from the Discover tab (`/plugin` → Discover). Once installed, the following skills are available:
+
+| Command | What it does |
+|---|---|
+| `/tinker:core` | Getting started — installation, models, SDK basics, hyperparameters |
+| `/tinker:sft` | Supervised fine-tuning, datasets, renderers, distillation |
+| `/tinker:rl` | Reinforcement learning — GRPO, custom environments, multi-turn |
+| `/tinker:preferences` | DPO and RLHF pipelines |
+| `/tinker:ops` | Checkpoints, weight export, logging, evaluation |
+| `/tinker:debug` | Diagnose slow training, hangs, output mismatches, errors |
+| `/tinker:dev` | Contributing to this repo — tests, CI, recipes |
+
+Skills also trigger automatically based on context — ask Claude to "set up SFT training" and it will load the right skill without a slash command. Skills update automatically when the repo is updated.
 
 ## Development Setup
 

--- a/skills/tinker-core/SKILL.md
+++ b/skills/tinker-core/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tinker-core
+name: core
 description: Core guide for using the Tinker API — installation, model selection, SDK basics, types, CLI, and hyperparameters. Use this skill whenever the user asks about getting started with Tinker, choosing a model, using the SDK, API types, CLI commands, or tuning hyperparameters. This is the foundational skill — trigger it for any general Tinker question.
 ---
 

--- a/skills/tinker-core/evals/evals.json
+++ b/skills/tinker-core/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "tinker-core",
+  "skill_name": "core",
   "evals": [
     {
       "id": 1,

--- a/skills/tinker-debug/SKILL.md
+++ b/skills/tinker-debug/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tinker-debug
+name: debug
 description: Diagnose training issues with Tinker — slow steps, hanging sessions, output mismatches, error messages, renderer problems, and deployment issues. Use this skill whenever a user reports that training is slow, steps take too long, sessions are hanging, model outputs differ between Tinker and external engines (vLLM, SGLang), they get a confusing error message, training quality is poor (high KL, bad outputs), or they suspect something is wrong. Also trigger when users ask "is this a Tinker issue or my issue?", "is Tinker down?", report unexpected wait times, see output quality regressions, get opaque errors, or want to profile/debug their training or deployment pipeline. This skill walks through systematic triage to determine root cause.
 ---
 

--- a/skills/tinker-debug/evals/evals.json
+++ b/skills/tinker-debug/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "tinker-debug",
+  "skill_name": "debug",
   "evals": [
     {
       "id": 1,

--- a/skills/tinker-dev/SKILL.md
+++ b/skills/tinker-dev/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tinker-dev
+name: dev
 description: Contributing to tinker-cookbook — development setup, code style, creating new recipes, testing, CI, and skill management. Use when the user wants to contribute code, create a new recipe, run tests, understand CI pipelines, or manage skills in this repo.
 ---
 

--- a/skills/tinker-dev/evals/evals.json
+++ b/skills/tinker-dev/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "tinker-dev",
+  "skill_name": "dev",
   "evals": [
     {
       "id": 1,

--- a/skills/tinker-ops/SKILL.md
+++ b/skills/tinker-ops/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tinker-ops
+name: ops
 description: Training lifecycle operations — checkpointing, weight export, logging/metrics analysis, and evaluation. Use when the user asks about saving/loading checkpoints, exporting weights to HuggingFace, reading training logs, parsing metrics, debugging training runs, evaluating models, or understanding training outputs.
 ---
 

--- a/skills/tinker-ops/evals/evals.json
+++ b/skills/tinker-ops/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "tinker-ops",
+  "skill_name": "ops",
   "evals": [
     {
       "id": 1,

--- a/skills/tinker-preferences/SKILL.md
+++ b/skills/tinker-preferences/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tinker-preferences
+name: preferences
 description: Set up and run preference-based training — DPO (Direct Preference Optimization) and RLHF (RL from Human Feedback) pipelines using the Tinker API. Use when the user wants to train with preference data, chosen/rejected pairs, DPO, reward models, RLHF, or human feedback alignment.
 ---
 

--- a/skills/tinker-preferences/evals/evals.json
+++ b/skills/tinker-preferences/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "tinker-preferences",
+  "skill_name": "preferences",
   "evals": [
     {
       "id": 1,

--- a/skills/tinker-rl/SKILL.md
+++ b/skills/tinker-rl/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tinker-rl
+name: rl
 description: Set up and run reinforcement learning — GRPO with verifiable rewards, custom RL environments, and multi-turn interactive training using the Tinker API. Use when the user wants to do RL training, GRPO, reward-based optimization, custom environments, multi-turn RL, tool-use training, or agentic training — even if they don't say "RL" explicitly.
 ---
 

--- a/skills/tinker-rl/evals/evals.json
+++ b/skills/tinker-rl/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "tinker-rl",
+  "skill_name": "rl",
   "evals": [
     {
       "id": 1,

--- a/skills/tinker-sft/SKILL.md
+++ b/skills/tinker-sft/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tinker-sft
+name: sft
 description: Set up and run supervised fine-tuning (SFT), knowledge distillation, or any supervised learning workflow using the Tinker API. Covers datasets, renderers, completers, and distillation. Use when the user wants to do instruction tuning, chat fine-tuning, supervised learning, dataset preparation, rendering, text generation, or knowledge distillation — even if they don't say "SFT" explicitly.
 ---
 

--- a/skills/tinker-sft/evals/evals.json
+++ b/skills/tinker-sft/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "tinker-sft",
+  "skill_name": "sft",
   "evals": [
     {
       "id": 1,

--- a/tests/downstream_compat/test_install_skills.py
+++ b/tests/downstream_compat/test_install_skills.py
@@ -49,21 +49,22 @@ class TestSkillStructure:
             )
 
     def test_skill_name_matches_directory(self):
-        """The name field in SKILL.md frontmatter must match the directory name."""
+        """The name field in SKILL.md frontmatter must match the directory name sans tinker- prefix."""
         for skill in _all_skill_dirs():
             text = (SKILLS_DIR / skill / "SKILL.md").read_text()
             fm = _frontmatter(text)
             match = re.search(r"^name:\s*(.+)$", fm, re.MULTILINE)
             assert match, f"{skill}/SKILL.md is missing a name field in frontmatter"
-            assert match.group(1).strip() == skill, (
-                f"{skill}/SKILL.md has name '{match.group(1).strip()}' but directory is '{skill}'"
+            expected_name = skill.removeprefix("tinker-")
+            assert match.group(1).strip() == expected_name, (
+                f"{skill}/SKILL.md has name '{match.group(1).strip()}' but expected '{expected_name}'"
             )
 
     def test_skills_and_marketplace_match(self):
         """Skills on disk and in marketplace.json must be the same set.
 
         If a skill exists on disk but not in marketplace.json, add it to
-        the appropriate plugin bundle (tinker-cookbook or tinker-dev).
+        the tinker plugin bundle in marketplace.json.
         """
         on_disk = _all_skill_dirs()
         in_marketplace = _marketplace_skills()


### PR DESCRIPTION
## Summary
- Rename plugin from `tinker-cookbook` to `tinker` and strip `tinker-` prefix from all skill names
- Commands become `/tinker:sft`, `/tinker:rl`, `/tinker:debug`, etc. instead of `/tinker-cookbook:tinker-sft`
- Merge `tinker-dev` plugin into the main `tinker` plugin to avoid redundant `/tinker-dev:dev`
- Update `skill_name` in all `evals.json` files and skill structure tests to match
- Update README with new skill commands table

## Test plan
- [x] `claude plugin validate .` passes
- [x] All 5 skill structure tests pass (`pytest tests/downstream_compat/test_install_skills.py`)
- [ ] Reinstall plugin and verify `/tinker:sft` etc. autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)