### PR TITLE
Add off-policy top-K distillation for multi-teacher knowledge merging

### DIFF
--- a/tinker_cookbook/distillation/train_off_policy.py
+++ b/tinker_cookbook/distillation/train_off_policy.py
@@ -385,6 +385,8 @@ async def main(config: Config) -> None:
         )
 
     teacher_clients: list[tinker.SamplingClient] = []
+    datasets: list[SupervisedDataset] = []
+    weights: list[float] = []
     for dc in config.dataset_configs:
         tc = dc.teacher_config
         if tc.load_checkpoint_path:
@@ -396,9 +398,6 @@ async def main(config: Config) -> None:
         teacher_clients.append(client)
         logger.info(f"Teacher: {tc.base_model} (checkpoint: {tc.load_checkpoint_path})")
 
-    datasets: list[SupervisedDataset] = []
-    weights: list[float] = []
-    for dc in config.dataset_configs:
         train_ds, _ = dc.dataset_builder()
         datasets.append(train_ds)
         weights.append(dc.weight)


### PR DESCRIPTION
## Summary

Adds `train_off_policy.py` to `tinker_cookbook.distillation` — off-policy distillation using soft targets from teacher model(s). This is the counterpart to the existing `train_on_policy.py`.

| | On-policy (`train_on_policy.py`) | Off-policy (this PR) |
|---|---|---|
| **Data** | Student's own rollouts | Fixed data (e.g., SFT mix) |
| **Teacher signal** | KL penalty on advantages | Soft targets via (N, n_teacher_targets) cross-entropy |
| **Loss** | RL (importance_sampling/ppo) | Supervised (cross_entropy) |
| **Use case** | Knowledge distillation during RL | MOPD — merging domain-specialized checkpoints |

## Design

- Teacher-forces each example through its domain-specific teacher via `sample_async(include_prompt_logprobs=True, topk_prompt_logprobs=n_teacher_targets)` — one forward pass, no sampling
- Renormalizes teacher logprobs over the selected set and uses them as soft target weights
- Uses Tinker's native `(N, n_teacher_targets)` cross-entropy — no `forward_backward_custom`, no extra FLOPs
- All teacher forward passes run concurrently (semaphore-bounded)
- Supports single-teacher and multi-teacher (MOPD) via `DatasetWithTeacher` configs
- Reuses `TeacherConfig` from `distillation.datasets`
- Sampling client created lazily (only when eval is due), avoiding unnecessary weight exports on non-eval steps

## Usage

```python
from tinker_cookbook.distillation.train_off_policy import Config, DatasetWithTeacher, main
from tinker_cookbook.distillation.datasets import TeacherConfig

# Multi-teacher MOPD
config = Config(
    dataset_configs=[
        DatasetWithTeacher(dataset_builder=code_sft, teacher_config=TeacherConfig(base_model=MODEL, load_checkpoint_path=code_rl_ckpt)),
        DatasetWithTeacher(dataset_builder=math_sft, teacher_config=TeacherConfig(base_model=MODEL, load_checkpoint_path=math_rl_ckpt)),
    ],
    model_name=MODEL,
    n_teacher_targets=20,
    learning_rate=1e-5,
    load_checkpoint_path=rlhf_ckpt,  # Student starts from RLHF
    log_path="~/experiments/mopd",
)
await main(config)
```

## Test plan

- [x] Smoke tested with self-distillation (same model as student/teacher)
- [x] Verified: teacher forward pass, (N, n_teacher_targets) datum construction, cross_entropy, optim_step
- [ ] Full integration test with different teacher checkpoints (blocked on domain-specific RL completion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)