### PR TITLE
Fix multi-teacher distillation smoke test timeout

### DIFF
--- a/tests/recipes/test_recipe_on_policy_multi_teacher.py
+++ b/tests/recipes/test_recipe_on_policy_multi_teacher.py
@@ -8,8 +8,9 @@ def test_on_policy_multi_teacher():
     run_recipe(
         "tinker_cookbook.recipes.distillation.on_policy_multi_teacher",
         [
-            "deepmath_groups_per_batch=16",
-            "tulu3_groups_per_batch=16",
+            "deepmath_groups_per_batch=4",
+            "tulu3_groups_per_batch=4",
             "behavior_if_log_dir_exists=delete",
         ],
+        max_steps=1,
     )


### PR DESCRIPTION
## Summary
- Reduce `groups_per_batch` from 16 → 4 per dataset and `max_steps` from 2 → 1 in the multi-teacher distillation smoke test
- The test was timing out at the 30-min mark having only completed 1 of 2 steps (~30 min per step with 2 datasets × 16 groups × 4 rollouts each)
- The reduced config still validates the full multi-teacher pipeline end-to-end

## Test plan
- [ ] CI smoke test passes within the 35-min job timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)