### PR TITLE
Add kimi-cli file tools to Harbor environment

### DIFF
--- a/tinker_cookbook/recipes/harbor_rl/eval.py
+++ b/tinker_cookbook/recipes/harbor_rl/eval.py
@@ -97,7 +97,7 @@ async def evaluate_task(
         env = build_agent_tool_env(
             renderer=renderer,
             tools=[bash_tool.bash],
-            initial_messages=_initial_messages(task, renderer, bash_tool),
+            initial_messages=_initial_messages(task, renderer, [bash_tool.bash]),
             reward_fn=reward_fn,
             max_turns=config.max_turns,
         )

--- a/tinker_cookbook/recipes/harbor_rl/harbor_env.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_env.py
@@ -12,7 +12,15 @@ from typing import Any
 import chz
 
 from tinker_cookbook import model_info, tokenizer_utils
-from tinker_cookbook.recipes.harbor_rl.harbor_tools import HarborBashTool, HarborReward
+from tinker_cookbook.recipes.harbor_rl.harbor_tools import (
+    HarborBashTool,
+    HarborGlobTool,
+    HarborGrepTool,
+    HarborReadFileTool,
+    HarborReward,
+    HarborStrReplaceFileTool,
+    HarborWriteFileTool,
+)
 from tinker_cookbook.renderers import get_renderer
 from tinker_cookbook.renderers.base import Message, Renderer
 from tinker_cookbook.rl.types import Env, EnvGroupBuilder, RLDataset, RLDatasetBuilder
@@ -79,13 +87,14 @@ def load_harbor_tasks(dataset: str) -> list[HarborTask]:
 def _initial_messages(
     task: HarborTask,
     renderer: Renderer,
-    bash_tool: HarborBashTool,
+    tools: list,
+    system_prompt: str = HARBOR_SYSTEM_PROMPT,
 ) -> list[Message]:
     """Build initial messages with tool schemas and task instruction."""
-    tool_schemas = [bash_tool.bash.to_spec()]
+    tool_schemas = [t.to_spec() for t in tools]
     prefix = renderer.create_conversation_prefix_with_tools(
         tools=tool_schemas,
-        system_prompt=HARBOR_SYSTEM_PROMPT,
+        system_prompt=system_prompt,
     )
     return prefix + [{"role": "user", "content": task.instruction}]
 
@@ -108,6 +117,8 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
         context_overflow_reward: float = -0.1,
         sandbox_factory: SandboxFactory | None = None,
         reward_fn: RewardFn | None = None,
+        enable_file_tools: bool = False,
+        rg_host_path: str | None = None,
     ):
         self.task = task
         self.model_name = model_name
@@ -122,28 +133,61 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
         self.context_overflow_reward = context_overflow_reward
         self.sandbox_factory = sandbox_factory or default_sandbox_factory
         self.reward_fn = reward_fn
+        self.enable_file_tools = enable_file_tools
+        self.rg_host_path = rg_host_path
         self._sandboxes: list[SandboxInterface] = []
+
+    def _create_renderer(self) -> Renderer:
+        tokenizer = tokenizer_utils.get_tokenizer(self.model_name)
+        renderer_name = self.renderer_name or model_info.get_recommended_renderer_name(
+            self.model_name
+        )
+        return get_renderer(renderer_name, tokenizer)
+
+    def _build_tools(self, sandbox: SandboxInterface | None = None) -> list:
+        """Build the list of tool objects for this environment."""
+        bash_tool = HarborBashTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
+        tools = [bash_tool.bash]
+        if self.enable_file_tools:
+            glob_tool = HarborGlobTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
+            grep_tool = HarborGrepTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
+            read_tool = HarborReadFileTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
+            write_tool = HarborWriteFileTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
+            replace_tool = HarborStrReplaceFileTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
+            tools.extend(
+                [
+                    glob_tool.Glob,
+                    grep_tool.Grep,
+                    read_tool.ReadFile,
+                    write_tool.WriteFile,
+                    replace_tool.StrReplaceFile,
+                ]
+            )
+        return tools
 
     async def make_envs(self) -> Sequence[Env]:
         self._sandboxes = []
 
         env_dir = self.task.task_dir / "environment"
-
-        # Create renderer (stateless, shared across envs)
-        tokenizer = tokenizer_utils.get_tokenizer(self.model_name)
-        renderer_name = self.renderer_name or model_info.get_recommended_renderer_name(
-            self.model_name
-        )
-        renderer = get_renderer(renderer_name, tokenizer)
+        renderer = self._create_renderer()
 
         tests_dir = self.task.task_dir / "tests"
+
+        # Read rg binary from host once if file tools are enabled
+        rg_bytes: bytes | None = None
+        if self.enable_file_tools and self.rg_host_path:
+            rg_bytes = Path(self.rg_host_path).read_bytes()
 
         envs = []
         for _ in range(self.group_size):
             sandbox = await self.sandbox_factory(env_dir, self.sandbox_timeout)
             self._sandboxes.append(sandbox)
 
-            bash_tool = HarborBashTool(sandbox, command_timeout=self.command_timeout)
+            # Upload rg binary into sandbox if file tools are enabled
+            if rg_bytes is not None:
+                await sandbox.write_file("/usr/local/bin/rg", rg_bytes, executable=True)
+
+            tools = self._build_tools(sandbox)
             reward_fn = self.reward_fn or HarborReward(
                 tests_dir=tests_dir,
                 sandbox=sandbox,
@@ -152,8 +196,8 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
             envs.append(
                 build_agent_tool_env(
                     renderer=renderer,
-                    tools=[bash_tool.bash],
-                    initial_messages=_initial_messages(self.task, renderer, bash_tool),
+                    tools=tools,
+                    initial_messages=_initial_messages(self.task, renderer, tools),
                     reward_fn=reward_fn,
                     max_turns=self.max_turns,
                     max_trajectory_tokens=self.max_trajectory_tokens,
@@ -213,6 +257,8 @@ class HarborDatasetBuilder(RLDatasetBuilder):
     context_overflow_reward: float = -0.1
     sandbox_factory: SandboxFactory | None = None
     reward_fn: RewardFn | None = None
+    enable_file_tools: bool = False
+    rg_host_path: str | None = None
 
     def _make_env_group_builders(self, group_size: int) -> list[HarborEnvGroupBuilder]:
         return [
@@ -230,6 +276,8 @@ class HarborDatasetBuilder(RLDatasetBuilder):
                 context_overflow_reward=self.context_overflow_reward,
                 sandbox_factory=self.sandbox_factory,
                 reward_fn=self.reward_fn,
+                enable_file_tools=self.enable_file_tools,
+                rg_host_path=self.rg_host_path,
             )
             for task in self.tasks
         ]

--- a/tinker_cookbook/recipes/harbor_rl/harbor_env.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_env.py
@@ -196,7 +196,9 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
 
             # Upload rg binary into sandbox if file tools are enabled
             if rg_bytes is not None:
-                await sandbox.write_file("/usr/local/bin/rg", rg_bytes, executable=True)
+                rg_result = await sandbox.write_file("/usr/local/bin/rg", rg_bytes, executable=True)
+                if rg_result.exit_code != 0:
+                    raise RuntimeError(f"Failed to upload rg binary to sandbox: {rg_result.stderr}")
 
             tools = self._build_tools(sandbox)
             reward_fn = self.reward_fn or HarborReward(

--- a/tinker_cookbook/recipes/harbor_rl/harbor_env.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_env.py
@@ -26,7 +26,7 @@ from tinker_cookbook.renderers.base import Message, Renderer
 from tinker_cookbook.rl.types import Env, EnvGroupBuilder, RLDataset, RLDatasetBuilder
 from tinker_cookbook.sandbox import SandboxInterface
 from tinker_cookbook.sandbox.modal_sandbox import ModalSandbox
-from tinker_cookbook.tool_use import build_agent_tool_env
+from tinker_cookbook.tool_use import FunctionTool, build_agent_tool_env
 from tinker_cookbook.tool_use.agent_tool_message_env import RewardFn
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,12 @@ HARBOR_CACHE_DIR = Path.home() / ".cache" / "harbor" / "tasks"
 HARBOR_SYSTEM_PROMPT = (
     "You are a skilled software engineer working in a sandboxed environment. "
     "You have access to a bash tool to execute commands. "
+    "Complete the task described by the user."
+)
+HARBOR_FILE_TOOLS_SYSTEM_PROMPT = (
+    "You are a skilled software engineer working in a sandboxed environment. "
+    "You have access to bash, file search (Glob, Grep), file reading (ReadFile), "
+    "file writing (WriteFile), and file editing (StrReplaceFile) tools. "
     "Complete the task described by the user."
 )
 
@@ -87,7 +93,7 @@ def load_harbor_tasks(dataset: str) -> list[HarborTask]:
 def _initial_messages(
     task: HarborTask,
     renderer: Renderer,
-    tools: list,
+    tools: list[FunctionTool],
     system_prompt: str = HARBOR_SYSTEM_PROMPT,
 ) -> list[Message]:
     """Build initial messages with tool schemas and task instruction."""
@@ -133,6 +139,8 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
         self.context_overflow_reward = context_overflow_reward
         self.sandbox_factory = sandbox_factory or default_sandbox_factory
         self.reward_fn = reward_fn
+        if enable_file_tools and not rg_host_path:
+            raise ValueError("rg_host_path is required when enable_file_tools=True")
         self.enable_file_tools = enable_file_tools
         self.rg_host_path = rg_host_path
         self._sandboxes: list[SandboxInterface] = []
@@ -144,16 +152,16 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
         )
         return get_renderer(renderer_name, tokenizer)
 
-    def _build_tools(self, sandbox: SandboxInterface | None = None) -> list:
+    def _build_tools(self, sandbox: SandboxInterface) -> list[FunctionTool]:
         """Build the list of tool objects for this environment."""
-        bash_tool = HarborBashTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
-        tools = [bash_tool.bash]
+        bash_tool = HarborBashTool(sandbox, command_timeout=self.command_timeout)
+        tools: list[FunctionTool] = [bash_tool.bash]
         if self.enable_file_tools:
-            glob_tool = HarborGlobTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
-            grep_tool = HarborGrepTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
-            read_tool = HarborReadFileTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
-            write_tool = HarborWriteFileTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
-            replace_tool = HarborStrReplaceFileTool(sandbox, command_timeout=self.command_timeout)  # type: ignore[arg-type]
+            glob_tool = HarborGlobTool(sandbox, command_timeout=self.command_timeout)
+            grep_tool = HarborGrepTool(sandbox, command_timeout=self.command_timeout)
+            read_tool = HarborReadFileTool(sandbox, command_timeout=self.command_timeout)
+            write_tool = HarborWriteFileTool(sandbox, command_timeout=self.command_timeout)
+            replace_tool = HarborStrReplaceFileTool(sandbox, command_timeout=self.command_timeout)
             tools.extend(
                 [
                     glob_tool.Glob,
@@ -170,6 +178,9 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
 
         env_dir = self.task.task_dir / "environment"
         renderer = self._create_renderer()
+        system_prompt = (
+            HARBOR_FILE_TOOLS_SYSTEM_PROMPT if self.enable_file_tools else HARBOR_SYSTEM_PROMPT
+        )
 
         tests_dir = self.task.task_dir / "tests"
 
@@ -197,7 +208,9 @@ class HarborEnvGroupBuilder(EnvGroupBuilder):
                 build_agent_tool_env(
                     renderer=renderer,
                     tools=tools,
-                    initial_messages=_initial_messages(self.task, renderer, tools),
+                    initial_messages=_initial_messages(
+                        self.task, renderer, tools, system_prompt=system_prompt
+                    ),
                     reward_fn=reward_fn,
                     max_turns=self.max_turns,
                     max_trajectory_tokens=self.max_trajectory_tokens,

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -150,13 +150,14 @@ class HarborGlobTool:
         # Use bash glob expansion (supports brace expansion like *.{js,ts})
         # shopt -s globstar enables ** for recursive matching
         # shopt -s nullglob prevents literal pattern output when no matches
+        # Wrap in subshell so cd failure stops the entire command
         type_flag = "" if include_dirs else '[ -f "$f" ] && '
         cmd = (
-            f"cd {shlex.quote(dir_path)} && "
-            "shopt -s globstar nullglob 2>/dev/null; "
+            f"(cd {shlex.quote(dir_path)} && "
+            "shopt -s globstar nullglob 2>/dev/null && "
             f"for f in {pattern}; do {type_flag}"
             'echo "$f"; done | sort | head -n '
-            f"{MAX_GLOB_MATCHES + 1}"
+            f"{MAX_GLOB_MATCHES + 1})"
         )
         result = await self._sandbox.run_command(cmd, workdir="/", timeout=self._command_timeout)
 
@@ -853,7 +854,9 @@ class HarborStrReplaceFileTool:
 
         original_content = content
 
-        edits = [edit] if isinstance(edit, Edit) else edit
+        # Normalize: model_dump() produces dicts, so coerce to Edit objects
+        raw_edits = [edit] if isinstance(edit, Edit | dict) else edit
+        edits = [e if isinstance(e, Edit) else Edit(**e) for e in raw_edits]
 
         # Apply edits sequentially, counting replacements as we go
         total_replacements = 0

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -147,42 +147,35 @@ class HarborGlobTool:
             )
 
         dir_path = directory or "/"
-        script = (
-            "import json, pathlib\n"
-            f"d = pathlib.Path({dir_path!r})\n"
-            "matches = []\n"
-            f"for p in sorted(d.glob({pattern!r})):\n"
-            f"    if not {include_dirs!r} and p.is_dir():\n"
-            "        continue\n"
-            "    matches.append(str(p.relative_to(d)))\n"
-            "total = len(matches)\n"
-            f"matches = matches[:{MAX_GLOB_MATCHES}]\n"
-            'print(json.dumps({"matches": matches, "total": total}))\n'
+        # Use bash glob expansion (supports brace expansion like *.{js,ts})
+        # shopt -s globstar enables ** for recursive matching
+        # shopt -s nullglob prevents literal pattern output when no matches
+        type_flag = "" if include_dirs else '[ -f "$f" ] && '
+        cmd = (
+            f"cd {shlex.quote(dir_path)} && "
+            "shopt -s globstar nullglob 2>/dev/null; "
+            f"for f in {pattern}; do {type_flag}"
+            'echo "$f"; done | sort | head -n '
+            f"{MAX_GLOB_MATCHES + 1}"
         )
-
-        result = await self._sandbox.run_command(
-            f"python3 -c {shlex.quote(script)}",
-            workdir="/",
-            timeout=self._command_timeout,
-        )
+        result = await self._sandbox.run_command(cmd, workdir="/", timeout=self._command_timeout)
 
         if result.exit_code != 0:
             return _error_result(
                 f"Failed to search for pattern {pattern}. Error: {result.stderr[:MAX_OUTPUT_CHARS]}"
             )
 
-        try:
-            data = json.loads(result.stdout.strip())
-            matches: list[str] = data["matches"]
-            total: int = data["total"]
-        except (json.JSONDecodeError, KeyError) as e:
-            return _error_result(f"Failed to parse glob results. Error: {e}")
+        matches = [m for m in result.stdout.strip().split("\n") if m]
+        total = len(matches)
+        truncated = total > MAX_GLOB_MATCHES
+        if truncated:
+            matches = matches[:MAX_GLOB_MATCHES]
 
         if not matches:
             return _tool_result(f"No matches found for pattern `{pattern}`.")
 
         message = f"Found {total} matches for pattern `{pattern}`."
-        if total > MAX_GLOB_MATCHES:
+        if truncated:
             message += (
                 f" Only the first {MAX_GLOB_MATCHES} matches are returned. "
                 "You may want to use a more specific pattern."

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -578,15 +578,20 @@ class HarborReadFileTool:
                 "to read from a specific position."
             )
 
+        n_lines = min(n_lines, MAX_READ_LINES)
+
         if line_offset < 0:
             # Use tail command for accurate tail reads regardless of file size
-            return await self._read_tail_via_sandbox(
-                path, line_offset, min(n_lines, MAX_READ_LINES)
-            )
+            return await self._read_tail_via_sandbox(path, line_offset, n_lines)
 
-        # Read 2x the byte budget so we can count total_lines even when content is capped
-        result = await self._sandbox.read_file(
-            path, max_bytes=MAX_READ_BYTES * 2, timeout=self._command_timeout
+        # Use sed + wc in sandbox to read the exact requested line range,
+        # so pagination works correctly for files larger than the byte budget
+        end_line = line_offset + n_lines - 1
+        cmd = (
+            f"wc -l < {shlex.quote(path)} && sed -n '{line_offset},{end_line}p' {shlex.quote(path)}"
+        )
+        result = await self._sandbox.run_command(
+            cmd, workdir="/", timeout=self._command_timeout, max_output_bytes=MAX_READ_BYTES * 2
         )
 
         if result.exit_code != 0:
@@ -597,12 +602,18 @@ class HarborReadFileTool:
                 return _error_result(f"`{path}` is not a file.")
             return _error_result(f"Failed to read {path}. Error: {stderr}")
 
-        content = result.stdout
-        all_lines = content.splitlines()
-        total_lines = len(all_lines)
+        output_lines = result.stdout.split("\n")
+        try:
+            total_lines = int(output_lines[0].strip())
+        except (ValueError, IndexError):
+            total_lines = 0
 
-        n_lines = min(n_lines, MAX_READ_LINES)
-        return self._format_forward(all_lines, total_lines, line_offset, n_lines, path)
+        # Lines after the first (wc -l output) are the sed content
+        content_lines = output_lines[1:]
+        if content_lines and content_lines[-1] == "":
+            content_lines = content_lines[:-1]
+
+        return self._format_forward(content_lines, total_lines, line_offset, n_lines, path)
 
     async def _read_tail_via_sandbox(self, path: str, line_offset: int, n_lines: int) -> ToolResult:
         """Read tail of file using sandbox commands for accuracy on large files."""
@@ -656,30 +667,26 @@ class HarborReadFileTool:
 
     def _format_forward(
         self,
-        all_lines: list[str],
+        content_lines: list[str],
         total_lines: int,
         line_offset: int,
         n_lines: int,
         path: str,
     ) -> ToolResult:
+        """Format pre-sliced lines (already at the requested offset) with cat -n style."""
         lines_read: list[str] = []
         truncated_line_numbers: list[int] = []
         n_bytes = 0
-        max_lines_reached = False
         max_bytes_reached = False
 
-        for i in range(line_offset - 1, len(all_lines)):
-            line = all_lines[i]
+        for i, line in enumerate(content_lines):
             truncated = _truncate_line(line, MAX_READ_LINE_LENGTH)
             if truncated != line:
-                truncated_line_numbers.append(i + 1)
+                truncated_line_numbers.append(line_offset + i)
             lines_read.append(truncated)
             n_bytes += len(truncated.encode("utf-8"))
 
             if len(lines_read) >= n_lines:
-                break
-            if len(lines_read) >= MAX_READ_LINES:
-                max_lines_reached = True
                 break
             if n_bytes >= MAX_READ_BYTES:
                 max_bytes_reached = True
@@ -696,9 +703,7 @@ class HarborReadFileTool:
             else "No lines read from file."
         )
         message += f" Total lines in file: {total_lines}."
-        if max_lines_reached:
-            message += f" Max {MAX_READ_LINES} lines reached."
-        elif max_bytes_reached:
+        if max_bytes_reached:
             message += f" Max {MAX_READ_BYTES} bytes reached."
         elif len(lines_read) < n_lines:
             message += " End of file reached."
@@ -747,6 +752,14 @@ class HarborWriteFileTool:
             return _error_result("path is required")
 
         try:
+            # Resolve relative paths so both modes target the same file
+            if not path.startswith("/"):
+                resolve = await self._sandbox.run_command(
+                    f"readlink -f {shlex.quote(path)}", workdir="/", timeout=self._command_timeout
+                )
+                if resolve.exit_code == 0 and resolve.stdout.strip():
+                    path = resolve.stdout.strip()
+
             if mode == "overwrite":
                 result = await self._sandbox.write_file(
                     path, content, timeout=self._command_timeout

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -1,12 +1,20 @@
-"""Harbor bash tool and reward function for RL training."""
+"""Harbor tools for RL training with sandbox environments.
+
+Tool interfaces mirror kimi-cli (src/kimi_cli/tools/) so models pretrained
+with kimi-cli see familiar tools.
+"""
 
 from __future__ import annotations
 
 import json
 import logging
+import shlex
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
 
 from tinker_cookbook.renderers.base import Message
 from tinker_cookbook.sandbox import SandboxInterface
@@ -15,6 +23,44 @@ from tinker_cookbook.tool_use import ToolResult, simple_tool_result, tool
 logger = logging.getLogger(__name__)
 
 MAX_OUTPUT_CHARS = 16384
+MAX_GLOB_MATCHES = 1000
+MAX_READ_LINES = 1000
+MAX_READ_LINE_LENGTH = 2000
+MAX_READ_BYTES = 100 * 1024  # 100KB
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_result(message: str, output: str = "") -> ToolResult:
+    """Build a ToolResult with kimi-cli style <system> tags."""
+    if output:
+        content = f"<system>{message}</system>\n{output}" if message else output
+    else:
+        content = f"<system>{message}</system>" if message else ""
+    return simple_tool_result(content)
+
+
+def _error_result(error: str, output: str = "") -> ToolResult:
+    """Build an error ToolResult with kimi-cli style <system> tags."""
+    if output:
+        content = f"<system>ERROR: {error}</system>\n{output}"
+    else:
+        content = f"<system>ERROR: {error}</system>"
+    return simple_tool_result(content)
+
+
+def _truncate_line(line: str, max_length: int) -> str:
+    if len(line) <= max_length:
+        return line
+    return line[: max(max_length - 3, 0)] + "..."
+
+
+# ---------------------------------------------------------------------------
+# HarborBashTool (existing)
+# ---------------------------------------------------------------------------
 
 
 class HarborBashTool:
@@ -43,6 +89,800 @@ class HarborBashTool:
         stderr = result.stderr[:MAX_OUTPUT_CHARS]
         output = json.dumps({"exit_code": result.exit_code, "stdout": stdout, "stderr": stderr})
         return simple_tool_result(output)
+
+
+# ---------------------------------------------------------------------------
+# HarborGlobTool (mirrors src/kimi_cli/tools/file/glob.py)
+# ---------------------------------------------------------------------------
+
+
+class HarborGlobTool:
+    """Glob tool that searches for files in a sandbox."""
+
+    def __init__(self, sandbox: SandboxInterface, command_timeout: int = 30) -> None:
+        self._sandbox = sandbox
+        self._command_timeout = command_timeout
+
+    @tool
+    async def Glob(
+        self,
+        pattern: Annotated[str, "Glob pattern to match files/directories."],
+        directory: Annotated[
+            str | None,
+            "Absolute path to the directory to search in (defaults to working directory).",
+        ] = None,
+        include_dirs: Annotated[bool, "Whether to include directories in results."] = True,
+    ) -> ToolResult:
+        """Find files and directories using glob patterns.
+
+        This tool supports standard glob syntax like *, ?, and ** for recursive searches.
+
+        When to use:
+        - Find files matching specific patterns (e.g., all Python files: *.py)
+        - Search for files recursively in subdirectories (e.g., src/**/*.js)
+        - Locate configuration files (e.g., *.config.*, *.json)
+        - Find test files (e.g., test_*.py, *_test.go)
+
+        Example patterns:
+        - *.py - All Python files in current directory
+        - src/**/*.js - All JavaScript files in src directory recursively
+        - test_*.py - Python test files starting with test_
+        - *.config.{js,ts} - Config files with .js or .ts extension
+
+        Bad example patterns:
+        - **, **/*.py - Starting with ** gets rejected as it would recursively search all directories.
+        - node_modules/**/*.js - Avoid recursively searching known large directories."""
+        # Reject patterns starting with **
+        if pattern.startswith("**"):
+            ls_result = await self._sandbox.run_command(
+                "ls /", workdir="/", timeout=self._command_timeout
+            )
+            listing = ls_result.stdout[:MAX_OUTPUT_CHARS] if ls_result.exit_code == 0 else ""
+            return _error_result(
+                f"Pattern `{pattern}` starts with '**' which is not allowed. "
+                "This would recursively search all directories and may include large "
+                "directories like `node_modules`. Use more specific patterns instead. "
+                "For your convenience, a list of all files and directories in the "
+                "top level of the working directory is provided below.",
+                output=listing,
+            )
+
+        dir_path = directory or "/"
+        script = (
+            "import json, pathlib\n"
+            f"d = pathlib.Path({dir_path!r})\n"
+            "matches = []\n"
+            f"for p in sorted(d.glob({pattern!r})):\n"
+            f"    if not {include_dirs!r} and p.is_dir():\n"
+            "        continue\n"
+            "    matches.append(str(p.relative_to(d)))\n"
+            "total = len(matches)\n"
+            f"matches = matches[:{MAX_GLOB_MATCHES}]\n"
+            'print(json.dumps({"matches": matches, "total": total}))\n'
+        )
+
+        result = await self._sandbox.run_command(
+            f"python3 -c {shlex.quote(script)}",
+            workdir="/",
+            timeout=self._command_timeout,
+        )
+
+        if result.exit_code != 0:
+            return _error_result(
+                f"Failed to search for pattern {pattern}. Error: {result.stderr[:MAX_OUTPUT_CHARS]}"
+            )
+
+        try:
+            data = json.loads(result.stdout.strip())
+            matches: list[str] = data["matches"]
+            total: int = data["total"]
+        except (json.JSONDecodeError, KeyError) as e:
+            return _error_result(f"Failed to parse glob results. Error: {e}")
+
+        if not matches:
+            return _tool_result(f"No matches found for pattern `{pattern}`.")
+
+        message = f"Found {total} matches for pattern `{pattern}`."
+        if total > MAX_GLOB_MATCHES:
+            message += (
+                f" Only the first {MAX_GLOB_MATCHES} matches are returned. "
+                "You may want to use a more specific pattern."
+            )
+
+        output = "\n".join(matches)
+        return _tool_result(message, output)
+
+
+# ---------------------------------------------------------------------------
+# HarborGrepTool (mirrors src/kimi_cli/tools/file/grep_local.py)
+# ---------------------------------------------------------------------------
+
+
+def _build_rg_args(
+    rg_path: str,
+    pattern: str,
+    path: str,
+    output_mode: str,
+    before_context: int | None,
+    after_context: int | None,
+    context: int | None,
+    line_number: bool,
+    ignore_case: bool,
+    file_type: str | None,
+    glob_filter: str | None,
+    multiline: bool,
+    include_ignored: bool,
+) -> list[str]:
+    """Build ripgrep command-line arguments, mirroring kimi-cli's _build_rg_args."""
+    args: list[str] = [rg_path]
+
+    # Fixed args
+    if output_mode != "content":
+        args.extend(["--max-columns", "500"])
+    args.append("--hidden")
+    if include_ignored:
+        args.append("--no-ignore")
+    for vcs_dir in (".git", ".svn", ".hg", ".bzr", ".jj", ".sl"):
+        args.extend(["--glob", f"!{vcs_dir}"])
+
+    # Search options
+    if ignore_case:
+        args.append("--ignore-case")
+    if multiline:
+        args.extend(["--multiline", "--multiline-dotall"])
+
+    # Content display options
+    if output_mode == "content":
+        if before_context is not None:
+            args.extend(["--before-context", str(before_context)])
+        if after_context is not None:
+            args.extend(["--after-context", str(after_context)])
+        if context is not None:
+            args.extend(["--context", str(context)])
+        if line_number:
+            args.append("--line-number")
+
+    # File filtering
+    if glob_filter:
+        args.extend(["--glob", glob_filter])
+    if file_type:
+        args.extend(["--type", file_type])
+
+    # Output mode
+    if output_mode == "files_with_matches":
+        args.append("--files-with-matches")
+    elif output_mode == "count_matches":
+        args.append("--count-matches")
+
+    args.append("--")
+    args.append(pattern)
+    args.append(path)
+
+    return args
+
+
+class HarborGrepTool:
+    """Grep tool backed by ripgrep in a sandbox."""
+
+    def __init__(
+        self,
+        sandbox: SandboxInterface,
+        rg_path: str = "/usr/local/bin/rg",
+        command_timeout: int = 60,
+    ) -> None:
+        self._sandbox = sandbox
+        self._rg_path = rg_path
+        self._command_timeout = command_timeout
+
+    @tool
+    async def Grep(
+        self,
+        pattern: Annotated[
+            str,
+            Field(description="The regular expression pattern to search for in file contents"),
+        ],
+        path: Annotated[
+            str,
+            Field(
+                description=(
+                    "File or directory to search in. Defaults to current working directory. "
+                    "If specified, it must be an absolute path."
+                ),
+                default=".",
+            ),
+        ] = ".",
+        glob: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Glob pattern to filter files (e.g. `*.js`, `*.{ts,tsx}`). "
+                    "No filter by default."
+                ),
+                default=None,
+            ),
+        ] = None,
+        output_mode: Annotated[
+            str,
+            Field(
+                description=(
+                    "`content`: Show matching lines (supports `-B`, `-A`, `-C`, `-n`, "
+                    "`head_limit`); `files_with_matches`: Show file paths (supports "
+                    "`head_limit`); `count_matches`: Show total number of matches. "
+                    "Defaults to `files_with_matches`."
+                ),
+                default="files_with_matches",
+            ),
+        ] = "files_with_matches",
+        before_context: Annotated[
+            int | None,
+            Field(
+                alias="-B",
+                description=(
+                    "Number of lines to show before each match (the `-B` option). "
+                    "Requires `output_mode` to be `content`."
+                ),
+                default=None,
+            ),
+        ] = None,
+        after_context: Annotated[
+            int | None,
+            Field(
+                alias="-A",
+                description=(
+                    "Number of lines to show after each match (the `-A` option). "
+                    "Requires `output_mode` to be `content`."
+                ),
+                default=None,
+            ),
+        ] = None,
+        context: Annotated[
+            int | None,
+            Field(
+                alias="-C",
+                description=(
+                    "Number of lines to show before and after each match (the `-C` option). "
+                    "Requires `output_mode` to be `content`."
+                ),
+                default=None,
+            ),
+        ] = None,
+        line_number: Annotated[
+            bool,
+            Field(
+                alias="-n",
+                description=(
+                    "Show line numbers in output (the `-n` option). "
+                    "Requires `output_mode` to be `content`. Defaults to true."
+                ),
+                default=True,
+            ),
+        ] = True,
+        ignore_case: Annotated[
+            bool,
+            Field(
+                alias="-i", description="Case insensitive search (the `-i` option).", default=False
+            ),
+        ] = False,
+        type: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "File type to search. Examples: py, rust, js, ts, go, java, etc. "
+                    "More efficient than `glob` for standard file types."
+                ),
+                default=None,
+            ),
+        ] = None,
+        head_limit: Annotated[
+            int | None,
+            Field(
+                description=(
+                    "Limit output to first N lines/entries, equivalent to `| head -N`. "
+                    "Works across all output modes: content (limits output lines), "
+                    "files_with_matches (limits file paths), count_matches (limits count "
+                    "entries). Defaults to 250. "
+                    "Pass 0 for unlimited (use sparingly — large result sets waste context)."
+                ),
+                default=250,
+                ge=0,
+            ),
+        ] = 250,
+        offset: Annotated[
+            int,
+            Field(
+                description=(
+                    "Skip first N lines/entries before applying head_limit, "
+                    "equivalent to `| tail -n +N | head -N`. "
+                    "Works across all output modes. Defaults to 0."
+                ),
+                default=0,
+                ge=0,
+            ),
+        ] = 0,
+        multiline: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Enable multiline mode where `.` matches newlines and patterns can span "
+                    "lines (the `-U` and `--multiline-dotall` options). "
+                    "By default, multiline mode is disabled."
+                ),
+                default=False,
+            ),
+        ] = False,
+        include_ignored: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Include files that are ignored by `.gitignore`, `.ignore`, and other "
+                    "ignore rules. Useful for searching gitignored artifacts such as build "
+                    "outputs (e.g. `dist/`, `build/`) or `node_modules`. "
+                    "Defaults to false."
+                ),
+                default=False,
+            ),
+        ] = False,
+    ) -> ToolResult:
+        """A powerful search tool based on ripgrep.
+
+        Tips:
+        - ALWAYS use Grep tool instead of running `grep` or `rg` command.
+        - Use ripgrep pattern syntax, not grep syntax. Escape braces like \\{ to search for {.
+        - Hidden files (dotfiles like .gitlab-ci.yml, .eslintrc.json) are always searched.
+        - To search files excluded by .gitignore, set include_ignored to true."""
+        args = _build_rg_args(
+            rg_path=self._rg_path,
+            pattern=pattern,
+            path=path,
+            output_mode=output_mode,
+            before_context=before_context,
+            after_context=after_context,
+            context=context,
+            line_number=line_number,
+            ignore_case=ignore_case,
+            file_type=type,
+            glob_filter=glob,
+            multiline=multiline,
+            include_ignored=include_ignored,
+        )
+        cmd = " ".join(shlex.quote(arg) for arg in args)
+
+        result = await self._sandbox.run_command(
+            cmd, workdir="/", timeout=self._command_timeout, max_output_bytes=MAX_OUTPUT_CHARS
+        )
+
+        # rg exit codes: 0=matches found, 1=no matches, 2+=error
+        if result.exit_code == 1:
+            return _tool_result("No matches found")
+        if result.exit_code not in (0, 1):
+            return _error_result(f"Failed to grep. Error: {result.stderr[:MAX_OUTPUT_CHARS]}")
+
+        output = result.stdout
+        if not output or not output.strip():
+            return _tool_result("No matches found")
+
+        message = ""
+
+        # Strip path prefix for relative paths
+        if path not in (".", "/"):
+            prefix = path.rstrip("/") + "/"
+            output = output.replace(prefix, "")
+
+        # Split into lines for post-processing
+        lines = output.split("\n")
+        if lines and lines[-1] == "":
+            lines = lines[:-1]
+
+        # Count matches summary (for count_matches mode)
+        if output_mode == "count_matches":
+            total_matches = 0
+            total_files = 0
+            for line in lines:
+                idx = line.rfind(":")
+                if idx > 0:
+                    try:
+                        total_matches += int(line[idx + 1 :])
+                        total_files += 1
+                    except ValueError:
+                        pass
+            count_summary = f"Found {total_matches} total occurrences across {total_files} files."
+            message = count_summary
+
+        # Offset + head_limit pagination
+        if offset > 0:
+            lines = lines[offset:]
+
+        if head_limit and len(lines) > head_limit:
+            total = len(lines) + offset
+            lines = lines[:head_limit]
+            trunc_msg = (
+                f"Results truncated to {head_limit} lines (total: {total}). "
+                f"Use offset={offset + head_limit} to see more."
+            )
+            message = f"{message} {trunc_msg}" if message else trunc_msg
+
+        output = "\n".join(lines)
+
+        if not output and not message:
+            return _tool_result("No matches found")
+
+        return _tool_result(message, output)
+
+
+# ---------------------------------------------------------------------------
+# HarborReadFileTool (mirrors src/kimi_cli/tools/file/read.py)
+# ---------------------------------------------------------------------------
+
+
+class HarborReadFileTool:
+    """ReadFile tool that reads files from a sandbox."""
+
+    def __init__(self, sandbox: SandboxInterface, command_timeout: int = 60) -> None:
+        self._sandbox = sandbox
+        self._command_timeout = command_timeout
+
+    @tool
+    async def ReadFile(
+        self,
+        path: Annotated[
+            str,
+            "The path to the file to read. "
+            "Absolute paths are required when reading files outside the working directory.",
+        ],
+        line_offset: Annotated[
+            int,
+            Field(
+                description=(
+                    "The line number to start reading from. "
+                    "By default read from the beginning of the file. "
+                    "Set this when the file is too large to read at once. "
+                    "Negative values read from the end of the file "
+                    f"(e.g. -100 reads the last 100 lines). "
+                    f"The absolute value of negative offset cannot exceed {MAX_READ_LINES}."
+                ),
+                default=1,
+            ),
+        ] = 1,
+        n_lines: Annotated[
+            int,
+            Field(
+                description=(
+                    "The number of lines to read. "
+                    f"By default read up to {MAX_READ_LINES} lines, which is the max "
+                    "allowed value. Set this value when the file is too large to read at once."
+                ),
+                default=MAX_READ_LINES,
+                ge=1,
+            ),
+        ] = MAX_READ_LINES,
+    ) -> ToolResult:
+        """Read text content from a file.
+
+Tips:
+- Content will be returned with a line number before each line like cat -n format.
+- Use line_offset and n_lines parameters when you only need to read a part of the file.
+- Always read multiple files in one response when possible.
+- The maximum number of lines that can be read at once is 1000.
+- Any lines longer than 2000 characters will be truncated, ending with "..."."""
+        if not path or not path.strip():
+            return _error_result("path is required")
+
+        # Validate line_offset
+        if line_offset == 0:
+            return _error_result(
+                "line_offset cannot be 0; use 1 for the first line or -1 for the last line"
+            )
+        if line_offset < -MAX_READ_LINES:
+            return _error_result(
+                f"line_offset cannot be less than -{MAX_READ_LINES}. "
+                "Use a positive line_offset with the total line count "
+                "to read from a specific position."
+            )
+
+        result = await self._sandbox.read_file(
+            path, max_bytes=MAX_READ_BYTES * 2, timeout=self._command_timeout
+        )
+
+        if result.exit_code != 0:
+            stderr = result.stderr.strip()
+            if "No such file" in stderr or "not found" in stderr.lower():
+                return _error_result(f"`{path}` does not exist.")
+            if "Is a directory" in stderr:
+                return _error_result(f"`{path}` is not a file.")
+            return _error_result(f"Failed to read {path}. Error: {stderr}")
+
+        content = result.stdout
+        all_lines = content.splitlines()
+        total_lines = len(all_lines)
+
+        n_lines = min(n_lines, MAX_READ_LINES)
+
+        if line_offset < 0:
+            return self._format_tail(all_lines, total_lines, line_offset, n_lines, path)
+        else:
+            return self._format_forward(all_lines, total_lines, line_offset, n_lines, path)
+
+    def _format_forward(
+        self,
+        all_lines: list[str],
+        total_lines: int,
+        line_offset: int,
+        n_lines: int,
+        path: str,
+    ) -> ToolResult:
+        lines_read: list[str] = []
+        truncated_line_numbers: list[int] = []
+        n_bytes = 0
+        max_lines_reached = False
+        max_bytes_reached = False
+
+        for i in range(line_offset - 1, len(all_lines)):
+            line = all_lines[i]
+            truncated = _truncate_line(line, MAX_READ_LINE_LENGTH)
+            if truncated != line:
+                truncated_line_numbers.append(i + 1)
+            lines_read.append(truncated)
+            n_bytes += len(truncated.encode("utf-8"))
+
+            if len(lines_read) >= n_lines:
+                break
+            if len(lines_read) >= MAX_READ_LINES:
+                max_lines_reached = True
+                break
+            if n_bytes >= MAX_READ_BYTES:
+                max_bytes_reached = True
+                break
+
+        formatted = []
+        for idx, line in enumerate(lines_read):
+            line_num = line_offset + idx
+            formatted.append(f"{line_num:6d}\t{line}")
+
+        message = (
+            f"{len(lines_read)} lines read from file starting from line {line_offset}."
+            if lines_read
+            else "No lines read from file."
+        )
+        message += f" Total lines in file: {total_lines}."
+        if max_lines_reached:
+            message += f" Max {MAX_READ_LINES} lines reached."
+        elif max_bytes_reached:
+            message += f" Max {MAX_READ_BYTES} bytes reached."
+        elif len(lines_read) < n_lines:
+            message += " End of file reached."
+        if truncated_line_numbers:
+            message += f" Lines {truncated_line_numbers} were truncated."
+
+        output = "\n".join(formatted)
+        return _tool_result(message, output)
+
+    def _format_tail(
+        self,
+        all_lines: list[str],
+        total_lines: int,
+        line_offset: int,
+        n_lines: int,
+        path: str,
+    ) -> ToolResult:
+        tail_count = abs(line_offset)
+
+        # Build tail buffer: (line_no, truncated_line, was_truncated)
+        tail_buf: deque[tuple[int, str, bool]] = deque(maxlen=tail_count)
+        for i, line in enumerate(all_lines):
+            truncated = _truncate_line(line, MAX_READ_LINE_LENGTH)
+            tail_buf.append((i + 1, truncated, truncated != line))
+
+        all_entries = list(tail_buf)
+        line_limit = min(n_lines, MAX_READ_LINES)
+        candidates = all_entries[:line_limit]
+        max_lines_reached = len(all_entries) > MAX_READ_LINES and len(candidates) == MAX_READ_LINES
+
+        # Apply MAX_BYTES — keep newest lines that fit
+        total_candidate_bytes = sum(len(e[1].encode("utf-8")) for e in candidates)
+        max_bytes_reached = False
+        if total_candidate_bytes > MAX_READ_BYTES:
+            max_bytes_reached = True
+            kept = 0
+            nb = 0
+            for entry in reversed(candidates):
+                nb += len(entry[1].encode("utf-8"))
+                if nb > MAX_READ_BYTES:
+                    break
+                kept += 1
+            candidates = candidates[len(candidates) - kept :]
+
+        lines_out: list[str] = []
+        truncated_line_numbers: list[int] = []
+        for line_no, truncated, was_truncated in candidates:
+            if was_truncated:
+                truncated_line_numbers.append(line_no)
+            lines_out.append(f"{line_no:6d}\t{truncated}")
+
+        start_line = candidates[0][0] if candidates else total_lines + 1
+        message = (
+            f"{len(candidates)} lines read from file starting from line {start_line}."
+            if candidates
+            else "No lines read from file."
+        )
+        message += f" Total lines in file: {total_lines}."
+        if max_lines_reached:
+            message += f" Max {MAX_READ_LINES} lines reached."
+        elif max_bytes_reached:
+            message += f" Max {MAX_READ_BYTES} bytes reached."
+        elif len(candidates) < n_lines:
+            message += " End of file reached."
+        if truncated_line_numbers:
+            message += f" Lines {truncated_line_numbers} were truncated."
+
+        output = "\n".join(lines_out)
+        return _tool_result(message, output)
+
+
+# ---------------------------------------------------------------------------
+# HarborWriteFileTool (mirrors src/kimi_cli/tools/file/write.py)
+# ---------------------------------------------------------------------------
+
+
+class HarborWriteFileTool:
+    """WriteFile tool that writes files in a sandbox."""
+
+    def __init__(self, sandbox: SandboxInterface, command_timeout: int = 60) -> None:
+        self._sandbox = sandbox
+        self._command_timeout = command_timeout
+
+    @tool
+    async def WriteFile(
+        self,
+        path: Annotated[
+            str,
+            "The path to the file to write. "
+            "Absolute paths are required when writing files outside the working directory.",
+        ],
+        content: Annotated[str, "The content to write to the file."],
+        mode: Annotated[
+            Literal["overwrite", "append"],
+            "The mode to use to write to the file. "
+            "Two modes are supported: `overwrite` for overwriting the whole file and "
+            "`append` for appending to the end of an existing file.",
+        ] = "overwrite",
+    ) -> ToolResult:
+        """Write content to a file.
+
+        Tips:
+        - When mode is not specified, defaults to overwrite. Always write with caution.
+        - When content is too long (e.g., > 100 lines), use this tool multiple times.
+        - Use overwrite mode first time, then append mode after."""
+        if not path or not path.strip():
+            return _error_result("path is required")
+
+        try:
+            if mode == "overwrite":
+                result = await self._sandbox.write_file(
+                    path, content, timeout=self._command_timeout
+                )
+            else:
+                # append mode: read existing content, concatenate, write back
+                existing = await self._sandbox.read_file(path, timeout=self._command_timeout)
+                if existing.exit_code == 0:
+                    new_content = existing.stdout + content
+                else:
+                    new_content = content
+                result = await self._sandbox.write_file(
+                    path, new_content, timeout=self._command_timeout
+                )
+
+            if result.exit_code != 0:
+                return _error_result(
+                    f"Failed to write to {path}. Error: {result.stderr[:MAX_OUTPUT_CHARS]}"
+                )
+
+            # Get file size
+            stat_result = await self._sandbox.run_command(
+                f"stat -c %s {shlex.quote(path)}",
+                workdir="/",
+                timeout=self._command_timeout,
+            )
+            file_size = stat_result.stdout.strip() if stat_result.exit_code == 0 else "unknown"
+            action = "overwritten" if mode == "overwrite" else "appended to"
+            return _tool_result(f"File successfully {action}. Current size: {file_size} bytes.")
+
+        except Exception as e:
+            return _error_result(f"Failed to write to {path}. Error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# HarborStrReplaceFileTool (mirrors src/kimi_cli/tools/file/replace.py)
+# ---------------------------------------------------------------------------
+
+
+class Edit(BaseModel):
+    """A single string replacement edit."""
+
+    old: str = Field(description="The old string to replace. Can be multi-line.")
+    new: str = Field(description="The new string to replace with. Can be multi-line.")
+    replace_all: bool = Field(description="Whether to replace all occurrences.", default=False)
+
+
+class HarborStrReplaceFileTool:
+    """StrReplaceFile tool that edits files in a sandbox."""
+
+    def __init__(self, sandbox: SandboxInterface, command_timeout: int = 60) -> None:
+        self._sandbox = sandbox
+        self._command_timeout = command_timeout
+
+    @tool
+    async def StrReplaceFile(
+        self,
+        path: Annotated[
+            str,
+            "The path to the file to edit. "
+            "Absolute paths are required when editing files outside the working directory.",
+        ],
+        edit: Annotated[
+            Edit | list[Edit],
+            "The edit(s) to apply to the file. "
+            "You can provide a single edit or a list of edits here.",
+        ],
+    ) -> ToolResult:
+        """Replace specific strings within a specified file.
+
+        Tips:
+        - Only use on text files.
+        - Multi-line strings are supported.
+        - Can specify single or multiple edits in one call.
+        - Should prefer this tool over WriteFile tool and Shell sed command."""
+        if not path or not path.strip():
+            return _error_result("path is required")
+
+        # Read the file
+        result = await self._sandbox.read_file(path, timeout=self._command_timeout)
+        if result.exit_code != 0:
+            stderr = result.stderr.strip()
+            if "No such file" in stderr or "not found" in stderr.lower():
+                return _error_result(f"`{path}` does not exist.")
+            return _error_result(f"Failed to read {path}. Error: {stderr}")
+
+        content = result.stdout
+        original_content = content
+
+        edits = [edit] if isinstance(edit, Edit) else edit
+
+        # Apply edits sequentially
+        for e in edits:
+            if e.replace_all:
+                content = content.replace(e.old, e.new)
+            else:
+                content = content.replace(e.old, e.new, 1)
+
+        if content == original_content:
+            return _error_result(
+                "No replacements were made. The old string was not found in the file."
+            )
+
+        # Write back
+        write_result = await self._sandbox.write_file(path, content, timeout=self._command_timeout)
+        if write_result.exit_code != 0:
+            return _error_result(
+                f"Failed to write {path}. Error: {write_result.stderr[:MAX_OUTPUT_CHARS]}"
+            )
+
+        # Count replacements
+        total_replacements = 0
+        for e in edits:
+            if e.replace_all:
+                total_replacements += original_content.count(e.old)
+            else:
+                total_replacements += 1 if e.old in original_content else 0
+
+        return _tool_result(
+            f"File successfully edited. "
+            f"Applied {len(edits)} edit(s) with {total_replacements} total replacement(s)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# HarborReward (existing)
+# ---------------------------------------------------------------------------
 
 
 @dataclass

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -252,7 +252,7 @@ def _build_rg_args(
     if output_mode == "files_with_matches":
         args.append("--files-with-matches")
     elif output_mode == "count_matches":
-        args.append("--count-matches")
+        args.extend(["--count-matches", "--with-filename"])
 
     args.append("--")
     args.append(pattern)
@@ -454,7 +454,7 @@ class HarborGrepTool:
         # rg exit codes: 0=matches found, 1=no matches, 2+=error
         if result.exit_code == 1:
             return _tool_result("No matches found")
-        if result.exit_code not in (0, 1):
+        if result.exit_code != 0:
             return _error_result(f"Failed to grep. Error: {result.stderr[:MAX_OUTPUT_CHARS]}")
 
         output = result.stdout
@@ -463,10 +463,10 @@ class HarborGrepTool:
 
         message = ""
 
-        # Strip path prefix for relative paths
+        # Strip path prefix for relative paths (per-line to avoid corrupting match content)
         if path not in (".", "/"):
             prefix = path.rstrip("/") + "/"
-            output = output.replace(prefix, "")
+            output = "\n".join(line.removeprefix(prefix) for line in output.split("\n"))
 
         # Split into lines for post-processing
         lines = output.split("\n")
@@ -558,12 +558,12 @@ class HarborReadFileTool:
     ) -> ToolResult:
         """Read text content from a file.
 
-Tips:
-- Content will be returned with a line number before each line like cat -n format.
-- Use line_offset and n_lines parameters when you only need to read a part of the file.
-- Always read multiple files in one response when possible.
-- The maximum number of lines that can be read at once is 1000.
-- Any lines longer than 2000 characters will be truncated, ending with "..."."""
+        Tips:
+        - Content will be returned with a line number before each line like cat -n format.
+        - Use line_offset and n_lines parameters when you only need to read a part of the file.
+        - Always read multiple files in one response when possible.
+        - The maximum number of lines that can be read at once is 1000.
+        - Any lines longer than 2000 characters will be truncated, ending with "..."."""
         if not path or not path.strip():
             return _error_result("path is required")
 
@@ -579,6 +579,7 @@ Tips:
                 "to read from a specific position."
             )
 
+        # Read 2x the byte budget so we can count total_lines even when content is capped
         result = await self._sandbox.read_file(
             path, max_bytes=MAX_READ_BYTES * 2, timeout=self._command_timeout
         )
@@ -761,14 +762,11 @@ class HarborWriteFileTool:
                     path, content, timeout=self._command_timeout
                 )
             else:
-                # append mode: read existing content, concatenate, write back
-                existing = await self._sandbox.read_file(path, timeout=self._command_timeout)
-                if existing.exit_code == 0:
-                    new_content = existing.stdout + content
-                else:
-                    new_content = content
-                result = await self._sandbox.write_file(
-                    path, new_content, timeout=self._command_timeout
+                # Append directly via shell to avoid truncating large files
+                result = await self._sandbox.run_command(
+                    f"cat >> {shlex.quote(path)} << 'HARBOR_EOF'\n{content}\nHARBOR_EOF",
+                    workdir="/",
+                    timeout=self._command_timeout,
                 )
 
             if result.exit_code != 0:
@@ -834,8 +832,10 @@ class HarborStrReplaceFileTool:
         if not path or not path.strip():
             return _error_result("path is required")
 
-        # Read the file
-        result = await self._sandbox.read_file(path, timeout=self._command_timeout)
+        # Read the full file (large cap to avoid truncating content before editing)
+        result = await self._sandbox.read_file(
+            path, max_bytes=10 * 1024 * 1024, timeout=self._command_timeout
+        )
         if result.exit_code != 0:
             stderr = result.stderr.strip()
             if "No such file" in stderr or "not found" in stderr.lower():
@@ -847,11 +847,15 @@ class HarborStrReplaceFileTool:
 
         edits = [edit] if isinstance(edit, Edit) else edit
 
-        # Apply edits sequentially
+        # Apply edits sequentially, counting replacements as we go
+        total_replacements = 0
         for e in edits:
             if e.replace_all:
+                total_replacements += content.count(e.old)
                 content = content.replace(e.old, e.new)
             else:
+                if e.old in content:
+                    total_replacements += 1
                 content = content.replace(e.old, e.new, 1)
 
         if content == original_content:
@@ -865,14 +869,6 @@ class HarborStrReplaceFileTool:
             return _error_result(
                 f"Failed to write {path}. Error: {write_result.stderr[:MAX_OUTPUT_CHARS]}"
             )
-
-        # Count replacements
-        total_replacements = 0
-        for e in edits:
-            if e.replace_all:
-                total_replacements += original_content.count(e.old)
-            else:
-                total_replacements += 1 if e.old in original_content else 0
 
         return _tool_result(
             f"File successfully edited. "

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -616,54 +616,48 @@ class HarborReadFileTool:
         return self._format_forward(content_lines, total_lines, line_offset, n_lines, path)
 
     async def _read_tail_via_sandbox(self, path: str, line_offset: int, n_lines: int) -> ToolResult:
-        """Read tail of file using sandbox commands for accuracy on large files."""
-        tail_count = min(abs(line_offset), n_lines, MAX_READ_LINES)
-        # Get total line count and tail content in one command
-        cmd = f"wc -l < {shlex.quote(path)} && tail -n {tail_count} {shlex.quote(path)}"
-        result = await self._sandbox.run_command(
-            cmd, workdir="/", timeout=self._command_timeout, max_output_bytes=MAX_READ_BYTES * 2
+        """Read from a negative offset using sandbox commands.
+
+        line_offset=-100, n_lines=10 means: start 100 lines from EOF, read 10 lines.
+        We get total lines via wc -l, compute the start line, then use sed.
+        """
+        qpath = shlex.quote(path)
+        # First get total line count
+        wc_result = await self._sandbox.run_command(
+            f"wc -l < {qpath}", workdir="/", timeout=self._command_timeout
         )
-        if result.exit_code != 0:
-            stderr = result.stderr.strip()
+        if wc_result.exit_code != 0:
+            stderr = wc_result.stderr.strip()
             if "No such file" in stderr or "not found" in stderr.lower():
                 return _error_result(f"`{path}` does not exist.")
             if "Is a directory" in stderr:
                 return _error_result(f"`{path}` is not a file.")
             return _error_result(f"Failed to read {path}. Error: {stderr}")
 
-        output_lines = result.stdout.split("\n")
         try:
-            total_lines = int(output_lines[0].strip())
-        except (ValueError, IndexError):
+            total_lines = int(wc_result.stdout.strip())
+        except ValueError:
             total_lines = 0
 
-        # Lines after the first (wc -l output) are the tail content
-        tail_lines = output_lines[1:]
-        if tail_lines and tail_lines[-1] == "":
-            tail_lines = tail_lines[:-1]
+        # Compute start line: e.g. total=500, offset=-100 → start=401
+        start_line = max(1, total_lines + line_offset + 1)
+        end_line = start_line + n_lines - 1
 
-        start_line = max(1, total_lines - len(tail_lines) + 1)
-        truncated_line_numbers: list[int] = []
-        formatted: list[str] = []
-        for idx, line in enumerate(tail_lines):
-            line_num = start_line + idx
-            truncated = _truncate_line(line, MAX_READ_LINE_LENGTH)
-            if truncated != line:
-                truncated_line_numbers.append(line_num)
-            formatted.append(f"{line_num:6d}\t{truncated}")
-
-        message = (
-            f"{len(tail_lines)} lines read from file starting from line {start_line}."
-            if tail_lines
-            else "No lines read from file."
+        # Read the computed range via sed
+        sed_result = await self._sandbox.run_command(
+            f"sed -n '{start_line},{end_line}p' {qpath}",
+            workdir="/",
+            timeout=self._command_timeout,
+            max_output_bytes=MAX_READ_BYTES * 2,
         )
-        message += f" Total lines in file: {total_lines}."
-        if len(tail_lines) < abs(line_offset):
-            message += " End of file reached."
-        if truncated_line_numbers:
-            message += f" Lines {truncated_line_numbers} were truncated."
+        if sed_result.exit_code != 0:
+            return _error_result(f"Failed to read {path}. Error: {sed_result.stderr.strip()}")
 
-        return _tool_result(message, "\n".join(formatted))
+        content_lines = sed_result.stdout.split("\n")
+        if content_lines and content_lines[-1] == "":
+            content_lines = content_lines[:-1]
+
+        return self._format_forward(content_lines, total_lines, start_line, n_lines, path)
 
     def _format_forward(
         self,

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import logging
 import shlex
-from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal
@@ -579,6 +578,12 @@ class HarborReadFileTool:
                 "to read from a specific position."
             )
 
+        if line_offset < 0:
+            # Use tail command for accurate tail reads regardless of file size
+            return await self._read_tail_via_sandbox(
+                path, line_offset, min(n_lines, MAX_READ_LINES)
+            )
+
         # Read 2x the byte budget so we can count total_lines even when content is capped
         result = await self._sandbox.read_file(
             path, max_bytes=MAX_READ_BYTES * 2, timeout=self._command_timeout
@@ -597,11 +602,57 @@ class HarborReadFileTool:
         total_lines = len(all_lines)
 
         n_lines = min(n_lines, MAX_READ_LINES)
+        return self._format_forward(all_lines, total_lines, line_offset, n_lines, path)
 
-        if line_offset < 0:
-            return self._format_tail(all_lines, total_lines, line_offset, n_lines, path)
-        else:
-            return self._format_forward(all_lines, total_lines, line_offset, n_lines, path)
+    async def _read_tail_via_sandbox(self, path: str, line_offset: int, n_lines: int) -> ToolResult:
+        """Read tail of file using sandbox commands for accuracy on large files."""
+        tail_count = min(abs(line_offset), n_lines, MAX_READ_LINES)
+        # Get total line count and tail content in one command
+        cmd = f"wc -l < {shlex.quote(path)} && tail -n {tail_count} {shlex.quote(path)}"
+        result = await self._sandbox.run_command(
+            cmd, workdir="/", timeout=self._command_timeout, max_output_bytes=MAX_READ_BYTES * 2
+        )
+        if result.exit_code != 0:
+            stderr = result.stderr.strip()
+            if "No such file" in stderr or "not found" in stderr.lower():
+                return _error_result(f"`{path}` does not exist.")
+            if "Is a directory" in stderr:
+                return _error_result(f"`{path}` is not a file.")
+            return _error_result(f"Failed to read {path}. Error: {stderr}")
+
+        output_lines = result.stdout.split("\n")
+        try:
+            total_lines = int(output_lines[0].strip())
+        except (ValueError, IndexError):
+            total_lines = 0
+
+        # Lines after the first (wc -l output) are the tail content
+        tail_lines = output_lines[1:]
+        if tail_lines and tail_lines[-1] == "":
+            tail_lines = tail_lines[:-1]
+
+        start_line = max(1, total_lines - len(tail_lines) + 1)
+        truncated_line_numbers: list[int] = []
+        formatted: list[str] = []
+        for idx, line in enumerate(tail_lines):
+            line_num = start_line + idx
+            truncated = _truncate_line(line, MAX_READ_LINE_LENGTH)
+            if truncated != line:
+                truncated_line_numbers.append(line_num)
+            formatted.append(f"{line_num:6d}\t{truncated}")
+
+        message = (
+            f"{len(tail_lines)} lines read from file starting from line {start_line}."
+            if tail_lines
+            else "No lines read from file."
+        )
+        message += f" Total lines in file: {total_lines}."
+        if len(tail_lines) < abs(line_offset):
+            message += " End of file reached."
+        if truncated_line_numbers:
+            message += f" Lines {truncated_line_numbers} were truncated."
+
+        return _tool_result(message, "\n".join(formatted))
 
     def _format_forward(
         self,
@@ -657,67 +708,6 @@ class HarborReadFileTool:
         output = "\n".join(formatted)
         return _tool_result(message, output)
 
-    def _format_tail(
-        self,
-        all_lines: list[str],
-        total_lines: int,
-        line_offset: int,
-        n_lines: int,
-        path: str,
-    ) -> ToolResult:
-        tail_count = abs(line_offset)
-
-        # Build tail buffer: (line_no, truncated_line, was_truncated)
-        tail_buf: deque[tuple[int, str, bool]] = deque(maxlen=tail_count)
-        for i, line in enumerate(all_lines):
-            truncated = _truncate_line(line, MAX_READ_LINE_LENGTH)
-            tail_buf.append((i + 1, truncated, truncated != line))
-
-        all_entries = list(tail_buf)
-        line_limit = min(n_lines, MAX_READ_LINES)
-        candidates = all_entries[:line_limit]
-        max_lines_reached = len(all_entries) > MAX_READ_LINES and len(candidates) == MAX_READ_LINES
-
-        # Apply MAX_BYTES — keep newest lines that fit
-        total_candidate_bytes = sum(len(e[1].encode("utf-8")) for e in candidates)
-        max_bytes_reached = False
-        if total_candidate_bytes > MAX_READ_BYTES:
-            max_bytes_reached = True
-            kept = 0
-            nb = 0
-            for entry in reversed(candidates):
-                nb += len(entry[1].encode("utf-8"))
-                if nb > MAX_READ_BYTES:
-                    break
-                kept += 1
-            candidates = candidates[len(candidates) - kept :]
-
-        lines_out: list[str] = []
-        truncated_line_numbers: list[int] = []
-        for line_no, truncated, was_truncated in candidates:
-            if was_truncated:
-                truncated_line_numbers.append(line_no)
-            lines_out.append(f"{line_no:6d}\t{truncated}")
-
-        start_line = candidates[0][0] if candidates else total_lines + 1
-        message = (
-            f"{len(candidates)} lines read from file starting from line {start_line}."
-            if candidates
-            else "No lines read from file."
-        )
-        message += f" Total lines in file: {total_lines}."
-        if max_lines_reached:
-            message += f" Max {MAX_READ_LINES} lines reached."
-        elif max_bytes_reached:
-            message += f" Max {MAX_READ_BYTES} bytes reached."
-        elif len(candidates) < n_lines:
-            message += " End of file reached."
-        if truncated_line_numbers:
-            message += f" Lines {truncated_line_numbers} were truncated."
-
-        output = "\n".join(lines_out)
-        return _tool_result(message, output)
-
 
 # ---------------------------------------------------------------------------
 # HarborWriteFileTool (mirrors src/kimi_cli/tools/file/write.py)
@@ -762,9 +752,12 @@ class HarborWriteFileTool:
                     path, content, timeout=self._command_timeout
                 )
             else:
-                # Append directly via shell to avoid truncating large files
+                # Write to temp file then append via cat to avoid both
+                # large-file truncation (read+concat) and heredoc delimiter collisions
+                tmp = f"/tmp/.harbor_append_{id(content):x}"
+                await self._sandbox.write_file(tmp, content, timeout=self._command_timeout)
                 result = await self._sandbox.run_command(
-                    f"cat >> {shlex.quote(path)} << 'HARBOR_EOF'\n{content}\nHARBOR_EOF",
+                    f"cat {shlex.quote(tmp)} >> {shlex.quote(path)} && rm -f {shlex.quote(tmp)}",
                     workdir="/",
                     timeout=self._command_timeout,
                 )
@@ -832,7 +825,9 @@ class HarborStrReplaceFileTool:
         if not path or not path.strip():
             return _error_result("path is required")
 
-        # Read the full file (large cap to avoid truncating content before editing)
+        # 10MB cap: sufficient for source files in Harbor coding tasks.
+        # Files exceeding this are truncated — acceptable since StrReplaceFile
+        # targets source code, not binary artifacts or large logs.
         result = await self._sandbox.read_file(
             path, max_bytes=10 * 1024 * 1024, timeout=self._command_timeout
         )

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -737,10 +737,11 @@ class HarborWriteFileTool:
             return _error_result("path is required")
 
         try:
-            # Resolve relative paths so both modes target the same file
+            # Resolve relative paths so both modes and other tools target the same file.
+            # Use readlink -m which resolves even if the file doesn't exist yet.
             if not path.startswith("/"):
                 resolve = await self._sandbox.run_command(
-                    f"readlink -f {shlex.quote(path)}", workdir="/", timeout=self._command_timeout
+                    f"readlink -m {shlex.quote(path)}", workdir="/", timeout=self._command_timeout
                 )
                 if resolve.exit_code == 0 and resolve.stdout.strip():
                     path = resolve.stdout.strip()
@@ -822,6 +823,14 @@ class HarborStrReplaceFileTool:
         - Should prefer this tool over WriteFile tool and Shell sed command."""
         if not path or not path.strip():
             return _error_result("path is required")
+
+        # Resolve relative paths so edits target the same file other tools see
+        if not path.startswith("/"):
+            resolve = await self._sandbox.run_command(
+                f"readlink -m {shlex.quote(path)}", workdir="/", timeout=self._command_timeout
+            )
+            if resolve.exit_code == 0 and resolve.stdout.strip():
+                path = resolve.stdout.strip()
 
         max_edit_bytes = 10 * 1024 * 1024  # 10MB
         result = await self._sandbox.read_file(

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -446,9 +446,7 @@ class HarborGrepTool:
         )
         cmd = " ".join(shlex.quote(arg) for arg in args)
 
-        result = await self._sandbox.run_command(
-            cmd, workdir="/", timeout=self._command_timeout, max_output_bytes=MAX_OUTPUT_CHARS
-        )
+        result = await self._sandbox.run_command(cmd, workdir="/", timeout=self._command_timeout)
 
         # rg exit codes: 0=matches found, 1=no matches, 2+=error
         if result.exit_code == 1:
@@ -832,11 +830,9 @@ class HarborStrReplaceFileTool:
         if not path or not path.strip():
             return _error_result("path is required")
 
-        # 10MB cap: sufficient for source files in Harbor coding tasks.
-        # Files exceeding this are truncated — acceptable since StrReplaceFile
-        # targets source code, not binary artifacts or large logs.
+        max_edit_bytes = 10 * 1024 * 1024  # 10MB
         result = await self._sandbox.read_file(
-            path, max_bytes=10 * 1024 * 1024, timeout=self._command_timeout
+            path, max_bytes=max_edit_bytes, timeout=self._command_timeout
         )
         if result.exit_code != 0:
             stderr = result.stderr.strip()
@@ -845,6 +841,14 @@ class HarborStrReplaceFileTool:
             return _error_result(f"Failed to read {path}. Error: {stderr}")
 
         content = result.stdout
+
+        # Fail if the file was truncated to avoid silent data loss on write-back
+        if len(content.encode("utf-8")) >= max_edit_bytes:
+            return _error_result(
+                f"File is too large to edit (>{max_edit_bytes // (1024 * 1024)}MB). "
+                "Use the bash tool with sed or other commands for large files."
+            )
+
         original_content = content
 
         edits = [edit] if isinstance(edit, Edit) else edit

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for HarborReward, HarborBashTool, and HarborEnvGroupBuilder."""
+"""Unit tests for Harbor tools and environment."""
 
 import asyncio
 import json
@@ -9,7 +9,12 @@ from tinker_cookbook.recipes.harbor_rl.harbor_env import HarborEnvGroupBuilder, 
 from tinker_cookbook.recipes.harbor_rl.harbor_tools import (
     MAX_OUTPUT_CHARS,
     HarborBashTool,
+    HarborGlobTool,
+    HarborGrepTool,
+    HarborReadFileTool,
     HarborReward,
+    HarborStrReplaceFileTool,
+    HarborWriteFileTool,
 )
 from tinker_cookbook.sandbox.sandbox_interface import SandboxResult
 from tinker_cookbook.tool_use.types import ToolInput
@@ -248,3 +253,309 @@ class TestHarborEnvGroupBuilderPickle:
         assert restored.command_timeout == 60
         assert restored.grader_timeout == 30
         assert restored.max_trajectory_tokens == 16 * 1024
+
+
+# ---------------------------------------------------------------------------
+# HarborGlobTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarborGlobTool:
+    def test_spec_shape(self) -> None:
+        sandbox = FakeSandbox()
+        tool_obj = HarborGlobTool(sandbox)
+        spec = tool_obj.Glob.to_spec()
+        assert spec["name"] == "Glob"
+        assert "pattern" in spec["parameters"]["properties"]
+        assert spec["parameters"]["required"] == ["pattern"]
+
+    def test_glob_basic(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.set_command_result(
+            sandbox._default_result.stdout,  # fallback
+            SandboxResult(
+                stdout='{"matches": ["a.py", "b.py"], "total": 2}', stderr="", exit_code=0
+            ),
+        )
+        tool_obj = HarborGlobTool(sandbox)
+        # The glob runs python3 inside sandbox; mock any python3 command
+        sandbox._command_results.clear()
+        sandbox._default_result = SandboxResult(
+            stdout='{"matches": ["a.py", "b.py"], "total": 2}', stderr="", exit_code=0
+        )
+
+        result = asyncio.run(tool_obj.Glob.run(ToolInput(arguments={"pattern": "*.py"})))
+        content = result.messages[0]["content"]
+        assert "Found 2 matches" in content
+        assert "a.py" in content
+
+    def test_glob_rejects_double_star(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox._default_result = SandboxResult(stdout="bin\netc\n", stderr="", exit_code=0)
+        tool_obj = HarborGlobTool(sandbox)
+
+        result = asyncio.run(tool_obj.Glob.run(ToolInput(arguments={"pattern": "**/*.py"})))
+        content = result.messages[0]["content"]
+        assert "ERROR" in content
+        assert "not allowed" in content
+
+
+# ---------------------------------------------------------------------------
+# HarborGrepTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarborGrepTool:
+    def test_spec_shape(self) -> None:
+        sandbox = FakeSandbox()
+        tool_obj = HarborGrepTool(sandbox)
+        spec = tool_obj.Grep.to_spec()
+        assert spec["name"] == "Grep"
+        assert "pattern" in spec["parameters"]["properties"]
+        assert spec["parameters"]["required"] == ["pattern"]
+
+    def test_grep_no_matches(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox._default_result = SandboxResult(stdout="", stderr="", exit_code=1)
+        tool_obj = HarborGrepTool(sandbox)
+
+        result = asyncio.run(tool_obj.Grep.run(ToolInput(arguments={"pattern": "nonexistent"})))
+        content = result.messages[0]["content"]
+        assert "No matches found" in content
+
+    def test_grep_error(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox._default_result = SandboxResult(stdout="", stderr="bad regex", exit_code=2)
+        tool_obj = HarborGrepTool(sandbox)
+
+        result = asyncio.run(tool_obj.Grep.run(ToolInput(arguments={"pattern": "[invalid"})))
+        content = result.messages[0]["content"]
+        assert "ERROR" in content
+
+    def test_grep_path_prefix_stripping(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox._default_result = SandboxResult(
+            stdout="/src/app/foo.py\n/src/app/bar.py\n", stderr="", exit_code=0
+        )
+        tool_obj = HarborGrepTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.Grep.run(ToolInput(arguments={"pattern": "test", "path": "/src/app"}))
+        )
+        content = result.messages[0]["content"]
+        assert "foo.py" in content
+        assert "/src/app/foo.py" not in content
+
+
+# ---------------------------------------------------------------------------
+# HarborReadFileTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarborReadFileTool:
+    def test_spec_shape(self) -> None:
+        sandbox = FakeSandbox()
+        tool_obj = HarborReadFileTool(sandbox)
+        spec = tool_obj.ReadFile.to_spec()
+        assert spec["name"] == "ReadFile"
+        assert "path" in spec["parameters"]["properties"]
+        assert spec["parameters"]["required"] == ["path"]
+
+    def test_read_file_basic(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.files["/test.py"] = "line1\nline2\nline3\n"
+        tool_obj = HarborReadFileTool(sandbox)
+
+        result = asyncio.run(tool_obj.ReadFile.run(ToolInput(arguments={"path": "/test.py"})))
+        content = result.messages[0]["content"]
+        assert "3 lines read" in content
+        assert "line1" in content
+        assert "line3" in content
+
+    def test_read_file_not_found(self) -> None:
+        sandbox = FakeSandbox()
+        tool_obj = HarborReadFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.ReadFile.run(ToolInput(arguments={"path": "/nonexistent.py"}))
+        )
+        content = result.messages[0]["content"]
+        assert "ERROR" in content
+        assert "does not exist" in content
+
+    def test_read_file_with_offset(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.files["/test.py"] = "a\nb\nc\nd\ne\n"
+        tool_obj = HarborReadFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.ReadFile.run(
+                ToolInput(arguments={"path": "/test.py", "line_offset": 3, "n_lines": 2})
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "2 lines read" in content
+        assert "c" in content
+
+
+# ---------------------------------------------------------------------------
+# HarborWriteFileTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarborWriteFileTool:
+    def test_spec_shape(self) -> None:
+        sandbox = FakeSandbox()
+        tool_obj = HarborWriteFileTool(sandbox)
+        spec = tool_obj.WriteFile.to_spec()
+        assert spec["name"] == "WriteFile"
+        assert "path" in spec["parameters"]["properties"]
+        assert "content" in spec["parameters"]["properties"]
+
+    def test_write_file_overwrite(self) -> None:
+        sandbox = FakeSandbox()
+        # Mock stat command for file size
+        sandbox.set_command_result(
+            "stat -c %s '/test.py'",
+            SandboxResult(stdout="13", stderr="", exit_code=0),
+        )
+        tool_obj = HarborWriteFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.WriteFile.run(
+                ToolInput(arguments={"path": "/test.py", "content": "hello world\n"})
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "overwritten" in content
+        assert sandbox.files["/test.py"] == "hello world\n"
+
+    def test_write_file_append(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.files["/test.py"] = "existing\n"
+        sandbox.set_command_result(
+            "stat -c %s '/test.py'",
+            SandboxResult(stdout="24", stderr="", exit_code=0),
+        )
+        tool_obj = HarborWriteFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.WriteFile.run(
+                ToolInput(arguments={"path": "/test.py", "content": "new line\n", "mode": "append"})
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "appended to" in content
+
+
+# ---------------------------------------------------------------------------
+# HarborStrReplaceFileTool tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarborStrReplaceFileTool:
+    def test_spec_shape(self) -> None:
+        sandbox = FakeSandbox()
+        tool_obj = HarborStrReplaceFileTool(sandbox)
+        spec = tool_obj.StrReplaceFile.to_spec()
+        assert spec["name"] == "StrReplaceFile"
+        assert "path" in spec["parameters"]["properties"]
+        assert "edit" in spec["parameters"]["properties"]
+
+    def test_str_replace_basic(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.files["/test.py"] = "hello world\n"
+        tool_obj = HarborStrReplaceFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.StrReplaceFile.run(
+                ToolInput(
+                    arguments={
+                        "path": "/test.py",
+                        "edit": {"old": "hello", "new": "goodbye"},
+                    }
+                )
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "successfully edited" in content
+        assert "1 total replacement" in content
+        assert sandbox.files["/test.py"] == "goodbye world\n"
+
+    def test_str_replace_not_found(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.files["/test.py"] = "hello world\n"
+        tool_obj = HarborStrReplaceFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.StrReplaceFile.run(
+                ToolInput(
+                    arguments={
+                        "path": "/test.py",
+                        "edit": {"old": "nonexistent", "new": "replacement"},
+                    }
+                )
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "ERROR" in content
+        assert "not found" in content
+
+    def test_str_replace_file_not_found(self) -> None:
+        sandbox = FakeSandbox()
+        tool_obj = HarborStrReplaceFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.StrReplaceFile.run(
+                ToolInput(
+                    arguments={
+                        "path": "/nonexistent.py",
+                        "edit": {"old": "a", "new": "b"},
+                    }
+                )
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "ERROR" in content
+        assert "does not exist" in content
+
+    def test_str_replace_multiple_edits(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.files["/test.py"] = "aaa bbb ccc\n"
+        tool_obj = HarborStrReplaceFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.StrReplaceFile.run(
+                ToolInput(
+                    arguments={
+                        "path": "/test.py",
+                        "edit": [
+                            {"old": "aaa", "new": "xxx"},
+                            {"old": "bbb", "new": "yyy"},
+                        ],
+                    }
+                )
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "2 edit(s)" in content
+        assert sandbox.files["/test.py"] == "xxx yyy ccc\n"
+
+    def test_str_replace_all(self) -> None:
+        sandbox = FakeSandbox()
+        sandbox.files["/test.py"] = "aaa bbb aaa\n"
+        tool_obj = HarborStrReplaceFileTool(sandbox)
+
+        result = asyncio.run(
+            tool_obj.StrReplaceFile.run(
+                ToolInput(
+                    arguments={
+                        "path": "/test.py",
+                        "edit": {"old": "aaa", "new": "xxx", "replace_all": True},
+                    }
+                )
+            )
+        )
+        content = result.messages[0]["content"]
+        assert "2 total replacement" in content
+        assert sandbox.files["/test.py"] == "xxx bbb xxx\n"


### PR DESCRIPTION
## Summary
- Add Glob, Grep, ReadFile, WriteFile, and StrReplaceFile tools to Harbor sandbox environments, mirroring kimi-cli's tool interfaces exactly
- Tools execute inside the sandbox via `SandboxInterface` (`run_command`, `read_file`, `write_file`)
- Grep is backed by ripgrep — the `rg` binary is resolved on the host and uploaded into the sandbox at setup time (no internet needed in sandbox)
- Gated behind `enable_file_tools` flag so existing bash-only configs are unaffected

## Test plan
- [ ] Unit tests with mock/local sandbox for each tool (Glob, Grep, ReadFile, WriteFile, StrReplaceFile)
- [ ] Verify tool schemas via `.to_spec()` match kimi-cli parameter names and defaults
- [ ] Integration test: run harbor_onpodi with `enable_file_tools=True` and verify tools appear in conversation prefix
- [ ] Verify `rg` binary upload works with Fishbowl sandboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)