### PR TITLE
Fix unembed_tokens merge for models with tied embeddings

### DIFF
--- a/tinker_cookbook/weights/_merge_utils.py
+++ b/tinker_cookbook/weights/_merge_utils.py
@@ -105,8 +105,16 @@ def build_name_remaps(
     """
     remaps: list[tuple[str, str]] = [
         ("base_model.model.", ""),
-        ("model.unembed_tokens", "lm_head"),
     ]
+    # Map unembed_tokens to lm_head if it exists as a separate parameter,
+    # otherwise to model.embed_tokens (models with tied embeddings).
+    has_lm_head = "lm_head.weight" in model_state_keys or any(
+        k.endswith(".lm_head.weight") for k in model_state_keys
+    )
+    if has_lm_head:
+        remaps.append(("model.unembed_tokens", "lm_head"))
+    else:
+        remaps.append(("model.unembed_tokens", "model.embed_tokens"))
     if profile.has_language_model_prefix:
         remaps.append(("model.", "model.language_model."))
     return remaps


### PR DESCRIPTION
## Summary

Models with `tie_word_embeddings=True` do not have a separate `lm_head.weight` in the state dict — it is tied to `model.embed_tokens.weight`. The adapter `unembed_tokens` LoRA was always mapped to `lm_head`, causing `WeightsMergeError` during both merge and adapter export.

### Impact

Affects **both** `build_hf_model` (merge) and `build_lora_adapter` (PEFT export) — they share `build_name_remaps`.

| Model | `tie_word_embeddings` | Affected? |
|-------|:---------------------:|:---------:|
| Qwen3-0.6B | True | Yes |
| Qwen3-4B-Instruct-2507 | True | Yes |
| Qwen3.5-4B | True | Yes |
| Qwen3-8B | False | No |
| Qwen3-30B-A3B | False | No |
| Qwen3.5-27B | False | No |
| Qwen3.5-35B-A3B | False | No |

Only triggers when training with `train_unembed=True`. Larger models are unaffected because they have a separate `lm_head.weight`.

### Fix

Check if `lm_head.weight` exists in model state dict. If not, map `unembed_tokens` to `model.embed_tokens` instead. Handles vision model prefix (`model.language_model.*`) correctly.

## Test plan

- [x] 258 unit tests pass (existing tests for untied models unaffected)
- [x] E2e merge with real adapter: **Qwen3-4B-Instruct-2507** (tied, 69s) — SUCCESS
- [x] E2e merge with real adapter: **Qwen3.5-4B** (tied, vision prefix, 73s) — SUCCESS
- [x] E2e adapter export: both models — SUCCESS
- [x] Verified output has `embed_tokens.weight` (no `lm_head`) for tied models
- [x] Verified vision prefix: Qwen3.5-4B outputs `model.language_model.embed_tokens.weight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)