### PR TITLE
Fix tokenizer_class corrupted to TokenizersBackend during export

### DIFF
--- a/tests/weights/test_tokenizer_coverage.py
+++ b/tests/weights/test_tokenizer_coverage.py
@@ -1,0 +1,85 @@
+"""Verify that the tokenizer file allowlist covers all supported models.
+
+Downloads only tokenizer files (not weights) from HuggingFace for one
+representative model per family, copies them using our allowlist, and
+confirms ``AutoTokenizer.from_pretrained`` succeeds on the result.
+
+Requires network access. Skipped when TINKER_API_KEY is not set (same
+gate as other integration tests).
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from huggingface_hub import hf_hub_download, list_repo_files
+from transformers import AutoTokenizer
+
+from tinker_cookbook.weights._export import _TOKENIZER_AND_PROCESSOR_FILES
+
+# One representative per model family — covers distinct tokenizer layouts.
+_REPRESENTATIVE_MODELS = (
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3.5-4B",
+    "Qwen/Qwen3-VL-30B-A3B-Instruct",
+    "deepseek-ai/DeepSeek-V3.1",
+    "openai/gpt-oss-20b",
+    "moonshotai/Kimi-K2-Thinking",
+    "moonshotai/Kimi-K2.5",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+)
+
+
+def _download_tokenizer_files(model: str, dest: Path) -> list[str]:
+    """Download allowlisted tokenizer files + *.py modules into *dest*."""
+    copied = []
+    for name in _TOKENIZER_AND_PROCESSOR_FILES:
+        try:
+            local = hf_hub_download(model, name)
+            shutil.copyfile(local, dest / name)
+            copied.append(name)
+        except Exception:
+            pass
+
+    # *.py modules (copied by copy_model_code_files in the real pipeline)
+    for f in list_repo_files(model):
+        if f.endswith(".py") and "/" not in f:
+            local = hf_hub_download(model, f)
+            shutil.copyfile(local, dest / f)
+            copied.append(f)
+
+    return copied
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("model", _REPRESENTATIVE_MODELS, ids=lambda m: m.split("/")[-1])
+def test_tokenizer_loadable_from_allowlist(model: str) -> None:
+    """Tokenizer loads from just the allowlisted files for each model family."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest = Path(tmpdir)
+        copied = _download_tokenizer_files(model, dest)
+        assert copied, f"No tokenizer files found for {model}"
+
+        tok = AutoTokenizer.from_pretrained(str(dest), trust_remote_code=True)
+        tokens = tok.encode("Hello world")
+        assert len(tokens) > 0, f"Tokenizer for {model} produced empty encoding"
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("model", _REPRESENTATIVE_MODELS, ids=lambda m: m.split("/")[-1])
+def test_tokenizer_class_not_corrupted(model: str) -> None:
+    """tokenizer_class in our copied config matches the HF source."""
+    import json
+
+    src_path = hf_hub_download(model, "tokenizer_config.json")
+    expected = json.loads(Path(src_path).read_text()).get("tokenizer_class")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest = Path(tmpdir)
+        _download_tokenizer_files(model, dest)
+        actual = json.loads((dest / "tokenizer_config.json").read_text()).get("tokenizer_class")
+
+    assert actual == expected, f"{model}: tokenizer_class={actual!r}, expected {expected!r}"

--- a/tinker_cookbook/weights/_export/__init__.py
+++ b/tinker_cookbook/weights/_export/__init__.py
@@ -22,12 +22,11 @@ from pathlib import Path
 import torch
 from transformers import (
     AutoConfig,
-    AutoProcessor,
-    AutoTokenizer,
     PretrainedConfig,
 )
 
 from tinker_cookbook.exceptions import ConfigurationError
+from tinker_cookbook.weights._artifacts import copy_artifact_file, resolve_model_dir
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +173,6 @@ def build_hf_model(
 
     # --- Quantized export path ---
     if quantize is not None:
-        from tinker_cookbook.weights._artifacts import resolve_model_dir
         from tinker_cookbook.weights._export._quantized import build_quantized
 
         model_dir = resolve_model_dir(base_model)
@@ -213,7 +211,6 @@ def build_hf_model(
                 dtype,
             )
 
-        from tinker_cookbook.weights._artifacts import resolve_model_dir
         from tinker_cookbook.weights._export._shard import build_sharded
 
         model_dir = resolve_model_dir(base_model)
@@ -304,25 +301,56 @@ def save_tokenizer_and_processor(
     base_model: str,
     output_path: Path,
     multimodal: bool,
-    trust_remote_code: bool,
 ) -> None:
-    """Save tokenizer and optional processor to the output directory."""
-    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=trust_remote_code)
-    tokenizer.save_pretrained(output_path)
+    """Save tokenizer and optional processor to the output directory.
 
-    if multimodal:
-        try:
-            processor = AutoProcessor.from_pretrained(
-                base_model, trust_remote_code=trust_remote_code
-            )
-            processor.save_pretrained(output_path)
-        except (OSError, ValueError) as e:
-            logger.warning(
-                "Could not load processor for vision model %s: %s. "
-                "You may need to copy the processor files manually.",
-                base_model,
-                e,
-            )
+    Copies tokenizer files directly from the source model rather than
+    loading and re-serializing via ``save_pretrained()``. This avoids
+    transformers v5 silently rewriting ``tokenizer_class`` to
+    ``"TokenizersBackend"`` in ``tokenizer_config.json``, which breaks
+    downstream loaders (vLLM, SGLang, older transformers).
+    """
+    model_dir = resolve_model_dir(base_model)
+
+    copied = []
+    for name in _TOKENIZER_AND_PROCESSOR_FILES:
+        src = model_dir / name
+        if src.exists():
+            copy_artifact_file(src, output_path / name)
+            copied.append(name)
+
+    if copied:
+        logger.info("Copied tokenizer/processor files: %s", ", ".join(copied))
+    else:
+        logger.warning(
+            "No tokenizer/processor files found in %s. You may need to copy them manually.",
+            model_dir,
+        )
+
+
+# All tokenizer and processor files across every model in the Tinker lineup.
+# When adding a new model, run the test in export_test.py::TestTokenizerFileCopy::
+# test_all_supported_models_tokenizer_loadable to verify coverage.
+_TOKENIZER_AND_PROCESSOR_FILES = (
+    # Core tokenizer
+    "tokenizer_config.json",
+    "tokenizer.json",
+    "tokenizer.model",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    # Vocabulary
+    "vocab.json",
+    "merges.txt",
+    # Chat templates
+    "chat_template.jinja",
+    "chat_template.json",
+    # Tiktoken (Kimi)
+    "tiktoken.model",
+    # Multimodal processor
+    "preprocessor_config.json",
+    "processor_config.json",
+    "video_preprocessor_config.json",
+)
 
 
 def cleanup_on_failure(out: Path) -> None:

--- a/tinker_cookbook/weights/_export/_full.py
+++ b/tinker_cookbook/weights/_export/_full.py
@@ -75,9 +75,7 @@ def build_full(
         logger.info("Saving merged model to: %s", out)
         hf_model.save_pretrained(out)
 
-        save_tokenizer_and_processor(
-            base_model, out, is_multimodal_from_dict(config_dict), trust_remote_code
-        )
+        save_tokenizer_and_processor(base_model, out, is_multimodal_from_dict(config_dict))
 
         logger.info("Done — merged model saved to %s", out)
     except Exception:

--- a/tinker_cookbook/weights/_export/_quantized.py
+++ b/tinker_cookbook/weights/_export/_quantized.py
@@ -733,9 +733,7 @@ def build_quantized(
 
     # 7. Copy model code and tokenizer
     copy_model_code_files(model_dir, out)
-    save_tokenizer_and_processor(
-        base_model, out, is_multimodal_from_dict(config_dict), trust_remote_code
-    )
+    save_tokenizer_and_processor(base_model, out, is_multimodal_from_dict(config_dict))
 
     # 8. Mark complete
     _save_merge_state(

--- a/tinker_cookbook/weights/_export/_shard.py
+++ b/tinker_cookbook/weights/_export/_shard.py
@@ -165,9 +165,7 @@ def build_sharded(
         if src_config.exists():
             copy_artifact_file(src_config, out / "config.json")
         copy_model_code_files(model_dir, out)
-        save_tokenizer_and_processor(
-            base_model, out, is_multimodal_from_dict(config_dict), trust_remote_code
-        )
+        save_tokenizer_and_processor(base_model, out, is_multimodal_from_dict(config_dict))
 
         logger.info("Done — merged model saved to %s", out)
     except Exception:

--- a/tinker_cookbook/weights/export_test.py
+++ b/tinker_cookbook/weights/export_test.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 from safetensors.torch import load_file, save_file
 
-from tinker_cookbook.weights._export import build_hf_model
+from tinker_cookbook.weights._export import _TOKENIZER_AND_PROCESSOR_FILES, build_hf_model
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -448,6 +448,117 @@ class TestBuildShardedNemotron:
         # Verify out_proj unchanged (no adapter targeting it)
         out_proj = out_tensors["backbone.layers.0.mixer.out_proj.weight"]
         assert out_proj.abs().sum() == 0
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer file copy (no re-serialization)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizerFileCopy:
+    """Verify that tokenizer files are copied verbatim from the source model.
+
+    Transformers v5 rewrites ``tokenizer_class`` to ``"TokenizersBackend"``
+    when loading and re-saving via ``save_pretrained()``.  Our export copies
+    files directly to preserve the original values.
+    """
+
+    def test_tokenizer_class_preserved(self, tmp_path: Path):
+        """tokenizer_config.json must be byte-identical to the source."""
+        model_dir = tmp_path / "model"
+        adapter_dir = tmp_path / "adapter"
+        output_dir = tmp_path / "output"
+
+        # Use a tokenizer_class that would be corrupted by save_pretrained()
+        tok_config = json.dumps({"tokenizer_class": "Qwen2Tokenizer", "model_max_length": 4096})
+
+        config = {"architectures": ["TestModel"], "model_type": "test"}
+        state_dict = {"model.layers.0.proj.weight": torch.zeros(4, 4, dtype=torch.float32)}
+        _create_synthetic_model(model_dir, config, state_dict)
+        # Overwrite tokenizer_config.json with our specific content
+        (model_dir / "tokenizer_config.json").write_text(tok_config)
+
+        _create_adapter(
+            adapter_dir,
+            {
+                "base_model.model.model.layers.0.proj.lora_A.weight": torch.ones(1, 4),
+                "base_model.model.model.layers.0.proj.lora_B.weight": torch.ones(4, 1),
+            },
+            {"lora_alpha": 1, "r": 1},
+        )
+
+        build_hf_model(
+            base_model=str(model_dir),
+            adapter_path=str(adapter_dir),
+            output_path=str(output_dir),
+        )
+
+        # tokenizer_config.json must be byte-identical to the source
+        assert (output_dir / "tokenizer_config.json").read_text() == tok_config
+
+    def test_all_allowlisted_files_copied(self, tmp_path: Path):
+        """Every file in _TOKENIZER_AND_PROCESSOR_FILES is copied when present."""
+        model_dir = tmp_path / "model"
+        adapter_dir = tmp_path / "adapter"
+        output_dir = tmp_path / "output"
+
+        config = {"architectures": ["TestModel"], "model_type": "test"}
+        state_dict = {"model.layers.0.proj.weight": torch.zeros(4, 4, dtype=torch.float32)}
+        _create_synthetic_model(model_dir, config, state_dict)
+
+        # Write every allowlisted file into the source model dir
+        for name in _TOKENIZER_AND_PROCESSOR_FILES:
+            (model_dir / name).write_text(f"content-of-{name}")
+
+        _create_adapter(
+            adapter_dir,
+            {
+                "base_model.model.model.layers.0.proj.lora_A.weight": torch.ones(1, 4),
+                "base_model.model.model.layers.0.proj.lora_B.weight": torch.ones(4, 1),
+            },
+            {"lora_alpha": 1, "r": 1},
+        )
+
+        build_hf_model(
+            base_model=str(model_dir),
+            adapter_path=str(adapter_dir),
+            output_path=str(output_dir),
+        )
+
+        for name in _TOKENIZER_AND_PROCESSOR_FILES:
+            assert (output_dir / name).exists(), f"{name} missing from output"
+            assert (output_dir / name).read_bytes() == (model_dir / name).read_bytes(), (
+                f"{name} content differs from source"
+            )
+
+    def test_tiktoken_model_copied(self, tmp_path: Path):
+        """tiktoken.model (used by Kimi) is copied as a tokenizer file."""
+        model_dir = tmp_path / "model"
+        adapter_dir = tmp_path / "adapter"
+        output_dir = tmp_path / "output"
+
+        config = {"architectures": ["TestModel"], "model_type": "test"}
+        state_dict = {"model.layers.0.proj.weight": torch.zeros(4, 4, dtype=torch.float32)}
+        _create_synthetic_model(model_dir, config, state_dict)
+        (model_dir / "tiktoken.model").write_text("fake-tiktoken-data")
+
+        _create_adapter(
+            adapter_dir,
+            {
+                "base_model.model.model.layers.0.proj.lora_A.weight": torch.ones(1, 4),
+                "base_model.model.model.layers.0.proj.lora_B.weight": torch.ones(4, 1),
+            },
+            {"lora_alpha": 1, "r": 1},
+        )
+
+        build_hf_model(
+            base_model=str(model_dir),
+            adapter_path=str(adapter_dir),
+            output_path=str(output_dir),
+        )
+
+        assert (output_dir / "tiktoken.model").exists()
+        assert (output_dir / "tiktoken.model").read_text() == "fake-tiktoken-data"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Bug:** Transformers v5 silently rewrites `tokenizer_class` to `"TokenizersBackend"` when loading a tokenizer and re-saving via `save_pretrained()`. This affects **8 models** in the Tinker lineup: all Qwen3.5, Nemotron-3, and gpt-oss models. Downstream loaders (vLLM, SGLang) may fail or behave incorrectly.
- **Fix:** `save_tokenizer_and_processor()` now copies tokenizer files directly from the source model directory instead of load+re-serialize. This preserves the original `tokenizer_config.json` byte-for-byte, including the correct `tokenizer_class` value.
- Uses `copy_artifact_file` (not `shutil.copy2`) for compatibility with GCS/FUSE output mounts.
- Uses an explicit allowlist (`_TOKENIZER_AND_PROCESSOR_FILES`) of tokenizer/processor files — controllable and testable. When adding a new model, run the integration test to verify coverage.

### Affected models
| Model | Was (broken) | Now (correct) |
|-------|-------------|---------------|
| `Qwen/Qwen3.5-*` (4B, 27B, 35B-A3B, 397B-A17B) | `TokenizersBackend` | `Qwen2Tokenizer` |
| `openai/gpt-oss-20b`, `gpt-oss-120b` | `TokenizersBackend` | `PreTrainedTokenizerFast` |
| `nvidia/NVIDIA-Nemotron-3-*` (Nano, Super) | `TokenizersBackend` | `PreTrainedTokenizerFast` |

## Test plan
- [x] 13 unit tests pass (`export_test.py` — includes 3 new tokenizer copy tests)
- [x] 32 quantized + 19 stress tests pass (unchanged)
- [x] New integration test (`test_tokenizer_coverage.py`): for each model family, downloads only tokenizer files via allowlist and verifies `AutoTokenizer.from_pretrained` succeeds and `tokenizer_class` matches HF source
- [x] E2e verified with real Tinker adapters: train → save → download → `build_hf_model` on Qwen3.5-4B and Nemotron-3-Nano — output `tokenizer_config.json` is byte-identical to HF source
- [x] CI: pre-commit, pyright (transformers 4.x + 5.x), pytest (transformers 4.x + 5.x), downstream-compat all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)