### PR TITLE
feat: add Nemotron-3 low thinking renderer for Super model

### DIFF
--- a/tests/downstream_compat/test_renderers.py
+++ b/tests/downstream_compat/test_renderers.py
@@ -180,6 +180,7 @@ EXPECTED_RENDERER_NAMES = [
     "gpt_oss_medium_reasoning",
     "gpt_oss_high_reasoning",
     "nemotron3",
+    "nemotron3_low_thinking",
     "nemotron3_disable_thinking",
 ]
 

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -27,6 +27,7 @@ _GPT_OSS = ("gpt_oss_no_sysprompt", "gpt_oss_medium_reasoning")
 _KIMI_K2 = ("kimi_k2",)
 _KIMI_K25 = ("kimi_k25", "kimi_k25_disable_thinking")
 _NEMOTRON3 = ("nemotron3", "nemotron3_disable_thinking")
+_NEMOTRON3_SUPER = _NEMOTRON3 + ("nemotron3_low_thinking",)
 
 
 @dataclass
@@ -172,7 +173,7 @@ def get_nvidia_info() -> dict[str, ModelAttributes]:
             org, "3", "30B-A3B", True, _NEMOTRON3
         ),
         "NVIDIA-Nemotron-3-Super-120B-A12B-BF16": ModelAttributes(
-            org, "3", "120B-A12B", True, _NEMOTRON3 + ("nemotron3_low_thinking",)
+            org, "3", "120B-A12B", True, _NEMOTRON3_SUPER
         ),
     }
 

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -172,7 +172,7 @@ def get_nvidia_info() -> dict[str, ModelAttributes]:
             org, "3", "30B-A3B", True, _NEMOTRON3
         ),
         "NVIDIA-Nemotron-3-Super-120B-A12B-BF16": ModelAttributes(
-            org, "3", "120B-A12B", True, _NEMOTRON3
+            org, "3", "120B-A12B", True, _NEMOTRON3 + ("nemotron3_low_thinking",)
         ),
     }
 

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -137,6 +137,7 @@ def get_renderer(
             - ``"kimi_k25"``: Kimi K2.5 with thinking enabled
             - ``"kimi_k25_disable_thinking"``: Kimi K2.5 with thinking disabled
             - ``"nemotron3"``: Nemotron-3 with thinking enabled
+            - ``"nemotron3_low_thinking"``: Nemotron-3 with low thinking effort (Super only)
             - ``"nemotron3_disable_thinking"``: Nemotron-3 with thinking disabled
             - ``"gpt_oss_no_sysprompt"``: GPT-OSS without system prompt
             - ``"gpt_oss_low_reasoning"``: GPT-OSS with low reasoning
@@ -191,6 +192,7 @@ def get_renderer(
     from tinker_cookbook.renderers.llama3 import Llama3Renderer
     from tinker_cookbook.renderers.nemotron3 import (
         Nemotron3DisableThinkingRenderer,
+        Nemotron3LowThinkingRenderer,
         Nemotron3Renderer,
     )
     from tinker_cookbook.renderers.qwen3 import (
@@ -238,6 +240,8 @@ def get_renderer(
         renderer = KimiK25DisableThinkingRenderer(tokenizer, image_processor=image_processor)
     elif name == "nemotron3":
         renderer = Nemotron3Renderer(tokenizer)
+    elif name == "nemotron3_low_thinking":
+        renderer = Nemotron3LowThinkingRenderer(tokenizer)
     elif name == "nemotron3_disable_thinking":
         renderer = Nemotron3DisableThinkingRenderer(tokenizer)
     elif name == "gpt_oss_no_sysprompt":

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -136,9 +136,9 @@ def get_renderer(
             - ``"kimi_k2"``: Kimi K2 Thinking format
             - ``"kimi_k25"``: Kimi K2.5 with thinking enabled
             - ``"kimi_k25_disable_thinking"``: Kimi K2.5 with thinking disabled
-            - ``"nemotron3"``: Nemotron-3 with thinking enabled
-            - ``"nemotron3_low_thinking"``: Nemotron-3 with low thinking effort (Super only)
-            - ``"nemotron3_disable_thinking"``: Nemotron-3 with thinking disabled
+            - ``"nemotron3"``: Nemotron-3 with full reasoning (Nano & Super)
+            - ``"nemotron3_low_thinking"``: Nemotron-3 with low-effort reasoning (Super only)
+            - ``"nemotron3_disable_thinking"``: Nemotron-3 with reasoning off (Nano & Super)
             - ``"gpt_oss_no_sysprompt"``: GPT-OSS without system prompt
             - ``"gpt_oss_low_reasoning"``: GPT-OSS with low reasoning
             - ``"gpt_oss_medium_reasoning"``: GPT-OSS with medium reasoning

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -379,7 +379,9 @@ class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
         """Render message, appending low-effort suffix to the last user message."""
         if message["role"] == "user" and ctx.idx == ctx.last_user_index:
             content = message.get("content", "")
-            assert isinstance(content, str), "Nemotron-3 Super is text-only; list content not supported"
+            assert isinstance(content, str), (
+                "Nemotron-3 Super is text-only; list content not supported"
+            )
             message = message.copy()
             message["content"] = content + "\n\n{reasoning effort: low}"
         return super().render_message(message, ctx)

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -347,19 +347,13 @@ class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
     (NVIDIA-Nemotron-3-Super-120B-A12B-BF16).
     """
 
-    _LOW_EFFORT_SUFFIX = "\n\n{reasoning effort: low}"
-
     def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
         """Render message, appending low-effort suffix to the last user message."""
         if message["role"] == "user" and ctx.idx == ctx.last_user_index:
             content = message.get("content", "")
+            assert isinstance(content, str), "Nemotron-3 Super is text-only; list content not supported"
             message = message.copy()
-            if isinstance(content, str):
-                message["content"] = content + self._LOW_EFFORT_SUFFIX
-            else:
-                message["content"] = list(content) + [
-                    TextPart(type="text", text=self._LOW_EFFORT_SUFFIX)
-                ]
+            message["content"] = content + "\n\n{reasoning effort: low}"
         return super().render_message(message, ctx)
 
 

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -350,27 +350,16 @@ class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
     _LOW_EFFORT_SUFFIX = "\n\n{reasoning effort: low}"
 
     def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
-        """Render message, appending low-effort suffix to the last user message.
-
-        Args:
-            message (Message): The chat message to render.
-            ctx (RenderContext): Positional context including index and is_last flag.
-
-        Returns:
-            RenderedMessage: Header and output token chunks for the message.
-        """
+        """Render message, appending low-effort suffix to the last user message."""
         if message["role"] == "user" and ctx.idx == ctx.last_user_index:
             content = message.get("content", "")
+            message = message.copy()
             if isinstance(content, str):
-                message = Message(**{**message, "content": content + self._LOW_EFFORT_SUFFIX})
+                message["content"] = content + self._LOW_EFFORT_SUFFIX
             else:
-                message = Message(
-                    **{
-                        **message,
-                        "content": list(content)
-                        + [TextPart(type="text", text=self._LOW_EFFORT_SUFFIX)],
-                    }
-                )
+                message["content"] = list(content) + [
+                    TextPart(type="text", text=self._LOW_EFFORT_SUFFIX)
+                ]
         return super().render_message(message, ctx)
 
 

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -335,6 +335,45 @@ class Nemotron3Renderer(Qwen3_5Renderer):
         return [Message(role="system", content=content)]
 
 
+class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
+    """Renderer for Nemotron-3 models with low thinking effort.
+
+    Matches the Nemotron-3 Super HF template with ``low_effort=True``.
+    Thinking is still enabled (generation suffix is ``<think>\\n``), but
+    ``{reasoning effort: low}`` is appended to the last user message to
+    signal the model should use less reasoning.
+
+    This mode is only available on the Nemotron-3 Super model
+    (NVIDIA-Nemotron-3-Super-120B-A12B-BF16).
+    """
+
+    _LOW_EFFORT_SUFFIX = "\n\n{reasoning effort: low}"
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        """Render message, appending low-effort suffix to the last user message.
+
+        Args:
+            message (Message): The chat message to render.
+            ctx (RenderContext): Positional context including index and is_last flag.
+
+        Returns:
+            RenderedMessage: Header and output token chunks for the message.
+        """
+        if message["role"] == "user" and ctx.idx == ctx.last_user_index:
+            content = message.get("content", "")
+            if isinstance(content, str):
+                message = Message(**{**message, "content": content + self._LOW_EFFORT_SUFFIX})
+            else:
+                message = Message(
+                    **{
+                        **message,
+                        "content": list(content)
+                        + [TextPart(type="text", text=self._LOW_EFFORT_SUFFIX)],
+                    }
+                )
+        return super().render_message(message, ctx)
+
+
 class Nemotron3DisableThinkingRenderer(Nemotron3Renderer):
     """Renderer for Nemotron-3 models with thinking disabled.
 

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -28,6 +28,28 @@ the following ways:
    prepends an empty system message in build_generation_prompt and
    build_supervised_example to match this behavior.
 
+Thinking modes
+--------------
+Both Nano and Super support reasoning ON/OFF. The Super model additionally
+supports a low-effort reasoning mode that produces shorter thinking traces.
+
++---------------------+-------------------------------+---------------------+
+| Mode                | HF template params            | Renderer name       |
++=====================+===============================+=====================+
+| Reasoning ON (full) | enable_thinking=True          | nemotron3           |
++---------------------+-------------------------------+---------------------+
+| Low-effort thinking | enable_thinking=True,         | nemotron3_low       |
+| (Super only)        | low_effort=True               | _thinking           |
++---------------------+-------------------------------+---------------------+
+| Reasoning OFF       | enable_thinking=False         | nemotron3_disable   |
+|                     |                               | _thinking           |
++---------------------+-------------------------------+---------------------+
+
+The low-effort mode appends ``{reasoning effort: low}`` to the last user
+message, signaling the model to use shorter reasoning traces. The generation
+suffix remains ``<think>\\n`` (thinking is still enabled).
+
+Reference: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
 """
 
 import dataclasses
@@ -336,15 +358,21 @@ class Nemotron3Renderer(Qwen3_5Renderer):
 
 
 class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
-    """Renderer for Nemotron-3 models with low thinking effort.
+    """Renderer for Nemotron-3 Super with low-effort reasoning.
 
-    Matches the Nemotron-3 Super HF template with ``low_effort=True``.
-    Thinking is still enabled (generation suffix is ``<think>\\n``), but
-    ``{reasoning effort: low}`` is appended to the last user message to
-    signal the model should use less reasoning.
+    Matches the Nemotron-3 Super HF template with ``enable_thinking=True``
+    and ``low_effort=True``. The model still produces a ``<think>`` block but
+    uses significantly fewer reasoning tokens than full thinking mode.
+
+    Mechanically, ``{reasoning effort: low}`` is appended to the last user
+    message content; the generation suffix remains ``<think>\\n`` (same as
+    the full-thinking ``Nemotron3Renderer``).
 
     This mode is only available on the Nemotron-3 Super model
-    (NVIDIA-Nemotron-3-Super-120B-A12B-BF16).
+    (NVIDIA-Nemotron-3-Super-120B-A12B-BF16); the Nano model's HF template
+    does not support ``low_effort``.
+
+    Reference: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
     """
 
     def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -8,6 +8,7 @@ Tests verify that the Nemotron3Renderer produces correct output:
 4. System prompt comes BEFORE tools in the system message
 5. <think></think> is prepended to ALL assistant messages without thinking (not just last)
 6. HF template compatibility for both build_generation_prompt and build_supervised_example
+7. Low-thinking variant appends {reasoning effort: low} to last user message
 """
 
 import json
@@ -17,6 +18,7 @@ import pytest
 from tinker_cookbook.renderers import Message, ToolCall, ToolSpec, get_renderer
 from tinker_cookbook.renderers.nemotron3 import (
     Nemotron3DisableThinkingRenderer,
+    Nemotron3LowThinkingRenderer,
     Nemotron3Renderer,
     _format_nemotron3_tool_declaration,
 )
@@ -47,11 +49,15 @@ def nemotron_renderer_disable_thinking(nemotron_tokenizer):
     return get_renderer("nemotron3_disable_thinking", nemotron_tokenizer)
 
 
-def _hf_generation_tokens(tokenizer, hf_messages, tools=None, enable_thinking: bool = True):
+def _hf_generation_tokens(
+    tokenizer, hf_messages, tools=None, enable_thinking: bool = True, low_effort: bool = False
+):
     """Run HF apply_chat_template with generation prompt and return token list."""
     kwargs = {"add_generation_prompt": True, "tokenize": True, "enable_thinking": enable_thinking}
     if tools is not None:
         kwargs["tools"] = tools
+    if low_effort:
+        kwargs["low_effort"] = True
     result = tokenizer.apply_chat_template(hf_messages, **kwargs)
     # apply_chat_template may return BatchEncoding (dict-like) when tools are provided.
     if hasattr(result, "input_ids"):
@@ -59,11 +65,15 @@ def _hf_generation_tokens(tokenizer, hf_messages, tools=None, enable_thinking: b
     return list(result)
 
 
-def _hf_supervised_tokens(tokenizer, hf_messages, tools=None, enable_thinking: bool = True):
+def _hf_supervised_tokens(
+    tokenizer, hf_messages, tools=None, enable_thinking: bool = True, low_effort: bool = False
+):
     """Run HF apply_chat_template without generation prompt, strip trailing newline, re-encode."""
     kwargs = {"add_generation_prompt": False, "tokenize": False, "enable_thinking": enable_thinking}
     if tools is not None:
         kwargs["tools"] = tools
+    if low_effort:
+        kwargs["low_effort"] = True
     result = tokenizer.apply_chat_template(hf_messages, **kwargs)
     # apply_chat_template with tokenize=False may return BatchEncoding when tools are provided.
     hf_str = result.input_ids if hasattr(result, "input_ids") else result
@@ -786,3 +796,143 @@ def test_renderer_is_not_qwen35(nemotron_renderer):
     from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
 
     assert type(nemotron_renderer) is not Qwen3_5Renderer
+
+
+# =============================================================================
+# Low Thinking Renderer Tests (Nemotron-3 Super only)
+# =============================================================================
+
+# The low_effort feature is only in the Super model's HF template, so we need
+# the Super tokenizer for HF comparison tests.
+
+
+@pytest.fixture(scope="module")
+def nemotron_super_tokenizer():
+    return get_tokenizer(NEMOTRON3_SUPER_MODEL)
+
+
+@pytest.fixture(scope="module")
+def nemotron_low_thinking_renderer(nemotron_super_tokenizer):
+    return get_renderer("nemotron3_low_thinking", nemotron_super_tokenizer)
+
+
+def test_low_thinking_renderer_type(nemotron_low_thinking_renderer):
+    assert isinstance(nemotron_low_thinking_renderer, Nemotron3LowThinkingRenderer)
+    assert isinstance(nemotron_low_thinking_renderer, Nemotron3Renderer)
+
+
+def test_low_thinking_generation_ends_with_think(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """Low-thinking generation prompt still uses <think>\\n (thinking is enabled)."""
+    messages = get_basic_conversation_for_generation()
+    decoded = nemotron_super_tokenizer.decode(
+        nemotron_low_thinking_renderer.build_generation_prompt(messages).to_ints()
+    )
+    assert decoded.endswith("<|im_start|>assistant\n<think>\n")
+
+
+def test_low_thinking_appends_effort_suffix(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """Low-thinking appends {reasoning effort: low} to the last user message."""
+    messages = get_basic_conversation_for_generation()
+    decoded = nemotron_super_tokenizer.decode(
+        nemotron_low_thinking_renderer.build_generation_prompt(messages).to_ints()
+    )
+    assert "{reasoning effort: low}<|im_end|>" in decoded
+
+
+def test_low_thinking_only_affects_last_user_message(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """Only the last user message gets the low-effort suffix."""
+    messages = get_basic_conversation_for_generation()
+    decoded = nemotron_super_tokenizer.decode(
+        nemotron_low_thinking_renderer.build_generation_prompt(messages).to_ints()
+    )
+    # Count occurrences — should only appear once (in last user message)
+    assert decoded.count("{reasoning effort: low}") == 1
+
+
+def test_low_thinking_generation_matches_hf(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """Low-thinking generation matches HF template with low_effort=True."""
+    messages = get_basic_conversation_for_generation()
+    r = nemotron_low_thinking_renderer
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_super_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        low_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_super_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_super_tokenizer.decode(hf)}"
+    )
+
+
+def test_low_thinking_supervised_matches_hf(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """Low-thinking supervised example matches HF template with low_effort=True."""
+    messages = get_basic_conversation_for_supervised()
+    r = nemotron_low_thinking_renderer
+    cookbook = r.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_super_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        low_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_super_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_super_tokenizer.decode(hf)}"
+    )
+
+
+def test_low_thinking_multiturn_generation_matches_hf(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """Multi-turn low-thinking generation matches HF template."""
+    messages = [
+        Message(role="system", content="You are a helpful assistant."),
+        Message(role="user", content="First question."),
+        Message(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "First turn reasoning."},
+                {"type": "text", "text": "First answer."},
+            ],
+        ),
+        Message(role="user", content="Second question."),
+    ]
+    r = nemotron_low_thinking_renderer
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_super_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        low_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_super_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_super_tokenizer.decode(hf)}"
+    )
+
+
+def test_low_thinking_multiturn_supervised_matches_hf(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """Multi-turn low-thinking supervised example matches HF template."""
+    messages = get_multiturn_thinking_conversation()
+    r = nemotron_low_thinking_renderer
+    cookbook = r.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_super_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        low_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_super_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_super_tokenizer.decode(hf)}"
+    )

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -821,40 +821,6 @@ def test_low_thinking_renderer_type(nemotron_low_thinking_renderer):
     assert isinstance(nemotron_low_thinking_renderer, Nemotron3Renderer)
 
 
-def test_low_thinking_generation_ends_with_think(
-    nemotron_super_tokenizer, nemotron_low_thinking_renderer
-):
-    """Low-thinking generation prompt still uses <think>\\n (thinking is enabled)."""
-    messages = get_basic_conversation_for_generation()
-    decoded = nemotron_super_tokenizer.decode(
-        nemotron_low_thinking_renderer.build_generation_prompt(messages).to_ints()
-    )
-    assert decoded.endswith("<|im_start|>assistant\n<think>\n")
-
-
-def test_low_thinking_appends_effort_suffix(
-    nemotron_super_tokenizer, nemotron_low_thinking_renderer
-):
-    """Low-thinking appends {reasoning effort: low} to the last user message."""
-    messages = get_basic_conversation_for_generation()
-    decoded = nemotron_super_tokenizer.decode(
-        nemotron_low_thinking_renderer.build_generation_prompt(messages).to_ints()
-    )
-    assert "{reasoning effort: low}<|im_end|>" in decoded
-
-
-def test_low_thinking_only_affects_last_user_message(
-    nemotron_super_tokenizer, nemotron_low_thinking_renderer
-):
-    """Only the last user message gets the low-effort suffix."""
-    messages = get_basic_conversation_for_generation()
-    decoded = nemotron_super_tokenizer.decode(
-        nemotron_low_thinking_renderer.build_generation_prompt(messages).to_ints()
-    )
-    # Count occurrences — should only appear once (in last user message)
-    assert decoded.count("{reasoning effort: low}") == 1
-
-
 def test_low_thinking_generation_matches_hf(
     nemotron_super_tokenizer, nemotron_low_thinking_renderer
 ):
@@ -895,18 +861,7 @@ def test_low_thinking_multiturn_generation_matches_hf(
     nemotron_super_tokenizer, nemotron_low_thinking_renderer
 ):
     """Multi-turn low-thinking generation matches HF template."""
-    messages = [
-        Message(role="system", content="You are a helpful assistant."),
-        Message(role="user", content="First question."),
-        Message(
-            role="assistant",
-            content=[
-                {"type": "thinking", "thinking": "First turn reasoning."},
-                {"type": "text", "text": "First answer."},
-            ],
-        ),
-        Message(role="user", content="Second question."),
-    ]
+    messages = get_multiturn_thinking_conversation()[:4]
     r = nemotron_low_thinking_renderer
     cookbook = r.build_generation_prompt(messages).to_ints()
     hf = _hf_generation_tokens(


### PR DESCRIPTION
## Summary

The Nemotron-3 Super model supports three thinking modes ([model card](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16)), but the cookbook only supported two. This PR adds the missing low-effort reasoning mode.

| Mode | HF template params | Renderer name |
|------|-------------------|---------------|
| Reasoning ON (full) | `enable_thinking=True` | `nemotron3` |
| **Low-effort reasoning** | `enable_thinking=True, low_effort=True` | **`nemotron3_low_thinking`** (new) |
| Reasoning OFF | `enable_thinking=False` | `nemotron3_disable_thinking` |

Low-effort mode appends `{reasoning effort: low}` to the last user message while keeping thinking enabled. The model still produces a `<think>` block but uses significantly fewer reasoning tokens. This mode is only available on the Super model (the Nano model's HF template does not support `low_effort`).

### Changes
- `tinker_cookbook/renderers/nemotron3.py` — Add `Nemotron3LowThinkingRenderer` class and document all three thinking modes in the module docstring
- `tinker_cookbook/renderers/__init__.py` — Register `"nemotron3_low_thinking"` in the factory
- `tinker_cookbook/model_info.py` — Add `_NEMOTRON3_SUPER` renderer tuple with `nemotron3_low_thinking` for the Super model
- `tinker_cookbook/renderers/nemotron3_test.py` — HF template token-exact match tests (generation + supervised, single + multi-turn)
- `tests/downstream_compat/test_renderers.py` — Add to expected renderer names

## Test plan
- [x] 34 Nemotron-3 renderer unit tests pass (29 existing + 5 new)
- [x] HF template token-exact match verified for generation (single-turn and multi-turn)
- [x] HF template token-exact match verified for supervised (single-turn and multi-turn)
- [x] 59 downstream compat tests pass (new renderer name registered)
- [x] E2e verified against live Tinker API — model produced short thinking and correct answer with low-effort mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)