### PR TITLE
tutorials: add an optional text input for the Tinker API key

### DIFF
--- a/tutorials/101_hello_tinker.py
+++ b/tutorials/101_hello_tinker.py
@@ -62,8 +62,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(api_key, mo, tinker):

--- a/tutorials/101_hello_tinker.py
+++ b/tutorials/101_hello_tinker.py
@@ -60,7 +60,23 @@ def _(mo):
 
 
 @app.cell
-async def _(tinker):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(api_key, mo, tinker):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     # Create a ServiceClient. This reads TINKER_API_KEY from your environment.
     service_client = tinker.ServiceClient()
 

--- a/tutorials/102_first_sft.py
+++ b/tutorials/102_first_sft.py
@@ -66,8 +66,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(api_key, mo, tinker):

--- a/tutorials/102_first_sft.py
+++ b/tutorials/102_first_sft.py
@@ -64,7 +64,23 @@ def _(mo):
 
 
 @app.cell
-async def _(tinker):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(api_key, mo, tinker):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     BASE_MODEL = "Qwen/Qwen3.5-4B"
 
     service_client = tinker.ServiceClient()

--- a/tutorials/103_async_patterns.py
+++ b/tutorials/103_async_patterns.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.0"
 app = marimo.App()
 
 
@@ -48,16 +48,37 @@ def _(mo):
 
 
 @app.cell
-async def _(get_renderer, tinker):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+
+@app.cell
+async def _(api_key, get_renderer, mo, tinker):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     BASE_MODEL = "Qwen/Qwen3.5-4B"
 
     service_client = tinker.ServiceClient()
-    sampling_client = await service_client.create_sampling_client_async(base_model=BASE_MODEL)
+    sampling_client = await service_client.create_sampling_client_async(
+        base_model=BASE_MODEL
+    )
     tokenizer = sampling_client.get_tokenizer()
     renderer = get_renderer("qwen3_5", tokenizer)
 
     stop_sequences = renderer.get_stop_sequences()
-    params = tinker.SamplingParams(max_tokens=150, temperature=0.7, stop=stop_sequences)
+    params = tinker.SamplingParams(
+        max_tokens=150, temperature=0.7, stop=stop_sequences
+    )
 
     # A diverse set of prompts to sample from
     prompts = [
@@ -87,7 +108,14 @@ def _(mo):
 
 
 @app.cell
-async def _(get_text_content, params, prompts, renderer, sampling_client, time):
+async def _(
+    get_text_content,
+    params,
+    prompts,
+    renderer,
+    sampling_client,
+    time,
+):
     _start = time.time()
     sequential_results = []
     for _prompt_text in prompts:
@@ -122,6 +150,7 @@ def _(mo):
 
 @app.cell
 async def _(
+    asyncio,
     get_text_content,
     params,
     prompts,
@@ -130,8 +159,6 @@ async def _(
     sequential_time,
     time,
 ):
-    import asyncio
-
     _start = time.time()
 
     # Step 1: Submit ALL requests concurrently using asyncio.gather
@@ -209,7 +236,14 @@ def _(mo):
 
 
 @app.cell
-async def _(get_text_content, params, prompts, renderer, sampling_client, time):
+async def _(
+    get_text_content,
+    params,
+    prompts,
+    renderer,
+    sampling_client,
+    time,
+):
     import asyncio
 
     _GROUP_SIZE = 4
@@ -238,7 +272,7 @@ async def _(get_text_content, params, prompts, renderer, sampling_client, time):
     batch_time = time.time() - _start
     print(f"Total: {total_completions} completions in {batch_time:.1f}s")
     print(f"Throughput: {total_completions / batch_time:.1f} completions/second")
-    return
+    return (asyncio,)
 
 
 @app.cell(hide_code=True)

--- a/tutorials/103_async_patterns.py
+++ b/tutorials/103_async_patterns.py
@@ -50,7 +50,7 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
 
 
@@ -69,16 +69,12 @@ async def _(api_key, get_renderer, mo, tinker):
     BASE_MODEL = "Qwen/Qwen3.5-4B"
 
     service_client = tinker.ServiceClient()
-    sampling_client = await service_client.create_sampling_client_async(
-        base_model=BASE_MODEL
-    )
+    sampling_client = await service_client.create_sampling_client_async(base_model=BASE_MODEL)
     tokenizer = sampling_client.get_tokenizer()
     renderer = get_renderer("qwen3_5", tokenizer)
 
     stop_sequences = renderer.get_stop_sequences()
-    params = tinker.SamplingParams(
-        max_tokens=150, temperature=0.7, stop=stop_sequences
-    )
+    params = tinker.SamplingParams(max_tokens=150, temperature=0.7, stop=stop_sequences)
 
     # A diverse set of prompts to sample from
     prompts = [

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -72,7 +72,23 @@ def _(mo):
 
 
 @app.cell
-async def _(get_renderer, tinker):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(api_key, get_renderer, mo, tinker):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     base_model = "meta-llama/Llama-3.1-8B"
 
     service_client = tinker.ServiceClient()

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -74,8 +74,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(api_key, get_renderer, mo, tinker):

--- a/tutorials/202_loss_functions.py
+++ b/tutorials/202_loss_functions.py
@@ -52,7 +52,23 @@ def _(mo):
 
 
 @app.cell
-async def _(tinker):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(api_key, mo, tinker):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
 
     service_client = tinker.ServiceClient()

--- a/tutorials/202_loss_functions.py
+++ b/tutorials/202_loss_functions.py
@@ -54,8 +54,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(api_key, mo, tinker):

--- a/tutorials/203_completers.py
+++ b/tutorials/203_completers.py
@@ -96,7 +96,23 @@ def _(mo):
 
 
 @app.cell
-def _(get_renderer, tinker):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+def _(api_key, get_renderer, mo, tinker):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
 
     service_client = tinker.ServiceClient()

--- a/tutorials/203_completers.py
+++ b/tutorials/203_completers.py
@@ -98,8 +98,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 def _(api_key, get_renderer, mo, tinker):

--- a/tutorials/204_weights.py
+++ b/tutorials/204_weights.py
@@ -56,7 +56,23 @@ def _(mo):
 
 
 @app.cell
-async def _(TensorData, tinker, torch):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(TensorData, api_key, mo, tinker, torch):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
 
     service_client = tinker.ServiceClient()

--- a/tutorials/204_weights.py
+++ b/tutorials/204_weights.py
@@ -58,8 +58,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(TensorData, api_key, mo, tinker, torch):

--- a/tutorials/205_evaluations.py
+++ b/tutorials/205_evaluations.py
@@ -93,7 +93,23 @@ def _(mo):
 
 
 @app.cell
-async def _(TensorData, get_renderer, tinker, torch):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(TensorData, api_key, get_renderer, mo, tinker, torch):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
 
     service_client = tinker.ServiceClient()

--- a/tutorials/205_evaluations.py
+++ b/tutorials/205_evaluations.py
@@ -95,8 +95,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(TensorData, api_key, get_renderer, mo, tinker, torch):

--- a/tutorials/301_cookbook_abstractions.py
+++ b/tutorials/301_cookbook_abstractions.py
@@ -209,6 +209,12 @@ def _(mo):
 
 
 @app.cell
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
 async def _(
     GROUP_SIZE,
     MODEL_NAME,
@@ -216,11 +222,23 @@ async def _(
     ProblemGroupBuilder,
     TinkerTokenCompleter,
     TrajectoryGroup,
+    api_key,
     do_group_rollout,
+    mo,
     partial,
     renderer,
     tinker,
 ):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     LORA_RANK = 32
     MAX_TOKENS = 512
     service_client = tinker.ServiceClient()

--- a/tutorials/301_cookbook_abstractions.py
+++ b/tutorials/301_cookbook_abstractions.py
@@ -211,8 +211,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(

--- a/tutorials/302_custom_environment.py
+++ b/tutorials/302_custom_environment.py
@@ -207,8 +207,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(FormatEnv, api_key, get_renderer, get_tokenizer, mo, tinker):

--- a/tutorials/302_custom_environment.py
+++ b/tutorials/302_custom_environment.py
@@ -205,7 +205,23 @@ def _(mo):
 
 
 @app.cell
-async def _(FormatEnv, get_renderer, get_tokenizer, tinker):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(FormatEnv, api_key, get_renderer, get_tokenizer, mo, tinker):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     # Create a renderer (we need a tokenizer for this)
     MODEL_NAME = "Qwen/Qwen3.5-4B"
     service_client = tinker.ServiceClient()

--- a/tutorials/303_sft_with_config.py
+++ b/tutorials/303_sft_with_config.py
@@ -183,7 +183,24 @@ def _(mo):
 
 
 @app.cell
-def _(asyncio, config, train):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key  # noqa: B018
+    return (api_key,)
+
+
+@app.cell
+def _(api_key, asyncio, config, mo, train):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     # Run the full SFT pipeline
     asyncio.run(train.main(config))
     return

--- a/tutorials/304_rl_with_config.py
+++ b/tutorials/304_rl_with_config.py
@@ -209,7 +209,24 @@ def _(ArithmeticDatasetBuilder):
 
 
 @app.cell
-def _(asyncio, rl_config, rl_train):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key  # noqa: B018
+    return (api_key,)
+
+
+@app.cell
+def _(api_key, asyncio, mo, rl_config, rl_train):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     # Run the full RL pipeline
     asyncio.run(rl_train.main(rl_config))
     return

--- a/tutorials/404_sequence_extension.py
+++ b/tutorials/404_sequence_extension.py
@@ -82,19 +82,19 @@ def _(TokensWithLogprobs, Trajectory, Transition, tinker, trajectory_to_data):
     transitions = [
         Transition(
             ob=tinker.ModelInput.from_ints(o1),
-            ac=TokensWithLogprobs(tokens=a1, logprobs=[-0.5, -0.3]),
+            ac=TokensWithLogprobs(tokens=a1, maybe_logprobs=[-0.5, -0.3]),
             reward=0.0,
             episode_done=False,
         ),
         Transition(
             ob=tinker.ModelInput.from_ints(o1 + a1 + o2),  # Extends previous
-            ac=TokensWithLogprobs(tokens=a2, logprobs=[-0.4, -0.2, -0.1]),
+            ac=TokensWithLogprobs(tokens=a2, maybe_logprobs=[-0.4, -0.2, -0.1]),
             reward=0.0,
             episode_done=False,
         ),
         Transition(
             ob=tinker.ModelInput.from_ints(o1 + a1 + o2 + a2 + o3),  # Extends again
-            ac=TokensWithLogprobs(tokens=a3, logprobs=[-0.6, -0.3]),
+            ac=TokensWithLogprobs(tokens=a3, maybe_logprobs=[-0.6, -0.3]),
             reward=1.0,
             episode_done=True,
         ),
@@ -132,13 +132,13 @@ def _(TokensWithLogprobs, Trajectory, Transition, tinker, trajectory_to_data):
     transitions_split = [
         Transition(
             ob=tinker.ModelInput.from_ints([100, 101]),
-            ac=TokensWithLogprobs(tokens=[200, 201], logprobs=[-0.5, -0.3]),
+            ac=TokensWithLogprobs(tokens=[200, 201], maybe_logprobs=[-0.5, -0.3]),
             reward=0.5,
             episode_done=False,
         ),
         Transition(
             ob=tinker.ModelInput.from_ints([300, 301, 302]),  # New context, not a prefix
-            ac=TokensWithLogprobs(tokens=[400, 401], logprobs=[-0.4, -0.2]),
+            ac=TokensWithLogprobs(tokens=[400, 401], maybe_logprobs=[-0.4, -0.2]),
             reward=0.5,
             episode_done=True,
         ),

--- a/tutorials/406_prompt_distillation.py
+++ b/tutorials/406_prompt_distillation.py
@@ -143,11 +143,14 @@ def _():
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
 
+
 @app.cell
-async def _(CLASSIFICATION_PROMPT, SENTENCES, api_key, get_tokenizer, mo, re, renderers, tinker, types):
+async def _(
+    CLASSIFICATION_PROMPT, SENTENCES, api_key, get_tokenizer, mo, re, renderers, tinker, types
+):
     import os
 
     mo.stop(

--- a/tutorials/406_prompt_distillation.py
+++ b/tutorials/406_prompt_distillation.py
@@ -141,7 +141,23 @@ def _():
 
 
 @app.cell
-async def _(CLASSIFICATION_PROMPT, SENTENCES, get_tokenizer, re, renderers, tinker, types):
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(CLASSIFICATION_PROMPT, SENTENCES, api_key, get_tokenizer, mo, re, renderers, tinker, types):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
     tokenizer = get_tokenizer(MODEL_NAME)
     renderer = renderers.get_renderer("qwen3", tokenizer)

--- a/tutorials/407_rlhf_pipeline.py
+++ b/tutorials/407_rlhf_pipeline.py
@@ -98,6 +98,12 @@ def _(mo):
 
 
 @app.cell
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
 def _(
     BASE_MODEL,
     BATCH_SIZE,
@@ -105,9 +111,21 @@ def _(
     LORA_RANK,
     MAX_LENGTH,
     TrainOnWhat,
+    api_key,
     asyncio,
+    mo,
     renderer_name,
 ):
+    import os
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
+
     from tinker_cookbook.recipes.chat_sl.chat_datasets import NoRobotsBuilder
     from tinker_cookbook.supervised import train as supervised_train
     from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig

--- a/tutorials/407_rlhf_pipeline.py
+++ b/tutorials/407_rlhf_pipeline.py
@@ -100,8 +100,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 def _(

--- a/tutorials/501_export_hf.py
+++ b/tutorials/501_export_hf.py
@@ -6,9 +6,11 @@ app = marimo.App()
 
 @app.cell
 def _():
+    import os
+
     import marimo as mo
 
-    return (mo,)
+    return mo, os
 
 
 @app.cell(hide_code=True)
@@ -44,12 +46,26 @@ def _(mo):
 
 
 @app.cell
-async def _():
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(api_key, mo, os):
     import tinker
 
     from tinker_cookbook import renderers
     from tinker_cookbook.supervised.data import conversation_to_datum
     from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
 
     BASE_MODEL = "Qwen/Qwen3.5-4B"
 
@@ -136,8 +152,7 @@ def _(mo):
 
 
 @app.cell
-def _(OUTPUT_PATH):
-    import os
+def _(OUTPUT_PATH, os):
 
     for _f in sorted(os.listdir(OUTPUT_PATH)):
         _size_mb = os.path.getsize(os.path.join(OUTPUT_PATH, _f)) / 1e6

--- a/tutorials/501_export_hf.py
+++ b/tutorials/501_export_hf.py
@@ -48,8 +48,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(api_key, mo, os):
@@ -153,7 +154,6 @@ def _(mo):
 
 @app.cell
 def _(OUTPUT_PATH, os):
-
     for _f in sorted(os.listdir(OUTPUT_PATH)):
         _size_mb = os.path.getsize(os.path.join(OUTPUT_PATH, _f)) / 1e6
         print(f"  {_f:45s} {_size_mb:>8.1f} MB")

--- a/tutorials/502_lora_adapter.py
+++ b/tutorials/502_lora_adapter.py
@@ -45,8 +45,9 @@ def _(mo):
 @app.cell
 def _(mo):
     api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
-    api_key
+    api_key  # noqa: B018
     return (api_key,)
+
 
 @app.cell
 async def _(api_key, mo, os):

--- a/tutorials/502_lora_adapter.py
+++ b/tutorials/502_lora_adapter.py
@@ -6,9 +6,11 @@ app = marimo.App()
 
 @app.cell
 def _():
+    import os
+
     import marimo as mo
 
-    return (mo,)
+    return mo, os
 
 
 @app.cell(hide_code=True)
@@ -41,12 +43,26 @@ def _(mo):
 
 
 @app.cell
-async def _():
+def _(mo):
+    api_key = mo.ui.text(kind="password", label="Paste your Tinker API key")
+    api_key
+    return (api_key,)
+
+@app.cell
+async def _(api_key, mo, os):
     import tinker
 
     from tinker_cookbook import renderers
     from tinker_cookbook.supervised.data import conversation_to_datum
     from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+    mo.stop(
+        "TINKER_API_KEY" not in os.environ and not api_key.value,
+        "Paste your API key above",
+    )
+
+    if api_key.value:
+        os.environ["TINKER_API_KEY"] = api_key.value
 
     BASE_MODEL = "Qwen/Qwen3.5-4B"
 
@@ -134,9 +150,8 @@ def _(mo):
 
 
 @app.cell
-def _(PEFT_OUTPUT):
+def _(PEFT_OUTPUT, os):
     import json
-    import os
 
     for f in sorted(os.listdir(PEFT_OUTPUT)):
         size_mb = os.path.getsize(os.path.join(PEFT_OUTPUT, f)) / 1e6

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -26,55 +26,57 @@ marimo edit tutorials/101_hello_tinker.py
 
 This opens the notebook in your browser with an interactive editor. Rendered versions are also available on the [Tinker docs site](https://tinker-docs.thinkingmachines.ai/tutorials).
 
+Alternatively, you can try notebooks online in [molab](https://molab.marimo.io/notebooks), using the links below.
+
 ## Tutorials
 
 ### Basics (1xx)
 
-| # | Notebook | What you'll learn |
-|---|----------|-------------------|
-| 101 | [Hello Tinker](101_hello_tinker.py) | Architecture overview, client hierarchy, sampling from a model |
-| 102 | [Your First SFT](102_first_sft.py) | Renderers, datum construction, training loop |
-| 103 | [Async Patterns](103_async_patterns.py) | Concurrent futures, `num_samples`, batch evaluation throughput |
-| 104 | [First RL](104_first_rl.py) | GRPO on GSM8K: reward functions, group-relative advantages |
+| # | Notebook | What you'll learn | Try on molab |
+|---|----------|-------------------|--------------|
+| 101 | [Hello Tinker](101_hello_tinker.py) | Architecture overview, client hierarchy, sampling from a model | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/101_hello_tinker.py) |
+| 102 | [Your First SFT](102_first_sft.py) | Renderers, datum construction, training loop | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/102_first_sft.py) |
+| 103 | [Async Patterns](103_async_patterns.py) | Concurrent futures, `num_samples`, batch evaluation throughput | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/103_async_patterns.py) |
+| 104 | [First RL](104_first_rl.py) | GRPO on GSM8K: reward functions, group-relative advantages | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/104_first_rl.py) |
 
 ### Core Concepts (2xx)
 
-| # | Notebook | What you'll learn |
-|---|----------|-------------------|
-| 201 | [Rendering](201_rendering.py) | Renderers, tokenization, vision inputs, TrainOnWhat |
-| 202 | [Loss Functions](202_loss_functions.py) | cross_entropy, IS, PPO, CISPO, custom loss |
-| 203 | [Completers](203_completers.py) | TokenCompleter vs MessageCompleter, LLM-as-judge |
-| 204 | [Weights](204_weights.py) | Checkpoint lifecycle, save/load/download/TTL |
-| 205 | [Evaluations](205_evaluations.py) | Custom evaluators, NLL, Inspect AI |
+| # | Notebook | What you'll learn | Try on molab |
+|---|----------|-------------------|--------------|
+| 201 | [Rendering](201_rendering.py) | Renderers, tokenization, vision inputs, TrainOnWhat | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/201_rendering.py) |
+| 202 | [Loss Functions](202_loss_functions.py) | cross_entropy, IS, PPO, CISPO, custom loss | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/202_loss_functions.py) |
+| 203 | [Completers](203_completers.py) | TokenCompleter vs MessageCompleter, LLM-as-judge | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/203_completers.py) |
+| 204 | [Weights](204_weights.py) | Checkpoint lifecycle, save/load/download/TTL | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/204_weights.py) |
+| 205 | [Evaluations](205_evaluations.py) | Custom evaluators, NLL, Inspect AI | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/205_evaluations.py) |
 
 ### Cookbook Abstractions (3xx)
 
-| # | Notebook | What you'll learn |
-|---|----------|-------------------|
-| 301 | [Cookbook Abstractions](301_cookbook_abstractions.py) | `Env`, `EnvGroupBuilder`, `RLDataset`, `ProblemEnv` |
-| 302 | [Custom Environment](302_custom_environment.py) | Build your own `ProblemEnv` subclass and `RLDataset` |
-| 303 | [SFT with Config](303_sft_with_config.py) | `train.Config`, `ChatDatasetBuilder`, `train.main()` |
-| 304 | [RL with Config](304_rl_with_config.py) | `RLDatasetBuilder`, RL training pipeline |
+| # | Notebook | What you'll learn | Try on molab |
+|---|----------|-------------------|--------------|
+| 301 | [Cookbook Abstractions](301_cookbook_abstractions.py) | `Env`, `EnvGroupBuilder`, `RLDataset`, `ProblemEnv` | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/301_cookbook_abstractions.py) |
+| 302 | [Custom Environment](302_custom_environment.py) | Build your own `ProblemEnv` subclass and `RLDataset` | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/302_custom_environment.py) |
+| 303 | [SFT with Config](303_sft_with_config.py) | `train.Config`, `ChatDatasetBuilder`, `train.main()` | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/303_sft_with_config.py) |
+| 304 | [RL with Config](304_rl_with_config.py) | `RLDatasetBuilder`, RL training pipeline | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/304_rl_with_config.py) |
 
 ### Advanced (4xx)
 
-| # | Notebook | What you'll learn |
-|---|----------|-------------------|
-| 401 | [SL Hyperparameters](401_sl_hyperparams.py) | LR scaling, rank selection, sweeps |
-| 402 | [RL Hyperparameters](402_rl_hyperparams.py) | KL penalty, group size, advantages |
-| 403 | [DPO & Preferences](403_dpo_preferences.py) | Comparison, DPO loss, PreferenceModel |
-| 404 | [Sequence Extension](404_sequence_extension.py) | Multi-turn RL, conversation masks |
-| 405 | [Multi-Agent RL](405_multi_agent.py) | MessageEnv, self-play, group rewards |
-| 406 | [Prompt Distillation](406_prompt_distillation.py) | Teacher/student, context distillation |
-| 407 | [RLHF Pipeline](407_rlhf_pipeline.py) | 3-stage SFT, preference model, RL |
+| # | Notebook | What you'll learn | Try on molab |
+|---|----------|-------------------|--------------|
+| 401 | [SL Hyperparameters](401_sl_hyperparams.py) | LR scaling, rank selection, sweeps | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/401_sl_hyperparams.py) |
+| 402 | [RL Hyperparameters](402_rl_hyperparams.py) | KL penalty, group size, advantages | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/402_rl_hyperparams.py) |
+| 403 | [DPO & Preferences](403_dpo_preferences.py) | Comparison, DPO loss, PreferenceModel | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/403_dpo_preferences.py) |
+| 404 | [Sequence Extension](404_sequence_extension.py) | Multi-turn RL, conversation masks | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/404_sequence_extension.py) |
+| 405 | [Multi-Agent RL](405_multi_agent.py) | MessageEnv, self-play, group rewards | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/405_multi_agent.py) |
+| 406 | [Prompt Distillation](406_prompt_distillation.py) | Teacher/student, context distillation | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/406_prompt_distillation.py) |
+| 407 | [RLHF Pipeline](407_rlhf_pipeline.py) | 3-stage SFT, preference model, RL | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/407_rlhf_pipeline.py) |
 
 ### Deployment (5xx)
 
-| # | Notebook | What you'll learn |
-|---|----------|-------------------|
-| 501 | [Export to HF](501_export_hf.py) | Merge LoRA into full model |
-| 502 | [Build LoRA Adapter](502_lora_adapter.py) | PEFT format for vLLM/SGLang |
-| 503 | [Publish to Hub](503_publish_hub.py) | Upload to HuggingFace with model card |
+| # | Notebook | What you'll learn | Try on molab |
+|---|----------|-------------------|--------------|
+| 501 | [Export to HF](501_export_hf.py) | Merge LoRA into full model | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/501_export_hf.py) |
+| 502 | [Build LoRA Adapter](502_lora_adapter.py) | PEFT format for vLLM/SGLang | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/502_lora_adapter.py) |
+| 503 | [Publish to Hub](503_publish_hub.py) | Upload to HuggingFace with model card | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/503_publish_hub.py) |
 
 Work through them in order — each builds on concepts from the previous one.
 


### PR DESCRIPTION
This PR adds a text input to each marimo tutorial notebook for inputting their API key, in case they did not set it in their environment before opening the notebook. If an API key was already present in the environment, then the notebook proceeds as before.

Additionally, this PR fixes an unrelated bug in `103_async_patterns.py`, which previously redefined a variable.

Finally, this PR adds "open in molab" links to the tutorials readme, making is easy for users to run the tutorials online should they wish.

<img width="827" height="1107" alt="image" src="https://github.com/user-attachments/assets/a993d0b4-77b7-4bfb-9201-ae6bc20e86e1" />

P.S. I am the original creator of marimo. It was very cool to see you all use marimo for these tutorials. Thanks!
