### PR TITLE
fix(docs): correct TinkerAPI to Tinker API in recipes README

### DIFF
--- a/tinker_cookbook/recipes/README.md
+++ b/tinker_cookbook/recipes/README.md
@@ -9,7 +9,7 @@ Tinker Cookbook comes with useful abstractions so you can flexibly customize you
 - [`rl_basic.py`](./rl_basic.py): a template script to configure reinforcement learning.
 - [`sl_basic.py`](./sl_basic.py): a template script to configure supervised learning.
 
-To explain what goes under-the-hood, we also provide minimal, self-contained scripts that directly use the TinkerAPI to train LLMs.
+To explain what goes under-the-hood, we also provide minimal, self-contained scripts that directly use the Tinker API to train LLMs.
 - [`rl_loop.py`](./rl_loop.py): a minimal reinforcement learning training loop.
 - [`sl_loop.py`](./sl_loop.py): a minimal supervised learning training loop.
 


### PR DESCRIPTION
Good day,

This PR fixes a minor documentation inconsistency where 'TinkerAPI' is used instead of the correct 'Tinker API' terminology. The tinker project name should be written as two separate words, consistent with usage elsewhere in the documentation.

**Changes:**
- Fixed "TinkerAPI" → "Tinker API" in recipes README

Thank you for your work on this excellent library!

Warmly,
RoomWithOutRoof