### PR TITLE
Fix rolling checkpoint test TTL to meet API minimum

### DIFF
--- a/tests/recipes/test_recipe_rolling_checkpoints.py
+++ b/tests/recipes/test_recipe_rolling_checkpoints.py
@@ -38,7 +38,7 @@ def test_rolling_checkpoint_train():
             f"log_path={LOG_PATH}",
             "save_every=2",
             "rolling_save_every=1",
-            "rolling_ttl_seconds=300",
+            "rolling_ttl_seconds=3600",
         ],
         max_steps=4,
     )
@@ -75,7 +75,7 @@ def test_rolling_checkpoint_resume():
             f"log_path={LOG_PATH}",
             "save_every=2",
             "rolling_save_every=1",
-            "rolling_ttl_seconds=300",
+            "rolling_ttl_seconds=3600",
         ],
         max_steps=6,
     )


### PR DESCRIPTION
## Summary
- The Tinker API now enforces `ttl_seconds >= 3600` (1 hour) for checkpoint saves
- The `test_recipe_rolling_checkpoints` smoke test was using `rolling_ttl_seconds=300`, causing rolling saves to fail with a 400 error
- Bumped to `3600` in both test functions to match the new API constraint

## Test plan
- [x] CI `test_recipe_rolling_checkpoints` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)