### PR TITLE
Add cispo and dro loss function examples

### DIFF
--- a/tinker_cookbook/recipes/math_rl/README.md
+++ b/tinker_cookbook/recipes/math_rl/README.md
@@ -65,6 +65,61 @@ So the best possible is sum1=20 and sum2=21, product 420. So the maximum sum is 
 \boxed{420}<|im_end|>
 ```
 
+## Choosing a loss function
+
+The `loss_fn` flag selects which policy-gradient loss to use. The default is `importance_sampling` (REINFORCE with IS correction). You can switch to `ppo`, `cispo`, or `dro` to compare training stability and final performance on the same task.
+
+### CISPO (Conservative Importance Sampling PPO)
+
+CISPO clips the importance-sampling ratio but applies it as a weight on the log-probability rather than on the advantage. This can be more stable than PPO when the policy drifts far off-policy.
+
+```bash
+python -m tinker_cookbook.recipes.math_rl.train \
+    env=arithmetic loss_fn=cispo \
+    model_name="meta-llama/Llama-3.2-1B" \
+    group_size=4 groups_per_batch=100 learning_rate=1e-4
+```
+
+You can tune the clipping range via `loss_fn_config`:
+
+```bash
+python -m tinker_cookbook.recipes.math_rl.train \
+    env=arithmetic loss_fn=cispo \
+    'loss_fn_config={"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}' \
+    model_name="meta-llama/Llama-3.2-1B" \
+    group_size=4 groups_per_batch=100 learning_rate=1e-4
+```
+
+### DRO (Distributionally Robust Optimization)
+
+DRO optimizes for worst-case performance across the batch, which can improve robustness on harder examples at the cost of slower average improvement.
+
+```bash
+python -m tinker_cookbook.recipes.math_rl.train \
+    env=arithmetic loss_fn=dro \
+    model_name="meta-llama/Llama-3.2-1B" \
+    group_size=4 groups_per_batch=100 learning_rate=1e-4
+```
+
+### Comparing loss functions on MATH
+
+To compare loss functions on a harder task, run the same configuration with different `loss_fn` values:
+
+```bash
+for loss in importance_sampling ppo cispo dro; do
+    python -m tinker_cookbook.recipes.math_rl.train \
+        env=math loss_fn=$loss \
+        model_name="Qwen/Qwen3-8B" \
+        group_size=16 groups_per_batch=64 learning_rate=2e-5 max_tokens=512 \
+        wandb_project=math-loss-comparison wandb_name="math-$loss"
+done
+```
+
+Compare the `test/env/all/correct` metric across runs to see how each loss affects convergence speed and final accuracy. As a rule of thumb:
+- Start with `importance_sampling` (unbounded ratio, fastest convergence on-policy)
+- Try `ppo` or `cispo` if you see instability from large policy updates
+- Try `dro` if you want to improve worst-case performance across problem types
+
 # RL on GSM8K
 
 ```bash

--- a/tutorials/202_loss_functions.py
+++ b/tutorials/202_loss_functions.py
@@ -21,7 +21,7 @@ def _(mo):
     In this tutorial you will:
 
     1. Prepare simple training data
-    2. Run `forward_backward` with `cross_entropy`, `importance_sampling`, `ppo`, and `cispo`
+    2. Run `forward_backward` with `cross_entropy`, `importance_sampling`, `ppo`, `cispo`, and `dro`
     3. Write a custom loss with `forward_backward_custom`
     4. Compare loss values and understand when to use each
     """)
@@ -95,6 +95,7 @@ def _(mo):
     | `importance_sampling` | `target_tokens`, `logprobs`, `advantages` |
     | `ppo` | `target_tokens`, `logprobs`, `advantages` |
     | `cispo` | `target_tokens`, `logprobs`, `advantages` |
+    | `dro` | `target_tokens`, `logprobs`, `advantages` |
 
     We will create one SFT datum and one RL datum (reused across the RL losses).
     """)
@@ -181,7 +182,12 @@ async def _(rl_datum, sft_datum, training_client):
     cispo_future = await training_client.forward_backward_async([rl_datum], loss_fn="cispo")
     cispo_result = await cispo_future.result_async()
     print(f"cispo              loss:sum = {cispo_result.metrics['loss:sum']:.4f}")
-    return ce_result, cispo_result, is_result, ppo_result
+
+    # DRO (distributionally robust optimization)
+    dro_future = await training_client.forward_backward_async([rl_datum], loss_fn="dro")
+    dro_result = await dro_future.result_async()
+    print(f"dro                loss:sum = {dro_result.metrics['loss:sum']:.4f}")
+    return ce_result, cispo_result, dro_result, is_result, ppo_result
 
 
 @app.cell(hide_code=True)
@@ -306,9 +312,10 @@ def _(mo):
     | `importance_sampling` | RL with on-policy or near-on-policy data | Corrects for sampler/learner mismatch; unbounded ratio |
     | `ppo` | RL with multiple gradient steps per rollout | Clips the IS ratio to prevent large updates |
     | `cispo` | RL; alternative to PPO | Clips the ratio but applies it as a weight on log-prob; sometimes more stable |
+    | `dro` | RL; robustness to hard examples | Distributionally robust optimization; improves worst-case performance across the batch |
     | `forward_backward_custom` | DPO, custom regularizers, research losses | Full flexibility; 1.5x FLOPs due to extra forward pass |
 
-    **Rule of thumb:** Start with `cross_entropy` for SFT and `importance_sampling` for RL. Switch to `ppo` or `cispo` if you see training instability from large policy updates. Use `forward_backward_custom` for anything that does not fit the built-in losses.
+    **Rule of thumb:** Start with `cross_entropy` for SFT and `importance_sampling` for RL. Switch to `ppo` or `cispo` if you see training instability from large policy updates. Try `dro` if you want to optimize for worst-case performance across problem types. Use `forward_backward_custom` for anything that does not fit the built-in losses.
     """)
     return
 


### PR DESCRIPTION
Closes #282.

Adds runnable examples for the `cispo` and `dro` loss functions, which were listed in the SDK but had no recipe coverage.

Changes:
- `recipes/math_rl/README.md` — CLI examples for `cispo` and `dro`, including a `loss_fn_config` override for CISPO clipping thresholds, and a loss-function sweep command using the existing `math_rl` recipe for side-by-side comparison on the same task
- `tutorials/202_loss_functions.py` — `dro` added to the forward_backward comparison cell, the required-inputs table, and the "when to use" reference table

No new recipes or scripts — the `math_rl` CLI already accepts `loss_fn=<name>` and `loss_fn_config=...`, so the fix is documentation plus one tutorial cell.