### PR TITLE
Generalize SandboxFactory to support non-Modal backends

### DIFF
--- a/tinker_cookbook/recipes/harbor_rl/README.md
+++ b/tinker_cookbook/recipes/harbor_rl/README.md
@@ -81,7 +81,7 @@ async def default_sandbox_factory(env_dir: Path, timeout: int) -> SandboxInterfa
     return await ModalSandbox.create(image=image, timeout=timeout)
 ```
 
-The first argument is the task's `environment/` directory (containing a Dockerfile and build context). Each backend converts this to its own image format internally (e.g. Modal builds a `modal.Image`, Fishbowl hashes the Dockerfile to an OCI URL).
+The first argument is the task's `environment/` directory (containing a Dockerfile and build context). Each backend converts this to its own image format internally (e.g. Modal builds a `modal.Image`).
 
 `cli_main()` accepts an optional `sandbox_factory` parameter. When `None`, it falls back to `default_sandbox_factory` (Modal). The factory flows through: `cli_main` -> `HarborDatasetBuilder` -> `HarborEnvGroupBuilder.make_envs()`.
 

--- a/tinker_cookbook/recipes/harbor_rl/README.md
+++ b/tinker_cookbook/recipes/harbor_rl/README.md
@@ -68,14 +68,20 @@ class SandboxInterface(Protocol):
 
 ### SandboxFactory and injection
 
-`harbor_env.py` defines a factory type and default:
+`harbor_env.py` defines a backend-agnostic factory type and a default Modal implementation:
 
 ```python
-SandboxFactory = Callable[[modal.Image, int], Awaitable[SandboxInterface]]
+SandboxFactory = Callable[[Path, int], Awaitable[SandboxInterface]]
 
-async def default_sandbox_factory(image: modal.Image, timeout: int) -> SandboxInterface:
+async def default_sandbox_factory(env_dir: Path, timeout: int) -> SandboxInterface:
+    """Create a Modal sandbox from a task environment directory."""
+    import modal
+    dockerfile_path = env_dir / "Dockerfile"
+    image = modal.Image.from_dockerfile(path=str(dockerfile_path), context_dir=str(env_dir))
     return await ModalSandbox.create(image=image, timeout=timeout)
 ```
+
+The first argument is the task's `environment/` directory (containing a Dockerfile and build context). Each backend converts this to its own image format internally (e.g. Modal builds a `modal.Image`, Fishbowl hashes the Dockerfile to an OCI URL).
 
 `cli_main()` accepts an optional `sandbox_factory` parameter. When `None`, it falls back to `default_sandbox_factory` (Modal). The factory flows through: `cli_main` -> `HarborDatasetBuilder` -> `HarborEnvGroupBuilder.make_envs()`.
 
@@ -84,7 +90,7 @@ async def default_sandbox_factory(image: modal.Image, timeout: int) -> SandboxIn
 First, download the Terminal-Bench tasks:
 
 ```bash
-uvx harbor datasets download terminal-bench@2.0
+uvx harbor datasets download terminal-bench@2.0 -o ~/.cache/harbor/tasks/terminal-bench-2.0/
 ```
 
 Then launch training:

--- a/tinker_cookbook/recipes/harbor_rl/eval.py
+++ b/tinker_cookbook/recipes/harbor_rl/eval.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from pathlib import Path
 
 import chz
-import modal
 import tinker
 
 from tinker_cookbook import model_info, tokenizer_utils
@@ -85,10 +84,8 @@ async def evaluate_task(
     """
     start = time.monotonic()
     env_dir = task.task_dir / "environment"
-    dockerfile_path = env_dir / "Dockerfile"
-    image = modal.Image.from_dockerfile(path=str(dockerfile_path), context_dir=str(env_dir))
 
-    sandbox = await sandbox_factory(image, config.sandbox_timeout)
+    sandbox = await sandbox_factory(env_dir, config.sandbox_timeout)
     try:
         bash_tool = HarborBashTool(sandbox, command_timeout=config.command_timeout)
         reward_fn = HarborReward(

--- a/tinker_cookbook/recipes/harbor_rl/harbor_env.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_env.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any
 
 import chz
-import modal
 
 from tinker_cookbook import model_info, tokenizer_utils
 from tinker_cookbook.recipes.harbor_rl.harbor_tools import HarborBashTool, HarborReward
@@ -31,10 +30,20 @@ HARBOR_SYSTEM_PROMPT = (
     "Complete the task described by the user."
 )
 
-SandboxFactory = Callable[[modal.Image, int], Awaitable[SandboxInterface]]
+SandboxFactory = Callable[[Path, int], Awaitable[SandboxInterface]]
 
 
-async def default_sandbox_factory(image: modal.Image, timeout: int) -> SandboxInterface:
+async def default_sandbox_factory(env_dir: Path, timeout: int) -> SandboxInterface:
+    """Create a Modal sandbox from a task environment directory.
+
+    Args:
+        env_dir: Path to the task's environment/ directory (must contain a Dockerfile).
+        timeout: Sandbox lifetime in seconds.
+    """
+    import modal
+
+    dockerfile_path = env_dir / "Dockerfile"
+    image = modal.Image.from_dockerfile(path=str(dockerfile_path), context_dir=str(env_dir))
     return await ModalSandbox.create(image=image, timeout=timeout)
 
 
@@ -52,8 +61,9 @@ def load_harbor_tasks(dataset: str) -> list[HarborTask]:
     """Load Harbor tasks from ~/.cache/harbor/tasks/<dataset>/."""
     tasks_dir = HARBOR_CACHE_DIR / dataset
     tasks: list[HarborTask] = []
-    for uuid_dir in sorted(tasks_dir.iterdir()):
-        (task_dir,) = [d for d in uuid_dir.iterdir() if d.is_dir()]
+    for task_dir in sorted(tasks_dir.iterdir()):
+        if not task_dir.is_dir():
+            continue
         tasks.append(
             HarborTask(
                 task_name=task_dir.name,
@@ -117,10 +127,7 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
     async def make_envs(self) -> Sequence[Env]:
         self._sandboxes = []
 
-        # Build Modal image from the task's Dockerfile
         env_dir = self.task.task_dir / "environment"
-        dockerfile_path = env_dir / "Dockerfile"
-        image = modal.Image.from_dockerfile(path=str(dockerfile_path), context_dir=str(env_dir))
 
         # Create renderer (stateless, shared across envs)
         tokenizer = tokenizer_utils.get_tokenizer(self.model_name)
@@ -133,7 +140,7 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
 
         envs = []
         for _ in range(self.group_size):
-            sandbox = await self.sandbox_factory(image, self.sandbox_timeout)
+            sandbox = await self.sandbox_factory(env_dir, self.sandbox_timeout)
             self._sandboxes.append(sandbox)
 
             bash_tool = HarborBashTool(sandbox, command_timeout=self.command_timeout)


### PR DESCRIPTION
  - Change SandboxFactory signature from `(modal.Image, int)` to `(Path, int)` so any sandbox backend can be plugged in without depending on Modal types
  - Move `modal.Image` construction into `default_sandbox_factory`, making modal a deferred import
  - Simplify `load_harbor_tasks` to use flat directory layout (`<dataset>/<task_name>/`) instead of requiring the legacy `<dataset>/<uuid>/<task_name>/` nesting