### PR TITLE
Fix model name typo in 502_lora_adapter notebook

### DIFF
--- a/tutorials/502_lora_adapter.py
+++ b/tutorials/502_lora_adapter.py
@@ -160,20 +160,20 @@ def _(mo):
     from peft import PeftModel
     from transformers import AutoModelForCausalLM
 
-    base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-8B")
+    base = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-4B")
     model = PeftModel.from_pretrained(base, "./peft_adapter")
     ```
 
     **With vLLM (multi-adapter serving):**
     ```bash
-    vllm serve Qwen/Qwen3-8B \
+    vllm serve Qwen/Qwen3.5-4B \
         --lora-modules my_adapter=./peft_adapter
     ```
 
     **With SGLang:**
     ```bash
     python -m sglang.launch_server \
-        --model Qwen/Qwen3-8B \
+        --model Qwen/Qwen3.5-4B \
         --lora-paths my_adapter=./peft_adapter
     ```
     """)


### PR DESCRIPTION
## Summary
- The marimo notebook `tutorials/502_lora_adapter.py` trains on `Qwen/Qwen3.5-4B` but the "Loading the adapter" markdown cell references `Qwen/Qwen3-8B` in three serving examples (PEFT, vLLM, SGLang)
- Fixed all three to use `Qwen/Qwen3.5-4B`
- Companion docs fix: iterationlab/tinker-docs#137

## Test plan
- [x] Ran the full tutorial end-to-end: train → download → PEFT convert → PEFT load → inference, all with `Qwen/Qwen3.5-4B` — passed

Fixes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)