### PR TITLE
Support separate teacher/student system prompts for KL computation

### DIFF
--- a/tinker_cookbook/distillation/datasets.py
+++ b/tinker_cookbook/distillation/datasets.py
@@ -35,6 +35,10 @@ class TeacherConfig:
 
     base_model: str
     load_checkpoint_path: str | None = None
+    system_prompt: str | None = None
+    """If set, the teacher uses this system prompt for KL computation instead of
+    sharing the student's. None (default) means teacher uses the same prompt as
+    the student. Set to "" for an empty system prompt."""
 
 
 @chz.chz
@@ -90,10 +94,14 @@ class PromptOnlyEnv(ProblemEnv):
         prompt: str,
         renderer: renderers.Renderer,
         convo_prefix: list[renderers.Message] | None = None,
+        teacher_renderer: renderers.Renderer | None = None,
+        teacher_convo_prefix: list[renderers.Message] | None = None,
     ):
         # Set format_coef to 0 since we don't care about format
         super().__init__(renderer, convo_prefix, format_coef=0.0)
         self.prompt = prompt
+        self.teacher_renderer = teacher_renderer
+        self.teacher_convo_prefix = teacher_convo_prefix
 
     def get_question(self) -> str:
         return self.prompt
@@ -109,6 +117,15 @@ class PromptOnlyEnv(ProblemEnv):
     def get_reference_answer(self) -> str:
         """No reference answer needed for distillation."""
         return ""
+
+    async def teacher_initial_observation(self) -> tinker.ModelInput | None:
+        """Render the initial observation with the teacher's system prompt."""
+        if self.teacher_renderer is None:
+            return None
+        convo = (self.teacher_convo_prefix or []) + [
+            {"role": "user", "content": self.get_question()},
+        ]
+        return self.teacher_renderer.build_generation_prompt(convo)
 
     async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Return zero reward always."""

--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -65,12 +65,17 @@ async def incorporate_kl_penalty(
         kl_penalty_coef: Coefficient for KL penalty
         kl_discount_factor: Discount factor for future KL
     """
-    # Note: if your teacher has a different renderer than the student, you may want to modify
-    #       the full_sequence_inputs_D to match the teacher's renderer.
-    full_sequence_inputs_D = [
-        datum.model_input.append_int(cast(int, datum.loss_fn_inputs["target_tokens"].data[-1]))
-        for datum in data_D
-    ]
+    # Build full sequences for teacher logprob computation. If a datum has a
+    # teacher_model_input (from a teacher renderer with a different system prompt),
+    # use it instead of the student's model_input.
+    full_sequence_inputs_D = []
+    for datum in data_D:
+        last_target = cast(int, datum.loss_fn_inputs["target_tokens"].data[-1])
+        teacher_input = datum.loss_fn_inputs.get("teacher_model_input")
+        if teacher_input is not None:
+            full_sequence_inputs_D.append(teacher_input.append_int(last_target))
+        else:
+            full_sequence_inputs_D.append(datum.model_input.append_int(last_target))
     # Compute the teacher's logprobs for each element of the batch
     # Each datum uses its corresponding teacher sampling client
     teacher_logprobs_D = await asyncio.gather(
@@ -84,12 +89,28 @@ async def incorporate_kl_penalty(
     #   - q: teacher_logprobs
     sampled_logprobs_D = [datum.loss_fn_inputs["logprobs"].to_torch() for datum in data_D]
     float_masks = [datum.loss_fn_inputs["mask"].to_torch().float() for datum in data_D]
-    reverse_kl = [
-        (sampled_logprobs - torch.tensor(teacher_logprobs[1:])) * mask
-        for teacher_logprobs, sampled_logprobs, mask in safezip(
-            teacher_logprobs_D, sampled_logprobs_D, float_masks
-        )
-    ]
+    reverse_kl = []
+    for datum, teacher_logprobs, sampled_logprobs, mask in safezip(
+        data_D, teacher_logprobs_D, sampled_logprobs_D, float_masks
+    ):
+        teacher_input = datum.loss_fn_inputs.get("teacher_model_input")
+        if teacher_input is not None:
+            # Teacher has a different prefix — logprobs don't align positionally.
+            # Extract teacher logprobs for generated tokens only (where mask=1).
+            # teacher_logprobs[k] = log p(token[k] | token[0..k-1]).
+            # Generated tokens start at teacher_input.length in the teacher sequence.
+            n_generated = int(mask.sum().item())
+            teacher_prefix_len = teacher_input.length
+            teacher_gen_lp = torch.tensor(
+                teacher_logprobs[teacher_prefix_len : teacher_prefix_len + n_generated]
+            )
+            kl = torch.zeros_like(mask)
+            mask_indices = mask.nonzero(as_tuple=True)[0]
+            student_gen_lp = sampled_logprobs[mask_indices]
+            kl[mask_indices] = student_gen_lp - teacher_gen_lp
+            reverse_kl.append(kl * mask)
+        else:
+            reverse_kl.append((sampled_logprobs - torch.tensor(teacher_logprobs[1:])) * mask)
     # Track per-dataset KL for logging
     # dataset_idx -> (sum of KL, sum of mask)
     per_dataset_kl: dict[int, tuple[float, float]] = {}

--- a/tinker_cookbook/rl/data_processing.py
+++ b/tinker_cookbook/rl/data_processing.py
@@ -124,6 +124,8 @@ def trajectory_to_data(traj: Trajectory, traj_advantage: float) -> list[tinker.D
 
     class SequenceAccumulator:
         full_sequence: list[FlatObElem] = []
+        teacher_sequence: list[FlatObElem] = []
+        has_teacher: bool = False
         sampled_logprobs: list[float] = []
         advantages: list[float] = []
         mask: list[float] = []
@@ -131,6 +133,8 @@ def trajectory_to_data(traj: Trajectory, traj_advantage: float) -> list[tinker.D
         @classmethod
         def clear(cls):
             cls.full_sequence = []
+            cls.teacher_sequence = []
+            cls.has_teacher = False
             cls.sampled_logprobs = []
             cls.advantages = []
             cls.mask = []
@@ -150,14 +154,22 @@ def trajectory_to_data(traj: Trajectory, traj_advantage: float) -> list[tinker.D
             == len(advantages_T)
             == len(mask_T)
         )
+        loss_fn_inputs = {
+            "target_tokens": TensorData.from_torch(torch.tensor(target_tokens_T)),
+            "logprobs": TensorData.from_torch(torch.tensor(sampled_logprobs_T)),
+            "advantages": TensorData.from_torch(torch.tensor(advantages_T)),
+            "mask": TensorData.from_torch(torch.tensor(mask_T)),
+        }
+        # Include teacher model input if teacher observations were provided
+        if SequenceAccumulator.has_teacher:
+            teacher_all_tokens = _flat_ob_to_model_input(SequenceAccumulator.teacher_sequence)
+            teacher_input, _ = create_rightshifted_model_input_and_leftshifted_targets(
+                list(teacher_all_tokens.chunks)
+            )
+            loss_fn_inputs["teacher_model_input"] = teacher_input
         return tinker.Datum(
             model_input=input_tokens_T,
-            loss_fn_inputs={
-                "target_tokens": TensorData.from_torch(torch.tensor(target_tokens_T)),
-                "logprobs": TensorData.from_torch(torch.tensor(sampled_logprobs_T)),
-                "advantages": TensorData.from_torch(torch.tensor(advantages_T)),
-                "mask": TensorData.from_torch(torch.tensor(mask_T)),
-            },
+            loss_fn_inputs=loss_fn_inputs,
         )
 
     data: list[tinker.Datum] = []
@@ -183,6 +195,21 @@ def trajectory_to_data(traj: Trajectory, traj_advantage: float) -> list[tinker.D
             [0] * delta_ob_len + [traj_advantage] * len(ac_with_logprobs.tokens)
         )
         SequenceAccumulator.mask.extend([0.0] * delta_ob_len + [1.0] * len(ac_with_logprobs.tokens))
+
+        # Track teacher observations in parallel if provided
+        if transition.teacher_ob is not None:
+            SequenceAccumulator.has_teacher = True
+            teacher_ob_flat = _flatten_chunks(transition.teacher_ob.chunks)
+            if len(SequenceAccumulator.teacher_sequence) == 0:
+                teacher_delta = teacher_ob_flat
+            elif _is_prefix(SequenceAccumulator.teacher_sequence, teacher_ob_flat):
+                teacher_delta = teacher_ob_flat[len(SequenceAccumulator.teacher_sequence) :]
+            else:
+                # Teacher sequence broke prefix extension — reset to full observation
+                SequenceAccumulator.teacher_sequence = []
+                teacher_delta = teacher_ob_flat
+            SequenceAccumulator.teacher_sequence.extend(teacher_delta)
+            SequenceAccumulator.teacher_sequence.extend(ac_with_logprobs.tokens)
 
     if SequenceAccumulator.full_sequence:
         data.append(make_datum_from_state())

--- a/tinker_cookbook/rl/rollouts.py
+++ b/tinker_cookbook/rl/rollouts.py
@@ -176,6 +176,7 @@ async def do_single_rollout(policy: TokenCompleter, env: Env) -> Trajectory:
     transitions = []
     async with trace.scope_span("env_initial_observation"):
         ob, stop_condition = await env.initial_observation()
+        teacher_ob = await env.teacher_initial_observation()
     while True:
         async with trace.scope_span("policy_sample"):
             ac_with_logprobs = await policy(ob, stop_condition)
@@ -191,9 +192,11 @@ async def do_single_rollout(policy: TokenCompleter, env: Env) -> Trajectory:
             episode_done=step_result.episode_done,
             metrics=step_result.metrics,
             logs=step_result.logs,
+            teacher_ob=teacher_ob,
         )
         transitions.append(transition)
         ob = step_result.next_observation
+        teacher_ob = step_result.teacher_observation
         stop_condition = step_result.next_stop_condition
         if step_result.episode_done:
             break

--- a/tinker_cookbook/rl/types.py
+++ b/tinker_cookbook/rl/types.py
@@ -65,6 +65,10 @@ class StepResult:
     """Numeric values aggregated and reported in training logs (e.g., timing, counts)."""
     logs: Logs = field(default_factory=dict)
     """Diagnostic info for display/debugging tools (not aggregated like metrics)."""
+    teacher_observation: Observation | None = None
+    """Optional teacher observation: the same conversation rendered with a different
+    system prompt. When set, incorporate_kl_penalty uses this for computing teacher
+    logprobs instead of the student's observation."""
 
 
 @dataclass
@@ -95,6 +99,10 @@ class Transition:
     """Numeric values aggregated and reported in training logs."""
     logs: Logs = field(default_factory=dict)
     """Diagnostic info for display/debugging tools (not aggregated like metrics)."""
+    teacher_ob: Observation | None = None
+    """Optional teacher observation for the same conversation, rendered with a
+    different system prompt. Used by incorporate_kl_penalty to compute teacher
+    logprobs conditioned on the teacher's prompt instead of the student's."""
 
 
 class ActionExtra(TypedDict, total=False):
@@ -166,6 +174,14 @@ class Env(ABC):
                 is done.
         """
         pass
+
+    async def teacher_initial_observation(self) -> Observation | None:
+        """Return the initial observation rendered with the teacher's system prompt.
+
+        Override this in envs that support separate teacher/student system prompts.
+        Returns None by default (teacher uses the same prompt as student).
+        """
+        return None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- Add infrastructure for computing teacher logprobs conditioned on a different system prompt than the student during on-policy distillation
- `TeacherConfig.system_prompt` — when set, the teacher uses this system prompt; `None` (default) means same as student
- Teacher observations flow through `Transition.teacher_ob` → `trajectory_to_data` → `loss_fn_inputs["teacher_model_input"]` → `incorporate_kl_penalty`
- `PromptOnlyEnv` accepts optional `teacher_renderer` / `teacher_convo_prefix` for dual-rendering
- Fully backward compatible — all new fields default to `None` and existing behavior is unchanged

## Test plan

- [ ] Existing tests pass (no interface changes for envs that don't use teacher prompts)
- [ ] Test with tibo onpodi: set `student_system_prompt=""` and verify teacher KL uses the renderer's default system prompt
- [ ] Test multi-turn: verify teacher observations accumulate correctly with prefix extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)