### PR TITLE
Add nightly branch push to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -78,12 +78,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  push-nightly-branch:
-    runs-on: ubuntu-latest
-    needs: build-and-release
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: Push nightly branch
+      - name: Update nightly branch
         run: git push origin HEAD:refs/heads/nightly --force


### PR DESCRIPTION
## Summary

Adds a step at the end of the `build-and-release` job that force-pushes HEAD as the `nightly` branch. This provides a stable ref that documentation can link to for API reference source URLs (e.g., `blob/nightly/tinker_cookbook/rl/problem_env.py#L65`).

The nightly branch gets updated whenever smoke tests pass and the nightly release is created.

## Changes

- One new step in `build-and-release`: `git push origin HEAD:refs/heads/nightly --force`
- No new jobs, runners, or secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)