### PR TITLE
Unify checkpoint machinery

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -521,28 +521,39 @@ def save_checkpoint(
     )
 
 
-class RollingCheckpointManager:
-    """Fire-and-forget rolling checkpoints with automatic cleanup.
+class CheckpointManager:
+    """Unified checkpoint manager for periodic, rolling, and final checkpoints.
 
-    Rolling checkpoints are cheap resume points (saves training state for
-    resume but skips the sampler-weight export) saved at a finer
-    interval than periodic checkpoints. After each successful save, the previous
-    rolling checkpoint is deleted to bound storage usage. A short TTL acts as a
-    safety net in case deletion fails.
+    Manages three kinds of checkpoints:
+
+    * **Periodic** – full checkpoints (state + sampler weights) saved every
+      ``save_every`` steps with a configurable TTL.
+    * **Rolling** – cheap resume-only checkpoints (state only, no sampler
+      export) saved every ``rolling_save_every`` steps.  After each save the
+      previous rolling checkpoint is deleted to bound storage.  A short TTL
+      acts as a safety net if deletion fails.
+    * **Final** – a permanent checkpoint saved at the end of training with no
+      TTL, followed by cleanup of any remaining rolling checkpoint.
+
+    For training loops where periodic and rolling saves happen at the same
+    point, use :meth:`maybe_save_async` / :meth:`maybe_save` which handles
+    both in one call.  For loops where they happen at different points,
+    call :meth:`should_save_periodic` + :meth:`save_periodic_async` and
+    :meth:`maybe_save_rolling_async` separately.
 
     Usage::
 
-        mgr = RollingCheckpointManager(
+        mgr = CheckpointManager(
             training_client=tc,
             service_client=sc,
             log_path="/tmp/logs",
-            rolling_save_every=1,
             save_every=20,
+            rolling_save_every=1,
         )
-        for step in range(num_steps):
+        for step in range(1, num_steps + 1):
             train_step(...)
             await mgr.maybe_save_async(step, {"batch": step})
-        await mgr.finalize_async()
+        await mgr.save_final_async({"batch": num_steps})
     """
 
     def __init__(
@@ -550,23 +561,68 @@ class RollingCheckpointManager:
         training_client: tinker.TrainingClient,
         service_client: tinker.ServiceClient,
         log_path: str,
-        rolling_save_every: int,
         save_every: int = 0,
+        ttl_seconds: int | None = 604800,
+        rolling_save_every: int = 0,
         rolling_ttl_seconds: int = 7200,
         store: "TrainingRunStore | None" = None,
     ) -> None:
         self._training_client = training_client
         self._service_client = service_client
         self._log_path = log_path
-        self._rolling_save_every = rolling_save_every
         self._save_every = save_every
+        self._ttl_seconds = ttl_seconds
+        self._rolling_save_every = rolling_save_every
         self._rolling_ttl_seconds = rolling_ttl_seconds
         self._store = store
 
         self._pending_task: asyncio.Task[None] | None = None
         self._prev_state_path: str | None = None
 
-    def _should_save(self, step: int) -> bool:
+    # ------------------------------------------------------------------
+    # Periodic checkpoints
+    # ------------------------------------------------------------------
+
+    def should_save_periodic(self, step: int) -> bool:
+        """Return True if *step* warrants a periodic checkpoint."""
+        return self._save_every > 0 and step > 0 and step % self._save_every == 0
+
+    async def save_periodic_async(self, step: int, loop_state: dict[str, Any]) -> dict[str, str]:
+        """Save a periodic checkpoint (state + sampler) and return paths.
+
+        Callers that need the returned ``sampler_path`` (e.g. to create a
+        sampling client) should call :meth:`should_save_periodic` first, then
+        this method directly.
+        """
+        async with trace.scope_span("save_checkpoint"):
+            return await save_checkpoint_async(
+                training_client=self._training_client,
+                name=f"{step:06d}",
+                log_path=self._log_path,
+                loop_state=loop_state,
+                kind="both",
+                ttl_seconds=self._ttl_seconds,
+                store=self._store,
+            )
+
+    def save_periodic(self, step: int, loop_state: dict[str, Any]) -> dict[str, str]:
+        """Synchronous version of :meth:`save_periodic_async`."""
+        with trace.scope_span_sync("save_checkpoint"):
+            return save_checkpoint(
+                training_client=self._training_client,
+                name=f"{step:06d}",
+                log_path=self._log_path,
+                loop_state=loop_state,
+                kind="both",
+                ttl_seconds=self._ttl_seconds,
+                store=self._store,
+            )
+
+    # ------------------------------------------------------------------
+    # Rolling checkpoints
+    # ------------------------------------------------------------------
+
+    def _should_save_rolling(self, step: int) -> bool:
         """Return True if *step* warrants a rolling save."""
         if self._rolling_save_every <= 0 or step <= 0:
             return False
@@ -575,35 +631,126 @@ class RollingCheckpointManager:
         # Skip when a periodic checkpoint fires on the same step.
         return not (self._save_every > 0 and step % self._save_every == 0)
 
-    # ------------------------------------------------------------------
-    # Async interface (SL / RL)
-    # ------------------------------------------------------------------
+    async def maybe_save_rolling_async(self, step: int, loop_state: dict[str, Any]) -> None:
+        """Resolve any pending rolling save, then fire a new one if *step* warrants it.
 
-    async def maybe_save_async(self, step: int, loop_state: dict[str, Any]) -> None:
-        """Resolve any pending save, then fire a new one if *step* warrants it.
-
-        Call once per training step. The save runs as a background
-        ``asyncio.Task`` so it overlaps with the next training step.
+        The save runs as a background ``asyncio.Task`` so it overlaps with the
+        next training step.
         """
         await self._resolve_pending_async()
 
-        if not self._should_save(step):
+        if not self._should_save_rolling(step):
             return
 
         self._pending_task = asyncio.create_task(
-            self._do_save_async(step, loop_state),
+            self._do_rolling_save_async(step, loop_state),
             name=f"rolling_checkpoint_{step:06d}",
         )
 
-    async def finalize_async(self) -> None:
-        """Await any pending save, then delete the last rolling checkpoint.
+    def maybe_save_rolling(self, step: int, loop_state: dict[str, Any]) -> None:
+        """Synchronous version of :meth:`maybe_save_rolling_async`.
 
-        Call after the final checkpoint save so that the last entry in
-        ``checkpoints.jsonl`` always points to valid server-side data.
-        In the happy path this leaves zero rolling checkpoints on the server.
+        Blocks on the save but catches all errors so it never crashes the
+        training loop.
+        """
+        if not self._should_save_rolling(step):
+            return
+        try:
+            asyncio.run(self._do_rolling_save_async(step, loop_state))
+        except Exception:
+            logger.warning("Rolling checkpoint save failed", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Combined convenience (periodic + rolling in one call)
+    # ------------------------------------------------------------------
+
+    async def maybe_save_async(
+        self, step: int, loop_state: dict[str, Any]
+    ) -> dict[str, str] | None:
+        """Save periodic checkpoint if due, then fire rolling save if due.
+
+        Returns the periodic checkpoint path dict if a periodic save happened,
+        otherwise ``None``.  Suitable for training loops where periodic and
+        rolling saves happen at the same point (SL, DPO).
+        """
+        result: dict[str, str] | None = None
+        if self.should_save_periodic(step):
+            result = await self.save_periodic_async(step, loop_state)
+        await self.maybe_save_rolling_async(step, loop_state)
+        return result
+
+    def maybe_save(self, step: int, loop_state: dict[str, Any]) -> dict[str, str] | None:
+        """Synchronous version of :meth:`maybe_save_async`."""
+        result: dict[str, str] | None = None
+        if self.should_save_periodic(step):
+            result = self.save_periodic(step, loop_state)
+        self.maybe_save_rolling(step, loop_state)
+        return result
+
+    # ------------------------------------------------------------------
+    # Final checkpoint
+    # ------------------------------------------------------------------
+
+    async def save_final_async(self, loop_state: dict[str, Any]) -> dict[str, str]:
+        """Save the final checkpoint (no TTL) and clean up rolling checkpoints.
+
+        The final checkpoint is saved with ``ttl_seconds=None`` so it persists
+        indefinitely.  After saving, any remaining rolling checkpoint is
+        deleted so that the last entry in ``checkpoints.jsonl`` always points
+        to valid server-side data.
+        """
+        paths = await save_checkpoint_async(
+            training_client=self._training_client,
+            name="final",
+            log_path=self._log_path,
+            kind="both",
+            loop_state=loop_state,
+            ttl_seconds=None,
+            store=self._store,
+        )
+        await self.finalize_async()
+        return paths
+
+    def save_final(self, loop_state: dict[str, Any]) -> dict[str, str]:
+        """Synchronous version of :meth:`save_final_async`."""
+        paths = save_checkpoint(
+            training_client=self._training_client,
+            name="final",
+            log_path=self._log_path,
+            kind="both",
+            loop_state=loop_state,
+            ttl_seconds=None,
+            store=self._store,
+        )
+        self.finalize()
+        return paths
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    async def finalize_async(self) -> None:
+        """Await any pending rolling save, then delete the last rolling checkpoint.
+
+        Called automatically by :meth:`save_final_async`.  Can also be called
+        directly if the final checkpoint is saved through other means.
         """
         await self._resolve_pending_async()
         await self._delete_prev_async()
+
+    def finalize(self) -> None:
+        """Synchronous version of :meth:`finalize_async`."""
+        try:
+            asyncio.run(self._delete_prev_async())
+        except Exception:
+            logger.warning(
+                "Failed to delete last rolling checkpoint (TTL will clean up)",
+                exc_info=True,
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
 
     async def _resolve_pending_async(self) -> None:
         if self._pending_task is None:
@@ -614,7 +761,7 @@ class RollingCheckpointManager:
             logger.warning("Rolling checkpoint save failed", exc_info=True)
         self._pending_task = None
 
-    async def _do_save_async(self, step: int, loop_state: dict[str, Any]) -> None:
+    async def _do_rolling_save_async(self, step: int, loop_state: dict[str, Any]) -> None:
         name = f"{step:06d}"
         paths = await save_checkpoint_async(
             training_client=self._training_client,
@@ -646,30 +793,3 @@ class RollingCheckpointManager:
                 exc_info=True,
             )
         self._prev_state_path = None
-
-    # ------------------------------------------------------------------
-    # Sync interface (DPO)
-    # ------------------------------------------------------------------
-
-    def maybe_save(self, step: int, loop_state: dict[str, Any]) -> None:
-        """Synchronous version of :meth:`maybe_save_async`.
-
-        Blocks on the save but catches all errors so it never crashes the
-        training loop. Suitable for synchronous training loops (e.g. DPO).
-        """
-        if not self._should_save(step):
-            return
-        try:
-            asyncio.run(self._do_save_async(step, loop_state))
-        except Exception:
-            logger.warning("Rolling checkpoint save failed", exc_info=True)
-
-    def finalize(self) -> None:
-        """Synchronous version of :meth:`finalize_async`."""
-        try:
-            asyncio.run(self._delete_prev_async())
-        except Exception:
-            logger.warning(
-                "Failed to delete last rolling checkpoint (TTL will clean up)",
-                exc_info=True,
-            )

--- a/tinker_cookbook/checkpoint_utils_test.py
+++ b/tinker_cookbook/checkpoint_utils_test.py
@@ -8,8 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from tinker_cookbook.checkpoint_utils import (
+    CheckpointManager,
     CheckpointRecord,
-    RollingCheckpointManager,
     get_last_checkpoint,
     load_checkpoints_file,
 )
@@ -165,17 +165,15 @@ def test_checkpoint_record_extra_overlap_with_known_keys():
 
 
 # ---------------------------------------------------------------------------
-# RollingCheckpointManager tests
+# CheckpointManager tests
 # ---------------------------------------------------------------------------
 
 
-class TestRollingCheckpointManagerShouldSave:
-    """Tests for _should_save logic."""
+class TestCheckpointManagerShouldSave:
+    """Tests for _should_save_rolling logic."""
 
-    def _make_mgr(
-        self, rolling_save_every: int = 1, save_every: int = 0
-    ) -> RollingCheckpointManager:
-        return RollingCheckpointManager(
+    def _make_mgr(self, rolling_save_every: int = 1, save_every: int = 0) -> CheckpointManager:
+        return CheckpointManager(
             training_client=MagicMock(),
             service_client=MagicMock(),
             log_path="/tmp/unused",
@@ -185,41 +183,76 @@ class TestRollingCheckpointManagerShouldSave:
 
     def test_disabled_when_zero(self):
         mgr = self._make_mgr(rolling_save_every=0)
-        assert not mgr._should_save(1)
-        assert not mgr._should_save(5)
+        assert not mgr._should_save_rolling(1)
+        assert not mgr._should_save_rolling(5)
 
     def test_skips_step_zero(self):
         mgr = self._make_mgr(rolling_save_every=1)
-        assert not mgr._should_save(0)
+        assert not mgr._should_save_rolling(0)
 
     def test_saves_on_cadence(self):
         mgr = self._make_mgr(rolling_save_every=3)
-        assert not mgr._should_save(1)
-        assert not mgr._should_save(2)
-        assert mgr._should_save(3)
-        assert not mgr._should_save(4)
-        assert not mgr._should_save(5)
-        assert mgr._should_save(6)
+        assert not mgr._should_save_rolling(1)
+        assert not mgr._should_save_rolling(2)
+        assert mgr._should_save_rolling(3)
+        assert not mgr._should_save_rolling(4)
+        assert not mgr._should_save_rolling(5)
+        assert mgr._should_save_rolling(6)
 
     def test_saves_every_step(self):
         mgr = self._make_mgr(rolling_save_every=1)
-        assert mgr._should_save(1)
-        assert mgr._should_save(2)
-        assert mgr._should_save(3)
+        assert mgr._should_save_rolling(1)
+        assert mgr._should_save_rolling(2)
+        assert mgr._should_save_rolling(3)
 
     def test_skips_when_periodic_fires(self):
         mgr = self._make_mgr(rolling_save_every=1, save_every=5)
-        assert mgr._should_save(1)
-        assert mgr._should_save(4)
-        assert not mgr._should_save(5)  # periodic fires here
-        assert mgr._should_save(6)
-        assert not mgr._should_save(10)  # periodic fires here
+        assert mgr._should_save_rolling(1)
+        assert mgr._should_save_rolling(4)
+        assert not mgr._should_save_rolling(5)  # periodic fires here
+        assert mgr._should_save_rolling(6)
+        assert not mgr._should_save_rolling(10)  # periodic fires here
 
     def test_skips_when_periodic_fires_same_cadence(self):
         """Rolling and periodic on same cadence means rolling never fires."""
         mgr = self._make_mgr(rolling_save_every=5, save_every=5)
-        assert not mgr._should_save(5)
-        assert not mgr._should_save(10)
+        assert not mgr._should_save_rolling(5)
+        assert not mgr._should_save_rolling(10)
+
+
+class TestCheckpointManagerShouldSavePeriodic:
+    """Tests for should_save_periodic logic."""
+
+    def _make_mgr(self, save_every: int = 5) -> CheckpointManager:
+        return CheckpointManager(
+            training_client=MagicMock(),
+            service_client=MagicMock(),
+            log_path="/tmp/unused",
+            save_every=save_every,
+        )
+
+    def test_disabled_when_zero(self):
+        mgr = self._make_mgr(save_every=0)
+        assert not mgr.should_save_periodic(1)
+        assert not mgr.should_save_periodic(5)
+
+    def test_skips_step_zero(self):
+        mgr = self._make_mgr(save_every=5)
+        assert not mgr.should_save_periodic(0)
+
+    def test_saves_on_cadence(self):
+        mgr = self._make_mgr(save_every=5)
+        assert not mgr.should_save_periodic(1)
+        assert not mgr.should_save_periodic(4)
+        assert mgr.should_save_periodic(5)
+        assert not mgr.should_save_periodic(6)
+        assert mgr.should_save_periodic(10)
+
+    def test_saves_every_step(self):
+        mgr = self._make_mgr(save_every=1)
+        assert mgr.should_save_periodic(1)
+        assert mgr.should_save_periodic(2)
+        assert mgr.should_save_periodic(3)
 
 
 def _make_save_state_mock(paths: list[str]) -> AsyncMock:
@@ -253,7 +286,7 @@ async def test_maybe_save_async_saves_and_deletes():
             ["tinker://run/state/000001", "tinker://run/state/000002", "tinker://run/state/000003"]
         )
 
-        mgr = RollingCheckpointManager(
+        mgr = CheckpointManager(
             training_client=mock_training_client,
             service_client=mock_service_client,
             log_path=tmpdir,
@@ -295,7 +328,7 @@ async def test_maybe_save_async_skips_when_disabled():
     mock_training_client = MagicMock()
     mock_training_client.save_state_async = AsyncMock()
 
-    mgr = RollingCheckpointManager(
+    mgr = CheckpointManager(
         training_client=mock_training_client,
         service_client=MagicMock(),
         log_path="/tmp/unused",
@@ -319,7 +352,7 @@ async def test_finalize_deletes_last_rolling_checkpoint():
 
         mock_training_client.save_state_async = _make_save_state_mock(["tinker://run/state/000001"])
 
-        mgr = RollingCheckpointManager(
+        mgr = CheckpointManager(
             training_client=mock_training_client,
             service_client=mock_service_client,
             log_path=tmpdir,
@@ -344,7 +377,7 @@ async def test_save_failure_is_swallowed():
     mock_training_client.save_state_async = AsyncMock(side_effect=RuntimeError("server error"))
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        mgr = RollingCheckpointManager(
+        mgr = CheckpointManager(
             training_client=mock_training_client,
             service_client=MagicMock(),
             log_path=tmpdir,
@@ -373,7 +406,7 @@ async def test_delete_failure_is_swallowed():
             ["tinker://run/state/000001", "tinker://run/state/000002", "tinker://run/state/000003"]
         )
 
-        mgr = RollingCheckpointManager(
+        mgr = CheckpointManager(
             training_client=mock_training_client,
             service_client=mock_service_client,
             log_path=tmpdir,

--- a/tinker_cookbook/distillation/sdft.py
+++ b/tinker_cookbook/distillation/sdft.py
@@ -888,9 +888,17 @@ async def main(
     teacher_client = service_client.create_sampling_client(base_model=cfg.model_name)
     logger.info(f"Created static teacher sampling client for {cfg.model_name}")
 
+    checkpoint_mgr = checkpoint_utils.CheckpointManager(
+        training_client=training_client,
+        service_client=service_client,
+        log_path=cfg.log_path,
+        save_every=cfg.save_every,
+        store=store,
+    )
+
     # Initial sampling client for student
     sampling_client, _ = await save_checkpoint_and_get_sampling_client(
-        training_client, start_batch, cfg.log_path, cfg.save_every, store=store
+        training_client, checkpoint_mgr, start_batch, start_batch
     )
 
     log_path = Path(cfg.log_path)
@@ -1038,7 +1046,7 @@ async def main(
 
             # Refresh sampling client
             sampling_client, _ = await save_checkpoint_and_get_sampling_client(
-                training_client, i_batch + 1, cfg.log_path, cfg.save_every, store=store
+                training_client, checkpoint_mgr, i_batch + 1
             )
 
             # Optional teacher hard-sync
@@ -1062,15 +1070,7 @@ async def main(
 
     # Final checkpoint
     if start_batch < num_batches:
-        await checkpoint_utils.save_checkpoint_async(
-            training_client=training_client,
-            name="final",
-            log_path=cfg.log_path,
-            kind="both",
-            loop_state={"batch": num_batches},
-            ttl_seconds=None,
-            store=store,
-        )
+        await checkpoint_mgr.save_final_async(loop_state={"batch": num_batches})
 
     ml_logger.close()
     logger.info("SDFT training completed successfully")

--- a/tinker_cookbook/distillation/train_off_policy.py
+++ b/tinker_cookbook/distillation/train_off_policy.py
@@ -414,6 +414,15 @@ async def main(config: Config) -> None:
 
     evaluators = [eb() for eb in config.evaluator_builders]
 
+    checkpoint_mgr = checkpoint_utils.CheckpointManager(
+        training_client=training_client,
+        service_client=service_client,
+        log_path=config.log_path,
+        save_every=config.save_every,
+        ttl_seconds=config.ttl_seconds,
+        store=store,
+    )
+
     sampling_client: tinker.SamplingClient | None = None
 
     for i_batch in range(start_batch, total_batches):
@@ -454,15 +463,9 @@ async def main(config: Config) -> None:
         if train_result.metrics:
             metrics.update({f"train/{k}": v for k, v in train_result.metrics.items()})
 
-        if config.save_every > 0 and i_batch > start_batch and i_batch % config.save_every == 0:
-            path_dict = await checkpoint_utils.save_checkpoint_async(
-                training_client=training_client,
-                name=f"{i_batch:06d}",
-                log_path=config.log_path,
-                kind="both",
-                loop_state={"batch": i_batch},
-                ttl_seconds=config.ttl_seconds,
-                store=store,
+        if i_batch > start_batch and checkpoint_mgr.should_save_periodic(i_batch):
+            path_dict = await checkpoint_mgr.save_periodic_async(
+                step=i_batch, loop_state={"batch": i_batch}
             )
             sampling_client = training_client.create_sampling_client(path_dict["sampler_path"])
         else:
@@ -476,15 +479,7 @@ async def main(config: Config) -> None:
 
     # Final checkpoint
     if start_batch < total_batches:
-        await checkpoint_utils.save_checkpoint_async(
-            training_client=training_client,
-            name="final",
-            log_path=config.log_path,
-            kind="both",
-            loop_state={"batch": total_batches},
-            ttl_seconds=None,
-            store=store,
-        )
+        await checkpoint_mgr.save_final_async(loop_state={"batch": total_batches})
 
     ml_logger.close()
     logger.info("Off-policy distillation completed successfully")

--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -229,6 +229,7 @@ async def do_train_step_and_get_sampling_client(
     config: Config,
     i_batch: int,
     training_client: tinker.TrainingClient,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager,
     service_client: tinker.ServiceClient,
     tokenizer: Tokenizer,
     env_group_builders_P: Sequence[EnvGroupBuilder],
@@ -264,14 +265,12 @@ async def do_train_step_and_get_sampling_client(
 
     sampling_client, full_batch_metrics = await compute_full_batch_metrics_and_get_sampling_client(
         training_client,
+        checkpoint_mgr,
         # NOTE: saving the checkpoint as the i + 1 step
         i_batch + 1,
         data_D,
         training_logprobs_D,
-        config.log_path,
-        config.save_every,
         config.compute_post_kl,
-        store=store,
     )
     metrics.update(full_batch_metrics)
 
@@ -285,6 +284,7 @@ async def do_sync_training(
     num_batches: int,
     config: Config,
     training_client: tinker.TrainingClient,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager,
     service_client: tinker.ServiceClient,
     evaluators: list[SamplingClientEvaluator],
     dataset: CompositeDataset,
@@ -296,7 +296,7 @@ async def do_sync_training(
 
     # Initial sampling client
     sampling_client, _ = await save_checkpoint_and_get_sampling_client(
-        training_client, start_batch, config.log_path, config.save_every, store=ml_logger.store
+        training_client, checkpoint_mgr, start_batch, start_batch
     )
 
     log_path = Path(config.log_path)
@@ -345,13 +345,13 @@ async def do_sync_training(
                 config,
                 i_batch,
                 training_client,
+                checkpoint_mgr,
                 service_client,
                 tokenizer,
                 env_group_builders_P,
                 trajectory_groups_P,
                 dataset_indices_P,
                 teacher_clients,
-                store=ml_logger.store,
             )
 
             metrics.update(train_step_metrics)
@@ -379,7 +379,6 @@ async def main(
         config=config,
         wandb_name=config.wandb_name,
     )
-    store = ml_logger.store
     if config.enable_trace:
         # Get and rename the current (main) task
         current_task = asyncio.current_task()
@@ -475,6 +474,14 @@ async def main(
     )
     logger.info(f"Will train on {num_batches} batches (dataset has {num_batches})")
 
+    checkpoint_mgr = checkpoint_utils.CheckpointManager(
+        training_client=training_client,
+        service_client=service_client,
+        log_path=config.log_path,
+        save_every=config.save_every,
+        store=ml_logger.store,
+    )
+
     # Training loop
     await do_sync_training(
         start_batch=start_batch,
@@ -482,6 +489,7 @@ async def main(
         num_batches=num_batches,
         config=config,
         training_client=training_client,
+        checkpoint_mgr=checkpoint_mgr,
         service_client=service_client,
         evaluators=evaluators,
         dataset=composite_dataset,
@@ -492,15 +500,7 @@ async def main(
 
     # Save final checkpoint
     if start_batch < num_batches:
-        _ = await checkpoint_utils.save_checkpoint_async(
-            training_client=training_client,
-            name="final",
-            log_path=config.log_path,
-            kind="both",
-            loop_state={"batch": num_batches},
-            ttl_seconds=None,
-            store=store,
-        )
+        await checkpoint_mgr.save_final_async(loop_state={"batch": num_batches})
     else:
         logger.info("Training was already complete; nothing to do")
 

--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -269,7 +269,7 @@ def do_update(
     ml_logger: ml_log.Logger,
     log_path: str,
     tokenizer: Tokenizer,
-    rolling_mgr: checkpoint_utils.RollingCheckpointManager | None = None,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager | None = None,
 ):
     """Perform a single DPO training update step.
 
@@ -299,23 +299,13 @@ def do_update(
     metrics: dict[str, int | float | str] = {"epoch": epoch_idx}
 
     with trace.trace_iteration(step=step) as window:
-        # Save checkpoint if needed
-        if config.save_every > 0 and step % config.save_every == 0 and step > 0:
-            with trace.scope_span_sync("save_checkpoint"):
-                save_result = checkpoint_utils.save_checkpoint(
-                    training_client=training_client,
-                    name=f"{step:06d}",
-                    log_path=log_path,
-                    kind="both",
-                    loop_state={"epoch": epoch_idx, "batch": batch_idx},
-                    ttl_seconds=config.ttl_seconds,
-                    store=ml_logger.store,
-                )
-            if "state_path" in save_result:
+        # Save checkpoint (periodic + rolling) if needed
+        if checkpoint_mgr is not None:
+            save_result = checkpoint_mgr.maybe_save(
+                step=step, loop_state={"epoch": epoch_idx, "batch": batch_idx}
+            )
+            if save_result and "state_path" in save_result:
                 metrics["state_path"] = save_result["state_path"]
-
-        if rolling_mgr is not None:
-            rolling_mgr.maybe_save(step=step, loop_state={"epoch": epoch_idx, "batch": batch_idx})
 
         learning_rate = config.learning_rate * compute_schedule_lr_multiplier(
             lr_schedule=config.lr_schedule, step=step, total_steps=total_steps
@@ -510,12 +500,13 @@ def main(config: Config):
     model_info.warn_if_renderer_not_recommended(config.model_name, config.renderer_name)
     training_client, reference_client = create_dpo_clients(config, resume_info, user_metadata)
     service_client = tinker.ServiceClient(base_url=config.base_url)
-    rolling_mgr = checkpoint_utils.RollingCheckpointManager(
+    checkpoint_mgr = checkpoint_utils.CheckpointManager(
         training_client=training_client,
         service_client=service_client,
         log_path=config.log_path,
-        rolling_save_every=config.rolling_save_every,
         save_every=config.save_every,
+        ttl_seconds=config.ttl_seconds,
+        rolling_save_every=config.rolling_save_every,
         rolling_ttl_seconds=config.rolling_ttl_seconds,
         store=store,
     )
@@ -560,7 +551,7 @@ def main(config: Config):
                 ml_logger=ml_logger,
                 log_path=config.log_path,
                 tokenizer=tokenizer,
-                rolling_mgr=rolling_mgr,
+                checkpoint_mgr=checkpoint_mgr,
             )
         if reached_max_steps:
             break
@@ -570,20 +561,10 @@ def main(config: Config):
         config.max_steps is None or start_epoch * n_batches + start_batch < config.max_steps
     )
     if did_train:
-        checkpoint_utils.save_checkpoint(
-            training_client=training_client,
-            name="final",
-            log_path=config.log_path,
-            kind="both",
-            loop_state={"epoch": config.num_epochs, "batch": 0},
-            ttl_seconds=None,
-            store=store,
-        )
+        checkpoint_mgr.save_final(loop_state={"epoch": config.num_epochs, "batch": 0})
     else:
         logger.info("Training was already complete; nothing to do")
-    # Clean up rolling checkpoints after the final save so that the last
-    # entry in checkpoints.jsonl always points to valid server-side data.
-    rolling_mgr.finalize()
+        checkpoint_mgr.finalize()
 
     # Cleanup
     ml_logger.close()

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -640,7 +640,7 @@ async def do_sync_training_with_stream_minibatch(
     tokenizer: Tokenizer,
     error_counter: RolloutErrorCounter | None = None,
     strategy: RolloutStrategy | None = None,
-    rolling_mgr: checkpoint_utils.RollingCheckpointManager | None = None,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager | None = None,
 ):
     """Implement fully synchronous on-policy training with minibatch streaming.
 
@@ -671,14 +671,9 @@ async def do_sync_training_with_stream_minibatch(
             Defaults to None.
     """
     # Initial sampling client
+    assert checkpoint_mgr is not None
     sampling_client, _ = await save_checkpoint_and_get_sampling_client(
-        training_client,
-        start_batch,
-        config.log_path,
-        config.save_every,
-        start_batch,
-        config.ttl_seconds,
-        store=ml_logger.store,
+        training_client, checkpoint_mgr, start_batch, start_batch
     )
 
     for i_batch in range(start_batch, end_batch):
@@ -765,9 +760,9 @@ async def do_sync_training_with_stream_minibatch(
                     i_batch,
                     trajectory_groups_queue,
                     training_client,
+                    checkpoint_mgr,
                     kl_reference_client,
                     tokenizer,
-                    store=ml_logger.store,
                 )
                 # _Shutdown cannot appear in the sync path's local queue
                 assert streaming_result is not None, "Unexpected shutdown in sync streaming path"
@@ -794,8 +789,10 @@ async def do_sync_training_with_stream_minibatch(
             )
 
         # Rolling checkpoint (fire-and-forget, overlaps with next iteration)
-        if rolling_mgr is not None:
-            await rolling_mgr.maybe_save_async(step=i_batch + 1, loop_state={"batch": i_batch + 1})
+        if checkpoint_mgr is not None:
+            await checkpoint_mgr.maybe_save_rolling_async(
+                step=i_batch + 1, loop_state={"batch": i_batch + 1}
+            )
 
         # Log metrics
         metrics.update(full_batch_metrics)
@@ -878,7 +875,7 @@ async def do_async_training(
     tokenizer: Tokenizer,
     error_counter: RolloutErrorCounter | None = None,
     strategy: RolloutStrategy | None = None,
-    rolling_mgr: checkpoint_utils.RollingCheckpointManager | None = None,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager | None = None,
 ):
     """Implement async off-policy training, capped at K steps off policy.
 
@@ -1093,10 +1090,10 @@ async def do_async_training(
                         i_batch,
                         trajectory_groups_queue,
                         training_client,
+                        checkpoint_mgr,
                         kl_reference_client,
                         tokenizer,
                         filter_stale_trajectory_group,
-                        store=ml_logger.store,
                     )
                 if streaming_result is None:
                     logger.info("[training_loop] Received shutdown signal from streaming")
@@ -1157,11 +1154,11 @@ async def do_async_training(
                         config,
                         i_batch,
                         training_client,
+                        checkpoint_mgr,
                         kl_reference_client,
                         tokenizer,
                         [g.env_group_builder for g in wrapped_trajectory_groups],
                         [g.trajectory_group for g in wrapped_trajectory_groups],
-                        store=ml_logger.store,
                     )
                 iter_dir = iteration_dir(config.log_path, i_batch)
                 _maybe_export_rollout_summary_jsonl(
@@ -1183,8 +1180,8 @@ async def do_async_training(
             sampling_client_updated_event.set()
 
             # Rolling checkpoint (fire-and-forget, overlaps with next iteration)
-            if rolling_mgr is not None:
-                await rolling_mgr.maybe_save_async(
+            if checkpoint_mgr is not None:
+                await checkpoint_mgr.maybe_save_rolling_async(
                     step=i_batch + 1, loop_state={"batch": i_batch + 1}
                 )
 
@@ -1253,50 +1250,38 @@ async def do_async_training(
 @trace.scope
 async def save_checkpoint_and_get_sampling_client(
     training_client: tinker.TrainingClient,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager,
     i_batch: int,
-    log_path: str,
-    save_every: int,
     start_batch: int = 0,
-    ttl_seconds: int | None = None,
-    store: TrainingRunStore | None = None,
 ) -> tuple[tinker.SamplingClient, dict[str, Any]]:
     """Save a checkpoint (if due) and return a fresh sampling client.
 
-    When ``save_every > 0`` and ``i_batch`` falls on the save cadence, a
-    full checkpoint (weights + optimizer state) is persisted. Otherwise a
-    lightweight sampler-only snapshot is created so that subsequent rollouts
-    use the latest weights.
+    When ``i_batch`` falls on the periodic checkpoint cadence, a full
+    checkpoint (weights + optimizer state) is persisted via
+    *checkpoint_mgr*. Otherwise a lightweight sampler-only snapshot is
+    created so that subsequent rollouts use the latest weights.
 
     Args:
         training_client (tinker.TrainingClient): Client connected to the
             Tinker training service.
+        checkpoint_mgr (checkpoint_utils.CheckpointManager): Manager that
+            handles periodic checkpoint saves.
         i_batch (int): Current training iteration index.
-        log_path (str): Directory for checkpoints and logs.
-        save_every (int): Checkpoint cadence in iterations. 0 disables
-            periodic checkpointing.
         start_batch (int): First iteration index of this run, used to avoid
             checkpointing on the very first step. Defaults to 0.
-        ttl_seconds (int | None): Time-to-live for periodic checkpoints.
-            None disables expiry. Defaults to None.
 
     Returns:
         tuple[tinker.SamplingClient, dict[str, Any]]: A sampling client
         loaded with the latest weights, and a (possibly empty) metrics dict.
     """
     metrics: dict[str, Any] = {}
-    async with trace.scope_span("save_checkpoint"):
-        if save_every > 0 and i_batch > start_batch and i_batch % save_every == 0:
-            path_dict = await checkpoint_utils.save_checkpoint_async(
-                training_client=training_client,
-                name=f"{i_batch:06d}",
-                log_path=log_path,
-                loop_state={"batch": i_batch},
-                kind="both",
-                ttl_seconds=ttl_seconds,
-                store=store,
-            )
-            return training_client.create_sampling_client(path_dict["sampler_path"]), metrics
-        else:
+    if i_batch > start_batch and checkpoint_mgr.should_save_periodic(i_batch):
+        path_dict = await checkpoint_mgr.save_periodic_async(
+            step=i_batch, loop_state={"batch": i_batch}
+        )
+        return training_client.create_sampling_client(path_dict["sampler_path"]), metrics
+    else:
+        async with trace.scope_span("save_checkpoint"):
             return await training_client.save_weights_and_get_sampling_client_async(), metrics
 
 
@@ -1364,14 +1349,11 @@ async def prepare_minibatch(
 @trace.scope
 async def compute_full_batch_metrics_and_get_sampling_client(
     training_client: tinker.TrainingClient,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager,
     i_batch: int,
     data_D: list[tinker.Datum],
     training_logprobs_D: list[torch.Tensor],
-    log_path: str,
-    save_every: int,
     do_compute_post_kl: bool,
-    ttl_seconds: int | None = None,
-    store: TrainingRunStore | None = None,
 ) -> tuple[tinker.SamplingClient, dict[str, Any]]:
     """Compute end-of-iteration metrics and return a fresh sampling client.
 
@@ -1382,17 +1364,15 @@ async def compute_full_batch_metrics_and_get_sampling_client(
     Args:
         training_client (tinker.TrainingClient): Client connected to the
             Tinker training service.
+        checkpoint_mgr (checkpoint_utils.CheckpointManager): Manager that
+            handles periodic checkpoint saves.
         i_batch (int): Current training iteration index (used for checkpoint
             naming).
         data_D (list[tinker.Datum]): Training data from the current iteration.
         training_logprobs_D (list[torch.Tensor]): Per-datum log-probabilities
             returned by the training forward pass.
-        log_path (str): Directory for checkpoints and logs.
-        save_every (int): Checkpoint cadence in iterations.
         do_compute_post_kl (bool): Whether to compute post-update KL metrics
             against the new sampling client (adds an extra sampling call).
-        ttl_seconds (int | None): Time-to-live for periodic checkpoints.
-            Defaults to None.
 
     Returns:
         tuple[tinker.SamplingClient, dict[str, Any]]: A sampling client
@@ -1408,7 +1388,7 @@ async def compute_full_batch_metrics_and_get_sampling_client(
 
     # Get a sampling client using the new weights
     sampling_client, checkpoint_metrics = await save_checkpoint_and_get_sampling_client(
-        training_client, i_batch, log_path, save_every, ttl_seconds=ttl_seconds, store=store
+        training_client, checkpoint_mgr, i_batch
     )
     metrics.update(checkpoint_metrics)
 
@@ -1427,10 +1407,10 @@ async def do_train_step_streaming_and_get_sampling_client(
     i_batch: int,
     trajectory_groups_queue: asyncio.Queue[WrappedTrajectoryGroup | _Shutdown | None],
     training_client: tinker.TrainingClient,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager,
     kl_reference_client: tinker.SamplingClient | None,
     tokenizer: Tokenizer,
     trajectory_group_filter: Callable[[WrappedTrajectoryGroup | None], bool] = lambda _: True,
-    store: TrainingRunStore | None = None,
 ) -> tuple[tinker.SamplingClient, dict[str, Any], list[WrappedTrajectoryGroup]] | None:
     """Consume trajectory groups from a queue and train as minibatches become ready.
 
@@ -1568,15 +1548,12 @@ async def do_train_step_streaming_and_get_sampling_client(
         full_batch_metrics,
     ) = await compute_full_batch_metrics_and_get_sampling_client(
         training_client,
+        checkpoint_mgr,
         # NOTE: saving the checkpoint as the i + 1 step
         i_batch + 1,
         all_data_D,
         all_training_logprobs_D,
-        config.log_path,
-        config.save_every,
         config.compute_post_kl,
-        config.ttl_seconds,
-        store=store,
     )
     metrics.update(full_batch_metrics)
     return sampling_client, metrics, all_wrapped_trajectory_groups
@@ -1587,11 +1564,11 @@ async def do_train_step_and_get_sampling_client(
     config: Config,
     i_batch: int,
     training_client: tinker.TrainingClient,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager,
     kl_reference_client: tinker.SamplingClient | None,
     tokenizer: Tokenizer,
     env_group_builders_P: Sequence[EnvGroupBuilder],
     trajectory_groups_P: list[TrajectoryGroup],
-    store: TrainingRunStore | None = None,
 ) -> tuple[tinker.SamplingClient, dict[str, Any]]:
     """Prepare a minibatch, run one training step, and return updated weights.
 
@@ -1642,15 +1619,12 @@ async def do_train_step_and_get_sampling_client(
 
     sampling_client, full_batch_metrics = await compute_full_batch_metrics_and_get_sampling_client(
         training_client,
+        checkpoint_mgr,
         # NOTE: saving the checkpoint as the i + 1 step
         i_batch + 1,
         data_D,
         training_logprobs_D,
-        config.log_path,
-        config.save_every,
         config.compute_post_kl,
-        config.ttl_seconds,
-        store=store,
     )
     metrics.update(full_batch_metrics)
 
@@ -1671,7 +1645,7 @@ async def do_sync_training(
     tokenizer: Tokenizer,
     error_counter: RolloutErrorCounter | None = None,
     strategy: RolloutStrategy | None = None,
-    rolling_mgr: checkpoint_utils.RollingCheckpointManager | None = None,
+    checkpoint_mgr: checkpoint_utils.CheckpointManager | None = None,
 ):
     """Implement fully synchronous on-policy training.
 
@@ -1702,14 +1676,9 @@ async def do_sync_training(
             Defaults to None.
     """
     # Initial sampling client
+    assert checkpoint_mgr is not None
     sampling_client, _ = await save_checkpoint_and_get_sampling_client(
-        training_client,
-        start_batch,
-        config.log_path,
-        config.save_every,
-        start_batch,
-        config.ttl_seconds,
-        store=ml_logger.store,
+        training_client, checkpoint_mgr, start_batch, start_batch
     )
 
     for i_batch in range(start_batch, end_batch):
@@ -1803,18 +1772,18 @@ async def do_sync_training(
                     config,
                     i_batch,
                     training_client,
+                    checkpoint_mgr,
                     kl_reference_client,
                     tokenizer,
                     env_group_builders_P,
                     trajectory_groups_P,
-                    store=ml_logger.store,
                 )
 
                 metrics.update(train_step_metrics)
 
                 # Rolling checkpoint (fire-and-forget, overlaps with next iteration)
-                if rolling_mgr is not None:
-                    await rolling_mgr.maybe_save_async(
+                if checkpoint_mgr is not None:
+                    await checkpoint_mgr.maybe_save_rolling_async(
                         step=i_batch + 1, loop_state={"batch": i_batch + 1}
                     )
 
@@ -1971,12 +1940,13 @@ async def main(
     else:
         kl_reference_client = None
 
-    rolling_mgr = checkpoint_utils.RollingCheckpointManager(
+    checkpoint_mgr = checkpoint_utils.CheckpointManager(
         training_client=training_client,
         service_client=service_client,
         log_path=config.log_path,
-        rolling_save_every=config.rolling_save_every,
         save_every=config.save_every,
+        ttl_seconds=config.ttl_seconds,
+        rolling_save_every=config.rolling_save_every,
         rolling_ttl_seconds=config.rolling_ttl_seconds,
         store=store,
     )
@@ -2001,26 +1971,15 @@ async def main(
         tokenizer=tokenizer,
         error_counter=error_counter,
         strategy=strategy,
-        rolling_mgr=rolling_mgr,
+        checkpoint_mgr=checkpoint_mgr,
     )
 
     # Save final checkpoint
     if start_batch < end_batch:
-        _ = await checkpoint_utils.save_checkpoint_async(
-            training_client=training_client,
-            name="final",
-            log_path=config.log_path,
-            kind="both",
-            loop_state={"batch": end_batch},
-            ttl_seconds=None,
-            store=store,
-        )
+        await checkpoint_mgr.save_final_async(loop_state={"batch": end_batch})
     else:
         logger.info("Training was already complete; nothing to do")
-
-    # Clean up rolling checkpoints after the final save so that the last
-    # entry in checkpoints.jsonl always points to valid server-side data.
-    await rolling_mgr.finalize_async()
+        await checkpoint_mgr.finalize_async()
 
     # Cleanup
     if rollout_executor is not None:

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -330,12 +330,13 @@ async def main(config: Config):
             user_metadata=user_metadata,
         )
 
-    rolling_mgr = checkpoint_utils.RollingCheckpointManager(
+    checkpoint_mgr = checkpoint_utils.CheckpointManager(
         training_client=training_client,
         service_client=service_client,
         log_path=config.log_path,
-        rolling_save_every=config.rolling_save_every,
         save_every=config.save_every,
+        ttl_seconds=config.ttl_seconds,
+        rolling_save_every=config.rolling_save_every,
         rolling_ttl_seconds=config.rolling_ttl_seconds,
         store=store,
     )
@@ -423,21 +424,7 @@ async def main(config: Config):
         metrics = submitted.metrics
         metrics["progress"] = min((submitted.step + 1) / progress_denominator, 1.0)
 
-        if config.save_every > 0 and submitted.step % config.save_every == 0 and submitted.step > 0:
-            async with trace.scope_span("save_checkpoint"):
-                # Enqueue a checkpoint save after the forward/backward and optimizer
-                # requests for this step; the snapshot will reflect post-step weights.
-                await checkpoint_utils.save_checkpoint_async(
-                    training_client=training_client,
-                    name=f"{submitted.step:06d}",
-                    log_path=config.log_path,
-                    loop_state={"epoch": submitted.epoch_idx, "batch": submitted.batch_idx},
-                    kind="both",
-                    ttl_seconds=config.ttl_seconds,
-                    store=store,
-                )
-
-        await rolling_mgr.maybe_save_async(
+        await checkpoint_mgr.maybe_save_async(
             step=submitted.step,
             loop_state={"epoch": submitted.epoch_idx, "batch": submitted.batch_idx},
         )
@@ -536,20 +523,12 @@ async def main(config: Config):
         config.max_steps is None or start_epoch * n_batches + start_batch < config.max_steps
     )
     if did_train:
-        await checkpoint_utils.save_checkpoint_async(
-            training_client=training_client,
-            name="final",
-            log_path=config.log_path,
-            kind="both",
+        await checkpoint_mgr.save_final_async(
             loop_state={"epoch": config.num_epochs, "batch": 0},
-            ttl_seconds=None,
-            store=store,
         )
     else:
         logger.info("Training was already complete; nothing to do")
-    # Clean up rolling checkpoints after the final save so that the last
-    # entry in checkpoints.jsonl always points to valid server-side data.
-    await rolling_mgr.finalize_async()
+        await checkpoint_mgr.finalize_async()
 
     ml_logger.close()
     logger.info("Training completed successfully")


### PR DESCRIPTION
Previously we had two checkpoints paths in all the recipes: a freestanding checkpoint_utils path as well as a RollingCheckpointManager path. What's worse was that RollingCheckpointManager was aware of the freestanding codepath (save_every was passed in).

This commit unifies both paths to always go through the new CheckpointManager. Being able to store some state inside a class instance is also generally useful.