### PR TITLE
Fix LaTeX rendering in SDFT README

### DIFF
--- a/tinker_cookbook/recipes/sdft/README.md
+++ b/tinker_cookbook/recipes/sdft/README.md
@@ -24,9 +24,9 @@ Our Tinker implementation differs from the paper in two ways:
 
 1. **Top-K instead of full-vocabulary KL.** The Tinker API does not expose full-vocabulary logits. Instead, we use Tinker's [top-K distillation API](https://tinker-docs.thinkingmachines.ai/tinker/losses) (`topk_prompt_logprobs`) to recover the teacher's top-K token distribution at each position, and train with `cross_entropy` loss:
 
-    $$\mathcal{L}_{\text{top-K}} = \frac{1}{T} \sum_{t=1}^{T} \left[ -\sum_{k=1}^{K} P_{\text{teacher}}(x_k \mid t) \cdot \log P_{\text{student}}(x_k \mid t) \right]$$
+$$\mathcal{L}_{\text{top-K}} = \frac{1}{T} \sum_{t=1}^{T} \left[ -\sum_{k=1}^{K} P_{\text{teacher}}(x_k \mid t) \cdot \log P_{\text{student}}(x_k \mid t) \right]$$
 
-    where the inner sum is over the $K$ tokens with highest teacher probability (renormalized to sum to 1).
+   where the inner sum is over the $K$ tokens with highest teacher probability (renormalized to sum to 1).
 
 2. **Static teacher instead of EMA.** The paper maintains the teacher as an EMA of the student (updated every step with `alpha=0.01`). Our implementation keeps the teacher frozen at the initial base model weights, which is simpler and avoids the overhead of periodic weight syncing.
 


### PR DESCRIPTION
## Summary
- Remove 4-space indentation from `$$...$$` math block in SDFT README so GitHub renders it as LaTeX instead of a code block

## Test plan
- [ ] Verify the formula renders correctly on the GitHub PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)