### PR TITLE
fix(sl_loop): use math.ceil for train batch count

### DIFF
--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -4,6 +4,7 @@ Uses existing modules but with a simple, flat training loop.
 """
 
 import logging
+import math
 import time
 
 import chz
@@ -58,7 +59,7 @@ def main(config: Config):
 
     # Drop the last incomplete batch (like PyTorch's drop_last=True) — a partial
     # batch has different effective gradient magnitude, which can cause a training spike.
-    n_train_batches = len(train_dataset) // config.batch_size
+    n_train_batches = math.ceil(len(train_dataset) / config.batch_size)
     n_dropped = len(train_dataset) % config.batch_size
     if n_dropped:
         logger.info(


### PR DESCRIPTION
Good day,

This PR changes the train batch count calculation in sl_loop.py from floor division to math.ceil.

## Change
- Import math module
- Change n_train_batches from len(train_dataset) // config.batch_size to math.ceil(len(train_dataset) / config.batch_size)

This ensures the total number of batches is correctly counted even when the dataset size is not evenly divisible by the batch size.

Note: This is submitted as a standalone PR as suggested in the review of PR #664, where the same math.ceil fix was found to be duplicated across PRs #665 and #666.

Thank you for your attention...

Warmly, RoomWithOutRoof