### PR TITLE
feat(renderers): add Nemotron-Cascade-2-30B-A3B support

### DIFF
--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -4,6 +4,7 @@ Uses existing modules but with a simple, flat training loop.
 """
 
 import logging
+import math
 import time
 
 import chz
@@ -55,7 +56,7 @@ def main(config: Config):
     assert isinstance(dataset, datasets.DatasetDict)
     train_dataset = dataset["train"]
 
-    n_train_batches = len(train_dataset) // config.batch_size
+    n_train_batches = math.ceil(len(train_dataset) / config.batch_size)
     logger.info(f"Train batches: {n_train_batches}")
 
     # Setup training client

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -106,12 +106,18 @@ def get_renderer(
             - "qwen3_vl_instruct": Qwen3 vision-language instruct (no thinking)
             - "qwen3_disable_thinking": Qwen3 with thinking disabled
             - "qwen3_instruct": Qwen3 instruct 2507 (no thinking)
+            - "qwen3_5": Qwen3.5 VL with thinking
+            - "qwen3_5_disable_thinking": Qwen3.5 VL with thinking disabled
             - "deepseekv3": DeepSeek V3 (defaults to non-thinking mode)
             - "deepseekv3_disable_thinking": DeepSeek V3 non-thinking (alias)
             - "deepseekv3_thinking": DeepSeek V3 thinking mode
             - "kimi_k2": Kimi K2 Thinking format
             - "kimi_k25": Kimi K2.5 with thinking enabled
             - "kimi_k25_disable_thinking": Kimi K2.5 with thinking disabled
+            - "nemotron3": Nemotron-3 with thinking enabled
+            - "nemotron3_disable_thinking": Nemotron-3 with thinking disabled
+            - "nemotron_cascade_2": Nemotron-Cascade-2-30B-A3B with thinking enabled
+            - "nemotron_cascade_2_disable_thinking": Nemotron-Cascade-2-30B-A3B without thinking
             - "gpt_oss_no_sysprompt": GPT-OSS without system prompt
             - "gpt_oss_low_reasoning": GPT-OSS with low reasoning
             - "gpt_oss_medium_reasoning": GPT-OSS with medium reasoning
@@ -132,17 +138,19 @@ def get_renderer(
         return renderer(tokenizer, image_processor)
 
     # Import renderer classes lazily to avoid circular imports and keep exports minimal
-    from tinker_cookbook.renderers.deepseek_v3 import DeepSeekV3DisableThinkingRenderer
+    from tinker_cookbook.renderers.deepseek_v3 import DeepSeekV3DisableThinkingRenderer, DeepSeekV3ThinkingRenderer
     from tinker_cookbook.renderers.gpt_oss import GptOssRenderer
     from tinker_cookbook.renderers.kimi_k2 import KimiK2Renderer
     from tinker_cookbook.renderers.kimi_k25 import KimiK25DisableThinkingRenderer, KimiK25Renderer
     from tinker_cookbook.renderers.llama3 import Llama3Renderer
+    from tinker_cookbook.renderers.nemotron3 import Nemotron3DisableThinkingRenderer, Nemotron3Renderer
     from tinker_cookbook.renderers.qwen3 import (
         Qwen3DisableThinkingRenderer,
         Qwen3InstructRenderer,
         Qwen3VLInstructRenderer,
         Qwen3VLRenderer,
     )
+    from tinker_cookbook.renderers.qwen3_5 import Qwen3_5DisableThinkingRenderer, Qwen3_5Renderer
     from tinker_cookbook.renderers.role_colon import RoleColonRenderer
 
     if name == "role_colon":
@@ -175,6 +183,20 @@ def get_renderer(
         return KimiK25Renderer(tokenizer, image_processor=image_processor)
     elif name == "kimi_k25_disable_thinking":
         return KimiK25DisableThinkingRenderer(tokenizer, image_processor=image_processor)
+    elif name == "nemotron3":
+        return Nemotron3Renderer(tokenizer)
+    elif name == "nemotron3_disable_thinking":
+        return Nemotron3DisableThinkingRenderer(tokenizer)
+    elif name == "nemotron_cascade_2":
+        # Nemotron-Cascade-2 uses the same format as Qwen3.5
+        return Qwen3_5Renderer(tokenizer, image_processor=image_processor)
+    elif name == "nemotron_cascade_2_disable_thinking":
+        # Nemotron-Cascade-2 without thinking mode
+        return Qwen3_5DisableThinkingRenderer(tokenizer, image_processor=image_processor)
+    elif name == "qwen3_5":
+        return Qwen3_5Renderer(tokenizer, image_processor=image_processor)
+    elif name == "qwen3_5_disable_thinking":
+        return Qwen3_5DisableThinkingRenderer(tokenizer, image_processor=image_processor)
     elif name == "gpt_oss_no_sysprompt":
         return GptOssRenderer(tokenizer, use_system_prompt=False)
     elif name == "gpt_oss_low_reasoning":

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -1,0 +1,358 @@
+"""
+Nemotron-3 family renderer.
+
+Nemotron-3 models (NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 and
+NVIDIA-Nemotron-3-Super-120B-A12B-BF16) use a chat format similar to Qwen3.5
+(im_start/im_end tokens, thinking blocks, XML-style tool calls) but differ in
+the following ways:
+
+1. Tool declarations: Nemotron-3 uses structured XML inside <tools>...</tools>
+   (Qwen3.5 uses JSON per line).
+
+2. System message ordering: system_prompt comes BEFORE tools text (Qwen3.5
+   puts tools first).
+
+3. Empty think block scope: Nemotron-3's HF template prepends <think></think>
+   to ALL assistant messages that lack thinking, including historical ones
+   (Qwen3.5 only does this for messages after the last user query).
+
+4. Think block separator: one newline between </think> and text content
+   (Qwen3.5 uses two newlines).
+
+5. Disable-thinking generation suffix: <think></think> with no trailing
+   newlines (Qwen3.5 uses <think>\\n\\n</think>\\n\\n).
+
+6. Empty system message injection: Nemotron-3's HF template always outputs
+   a system message block even when none is provided (it always sets
+   system_message = "" which is "defined" in Jinja2). Our renderer
+   prepends an empty system message in build_generation_prompt and
+   build_supervised_example to match this behavior.
+
+"""
+
+import dataclasses
+import json
+from collections.abc import Mapping
+
+from tinker_cookbook.renderers.base import (
+    ImagePart,
+    Message,
+    RenderContext,
+    RenderedMessage,
+    Role,
+    TextPart,
+    ToolSpec,
+)
+from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
+
+
+def _render_extra_keys(obj: Mapping[str, object], handled_keys: set[str]) -> list[str]:
+    """Render extra dict keys as XML, mirroring the HF template's render_extra_keys macro.
+
+    Dicts and lists are JSON-encoded; scalars are string-coerced.
+    """
+    lines: list[str] = []
+    for key, value in obj.items():
+        if key in handled_keys:
+            continue
+        if isinstance(value, (dict, list)):
+            lines.append(f"<{key}>{json.dumps(value)}</{key}>")
+        else:
+            lines.append(f"<{key}>{value!s}</{key}>")
+    return lines
+
+
+def _format_nemotron3_tool_declaration(tool: ToolSpec) -> str:
+    """Format a single tool declaration in Nemotron-3's XML format.
+
+    Mirrors the Jinja template logic from chat_template.jinja, including the
+    render_extra_keys macro that outputs additional parameter fields beyond
+    the core name/type/description/enum set (e.g. default, minimum, items).
+    """
+    lines = [
+        "<function>",
+        f"<name>{tool['name']}</name>",
+    ]
+    if tool.get("description", "").strip():
+        lines.append(f"<description>{tool['description'].strip()}</description>")
+    lines.append("<parameters>")
+    params = tool.get("parameters") or {}
+    if isinstance(params, dict) and "properties" in params:
+        for param_name, param_fields in params["properties"].items():
+            lines.append("<parameter>")
+            lines.append(f"<name>{param_name}</name>")
+            if "type" in param_fields:
+                lines.append(f"<type>{param_fields['type']!s}</type>")
+            if "description" in param_fields:
+                lines.append(f"<description>{param_fields['description'].strip()}</description>")
+            if "enum" in param_fields:
+                lines.append(f"<enum>{json.dumps(param_fields['enum'])}</enum>")
+            lines.extend(_render_extra_keys(param_fields, {"name", "type", "description", "enum"}))
+            lines.append("</parameter>")
+    if isinstance(params, dict):
+        lines.extend(_render_extra_keys(params, {"type", "properties", "required"}))
+    if isinstance(params, dict) and "required" in params:
+        lines.append(f"<required>{json.dumps(params['required'])}</required>")
+    lines.append("</parameters>")
+    lines.extend(_render_extra_keys(tool, {"type", "name", "description", "parameters"}))
+    lines.append("</function>")
+    return "\n".join(lines)
+
+
+class Nemotron3Renderer(Qwen3_5Renderer):
+    """Renderer for Nemotron-3 models.
+
+    Subclasses Qwen3_5Renderer for the shared im_start/im_end/thinking/tool-call
+    infrastructure, overriding the parts that differ from Qwen3.5:
+
+    - _assistant_header_suffix: adds <think></think> to ALL assistant messages
+      whose thinking will NOT appear in the output.
+    - render_message: strips thinking only for messages before last_user_index
+      (matching HF template's truncate_history_thinking condition).
+    - _format_thinking_text: one separator newline after </think> (not two).
+    - _format_tool_calls_chunks: single newline prefix + trailing newline after
+      each </tool_call> (matching HF template format).
+    - parse_response: strips one newline separator after </think> (not two).
+    - create_conversation_prefix_with_tools: XML tool declarations, system
+      prompt before tools.
+    - build_generation_prompt / build_supervised_example: inject empty system
+      message when none is present, matching HF template behavior.
+    """
+
+    def _normalize_messages(self, messages: list[Message]) -> list[Message]:
+        """Prepend empty system message if not present.
+
+        Nemotron-3's HF template always outputs a system message block even
+        when none is provided (because it always sets system_message = "" which
+        is "defined" in Jinja2). This ensures our token sequence matches.
+        """
+        if not messages or messages[0]["role"] != "system":
+            return [Message(role="system", content="")] + list(messages)
+        return messages
+
+    def build_generation_prompt(self, messages: list[Message], *args: object, **kwargs: object):  # type: ignore[override]
+        """Build generation prompt, prepending an empty system message if none exists.
+
+        Args:
+            messages (list[Message]): The conversation messages.
+            *args: Additional positional arguments passed to the parent.
+            **kwargs: Additional keyword arguments passed to the parent.
+
+        Returns:
+            tinker.ModelInput: The tokenized model input ready for sampling.
+        """
+        return super().build_generation_prompt(self._normalize_messages(messages), *args, **kwargs)  # type: ignore[arg-type]
+
+    def build_supervised_example(self, messages: list[Message], *args: object, **kwargs: object):  # type: ignore[override]
+        """Build supervised example, prepending an empty system message if none exists.
+
+        Args:
+            messages (list[Message]): The conversation messages for supervised training.
+            *args: Additional positional arguments passed to the parent.
+            **kwargs: Additional keyword arguments passed to the parent.
+
+        Returns:
+            tuple[tinker.ModelInput, torch.Tensor]: The tokenized model input and
+                per-token weight tensor.
+        """
+        return super().build_supervised_example(self._normalize_messages(messages), *args, **kwargs)  # type: ignore[arg-type]
+
+    def _assistant_header_suffix(self, message: Message, ctx: RenderContext) -> str:
+        """Prepend <think></think> when thinking will not appear in the output.
+
+        Nemotron-3's HF template prepends <think></think> to assistant message
+        content when there are no <think> tags in the output:
+        - Historical messages (idx < last_user_index): thinking is stripped,
+          so <think></think> is always prepended regardless of original content.
+        - Non-historical messages: prepend only if the message has no thinking.
+
+        When a historical message has non-empty text content, the HF template
+        produces "<think></think>\\ntext" (with a newline separator). This comes
+        from c.split('</think>')[-1] preserving the \\n in _format_thinking_text's
+        output. We add the \\n to the header suffix in that case.
+        """
+        is_historical = ctx.idx < ctx.last_user_index
+        content = message.get("content", "")
+        has_think = False
+        if isinstance(content, list):
+            has_think = any(p["type"] == "thinking" for p in content)
+        elif isinstance(content, str):
+            has_think = "<think>" in content
+        # Non-historical with thinking: thinking will be in output, no prefix needed.
+        if has_think and not is_historical:
+            return ""
+        # For historical messages with stripped thinking and non-empty text:
+        # add \n separator to match HF template's c.split('</think>')[-1] behavior.
+        # Exception: when the message has tool_calls, the HF template's tool_calls
+        # branch applies ``| trim`` (which binds tighter than ``~``) to the content
+        # before concatenation, stripping the leading \n. So no separator in that case.
+        if is_historical and has_think:
+            has_nonempty_text = isinstance(content, list) and any(
+                p["type"] == "text" and p.get("text", "") for p in content
+            )
+            has_tool_calls = bool(message.get("tool_calls"))
+            if has_nonempty_text and not has_tool_calls:
+                return "<think></think>\n"
+        return "<think></think>"
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        """Render a message, using idx < last_user_index for thinking stripping.
+
+        Nemotron-3's HF template strips thinking only for messages BEFORE the
+        last user message (truncate_history_thinking and loop.index0 < last_user_idx).
+        The base Qwen3VLRenderer uses `not ctx.is_last`, which incorrectly strips
+        thinking from assistant messages that follow tool responses.
+        """
+        if message["role"] == "assistant" and ctx.idx >= ctx.last_user_index and not ctx.is_last:
+            # Prevent thinking from being stripped: patch is_last=True so that
+            # the base class's `not ctx.is_last` condition evaluates to False.
+            ctx = dataclasses.replace(ctx, is_last=True)
+        return super().render_message(message, ctx)
+
+    def _format_thinking_text(self, thinking: str) -> str:
+        """Nemotron-3 uses a single separator newline after </think>."""
+        return f"<think>\n{thinking}\n</think>\n"
+
+    def _wrap_qwen_tool_response_chunks(
+        self, chunks: list[ImagePart | TextPart]
+    ) -> list[ImagePart | TextPart]:
+        """Wrap tool response with Nemotron-3's format.
+
+        Nemotron-3 HF template outputs '\\n</tool_response>\\n' (with trailing \\n),
+        while the base class uses '\\n</tool_response>' (no trailing \\n).
+        """
+        return (
+            [TextPart(type="text", text="<tool_response>\n")]
+            + chunks
+            + [TextPart(type="text", text="\n</tool_response>\n")]
+        )
+
+    def _format_tool_calls_chunks(self, message: Message) -> list[ImagePart | TextPart]:
+        """Format tool_calls for Nemotron-3.
+
+        Differences from Qwen3.5:
+        - Single newline prefix (not two) before the first <tool_call>, unless the
+          preceding content (thinking) already ends with \\n.
+        - Trailing \\n after each </tool_call> (matching HF template line 156:
+          '</function>\\n</tool_call>\\n').
+
+        The prefix is omitted when the message has thinking-only content (no
+        non-empty text parts), because _format_thinking_text already ends with \\n.
+        """
+        assert "tool_calls" in message
+        content = message.get("content", "")
+        has_thinking = isinstance(content, list) and any(p["type"] == "thinking" for p in content)
+        has_nonempty_text = isinstance(content, list) and any(
+            p["type"] == "text" and p.get("text", "") for p in content
+        )
+        # Thinking ends with \n; only add \n prefix if there's text after thinking
+        # (which won't end with \n) or no thinking at all.
+        prefix = "" if (has_thinking and not has_nonempty_text) else "\n"
+        calls = "".join(self._format_tool_call_xml(tc) + "\n" for tc in message["tool_calls"])
+        return [TextPart(type="text", text=prefix + calls)]
+
+    def _postprocess_parsed_message(self, message: Message) -> None:
+        """Strip one separator newline after </think> (not two like Qwen3.5).
+
+        Nemotron-3 uses a single ``\\n`` between ``</think>`` and text content,
+        while Qwen3.5 uses ``\\n\\n``. We strip the single newline here, then
+        delegate to the parent for thinking whitespace trimming and XML tool
+        call conversion. This ensures both ``parse_response`` and
+        ``_parse_response_for_streaming`` get the correct behavior.
+        """
+        content = message.get("content")
+        if isinstance(content, list):
+            seen_thinking = False
+            for p in content:
+                if p["type"] == "thinking":
+                    seen_thinking = True
+                elif seen_thinking and p["type"] == "text":
+                    # Strip exactly one separator newline (Nemotron-3's format).
+                    # Do this before super() so its \n\n check becomes a no-op.
+                    if p["text"].startswith("\n"):
+                        p["text"] = p["text"][1:]
+                    break
+        super()._postprocess_parsed_message(message)
+
+    def create_conversation_prefix_with_tools(
+        self, tools: list[ToolSpec], system_prompt: str = ""
+    ) -> list[Message]:
+        """Create system message with Nemotron-3 XML tool specifications.
+
+        Nemotron-3 uses structured XML for tool declarations (unlike Qwen3.5's
+        JSON-per-line format). The system prompt also comes *before* the tools
+        block, matching the HF template:
+
+            <|im_start|>system
+            {system_prompt}
+
+            # Tools
+            ...
+        """
+        tools_text = ""
+        if tools:
+            tool_declarations = "\n".join(
+                _format_nemotron3_tool_declaration(tool) for tool in tools
+            )
+            tools_text = (
+                "# Tools\n\n"
+                "You have access to the following functions:\n\n"
+                "<tools>\n"
+                f"{tool_declarations}\n"
+                "</tools>\n\n"
+                "If you choose to call a function ONLY reply in the following format with NO suffix:\n\n"
+                "<tool_call>\n"
+                "<function=example_function_name>\n"
+                "<parameter=example_parameter_1>\n"
+                "value_1\n"
+                "</parameter>\n"
+                "<parameter=example_parameter_2>\n"
+                "This is the value for the second parameter\n"
+                "that can span\n"
+                "multiple lines\n"
+                "</parameter>\n"
+                "</function>\n"
+                "</tool_call>\n\n"
+                "<IMPORTANT>\n"
+                "Reminder:\n"
+                "- Function calls MUST follow the specified format: "
+                "an inner <function=...></function> block must be nested within "
+                "<tool_call></tool_call> XML tags\n"
+                "- Required parameters MUST be specified\n"
+                "- You may provide optional reasoning for your function call in natural language "
+                "BEFORE the function call, but NOT after\n"
+                "- If there is no function call available, answer the question like normal with "
+                "your current knowledge and do not tell the user about function calls\n"
+                "</IMPORTANT>"
+            )
+
+        if tools_text:
+            # Nemotron-3 puts system_prompt BEFORE tools (opposite of Qwen3.5)
+            content = system_prompt + "\n\n" + tools_text if system_prompt else tools_text
+        else:
+            content = system_prompt
+
+        return [Message(role="system", content=content)]
+
+
+class Nemotron3DisableThinkingRenderer(Nemotron3Renderer):
+    """Renderer for Nemotron-3 models with thinking disabled.
+
+    Matches the Nemotron-3 HF template with enable_thinking=False. The only
+    difference from Nemotron3Renderer is the generation suffix:
+    <think></think> (no trailing newlines) instead of <think>\\n.
+    """
+
+    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
+        """Return generation suffix tokens with ``<think></think>`` to disable thinking.
+
+        Args:
+            role (Role): The role for the generation prompt.
+            ctx (RenderContext): Positional context for the generation message.
+
+        Returns:
+            list[int]: Encoded tokens for the generation suffix.
+        """
+        maybe_newline = "\n" if ctx.idx > 0 else ""
+        header_str = f"{maybe_newline}<|im_start|>{role}\n<think></think>"
+        return self.tokenizer.encode(header_str, add_special_tokens=False)

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -1,0 +1,788 @@
+"""
+Tests for Nemotron-3 renderer.
+
+Tests verify that the Nemotron3Renderer produces correct output:
+1. Generation prompt ends with <|im_start|>assistant\n<think>\n (thinking enabled)
+2. Disable-thinking variant ends with <|im_start|>assistant\n<think></think>
+3. Tool declarations use Nemotron-3's structured XML format
+4. System prompt comes BEFORE tools in the system message
+5. <think></think> is prepended to ALL assistant messages without thinking (not just last)
+6. HF template compatibility for both build_generation_prompt and build_supervised_example
+"""
+
+import json
+
+import pytest
+
+from tinker_cookbook.renderers import Message, ToolCall, ToolSpec, get_renderer
+from tinker_cookbook.renderers.nemotron3 import (
+    Nemotron3DisableThinkingRenderer,
+    Nemotron3Renderer,
+    _format_nemotron3_tool_declaration,
+)
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+NEMOTRON3_NANO_MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+NEMOTRON3_SUPER_MODEL = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
+NEMOTRON3_TOKENIZER_PATH = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def nemotron_tokenizer():
+    return get_tokenizer(NEMOTRON3_TOKENIZER_PATH)
+
+
+@pytest.fixture(scope="module")
+def nemotron_renderer(nemotron_tokenizer):
+    return get_renderer("nemotron3", nemotron_tokenizer)
+
+
+@pytest.fixture(scope="module")
+def nemotron_renderer_disable_thinking(nemotron_tokenizer):
+    return get_renderer("nemotron3_disable_thinking", nemotron_tokenizer)
+
+
+def _hf_generation_tokens(tokenizer, hf_messages, tools=None, enable_thinking: bool = True):
+    """Run HF apply_chat_template with generation prompt and return token list."""
+    kwargs = {"add_generation_prompt": True, "tokenize": True, "enable_thinking": enable_thinking}
+    if tools is not None:
+        kwargs["tools"] = tools
+    result = tokenizer.apply_chat_template(hf_messages, **kwargs)
+    # apply_chat_template may return BatchEncoding (dict-like) when tools are provided.
+    if hasattr(result, "input_ids"):
+        return list(result.input_ids)
+    return list(result)
+
+
+def _hf_supervised_tokens(tokenizer, hf_messages, tools=None, enable_thinking: bool = True):
+    """Run HF apply_chat_template without generation prompt, strip trailing newline, re-encode."""
+    kwargs = {"add_generation_prompt": False, "tokenize": False, "enable_thinking": enable_thinking}
+    if tools is not None:
+        kwargs["tools"] = tools
+    result = tokenizer.apply_chat_template(hf_messages, **kwargs)
+    # apply_chat_template with tokenize=False may return BatchEncoding when tools are provided.
+    hf_str = result.input_ids if hasattr(result, "input_ids") else result
+    assert isinstance(hf_str, str)
+    return tokenizer.encode(hf_str.rstrip("\n"), add_special_tokens=False)
+
+
+# =============================================================================
+# Test Conversations
+# =============================================================================
+
+
+def get_basic_conversation_for_generation() -> list[Message]:
+    """3-turn conversation ending with user message (for generation)."""
+    return [
+        Message(role="system", content="You are a helpful assistant."),
+        Message(role="user", content="Hello, how are you?"),
+        Message(role="assistant", content="I'm fine, thank you!"),
+        Message(role="user", content="What is the capital of France?"),
+    ]
+
+
+def get_basic_conversation_for_supervised() -> list[Message]:
+    """2-turn conversation ending with assistant (for supervised)."""
+    return [
+        Message(role="system", content="You are a helpful assistant."),
+        Message(role="user", content="Hello, how are you?"),
+        Message(role="assistant", content="I'm fine, thank you!"),
+    ]
+
+
+def get_thinking_conversation_for_supervised() -> list[Message]:
+    """Conversation with thinking content, ending with assistant."""
+    return [
+        Message(role="system", content="You are a helpful assistant."),
+        Message(role="user", content="Solve 2+2."),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "2 plus 2 equals 4."},
+                {"type": "text", "text": "The answer is 4."},
+            ],
+        ),
+    ]
+
+
+def get_multiturn_thinking_conversation() -> list[Message]:
+    """Multi-turn with thinking in both assistant messages."""
+    return [
+        Message(role="system", content="You are a helpful assistant."),
+        Message(role="user", content="First question."),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "First turn reasoning."},
+                {"type": "text", "text": "First answer."},
+            ],
+        ),
+        Message(role="user", content="Second question."),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "Second turn reasoning."},
+                {"type": "text", "text": "Second answer."},
+            ],
+        ),
+    ]
+
+
+def get_tool_spec() -> ToolSpec:
+    return ToolSpec(
+        name="get_weather",
+        description="Get the current weather for a location",
+        parameters={
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA",
+                },
+                "unit": {
+                    "type": "string",
+                    "enum": ["celsius", "fahrenheit"],
+                    "description": "Temperature unit",
+                },
+            },
+            "required": ["location"],
+        },
+    )
+
+
+def get_rich_tool_spec() -> ToolSpec:
+    """Tool spec with extra JSON Schema fields beyond name/type/description/enum."""
+    return ToolSpec(
+        name="search",
+        description="Search for items",
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query",
+                    "default": "*",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results",
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "Filter tags",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def get_tool_call_conversation_for_generation() -> tuple[list[Message], list[ToolSpec]]:
+    tools = [get_tool_spec()]
+    tool_call = ToolCall(
+        id="call_abc123",
+        function=ToolCall.FunctionBody(
+            name="get_weather",
+            arguments='{"location": "New York, NY"}',
+        ),
+    )
+    messages: list[Message] = [
+        Message(role="user", content="What's the weather in NYC?"),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "I need to check the weather in NYC."},
+                {"type": "text", "text": ""},
+            ],
+            tool_calls=[tool_call],
+        ),
+        Message(
+            role="tool",
+            name="get_weather",
+            tool_call_id="call_abc123",
+            content='{"temperature": 72, "condition": "sunny"}',
+        ),
+    ]
+    return messages, tools
+
+
+def get_historical_tool_call_with_nonempty_text_conversation() -> tuple[
+    list[Message], list[ToolSpec]
+]:
+    """Conversation where a historical assistant message has thinking + non-empty text + tool_calls.
+
+    This is an edge case where the HF Jinja template's tool_calls branch applies
+    ``| trim`` to the content *before* concatenation with ``<think></think>``,
+    stripping the leading ``\\n`` that would otherwise be preserved in the
+    non-tool_calls branch. The result is ``<think></think>text`` (no newline)
+    for the historical message.
+
+    The first assistant message becomes historical because a later user message
+    follows the tool response + second assistant exchange.
+    """
+    tools = [get_tool_spec()]
+    tool_call = ToolCall(
+        id="call_abc123",
+        function=ToolCall.FunctionBody(
+            name="get_weather",
+            arguments='{"location": "New York, NY"}',
+        ),
+    )
+    messages: list[Message] = [
+        Message(role="user", content="What's the weather in NYC?"),
+        # This assistant message has thinking + non-empty text + tool_calls
+        # and will be historical (before the last user message).
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "I need to check the weather."},
+                {"type": "text", "text": "Let me check that for you."},
+            ],
+            tool_calls=[tool_call],
+        ),
+        Message(
+            role="tool",
+            name="get_weather",
+            tool_call_id="call_abc123",
+            content='{"temperature": 72, "condition": "sunny"}',
+        ),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "The weather is 72F and sunny."},
+                {"type": "text", "text": "It's 72°F and sunny in NYC."},
+            ],
+        ),
+        Message(role="user", content="Thanks!"),
+    ]
+    return messages, tools
+
+
+def get_tool_call_conversation_for_supervised() -> tuple[list[Message], list[ToolSpec]]:
+    tools = [get_tool_spec()]
+    tool_call = ToolCall(
+        id="call_abc123",
+        function=ToolCall.FunctionBody(
+            name="get_weather",
+            arguments='{"location": "New York, NY"}',
+        ),
+    )
+    messages: list[Message] = [
+        Message(role="user", content="What's the weather in NYC?"),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "I need to check the weather in NYC."},
+                {"type": "text", "text": ""},
+            ],
+            tool_calls=[tool_call],
+        ),
+        Message(
+            role="tool",
+            name="get_weather",
+            tool_call_id="call_abc123",
+            content='{"temperature": 72, "condition": "sunny"}',
+        ),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "The weather is 72F and sunny."},
+                {"type": "text", "text": "The weather in NYC is 72°F and sunny."},
+            ],
+        ),
+    ]
+    return messages, tools
+
+
+# =============================================================================
+# Tool Declaration Format Tests (no tokenizer required)
+# =============================================================================
+
+
+def test_tool_declaration_xml_format():
+    """Tool declarations use Nemotron-3's structured XML format."""
+    tool = get_tool_spec()
+    declaration = _format_nemotron3_tool_declaration(tool)
+
+    assert "<function>" in declaration
+    assert "<name>get_weather</name>" in declaration
+    assert "<description>Get the current weather for a location</description>" in declaration
+    assert "<parameters>" in declaration
+    assert "<parameter>" in declaration
+    assert "<name>location</name>" in declaration
+    assert "<type>string</type>" in declaration
+    assert "<name>unit</name>" in declaration
+    assert "<enum>" in declaration
+    assert '"celsius"' in declaration
+    assert "<required>" in declaration
+    assert '"location"' in declaration
+    assert "</function>" in declaration
+
+
+def test_tool_declaration_not_json_per_line():
+    """Tool declarations should NOT use Qwen3.5's JSON-per-line format."""
+    tool = get_tool_spec()
+    declaration = _format_nemotron3_tool_declaration(tool)
+    assert not declaration.strip().startswith("{")
+    assert '"name": "get_weather"' not in declaration
+
+
+def test_tool_declaration_minimal_tool():
+    """Tool with no description and no parameters."""
+    tool = ToolSpec(name="ping", description="", parameters={})
+    declaration = _format_nemotron3_tool_declaration(tool)
+    assert "<name>ping</name>" in declaration
+    assert "<description>" not in declaration
+    assert "<parameter>" not in declaration
+    assert "<required>" not in declaration
+
+
+def test_tool_declaration_extra_schema_keys_match_hf(nemotron_tokenizer, nemotron_renderer):
+    """Tool with extra JSON Schema fields (default, minimum, items, etc.) matches HF.
+
+    The HF Jinja template has a render_extra_keys macro that outputs additional
+    parameter fields beyond name/type/description/enum. This test verifies our
+    renderer handles those extra keys the same way.
+    """
+    tools = [get_rich_tool_spec()]
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(
+        tools, system_prompt=system_prompt
+    )
+    messages = prefix + [Message(role="user", content="Search for cats")]
+    cookbook = nemotron_renderer.build_generation_prompt(messages).to_ints()
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": "Search for cats"},
+    ]
+    hf = _hf_generation_tokens(nemotron_tokenizer, hf_messages, tools=openai_tools)
+
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_create_conversation_prefix_system_before_tools(nemotron_renderer):
+    """System prompt should appear BEFORE tools block."""
+    tools = [get_tool_spec()]
+    system_prompt = "You are a helpful assistant."
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(tools, system_prompt)
+
+    assert len(prefix) == 1
+    assert prefix[0]["role"] == "system"
+    content = prefix[0]["content"]
+    assert isinstance(content, str)
+
+    sysprompt_idx = content.index(system_prompt)
+    tools_idx = content.index("# Tools")
+    assert sysprompt_idx < tools_idx
+
+
+def test_create_conversation_prefix_without_system_prompt(nemotron_renderer):
+    """Without system_prompt, content starts directly with # Tools."""
+    tools = [get_tool_spec()]
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(tools)
+    content = prefix[0]["content"]
+    assert isinstance(content, str)
+    assert content.startswith("# Tools")
+
+
+def test_create_conversation_prefix_xml_tool_format(nemotron_renderer):
+    """Tool declarations in prefix use XML format, not JSON."""
+    tools = [get_tool_spec()]
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(tools)
+    content = prefix[0]["content"]
+    assert "<tools>" in content
+    assert "<function>" in content
+    assert "<name>get_weather</name>" in content
+    assert "<parameter>" in content
+    assert "</tools>" in content
+    assert '{"name": "get_weather"' not in content
+
+
+def test_create_conversation_prefix_no_tools(nemotron_renderer):
+    """No tools: returns just the system_prompt."""
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(
+        [], system_prompt="You are helpful."
+    )
+    assert prefix[0]["content"] == "You are helpful."
+
+
+# =============================================================================
+# Generation Prompt Tests
+# =============================================================================
+
+
+def test_generation_prompt_ends_with_think(nemotron_tokenizer, nemotron_renderer):
+    """Nemotron3Renderer prefills with <think>\\n."""
+    messages = get_basic_conversation_for_generation()
+    decoded = nemotron_tokenizer.decode(
+        nemotron_renderer.build_generation_prompt(messages).to_ints()
+    )
+    assert decoded.endswith("<|im_start|>assistant\n<think>\n")
+
+
+def test_disable_thinking_generation_prompt(nemotron_tokenizer, nemotron_renderer_disable_thinking):
+    """Nemotron3DisableThinkingRenderer prefills with <think></think>."""
+    messages = get_basic_conversation_for_generation()
+    decoded = nemotron_tokenizer.decode(
+        nemotron_renderer_disable_thinking.build_generation_prompt(messages).to_ints()
+    )
+    assert decoded.endswith("<|im_start|>assistant\n<think></think>")
+
+
+def test_custom_prefill_overrides_think(nemotron_tokenizer, nemotron_renderer):
+    """Custom prefill overrides the default <think>\\n."""
+    messages = get_basic_conversation_for_generation()
+    decoded = nemotron_tokenizer.decode(
+        nemotron_renderer.build_generation_prompt(messages, prefill="Sure, ").to_ints()
+    )
+    assert decoded.endswith("Sure, ")
+    assert not decoded.endswith("<think>\n")
+
+
+# =============================================================================
+# HF Template Compatibility Tests — Generation
+# =============================================================================
+
+
+def test_basic_conversation_generation_matches_hf(nemotron_tokenizer, nemotron_renderer):
+    """Basic conversation generation matches HF template."""
+    messages = get_basic_conversation_for_generation()
+    cookbook = nemotron_renderer.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_tokenizer,
+        [nemotron_renderer.to_openai_message(m) for m in messages],
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_disable_thinking_generation_matches_hf(
+    nemotron_tokenizer, nemotron_renderer_disable_thinking
+):
+    """Disable-thinking generation matches HF with enable_thinking=False."""
+    messages = [
+        Message(role="system", content="You are helpful."),
+        Message(role="user", content="Hello"),
+        Message(role="assistant", content="Hi!"),
+        Message(role="user", content="What is 2+2?"),
+    ]
+    r = nemotron_renderer_disable_thinking
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        enable_thinking=False,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+# =============================================================================
+# HF Template Compatibility Tests — Supervised
+# =============================================================================
+
+
+def test_basic_conversation_supervised_matches_hf(nemotron_tokenizer, nemotron_renderer):
+    """Basic supervised example matches HF template (no gen prompt)."""
+    messages = get_basic_conversation_for_supervised()
+    cookbook = nemotron_renderer.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_tokenizer,
+        [nemotron_renderer.to_openai_message(m) for m in messages],
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_thinking_conversation_supervised_matches_hf(nemotron_tokenizer, nemotron_renderer):
+    """Supervised example with thinking content matches HF template."""
+    messages = get_thinking_conversation_for_supervised()
+    cookbook = nemotron_renderer.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_tokenizer,
+        [nemotron_renderer.to_openai_message(m) for m in messages],
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_multiturn_thinking_supervised_matches_hf(nemotron_tokenizer, nemotron_renderer):
+    """Multi-turn with thinking in both assistant messages matches HF template.
+
+    Nemotron-3's HF template truncates thinking in historical messages to
+    <think></think>. This test verifies our renderer does the same.
+    """
+    messages = get_multiturn_thinking_conversation()
+    cookbook = nemotron_renderer.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_tokenizer,
+        [nemotron_renderer.to_openai_message(m) for m in messages],
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_think_block_added_to_all_assistant_history(nemotron_tokenizer, nemotron_renderer):
+    """<think></think> is prepended to historical assistant messages without thinking."""
+    messages = get_basic_conversation_for_generation()  # ends with user, has one assistant
+    decoded = nemotron_tokenizer.decode(
+        nemotron_renderer.build_generation_prompt(messages).to_ints()
+    )
+    # The historical assistant message should have <think></think> prepended
+    assert "<think></think>I'm fine, thank you!" in decoded
+
+
+# =============================================================================
+# HF Template Compatibility Tests — Tool Declarations
+# =============================================================================
+
+
+@pytest.mark.parametrize("build_mode", ["generation", "supervised"])
+def test_tool_declaration_matches_hf(build_mode: str, nemotron_tokenizer, nemotron_renderer):
+    """Tool declarations match HF template output."""
+    tools = [get_tool_spec()]
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+
+    prefix_messages = nemotron_renderer.create_conversation_prefix_with_tools(
+        tools, system_prompt=system_prompt
+    )
+    user_msg = Message(role="user", content="What's the weather in NYC?")
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": "What's the weather in NYC?"},
+    ]
+
+    if build_mode == "generation":
+        cookbook = nemotron_renderer.build_generation_prompt(prefix_messages + [user_msg]).to_ints()
+        hf = _hf_generation_tokens(nemotron_tokenizer, hf_messages, tools=openai_tools)
+    else:
+        assistant_msg = Message(role="assistant", content="Let me check that for you.")
+        cookbook = nemotron_renderer.build_supervised_example(
+            prefix_messages + [user_msg, assistant_msg]
+        )[0].to_ints()
+        hf_messages.append({"role": "assistant", "content": "Let me check that for you."})
+        hf = _hf_supervised_tokens(nemotron_tokenizer, hf_messages, tools=openai_tools)
+
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_tool_call_conversation_generation_matches_hf(nemotron_tokenizer, nemotron_renderer):
+    """Tool call + tool response conversation (generation) matches HF template."""
+    messages, tools = get_tool_call_conversation_for_generation()
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(
+        tools, system_prompt=system_prompt
+    )
+    cookbook = nemotron_renderer.build_generation_prompt(prefix + messages).to_ints()
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        *[nemotron_renderer.to_openai_message(m) for m in messages],
+    ]
+    hf = _hf_generation_tokens(nemotron_tokenizer, hf_messages, tools=openai_tools)
+
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_tool_call_conversation_supervised_matches_hf(nemotron_tokenizer, nemotron_renderer):
+    """Complete tool call conversation (supervised) matches HF template."""
+    messages, tools = get_tool_call_conversation_for_supervised()
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(
+        tools, system_prompt=system_prompt
+    )
+    cookbook = nemotron_renderer.build_supervised_example(prefix + messages)[0].to_ints()
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        *[nemotron_renderer.to_openai_message(m) for m in messages],
+    ]
+    hf = _hf_supervised_tokens(nemotron_tokenizer, hf_messages, tools=openai_tools)
+
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_historical_tool_call_with_nonempty_text_generation_matches_hf(
+    nemotron_tokenizer, nemotron_renderer
+):
+    """Historical tool_call message with thinking + non-empty text matches HF.
+
+    In the HF Jinja template's tool_calls branch, ``| trim`` binds tighter than
+    ``~``, so the leading ``\\n`` from the content is stripped before concatenation
+    with ``<think></think>``, producing ``<think></think>text`` (no newline).
+    This differs from the non-tool_calls branch which preserves the newline.
+    """
+    messages, tools = get_historical_tool_call_with_nonempty_text_conversation()
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(
+        tools, system_prompt=system_prompt
+    )
+    cookbook = nemotron_renderer.build_generation_prompt(prefix + messages).to_ints()
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        *[nemotron_renderer.to_openai_message(m) for m in messages],
+    ]
+    hf = _hf_generation_tokens(nemotron_tokenizer, hf_messages, tools=openai_tools)
+
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_historical_tool_call_with_nonempty_text_supervised_matches_hf(
+    nemotron_tokenizer, nemotron_renderer
+):
+    """Supervised version of the historical tool_call + non-empty text edge case."""
+    messages, tools = get_historical_tool_call_with_nonempty_text_conversation()
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+
+    prefix = nemotron_renderer.create_conversation_prefix_with_tools(
+        tools, system_prompt=system_prompt
+    )
+    cookbook = nemotron_renderer.build_supervised_example(prefix + messages)[0].to_ints()
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        *[nemotron_renderer.to_openai_message(m) for m in messages],
+    ]
+    hf = _hf_supervised_tokens(nemotron_tokenizer, hf_messages, tools=openai_tools)
+
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+# =============================================================================
+# Parse Response Tests
+# =============================================================================
+
+
+def test_parse_response_plain_text(nemotron_tokenizer, nemotron_renderer):
+    """parse_response decodes a plain text response (no thinking)."""
+    tokens = nemotron_tokenizer.encode("The answer is 42.<|im_end|>", add_special_tokens=False)
+    message, success = nemotron_renderer.parse_response(tokens)
+    assert success
+    from tinker_cookbook.renderers import get_text_content
+
+    assert "42" in get_text_content(message)
+
+
+def test_parse_response_with_thinking(nemotron_tokenizer, nemotron_renderer):
+    """parse_response extracts thinking content from the response."""
+    # Simulates what the model generates after the <think>\n prefill
+    response_text = "I should reason carefully.\n</think>\nThe answer is 42.<|im_end|>"
+    tokens = nemotron_tokenizer.encode(response_text, add_special_tokens=False)
+    message, success = nemotron_renderer.parse_response(tokens)
+
+    assert success
+    content = message.get("content")
+    assert isinstance(content, list)
+    thinking_parts = [p for p in content if p["type"] == "thinking"]
+    text_parts = [p for p in content if p["type"] == "text"]
+    assert len(thinking_parts) == 1
+    assert "reason" in thinking_parts[0]["thinking"]
+    assert len(text_parts) == 1
+    assert "42" in text_parts[0]["text"]
+
+
+def test_parse_response_for_streaming_with_thinking(nemotron_tokenizer, nemotron_renderer):
+    """_parse_response_for_streaming preserves the single \\n separator after </think>.
+
+    The inherited _parse_response_for_streaming calls _postprocess_parsed_message
+    which strips separator newlines. For Nemotron-3, the separator is one \\n (not
+    two like Qwen3.5), so the text after thinking should NOT start with \\n (the
+    single separator should be stripped) and must not lose content by over-stripping.
+    """
+    # Include <think>\n prefix — in real streaming, _normalize_response_tokens
+    # prepends this before _parse_response_for_streaming is called.
+    response_text = "<think>\nI should reason carefully.\n</think>\nThe answer is 42.<|im_end|>"
+    tokens = nemotron_tokenizer.encode(response_text, add_special_tokens=False)
+    message, success = nemotron_renderer._parse_response_for_streaming(tokens)
+
+    assert success
+    content = message.get("content")
+    assert isinstance(content, list)
+    thinking_parts = [p for p in content if p["type"] == "thinking"]
+    text_parts = [p for p in content if p["type"] == "text"]
+    assert len(thinking_parts) == 1
+    assert "reason" in thinking_parts[0]["thinking"]
+    assert len(text_parts) == 1
+    # The text should start with "The answer" — the \n separator should be stripped,
+    # not left as-is (0 newlines stripped) or double-stripped.
+    assert text_parts[0]["text"].startswith("The answer"), (
+        f"Expected text to start with 'The answer' but got: {text_parts[0]['text']!r}"
+    )
+
+
+def test_parse_response_tool_call(nemotron_tokenizer, nemotron_renderer):
+    """parse_response parses XML-format tool calls."""
+    tool_call_text = (
+        "\n</think>\n"
+        "<tool_call>\n"
+        "<function=get_weather>\n"
+        "<parameter=location>\n"
+        "New York, NY\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call><|im_end|>"
+    )
+    tokens = nemotron_tokenizer.encode(tool_call_text, add_special_tokens=False)
+    message, success = nemotron_renderer.parse_response(tokens)
+
+    assert success
+    tool_calls = message.get("tool_calls", [])
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "get_weather"
+    args = json.loads(tool_calls[0].function.arguments)
+    assert args["location"] == "New York, NY"
+
+
+# =============================================================================
+# Renderer Identity Tests
+# =============================================================================
+
+
+def test_renderer_types(nemotron_renderer, nemotron_renderer_disable_thinking):
+    assert isinstance(nemotron_renderer, Nemotron3Renderer)
+    assert isinstance(nemotron_renderer_disable_thinking, Nemotron3DisableThinkingRenderer)
+
+
+def test_renderer_is_not_qwen35(nemotron_renderer):
+    from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
+
+    assert type(nemotron_renderer) is not Qwen3_5Renderer

--- a/tinker_cookbook/renderers/qwen3_5.py
+++ b/tinker_cookbook/renderers/qwen3_5.py
@@ -1,0 +1,303 @@
+"""
+Qwen3.5 family renderer.
+
+Qwen3.5 models are VL models with the same basic
+chat format as Qwen3-VL (im_start/im_end, thinking, vision tokens) but with a
+different tool calling format.
+
+Tool calling differences from Qwen3:
+- Qwen3: JSON format  {"name": ..., "arguments": ...}
+- Qwen3.5: XML format  <function=name><parameter=param>value</parameter></function>
+
+Unlike Qwen3, the Qwen3.5 HF template:
+- Always adds <think>...</think> blocks to assistant messages after the last user
+  message (empty if no reasoning content).
+- Always adds <think>\\n to the generation prompt.
+
+Reference: https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/tokenizer_config.json
+"""
+
+import json
+import re
+
+from tinker_cookbook.renderers.base import (
+    ImagePart,
+    Message,
+    RenderContext,
+    Role,
+    TextPart,
+    ToolCall,
+    ToolSpec,
+    UnparsedToolCall,
+)
+from tinker_cookbook.renderers.qwen3 import Qwen3VLRenderer
+
+_FUNCTION_BLOCK_RE = re.compile(
+    r"^\s*<tool_call>\s*<function=(?P<name>[^>\n]+)>\s*(?P<body>.*?)\s*</function>\s*</tool_call>\s*$",
+    re.DOTALL,
+)
+_PARAM_BLOCK_RE = re.compile(
+    r"<parameter=(?P<name>[^>\n]+)>\s*(?P<value>.*?)\s*</parameter>",
+    re.DOTALL,
+)
+
+
+class Qwen3_5Renderer(Qwen3VLRenderer):
+    """
+    Renderer for Qwen3.5 models.
+
+    Subclasses Qwen3VLRenderer since Qwen3.5 models are VL models sharing the same
+    basic chat format. Overrides tool calling to use Qwen3.5's XML parameter format.
+
+    The Qwen3.5 HF template adds empty <think> blocks to assistant messages after
+    the last user message. This is handled via ctx.last_user_index, which is
+    populated by the base build_generation_prompt/build_supervised_example.
+    """
+
+    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
+        """Override to produce the full generation suffix directly.
+
+        Builds the header tokens manually and appends <think>\\n. This matches
+        the Qwen3.5 template's add_generation_prompt behavior for thinking mode.
+        """
+        maybe_newline = "\n" if ctx.idx > 0 else ""
+        header_str = f"{maybe_newline}<|im_start|>{role}\n<think>\n"
+        return self.tokenizer.encode(header_str, add_special_tokens=False)
+
+    def _assistant_header_suffix(self, message: Message, ctx: RenderContext) -> str:
+        """Insert empty think block for assistant messages after the last user query."""
+        if ctx.idx <= ctx.last_user_index:
+            return ""
+
+        content = message.get("content", "")
+        has_think = False
+        if isinstance(content, list):
+            has_think = any(p["type"] == "thinking" for p in content)
+        elif isinstance(content, str):
+            has_think = "<think>" in content
+
+        return "" if has_think else "<think>\n\n</think>\n\n"
+
+    def _format_thinking_text(self, thinking: str) -> str:
+        """Qwen3.5 uses newline-padded think blocks."""
+        return f"<think>\n{thinking}\n</think>\n\n"
+
+    def _to_openai_tool_arguments(self, arguments: str) -> str | dict:
+        """Qwen3.5 chat template expects arguments as a mapping for |items."""
+        return json.loads(arguments)
+
+    def _parse_qwen3_5_tool_call_xml(self, raw_text: str) -> ToolCall | UnparsedToolCall:
+        """Parse Qwen3.5 XML-style tool calls from a raw <tool_call> block."""
+        match = _FUNCTION_BLOCK_RE.match(raw_text)
+        if not match:
+            return UnparsedToolCall(raw_text=raw_text, error="Malformed Qwen3.5 tool call XML")
+
+        function_name = match.group("name").strip()
+        body = match.group("body")
+        if not function_name:
+            return UnparsedToolCall(raw_text=raw_text, error="Missing function name")
+
+        arguments: dict[str, object] = {}
+        pos = 0
+        for param in _PARAM_BLOCK_RE.finditer(body):
+            if body[pos : param.start()].strip():
+                return UnparsedToolCall(
+                    raw_text=raw_text,
+                    error="Unexpected non-parameter content inside <function> block",
+                )
+
+            param_name = param.group("name").strip()
+            param_value_text = param.group("value").strip("\n")
+            if not param_name:
+                return UnparsedToolCall(raw_text=raw_text, error="Empty parameter name")
+
+            try:
+                param_value: object = json.loads(param_value_text)
+            except json.JSONDecodeError:
+                param_value = param_value_text
+
+            arguments[param_name] = param_value
+            pos = param.end()
+
+        if body[pos:].strip():
+            return UnparsedToolCall(
+                raw_text=raw_text,
+                error="Unexpected trailing content inside <function> block",
+            )
+
+        return ToolCall(
+            function=ToolCall.FunctionBody(
+                name=function_name,
+                arguments=json.dumps(arguments),
+            )
+        )
+
+    def _normalize_response_tokens(self, response: list[int]) -> list[int]:
+        """Restore the prefilled <think>\\n before parsing sampled tokens.
+
+        Qwen3.5's generation suffix includes <think>\\n, so sampled tokens start
+        after that prefix. If the response contains </think> but doesn't start
+        with <think>\\n, we prepend it so the parser sees a complete think block.
+        """
+        think_prefix_tokens = self.tokenizer.encode("<think>\n", add_special_tokens=False)
+        think_suffix_token = self.tokenizer.encode("</think>", add_special_tokens=False)
+        assert len(think_suffix_token) == 1
+
+        starts_with_think = (
+            len(response) >= len(think_prefix_tokens)
+            and response[: len(think_prefix_tokens)] == think_prefix_tokens
+        )
+        if not starts_with_think and think_suffix_token[0] in response:
+            return think_prefix_tokens + response
+        return response
+
+    def _postprocess_parsed_message(self, message: Message) -> None:
+        """Apply Qwen3.5-specific post-processing to a parsed message in-place.
+
+        1. Strips whitespace from thinking content (matches HF template |trim).
+        2. Removes the two separator newlines between </think> and text.
+        3. Converts Qwen3.5 XML tool calls from the parent's unparsed_tool_calls.
+        """
+        content = message.get("content")
+        if isinstance(content, list):
+            first_text_after_thinking: TextPart | None = None
+            seen_thinking = False
+            for p in content:
+                if p["type"] == "thinking":
+                    p["thinking"] = p["thinking"].strip()
+                    seen_thinking = True
+                elif seen_thinking and p["type"] == "text":
+                    first_text_after_thinking = p
+                    break
+
+            # Template inserts exactly two separator newlines between </think> and text.
+            if first_text_after_thinking is not None and first_text_after_thinking[
+                "text"
+            ].startswith("\n\n"):
+                first_text_after_thinking["text"] = first_text_after_thinking["text"][2:]
+
+        # Qwen3 parent parser assumes JSON inside <tool_call>; convert XML blocks here.
+        converted_xml_calls: list[ToolCall] = []
+        remaining_unparsed: list[UnparsedToolCall] = []
+        for unparsed in message.get("unparsed_tool_calls", []):
+            if "<function=" not in unparsed.raw_text:
+                remaining_unparsed.append(unparsed)
+                continue
+            parsed = self._parse_qwen3_5_tool_call_xml(unparsed.raw_text)
+            if isinstance(parsed, ToolCall):
+                converted_xml_calls.append(parsed)
+            else:
+                remaining_unparsed.append(parsed)
+
+        if converted_xml_calls:
+            message["tool_calls"] = message.get("tool_calls", []) + converted_xml_calls
+        if remaining_unparsed:
+            message["unparsed_tool_calls"] = remaining_unparsed
+        else:
+            message.pop("unparsed_tool_calls", None)
+
+    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+        """Parse response with Qwen3.5-specific post-processing."""
+        message, success = super().parse_response(response)
+        if not success:
+            return message, success
+
+        self._postprocess_parsed_message(message)
+        return message, success
+
+    def _parse_response_for_streaming(self, response: list[int]) -> tuple[Message, bool]:
+        """Parse response for streaming with Qwen3.5-specific post-processing."""
+        message, parse_success = super()._parse_response_for_streaming(response)
+        self._postprocess_parsed_message(message)
+        return message, parse_success
+
+    def _format_tool_call_xml(self, tool_call: ToolCall) -> str:
+        """Format a single tool call in Qwen3.5's XML parameter format."""
+        args = json.loads(tool_call.function.arguments) if tool_call.function.arguments else {}
+        lines = [f"<tool_call>\n<function={tool_call.function.name}>"]
+        for param_name, param_value in args.items():
+            if isinstance(param_value, (dict, list)):
+                value_str = json.dumps(param_value)
+            else:
+                value_str = str(param_value)
+            lines.append(f"<parameter={param_name}>\n{value_str}\n</parameter>")
+        lines.append("</function>\n</tool_call>")
+        return "\n".join(lines)
+
+    def _format_tool_calls_chunks(self, message: Message) -> list[ImagePart | TextPart]:
+        """Format tool_calls using Qwen3.5's XML parameter format."""
+        assert "tool_calls" in message, "tool_calls are required to format tool calls"
+        return [
+            TextPart(
+                type="text",
+                text="\n\n"
+                + "\n".join(self._format_tool_call_xml(tc) for tc in message["tool_calls"]),
+            )
+        ]
+
+    def create_conversation_prefix_with_tools(
+        self, tools: list[ToolSpec], system_prompt: str = ""
+    ) -> list[Message]:
+        """Create system message with Qwen3.5 tool specifications.
+
+        Qwen3.5 uses a different tool declaration format from Qwen3, with XML-based
+        function/parameter calling syntax.
+
+        Reference: https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/tokenizer_config.json
+        """
+        tools_text = ""
+        if tools:
+            tool_lines = "\n".join(json.dumps(tool) for tool in tools)
+            tools_text = (
+                "# Tools\n\n"
+                "You have access to the following functions:\n\n"
+                "<tools>\n"
+                f"{tool_lines}\n"
+                "</tools>\n\n"
+                "If you choose to call a function ONLY reply in the following format with NO suffix:\n\n"
+                "<tool_call>\n"
+                "<function=example_function_name>\n"
+                "<parameter=example_parameter_1>\n"
+                "value_1\n"
+                "</parameter>\n"
+                "<parameter=example_parameter_2>\n"
+                "This is the value for the second parameter\n"
+                "that can span\n"
+                "multiple lines\n"
+                "</parameter>\n"
+                "</function>\n"
+                "</tool_call>\n\n"
+                "<IMPORTANT>\n"
+                "Reminder:\n"
+                "- Function calls MUST follow the specified format: "
+                "an inner <function=...></function> block must be nested within "
+                "<tool_call></tool_call> XML tags\n"
+                "- Required parameters MUST be specified\n"
+                "- You may provide optional reasoning for your function call in natural language "
+                "BEFORE the function call, but NOT after\n"
+                "- If there is no function call available, answer the question like normal with "
+                "your current knowledge and do not tell the user about function calls\n"
+                "</IMPORTANT>"
+            )
+
+        if tools_text:
+            content = tools_text + "\n\n" + system_prompt if system_prompt else tools_text
+        else:
+            content = system_prompt
+
+        return [Message(role="system", content=content)]
+
+
+class Qwen3_5DisableThinkingRenderer(Qwen3_5Renderer):
+    """
+    Renderer for Qwen3.5 models with thinking disabled.
+
+    Matches the Qwen3.5 HF template with enable_thinking=False. The only difference
+    from Qwen3_5Renderer is the generation suffix: <think>\\n\\n</think>\\n\\n instead
+    of <think>\\n, signaling to the model to respond directly without reasoning.
+    """
+
+    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
+        maybe_newline = "\n" if ctx.idx > 0 else ""
+        header_str = f"{maybe_newline}<|im_start|>{role}\n<think>\n\n</think>\n\n"
+        return self.tokenizer.encode(header_str, add_special_tokens=False)


### PR DESCRIPTION
Good day,

This PR adds renderer support for the nvidia/Nemotron-Cascade-2-30B-A3B model as requested in issue #511.

## Changes
- Add `nemotron_cascade_2` renderer (with thinking enabled, using Qwen3.5 format)
- Add `nemotron_cascade_2_disable_thinking` renderer (without thinking)
- Also includes Qwen3.5 and Nemotron-3 renderers from upstream

## Technical Details
Nemotron-Cascade-2-30B-A3B uses the same chat template as Qwen3.5 with `<|im_start|>` tokens and supports the `enable_thinking` parameter. The implementation reuses the existing Qwen3.5 renderer classes.

Example usage:
```python
from tinker_cookbook import renderers
renderer = renderers.get_renderer("nemotron_cascade_2", tokenizer)
```

Thank you for your work on this excellent library!

Warmly,
RoomWithRoof