### PR TITLE
Guard against edge-case crashes in RL, preference, and xmux

### DIFF
--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -200,9 +200,7 @@ def get_model_attributes(model_name: str) -> ModelAttributes:
     """
     model_name = model_name.split(":")[0]
     if "/" not in model_name:
-        raise ValueError(
-            f"Model name must be in 'org/model' format, got {model_name!r}"
-        )
+        raise ValueError(f"Model name must be in 'org/model' format, got {model_name!r}")
     org, model_version_full = model_name.split("/", 1)
     model_version_full = model_version_full.split(":")[0]
     if org == "meta-llama":

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -199,7 +199,11 @@ def get_model_attributes(model_name: str) -> ModelAttributes:
         print(attrs.size_str, attrs.recommended_renderers)
     """
     model_name = model_name.split(":")[0]
-    org, model_version_full = model_name.split("/")
+    if "/" not in model_name:
+        raise ValueError(
+            f"Model name must be in 'org/model' format, got {model_name!r}"
+        )
+    org, model_version_full = model_name.split("/", 1)
     model_version_full = model_version_full.split(":")[0]
     if org == "meta-llama":
         return get_llama_info()[model_version_full]

--- a/tinker_cookbook/preference/types.py
+++ b/tinker_cookbook/preference/types.py
@@ -181,7 +181,10 @@ class ComparisonRendererFromChatRenderer(ComparisonRenderer):
         )
         # Truncate at the first weight==1 position + 1
         tokens = model_input.to_ints()
-        first_weight_one_index = int(torch.nonzero(weights == 1.0)[0])
+        nonzero_indices = torch.nonzero(weights == 1.0)
+        if len(nonzero_indices) == 0:
+            return model_input, weights
+        first_weight_one_index = int(nonzero_indices[0])
         truncated_tokens = tokens[: first_weight_one_index + 1]
         truncated_weights = weights[: first_weight_one_index + 1]
         return types.ModelInput.from_ints(truncated_tokens), truncated_weights

--- a/tinker_cookbook/rl/metrics.py
+++ b/tinker_cookbook/rl/metrics.py
@@ -234,6 +234,8 @@ def compute_sampling_client_metrics(
             - ``time/sampling_time_min``: Minimum sampling time across groups.
             - ``time/sampling_time_mean``: Mean sampling time across groups.
     """
+    if not wrapped_trajectory_groups:
+        return {}
     sampling_client_steps = [
         wrapped_trajectory_group.sampling_client_step
         for wrapped_trajectory_group in wrapped_trajectory_groups

--- a/tinker_cookbook/rl/preference_envs.py
+++ b/tinker_cookbook/rl/preference_envs.py
@@ -340,10 +340,11 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
 
         return [
             (
-                win_minus_loss / matchup_count + format_coef * (float(is_valid) - 1.0),
-                {"win_minus_loss": win_minus_loss / matchup_count, "format": is_valid},
+                (win_minus_loss / mc if mc > 0 else 0.0)
+                + format_coef * (float(is_valid) - 1.0),
+                {"win_minus_loss": win_minus_loss / mc if mc > 0 else 0.0, "format": is_valid},
             )
-            for win_minus_loss, is_valid, matchup_count in safezip(
+            for win_minus_loss, is_valid, mc in safezip(
                 win_minus_loss_list, is_valid_list, matchup_count
             )
         ]

--- a/tinker_cookbook/rl/preference_envs.py
+++ b/tinker_cookbook/rl/preference_envs.py
@@ -340,8 +340,7 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
 
         return [
             (
-                (win_minus_loss / mc if mc > 0 else 0.0)
-                + format_coef * (float(is_valid) - 1.0),
+                (win_minus_loss / mc if mc > 0 else 0.0) + format_coef * (float(is_valid) - 1.0),
                 {"win_minus_loss": win_minus_loss / mc if mc > 0 else 0.0, "format": is_valid},
             )
             for win_minus_loss, is_valid, mc in safezip(

--- a/tinker_cookbook/utils/lr_scheduling.py
+++ b/tinker_cookbook/utils/lr_scheduling.py
@@ -34,6 +34,8 @@ def compute_schedule_lr_multiplier(lr_schedule: LRSchedule, step: int, total_ste
         base_lr = 1e-4
         effective_lr = base_lr * compute_schedule_lr_multiplier("cosine", step=50, total_steps=100)
     """
+    if total_steps <= 0:
+        raise ConfigurationError(f"total_steps must be positive, got {total_steps}")
     if lr_schedule == "linear":
         return 1 - step / total_steps
     elif lr_schedule == "cosine":

--- a/tinker_cookbook/xmux/control.py
+++ b/tinker_cookbook/xmux/control.py
@@ -158,13 +158,14 @@ class ControlWindow:
             for line in result.stdout.strip().split("\n"):
                 if line and ":" in line:
                     parts = line.split(":")
-                    panes.append(
-                        PaneInfo(
-                            index=int(parts[0]),
-                            pid=int(parts[1]) if parts[1] else None,
-                            dead=parts[2] == "1",
+                    if len(parts) >= 3:
+                        panes.append(
+                            PaneInfo(
+                                index=int(parts[0]),
+                                pid=int(parts[1]) if parts[1] else None,
+                                dead=parts[2] == "1",
+                            )
                         )
-                    )
             return panes
         except subprocess.CalledProcessError:
             return []
@@ -389,7 +390,7 @@ class ControlWindow:
         elif key == curses.KEY_UP:
             self.selected_index = max(0, self.selected_index - 1)
 
-        elif key == curses.KEY_DOWN:
+        elif key == curses.KEY_DOWN and self.jobs:
             self.selected_index = min(len(self.jobs) - 1, self.selected_index + 1)
 
         elif ord("0") <= key <= ord("9"):
@@ -403,7 +404,7 @@ class ControlWindow:
                     )
                     break
 
-        elif key == ord("\n") or key == ord(" "):
+        elif (key == ord("\n") or key == ord(" ")) and self.jobs:
             # Select job
             job = self.jobs[self.selected_index]
             _ = subprocess.run(


### PR DESCRIPTION
## Summary

Six edge-case crash fixes across RL, preference, and xmux modules.

- **preference_envs: ZeroDivisionError when matchup_count is 0** — With `group_size=1`, no pairwise comparisons are generated so `matchup_count` stays `[0]`. Fixed by guarding division: `win_minus_loss / mc if mc > 0 else 0.0`.

- **preference/types: IndexError when no weights equal 1.0** — `torch.nonzero(weights == 1.0)[0]` crashes on an empty tensor if a degenerate comparison has no weight-1 tokens. Fixed by checking `len(nonzero_indices) == 0` and returning the untruncated input.

- **rl/metrics: ValueError from max()/min() on empty list** — `compute_sampling_metrics` crashes when all trajectory groups in a streaming minibatch failed. Fixed by returning an empty dict early when the input list is empty.

- **lr_scheduling: ZeroDivisionError when total_steps=0** — `step / total_steps` crashes with an empty dataset. Fixed by raising `ConfigurationError` with a clear message instead.

- **model_info: ValueError on model names without "/"** — `org, model = name.split("/")` fails with an unhelpful unpacking error. Fixed by validating the format first and using `split("/", 1)`.

- **xmux/control: IndexError with empty jobs list** — DOWN arrow sets `selected_index = min(-1, ...)`, and Enter/Space accesses `self.jobs[self.selected_index]` without a guard. Fixed by adding `and self.jobs` guards (matching the existing "k" handler pattern). Also guards malformed tmux output with `len(parts) >= 3`.

## Test plan
- [x] 1229 tests pass, 79 skipped (same as main)
- [x] All fixes are defensive guards that don't change behavior for valid inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)