### PR TITLE
Serialize conversation history in AgentToolMessageEnv 

### DIFF
--- a/tinker_cookbook/tool_use/agent_tool_message_env.py
+++ b/tinker_cookbook/tool_use/agent_tool_message_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
@@ -12,6 +13,7 @@ from tinker_cookbook.renderers.base import (
     ToolCall,
     format_content_as_string,
     get_text_content,
+    message_to_jsonable,
 )
 from tinker_cookbook.rl import types
 from tinker_cookbook.rl.message_env import EnvFromMessageEnv, MessageEnv, MessageStepResult
@@ -118,6 +120,9 @@ class AgentToolMessageEnv(MessageEnv):
         if done:
             reward, reward_metrics = await self.reward_fn(self.history)
             metrics.update(reward_metrics)
+            logs["conversation_history"] = json.dumps(
+                [message_to_jsonable(m) for m in self.history]
+            )
 
         return MessageStepResult(
             reward=reward,

--- a/tinker_cookbook/tool_use/agent_tool_message_env_test.py
+++ b/tinker_cookbook/tool_use/agent_tool_message_env_test.py
@@ -160,7 +160,7 @@ class TestStepLogs:
         assert result.logs["tool_result_1"] == "42"
 
     def test_logs_no_tool_calls(self):
-        """When there are no tool calls, only assistant_content is logged."""
+        """When there are no tool calls, only assistant_content and conversation_history are logged."""
         env = AgentToolMessageEnv(
             tools=[],
             initial_messages=[{"role": "user", "content": "hi"}],
@@ -171,7 +171,8 @@ class TestStepLogs:
 
         result = asyncio.run(env.step({"role": "assistant", "content": "Just text."}))
 
-        assert result.logs == {"assistant_content": "Just text."}
+        assert result.logs["assistant_content"] == "Just text."
+        assert "conversation_history" in result.logs
         assert "tool_call_0" not in result.logs
         assert "tool_result_0" not in result.logs
 


### PR DESCRIPTION
## Summary
- On episode end in `AgentToolMessageEnv.step()`, serializes `self.history` into `logs["conversation_history"]` as JSON
- Uses existing `message_to_jsonable()` to handle ToolCall pydantic objects and PIL images