### PR TITLE
fix(model_info): add NVIDIA-Nemotron-Cascade-2-30B-A3B entry

### DIFF
--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -231,6 +231,7 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
         "openai/gpt-oss-120b",
         "moonshotai/Kimi-K2-Thinking",
         "moonshotai/Kimi-K2.5",
+        "nvidia/Nemotron-Cascade-2-30B-A3B",
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
         "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
     ):

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -172,6 +172,9 @@ def get_nvidia_info() -> dict[str, ModelAttributes]:
         "NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": ModelAttributes(
             org, "3", "30B-A3B", True, _NEMOTRON3
         ),
+        "NVIDIA-Nemotron-Cascade-2-30B-A3B": ModelAttributes(
+            org, "Cascade-2", "30B-A3B", True, _NEMOTRON3
+        ),
         "NVIDIA-Nemotron-3-Super-120B-A12B-BF16": ModelAttributes(
             org, "3", "120B-A12B", True, _NEMOTRON3_SUPER
         ),

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -172,7 +172,7 @@ def get_nvidia_info() -> dict[str, ModelAttributes]:
         "NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": ModelAttributes(
             org, "3", "30B-A3B", True, _NEMOTRON3
         ),
-        "NVIDIA-Nemotron-Cascade-2-30B-A3B": ModelAttributes(
+        "Nemotron-Cascade-2-30B-A3B": ModelAttributes(
             org, "Cascade-2", "30B-A3B", True, _NEMOTRON3
         ),
         "NVIDIA-Nemotron-3-Super-120B-A12B-BF16": ModelAttributes(


### PR DESCRIPTION
Good day,

This PR adds a model_info entry for NVIDIA-Nemotron-Cascade-2-30B-A3B pointing to the existing nemotron3 renderer.

As noted in the review of PR #664, Nemotron-Cascade-2 and Nemotron-3 Nano use nearly identical HF chat templates (same im_start/im_end format, same XML tool calling, same thinking block handling). Therefore, no new renderer is needed — only a model_info entry is required.

## Changes
- Add model_info entry for NVIDIA-Nemotron-Cascade-2-30B-A3B pointing to the existing nemotron3 renderer names

## Example usage


Thank you for your attention...

Warmly, RoomWithOutRoof