### PR TITLE
Filter empty EncodedTextChunks in RenderedMessage to fix SFT crash

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1076,6 +1076,20 @@ class RenderedMessage:
     stop_overlap: tinker.EncodedTextChunk | None = None
     """Tokens that overlap between stop sequence and next message's header."""
 
+    def __post_init__(self) -> None:
+        # Filter out empty EncodedTextChunks from output. These arise when renderers
+        # strip thinking content from historical assistant messages and the message has
+        # no remaining text. Tinker rejects empty token chunks with
+        # "Chunk N has empty tokens list", so we filter them at construction time to
+        # prevent any consumer from encountering them.
+        filtered = [
+            chunk
+            for chunk in self.output
+            if not isinstance(chunk, tinker.EncodedTextChunk) or chunk.tokens
+        ]
+        if len(filtered) != len(self.output):
+            object.__setattr__(self, "output", filtered)
+
 
 class TrainOnWhat(StrEnum):
     """Enum controlling which parts of the sequence to compute loss on.
@@ -1465,10 +1479,7 @@ class Renderer(ABC):
             output_chunks = rendered_message.output
             if header_chunk:
                 chunks.append(header_chunk)
-            # Filter out empty EncodedTextChunks, which cause 400 errors in model requests
-            chunks.extend(
-                [x for x in output_chunks if not isinstance(x, tinker.EncodedTextChunk) or x.tokens]
-            )
+            chunks.extend(output_chunks)
 
         suffix_ctx = RenderContext(
             idx=len(messages),
@@ -1628,7 +1639,7 @@ class Renderer(ABC):
                     raise RendererError(f"Unknown train_on_what: {train_on_what}")
 
             model_input_chunks_weights += [
-                (output_part, int(output_has_weight)) for output_part in output_parts if output_part
+                (output_part, int(output_has_weight)) for output_part in output_parts
             ]
 
             # stop_overlap completes the stop sequence for formats like RoleColon (e.g., "User:")

--- a/tinker_cookbook/renderers/deepseek_v3_test.py
+++ b/tinker_cookbook/renderers/deepseek_v3_test.py
@@ -269,3 +269,34 @@ class TestDeepSeekStreamingBatchEquivalence:
         text = [p for p in content if p["type"] == "text"]
         assert len(thinking) == 1 and thinking[0]["thinking"] == "reasoning"
         assert len(text) == 1 and text[0]["text"] == "partial"
+
+
+# =============================================================================
+# RenderedMessage empty chunk filtering (DeepSeek-specific)
+# =============================================================================
+
+
+def test_deepseek_render_message_thinking_only_produces_no_empty_chunks():
+    """
+    When a historical assistant message has only thinking content, render_message
+    should not produce EncodedTextChunk(tokens=[]) in the output.
+    """
+    model_name = "deepseek-ai/DeepSeek-V3.1"
+    tokenizer = get_tokenizer(model_name)
+    renderer = DeepSeekV3ThinkingRenderer(tokenizer)
+
+    message: Message = {
+        "role": "assistant",
+        "content": [
+            ThinkingPart(type="thinking", thinking="Only reasoning, no text output."),
+        ],
+    }
+
+    ctx = RenderContext(idx=1, is_last=False, prev_message={"role": "user", "content": "Hi"})
+    rendered = renderer.render_message(message, ctx)
+
+    for chunk in rendered.output:
+        if isinstance(chunk, tinker.EncodedTextChunk):
+            assert len(chunk.tokens) > 0, (
+                "render_message should not produce EncodedTextChunk with empty tokens"
+            )

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -482,7 +482,7 @@ class KimiK2Renderer(Renderer):
                     raise RendererError(f"Unknown train_on_what: {train_on_what}")
 
             model_input_chunks_weights += [
-                (output_part, int(output_has_weight)) for output_part in output_parts if output_part
+                (output_part, int(output_has_weight)) for output_part in output_parts
             ]
 
         weights_data = [w for chunk, w in model_input_chunks_weights for _ in range(chunk.length)]

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -876,6 +876,97 @@ def test_strip_thinking_from_history_false(model_name: str, renderer_class):
     assert "Second turn reasoning" in decoded, f"Second thinking should be preserved: {decoded}"
 
 
+@pytest.mark.parametrize(
+    "model_name,renderer_class",
+    [
+        ("Qwen/Qwen3-8B", Qwen3Renderer),
+        ("Qwen/Qwen3.5-35B-A3B", Qwen3_5Renderer),
+        ("deepseek-ai/DeepSeek-V3.1", DeepSeekV3ThinkingRenderer),
+        ("moonshotai/Kimi-K2-Thinking", KimiK2Renderer),
+        ("moonshotai/Kimi-K2.5", KimiK25Renderer),
+        ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", Nemotron3Renderer),
+    ],
+)
+def test_thinking_only_assistant_message_does_not_crash(model_name: str, renderer_class):
+    """
+    Regression test: when an earlier assistant message has ONLY thinking content (no text),
+    stripping thinking produces an empty token sequence. This must not produce an
+    EncodedTextChunk(tokens=[]) which Tinker would reject.
+    """
+    skip_if_deepseek_tokenizer_bug(model_name)
+    tokenizer = get_tokenizer(model_name)
+    renderer = renderer_class(tokenizer)  # Default strip_thinking_from_history=True
+
+    messages: list[Message] = [
+        {"role": "user", "content": "Think about this carefully."},
+        {
+            "role": "assistant",
+            "content": [
+                ThinkingPart(type="thinking", thinking="Deep internal reasoning only."),
+            ],
+        },
+        {"role": "user", "content": "Now answer: what is 2+2?"},
+        {
+            "role": "assistant",
+            "content": [
+                ThinkingPart(type="thinking", thinking="Simple arithmetic."),
+                TextPart(type="text", text="The answer is 4."),
+            ],
+        },
+    ]
+
+    # Should not raise — the thinking-only message's empty chunk must be filtered
+    model_input, weights = renderer.build_supervised_example(messages)
+    tokens = model_input.to_ints()
+
+    assert len(tokens) == len(weights), (
+        f"Token/weight length mismatch: {len(tokens)} vs {len(weights)}"
+    )
+    assert len(tokens) > 0, "Should produce a non-empty token sequence"
+
+    # The thinking-only message's content should be fully stripped
+    assert "Deep internal reasoning only" not in tokenizer.decode(tokens), (
+        "First assistant thinking should be stripped from history"
+    )
+    # The last message's content should be present
+    assert "The answer is 4" in tokenizer.decode(tokens), (
+        "Last assistant text should be present"
+    )
+
+
+# =============================================================================
+# RenderedMessage empty chunk filtering
+# =============================================================================
+
+
+def test_rendered_message_filters_empty_encoded_text_chunks():
+    """RenderedMessage.__post_init__ should drop EncodedTextChunk(tokens=[])."""
+    import tinker
+    from tinker_cookbook.renderers.base import RenderedMessage
+
+    non_empty = tinker.EncodedTextChunk(tokens=[1, 2, 3])
+    empty = tinker.EncodedTextChunk(tokens=[])
+
+    msg = RenderedMessage(output=[non_empty, empty, non_empty])
+    assert len(msg.output) == 2
+    assert all(
+        isinstance(c, tinker.EncodedTextChunk) and len(c.tokens) > 0 for c in msg.output
+    )
+
+
+def test_rendered_message_preserves_non_empty_chunks():
+    """RenderedMessage should not filter non-empty EncodedTextChunks."""
+    import tinker
+    from tinker_cookbook.renderers.base import RenderedMessage
+
+    chunks = [
+        tinker.EncodedTextChunk(tokens=[1]),
+        tinker.EncodedTextChunk(tokens=[2, 3]),
+    ]
+    msg = RenderedMessage(output=chunks)
+    assert len(msg.output) == 2
+
+
 # =============================================================================
 # Supervised/Generation/Parse Consistency Tests
 # =============================================================================


### PR DESCRIPTION
## Summary
- Thinking-capable renderers (DeepSeek, Qwen3, Kimi, Nemotron) strip thinking content from historical assistant messages. When a message has only thinking content and no text, this produces `EncodedTextChunk(tokens=[])` which Tinker rejects with "Chunk N has empty tokens list".
- Moved the empty-chunk filter into `RenderedMessage.__post_init__` so all consumers (`build_supervised_example`, `build_generation_prompt`, and any future code) are protected at construction time. Removed the now-redundant ad-hoc filters from `build_generation_prompt`, `build_supervised_example`, and `KimiK2Renderer.build_supervised_example`.
- Added regression tests: parametrized test across all 6 thinking renderers with thinking-only assistant messages, unit tests for `RenderedMessage` filtering, and a DeepSeek-specific `render_message` test.

## Test plan
- [x] `test_rendered_message_filters_empty_encoded_text_chunks` — verifies `__post_init__` drops empty chunks
- [x] `test_rendered_message_preserves_non_empty_chunks` — verifies no over-filtering
- [x] `test_thinking_only_assistant_message_does_not_crash` — parametrized across Qwen3, Qwen3.5, DeepSeek, KimiK2, KimiK2.5, Nemotron3
- [x] `test_deepseek_render_message_thinking_only_produces_no_empty_chunks` — render_message level
- [x] Full renderer test suite: 381 passed, 71 skipped (all skips are pre-existing DeepSeek tokenizer bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)