### PR TITLE
sdft: reverse KL fix

### DIFF
--- a/tinker_cookbook/distillation/sdft.py
+++ b/tinker_cookbook/distillation/sdft.py
@@ -627,7 +627,8 @@ def reverse_kl_custom_loss(
     the per-slot validity mask via ``weights > 0`` and reconstruct
     ``log q_renorm = log(weights)`` for the KL computation.
     """
-    total_loss = torch.tensor(0.0)
+    device = logprobs_list[0].device if logprobs_list else torch.device("cpu")
+    total_loss = torch.zeros((), device=device)
     sum_kl = 0.0
     sum_student_entropy = 0.0
     sum_positions = 0.0
@@ -648,6 +649,7 @@ def reverse_kl_custom_loss(
         neg_inf = torch.full_like(student_logp_NK, float("-inf"))
         masked_logp = torch.where(slot_mask_NK, student_logp_NK, neg_inf)
         log_p_renorm = torch.log_softmax(masked_logp, dim=-1)
+        # Invalid slots land at 0 here (→ p_renorm=1), but are zeroed below via slot_mask_NK.
         log_p_renorm = torch.nan_to_num(log_p_renorm, nan=0.0, neginf=0.0)
         p_renorm = log_p_renorm.exp()
 
@@ -687,9 +689,9 @@ async def _train_step_reverse_kl(
 
     Mirrors :func:`tinker_cookbook.rl.train.train_step` but uses
     ``forward_backward_custom_async`` with :func:`reverse_kl_custom_loss`.
-    The datums produced by :func:`build_reverse_kl_datums` carry
-    ``position_mask`` / ``k_valid`` / ``teacher_logprobs`` instead of the
-    standard ``mask`` key, so no mask stripping is needed.
+    The datums produced by :func:`build_reverse_kl_datums` carry only
+    ``target_tokens`` and ``weights`` (with ``0`` in ``weights`` acting as
+    the mask sentinel), so no ``mask`` stripping is needed.
     """
     batches = split_list(data_D, min(num_substeps, len(data_D)))
     if not batches:
@@ -809,6 +811,12 @@ async def main(
             batches. Use :class:`~tinker_cookbook.recipes.sdft.datasets.SDFTDataset`.
         test_dataset: Optional test dataset for periodic evaluation.
     """
+    if cfg.reverse and cfg.topk == 0:
+        raise ValueError(
+            "reverse=True requires topk>0: the analytical reverse KL runs over "
+            "the teacher's top-K set, which doesn't exist when topk=0."
+        )
+
     ml_logger = ml_log.setup_logging(
         log_dir=cfg.log_path,
         wandb_project=cfg.wandb_project,

--- a/tinker_cookbook/distillation/sdft.py
+++ b/tinker_cookbook/distillation/sdft.py
@@ -70,6 +70,7 @@ from tinker_cookbook.rl.types import (
     TrajectoryGroup,
 )
 from tinker_cookbook.utils import ml_log, trace
+from tinker_cookbook.utils.misc_utils import split_list
 
 logger = logging.getLogger(__name__)
 
@@ -464,6 +465,269 @@ async def build_topk_distillation_datums(
     return new_datums, metrics
 
 
+@trace.scope
+async def build_reverse_kl_datums(
+    data_D: list[tinker.Datum],
+    metadata_D: list[dict[str, int]],
+    teacher_client: tinker.SamplingClient,
+    teacher_prompts_P: list[tinker.ModelInput],
+    topk: int = 20,
+    max_context_length: int = 32768,
+    vocab_size: int | None = None,
+    skip_first_n_tokens: int = 3,
+) -> tuple[list[tinker.Datum], dict[str, float]]:
+    """Build datums for reverse-KL custom-loss training over the teacher's top-K.
+
+    Teacher-forces each student completion through the teacher, extracts the
+    teacher's top-K token distribution at every completion position, and
+    renormalizes it.
+
+    Tinker's ``forward_backward_custom`` only accepts ``loss_fn_inputs`` keys in
+    ``{"target_tokens", "weights"}`` (and only JSON-serializable floats), so we
+    pack the renormalized teacher probability into ``weights`` with ``0`` as
+    the sentinel for both (a) invalid top-K slots (after vocab filtering) and
+    (b) masked positions (prompt, trailing, or skipped). This matches the
+    forward-KL CE encoding. :func:`reverse_kl_custom_loss` recovers the mask
+    via ``weights > 0`` and reconstructs ``log q_renorm = log(weights)``.
+
+    The loss (REINFORCE form, stop-grad on the advantage):
+
+        L = sum_t sum_{k in S_t} p_renorm(x_k|t) * sg[log p_renorm - log q_renorm]
+    """
+    teacher_forced_sequences_D: list[tinker.ModelInput] = []
+    teacher_prompt_lengths_D: list[int] = []
+    completion_lengths_D: list[int] = []
+    truncated_count = 0
+
+    for i, datum in enumerate(data_D):
+        group_idx = metadata_D[i]["group_idx"]
+        teacher_prompt = teacher_prompts_P[group_idx]
+
+        completion_tokens, teacher_prompt_len, _, was_truncated = _extract_completion_tokens(
+            datum, teacher_prompt, max_context_length
+        )
+        if was_truncated:
+            truncated_count += 1
+
+        if not completion_tokens:
+            teacher_forced_sequences_D.append(teacher_prompt)
+            teacher_prompt_lengths_D.append(teacher_prompt_len)
+            completion_lengths_D.append(0)
+            continue
+
+        teacher_forced = _build_teacher_forced_sequence(teacher_prompt, completion_tokens)
+        teacher_forced_sequences_D.append(teacher_forced)
+        teacher_prompt_lengths_D.append(teacher_prompt_len)
+        completion_lengths_D.append(len(completion_tokens))
+
+    topk_responses_D = await asyncio.gather(
+        *[
+            teacher_client.sample_async(
+                prompt=teacher_forced,
+                num_samples=1,
+                sampling_params=tinker.SamplingParams(max_tokens=1),
+                include_prompt_logprobs=True,
+                topk_prompt_logprobs=topk,
+            )
+            for teacher_forced in teacher_forced_sequences_D
+        ]
+    )
+
+    new_datums: list[tinker.Datum] = []
+    total_positions = 0.0
+    total_teacher_entropy = 0.0
+
+    for i, datum in enumerate(data_D):
+        mask = datum.loss_fn_inputs["mask"].to_torch()
+        completion_mask_indices = torch.where(mask > 0)[0]
+        N = datum.model_input.length
+        completion_len = completion_lengths_D[i]
+        teacher_prompt_len = teacher_prompt_lengths_D[i]
+
+        target_tokens_NK = torch.zeros(N, topk, dtype=torch.long)
+        # All slots start at 0 (masked). Valid slots get the renormalized
+        # teacher probability; masked positions and unused slots keep 0.
+        weights_NK = torch.zeros(N, topk, dtype=torch.float32)
+
+        if completion_len > 0 and len(completion_mask_indices) > 0:
+            topk_all = topk_responses_D[i].topk_prompt_logprobs
+
+            num_tokens = min(completion_len, len(completion_mask_indices))
+            for t in range(num_tokens):
+                if t < skip_first_n_tokens:
+                    continue
+
+                teacher_pos = teacher_prompt_len + t
+                student_pos = int(completion_mask_indices[t].item())
+
+                if topk_all is None or teacher_pos >= len(topk_all):
+                    continue
+                topk_entries = topk_all[teacher_pos]
+                if topk_entries is None:
+                    continue
+
+                filtered = [
+                    (tok_id, lp)
+                    for tok_id, lp in topk_entries[:topk]
+                    if vocab_size is None or tok_id < vocab_size
+                ]
+                if not filtered:
+                    continue
+
+                k_actual = len(filtered)
+                token_ids = torch.tensor([tok_id for tok_id, _ in filtered], dtype=torch.long)
+                raw_lps = torch.tensor([lp for _, lp in filtered], dtype=torch.float32)
+
+                teacher_log_renorm = raw_lps - torch.logsumexp(raw_lps, dim=0)
+                teacher_probs = teacher_log_renorm.exp()
+
+                target_tokens_NK[student_pos, :k_actual] = token_ids
+                weights_NK[student_pos, :k_actual] = teacher_probs
+
+                total_teacher_entropy += -(teacher_probs * teacher_log_renorm).sum().item()
+                total_positions += 1
+
+        new_datums.append(
+            tinker.Datum(
+                model_input=datum.model_input,
+                loss_fn_inputs={
+                    "target_tokens": tinker.TensorData.from_torch(target_tokens_NK),
+                    "weights": tinker.TensorData.from_torch(weights_NK),
+                },
+            )
+        )
+
+    metrics: dict[str, float] = {
+        "sdft/teacher_truncated_count": float(truncated_count),
+        "sdft/num_datums": float(len(data_D)),
+        "sdft/topk": float(topk),
+    }
+    if total_positions > 0:
+        metrics["sdft/total_completion_positions"] = total_positions
+        metrics["sdft/mean_teacher_entropy"] = total_teacher_entropy / total_positions
+
+    return new_datums, metrics
+
+
+def reverse_kl_custom_loss(
+    data: list[tinker.Datum],
+    logprobs_list: list[torch.Tensor],
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """Analytical reverse-KL loss over the teacher's top-K (REINFORCE form).
+
+    Consumes datums built by :func:`build_reverse_kl_datums`. The server
+    returns student logprobs at the teacher-top-K ``target_tokens`` (shape
+    ``(N, K)``); we renormalize student over those K slots, stop-grad the
+    ``[log p_renorm - log q_renorm]`` bracket, and take the mass-weighted
+    sum. Gradient flows only through the outer ``p_renorm`` weight, matching
+    Tinker's ``importance_sampling`` convention.
+
+    The per-slot ``weights`` carry renormalized teacher probability (``q_renorm``)
+    at valid slots and ``0`` at padding slots or masked positions. We recover
+    the per-slot validity mask via ``weights > 0`` and reconstruct
+    ``log q_renorm = log(weights)`` for the KL computation.
+    """
+    total_loss = torch.tensor(0.0)
+    sum_kl = 0.0
+    sum_student_entropy = 0.0
+    sum_positions = 0.0
+
+    for i, datum in enumerate(data):
+        student_logp_NK = logprobs_list[i]
+        weights_NK = datum.loss_fn_inputs["weights"].to_torch()  # q_renorm or 0
+
+        slot_mask_NK = weights_NK > 0  # (N, K)
+        position_mask_N = slot_mask_NK.any(dim=-1).float()  # (N,)
+
+        # Reconstruct log q_renorm safely; clamp away from 0 for the log op.
+        safe_weights = weights_NK.clamp(min=1e-30)
+        teacher_log_renorm_NK = torch.where(
+            slot_mask_NK, torch.log(safe_weights), torch.zeros_like(weights_NK)
+        )
+
+        neg_inf = torch.full_like(student_logp_NK, float("-inf"))
+        masked_logp = torch.where(slot_mask_NK, student_logp_NK, neg_inf)
+        log_p_renorm = torch.log_softmax(masked_logp, dim=-1)
+        log_p_renorm = torch.nan_to_num(log_p_renorm, nan=0.0, neginf=0.0)
+        p_renorm = log_p_renorm.exp()
+
+        adv_NK = (log_p_renorm - teacher_log_renorm_NK).detach()
+        per_pos_NK = p_renorm * adv_NK * slot_mask_NK.float()
+        per_pos_N = per_pos_NK.sum(dim=-1)
+        loss_d = (per_pos_N * position_mask_N).sum()
+        total_loss = total_loss + loss_d
+
+        with torch.no_grad():
+            kl_NK = p_renorm * (log_p_renorm - teacher_log_renorm_NK) * slot_mask_NK.float()
+            per_pos_kl = kl_NK.sum(dim=-1)
+            sum_kl += (per_pos_kl * position_mask_N).sum().item()
+            ent_NK = -(p_renorm * log_p_renorm * slot_mask_NK.float())
+            per_pos_ent = ent_NK.sum(dim=-1)
+            sum_student_entropy += (per_pos_ent * position_mask_N).sum().item()
+            sum_positions += position_mask_N.sum().item()
+
+    metrics: dict[str, float] = {"sdft/reverse_kl_loss": total_loss.item()}
+    if sum_positions > 0:
+        metrics["sdft/reverse_kl_mean"] = sum_kl / sum_positions
+        metrics["sdft/student_entropy_mean"] = sum_student_entropy / sum_positions
+    metrics["sdft/reverse_kl_positions"] = sum_positions
+
+    return total_loss, metrics
+
+
+@trace.scope
+async def _train_step_reverse_kl(
+    data_D: list[tinker.Datum],
+    training_client: tinker.TrainingClient,
+    learning_rate: float,
+    num_substeps: int,
+    metrics: dict[str, Any] | None = None,
+) -> None:
+    """Substep-pipelined custom forward/backward for the reverse-KL loss.
+
+    Mirrors :func:`tinker_cookbook.rl.train.train_step` but uses
+    ``forward_backward_custom_async`` with :func:`reverse_kl_custom_loss`.
+    The datums produced by :func:`build_reverse_kl_datums` carry
+    ``position_mask`` / ``k_valid`` / ``teacher_logprobs`` instead of the
+    standard ``mask`` key, so no mask stripping is needed.
+    """
+    batches = split_list(data_D, min(num_substeps, len(data_D)))
+    if not batches:
+        return
+
+    adam_params = tinker.AdamParams(learning_rate=learning_rate, beta1=0.9, beta2=0.95, eps=1e-8)
+    fwd_bwd_future = await training_client.forward_backward_custom_async(
+        batches[0], reverse_kl_custom_loss
+    )
+    optim_future = await training_client.optim_step_async(adam_params)
+    loss_metrics: dict[str, float] = {}
+    optim_result: tinker.OptimStepResponse | None = None
+
+    for i in range(len(batches)):
+        if i + 1 < len(batches):
+            next_fwd_bwd_future = await training_client.forward_backward_custom_async(
+                batches[i + 1], reverse_kl_custom_loss
+            )
+            next_optim_future = await training_client.optim_step_async(adam_params)
+        else:
+            next_fwd_bwd_future = None
+            next_optim_future = None
+
+        fwd_bwd_result = await fwd_bwd_future.result_async()
+        if fwd_bwd_result.metrics:
+            loss_metrics.update(fwd_bwd_result.metrics)
+        optim_result = await optim_future.result_async()
+
+        if next_fwd_bwd_future is not None and next_optim_future is not None:
+            fwd_bwd_future = next_fwd_bwd_future
+            optim_future = next_optim_future
+
+    if metrics is not None:
+        metrics.update(loss_metrics)
+        if optim_result is not None and optim_result.metrics:
+            metrics.update(optim_result.metrics)
+
+
 @chz.chz
 class Config:
     """Configuration for SDFT training.
@@ -498,6 +762,7 @@ class Config:
 
     # SDFT-specific
     topk: int = 20
+    reverse: bool = False
     demo_template: str = DEFAULT_DEMO_TEMPLATE
     system_prompt: str | None = None
     teacher_sync_every: int | None = None
@@ -690,8 +955,30 @@ async def main(
                 for question, golden_answer in zip(questions_P, golden_answers_P)
             ]
 
-            if cfg.topk > 0:
-                # Top-K CE distillation
+            if cfg.topk > 0 and cfg.reverse:
+                # Analytical reverse KL over teacher top-K via custom loss
+                async with trace.scope_span("build_reverse_kl_datums"):
+                    rev_datums, rev_metrics = await build_reverse_kl_datums(
+                        data_D,
+                        metadata_D,
+                        teacher_client,
+                        teacher_prompts_P,
+                        topk=cfg.topk,
+                        max_context_length=cfg.max_context_length,
+                        vocab_size=len(tokenizer),
+                    )
+                metrics.update(rev_metrics)
+
+                async with trace.scope_span("train"):
+                    await _train_step_reverse_kl(
+                        data_D=rev_datums,
+                        training_client=training_client,
+                        learning_rate=cfg.learning_rate,
+                        num_substeps=cfg.num_substeps,
+                        metrics=metrics,
+                    )
+            elif cfg.topk > 0:
+                # Top-K CE distillation (forward KL)
                 async with trace.scope_span("build_topk_distillation_datums"):
                     topk_datums, topk_metrics = await build_topk_distillation_datums(
                         data_D,
@@ -715,7 +1002,12 @@ async def main(
                         metrics=metrics,
                     )
             else:
-                # IS only (old approach): compute advantages then train
+                # DEPRECATED: single-sample importance-sampling approximation of
+                # reverse KL. Superseded by `reverse=True` (analytical top-K
+                # reverse KL over the teacher distribution). Kept only so that
+                # historical configs with `topk=0` continue to run; new work
+                # should set `topk>0` and toggle `reverse` for the forward/reverse
+                # choice.
                 async with trace.scope_span("compute_sdft_advantages"):
                     is_metrics = await compute_sdft_advantages(
                         data_D,

--- a/tinker_cookbook/recipes/sdft/sdft_test.py
+++ b/tinker_cookbook/recipes/sdft/sdft_test.py
@@ -9,11 +9,13 @@ import torch
 
 from tinker_cookbook.distillation.sdft import (
     DEFAULT_DEMO_TEMPLATE,
+    Config,
     _build_teacher_forced_sequence,
     _extract_completion_tokens,
     build_reverse_kl_datums,
     build_sdft_teacher_prompt,
     build_topk_distillation_datums,
+    main as sdft_main,
     reverse_kl_custom_loss,
 )
 from tinker_cookbook.recipes.sdft.datasets import SDFTDataset, _format_sciknoweval_choices
@@ -567,3 +569,40 @@ class TestReverseKLCustomLoss:
         loss_all, _ = reverse_kl_custom_loss([datum_all], [student_logp2])
         assert abs(loss_masked.item() * 2 - loss_all.item()) < 1e-5
         assert metrics_masked["sdft/reverse_kl_positions"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_reverse_with_topk_zero_raises(self, tmp_path):
+        """reverse=True requires topk>0; otherwise fail loudly up-front."""
+        cfg = Config(
+            model_name="Qwen/Qwen3-8B",
+            log_path=str(tmp_path),
+            topk=0,
+            reverse=True,
+        )
+        with pytest.raises(ValueError, match="reverse=True requires topk>0"):
+            await sdft_main(cfg, sdft_dataset=MagicMock())
+
+    def test_all_masked_row_is_nan_safe(self):
+        """A row with zero valid top-K slots must not produce NaN — it's guarded
+        by `nan_to_num` after `log_softmax(all -inf)`. Guardrail regression test."""
+        N, K = 3, 3
+        # Row 0 and 1 fully masked (no valid slots); row 2 has normal teacher probs.
+        teacher_log_renorm_NK = torch.zeros(N, K)
+        teacher_log_renorm_NK[2] = torch.log_softmax(
+            torch.tensor([0.0, -1.0, -2.0]), dim=0
+        )
+        position_mask = torch.tensor([0.0, 0.0, 1.0])
+        k_valid = torch.tensor([0, 0, K], dtype=torch.long)
+
+        student_logp = torch.randn(N, K, requires_grad=True)
+        datum = self._make_rev_datum(N, K, teacher_log_renorm_NK, position_mask, k_valid)
+        loss, metrics = reverse_kl_custom_loss([datum], [student_logp])
+
+        assert torch.isfinite(loss)
+        assert metrics["sdft/reverse_kl_positions"] == 1.0
+        loss.backward()
+        assert student_logp.grad is not None
+        assert torch.isfinite(student_logp.grad).all()
+        # Gradient on the fully-masked rows should be exactly zero.
+        assert (student_logp.grad[0] == 0).all()
+        assert (student_logp.grad[1] == 0).all()

--- a/tinker_cookbook/recipes/sdft/sdft_test.py
+++ b/tinker_cookbook/recipes/sdft/sdft_test.py
@@ -15,8 +15,10 @@ from tinker_cookbook.distillation.sdft import (
     build_reverse_kl_datums,
     build_sdft_teacher_prompt,
     build_topk_distillation_datums,
-    main as sdft_main,
     reverse_kl_custom_loss,
+)
+from tinker_cookbook.distillation.sdft import (
+    main as sdft_main,
 )
 from tinker_cookbook.recipes.sdft.datasets import SDFTDataset, _format_sciknoweval_choices
 from tinker_cookbook.recipes.sdft.eval import (
@@ -527,7 +529,7 @@ class TestReverseKLCustomLoss:
         """L_rev > 0 when p ≠ q, and gradient flows through student logits."""
         N, K = 2, 3
         teacher_raw = torch.tensor([0.0, -2.0, -4.0])
-        teacher_log_renorm = (teacher_raw - torch.logsumexp(teacher_raw, dim=0))
+        teacher_log_renorm = teacher_raw - torch.logsumexp(teacher_raw, dim=0)
         teacher_log_renorm_NK = teacher_log_renorm.unsqueeze(0).repeat(N, 1)
 
         student_logp = torch.tensor([[-4.0, -2.0, 0.0], [-4.0, -2.0, 0.0]], requires_grad=True)
@@ -541,8 +543,7 @@ class TestReverseKLCustomLoss:
 
         p_renorm = torch.log_softmax(student_logp, dim=-1).exp()
         kl_full = (
-            p_renorm
-            * (torch.log_softmax(student_logp, dim=-1) - teacher_log_renorm_NK)
+            p_renorm * (torch.log_softmax(student_logp, dim=-1) - teacher_log_renorm_NK)
         ).sum()
         assert abs(metrics["sdft/reverse_kl_mean"] * 2 - kl_full.item()) < 1e-4
 
@@ -553,9 +554,7 @@ class TestReverseKLCustomLoss:
     def test_position_mask_zeros_contribution(self):
         """Position-mask=0 fully excludes a position from the loss and metrics."""
         N, K = 2, 2
-        teacher_log_renorm_NK = torch.tensor(
-            [[-0.1, -2.5], [-0.1, -2.5]], dtype=torch.float32
-        )
+        teacher_log_renorm_NK = torch.tensor([[-0.1, -2.5], [-0.1, -2.5]], dtype=torch.float32)
         student_logp = torch.tensor([[2.0, -2.0], [2.0, -2.0]], requires_grad=True)
         position_mask = torch.tensor([0.0, 1.0])
         k_valid = torch.tensor([K, K], dtype=torch.long)
@@ -588,9 +587,7 @@ class TestReverseKLCustomLoss:
         N, K = 3, 3
         # Row 0 and 1 fully masked (no valid slots); row 2 has normal teacher probs.
         teacher_log_renorm_NK = torch.zeros(N, K)
-        teacher_log_renorm_NK[2] = torch.log_softmax(
-            torch.tensor([0.0, -1.0, -2.0]), dim=0
-        )
+        teacher_log_renorm_NK[2] = torch.log_softmax(torch.tensor([0.0, -1.0, -2.0]), dim=0)
         position_mask = torch.tensor([0.0, 0.0, 1.0])
         k_valid = torch.tensor([0, 0, K], dtype=torch.long)
 

--- a/tinker_cookbook/recipes/sdft/sdft_test.py
+++ b/tinker_cookbook/recipes/sdft/sdft_test.py
@@ -11,8 +11,10 @@ from tinker_cookbook.distillation.sdft import (
     DEFAULT_DEMO_TEMPLATE,
     _build_teacher_forced_sequence,
     _extract_completion_tokens,
+    build_reverse_kl_datums,
     build_sdft_teacher_prompt,
     build_topk_distillation_datums,
+    reverse_kl_custom_loss,
 )
 from tinker_cookbook.recipes.sdft.datasets import SDFTDataset, _format_sciknoweval_choices
 from tinker_cookbook.recipes.sdft.eval import (
@@ -381,3 +383,187 @@ class TestBuildTopkDistillationDatums:
 
         weights = new_datums[0].loss_fn_inputs["weights"].to_torch()
         assert weights.sum() == 0.0
+
+
+def _pack_weights(
+    teacher_log_renorm_NK: torch.Tensor,
+    position_mask_N: torch.Tensor,
+    k_valid_N: torch.Tensor,
+) -> torch.Tensor:
+    """Test helper: pack teacher renorm probs into the `0` sentinel encoding."""
+    N, K = teacher_log_renorm_NK.shape
+    weights = torch.zeros(N, K, dtype=torch.float32)
+    probs = teacher_log_renorm_NK.exp()
+    for n in range(N):
+        if position_mask_N[n].item() > 0:
+            k = int(k_valid_N[n].item())
+            weights[n, :k] = probs[n, :k]
+    return weights
+
+
+class TestBuildReverseKLDatums:
+    @pytest.mark.asyncio
+    async def test_shapes_and_renorm(self):
+        """Reverse-KL datums carry (N, K) target_tokens + weights (log q renorm
+        at valid slots, -inf elsewhere)."""
+        K = 3
+        datum = _make_datum([10, 20, 30], [40, 50, 60, 70, 80])
+        teacher_prompt = tinker.ModelInput.from_ints([100, 200])
+
+        # Teacher-forced length = 2 prompt + 5 completion = 7 positions
+        mock_topk = [None] * 2 + [
+            [(40, -0.5), (41, -1.5), (42, -2.5)],
+            [(50, -0.3), (51, -1.3), (52, -2.3)],
+            [(60, -0.8), (61, -1.8), (62, -2.8)],
+            [(70, -0.1), (71, -1.1), (72, -2.1)],
+            [(80, -0.4), (81, -1.4), (82, -2.4)],
+        ]
+        mock_response = MagicMock()
+        mock_response.topk_prompt_logprobs = mock_topk
+        mock_client = AsyncMock()
+        mock_client.sample_async = AsyncMock(return_value=mock_response)
+
+        rev_datums, metrics = await build_reverse_kl_datums(
+            data_D=[datum],
+            metadata_D=[{"group_idx": 0, "traj_idx": 0}],
+            teacher_client=mock_client,
+            teacher_prompts_P=[teacher_prompt],
+            topk=K,
+            skip_first_n_tokens=0,
+        )
+
+        rd = rev_datums[0]
+        target_tokens = rd.loss_fn_inputs["target_tokens"].to_torch()
+        weights = rd.loss_fn_inputs["weights"].to_torch()
+
+        N = datum.model_input.length
+        assert target_tokens.shape == (N, K)
+        assert weights.shape == (N, K)
+
+        prompt_len = 2  # [10, 20] → input_tokens length before completion mask starts
+        for pos in range(prompt_len):
+            # Prompt positions are fully masked (all zeros)
+            assert (weights[pos] == 0).all()
+        for pos in range(prompt_len, N):
+            assert (weights[pos] > 0).all()  # all K slots valid for this mock
+            # Teacher probs sum to 1 (renormalized over top-K)
+            assert math.isclose(weights[pos].sum().item(), 1.0, rel_tol=1e-5)
+
+        assert metrics["sdft/num_datums"] == 1.0
+        assert metrics["sdft/topk"] == float(K)
+        assert metrics["sdft/mean_teacher_entropy"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_skip_first_n_tokens(self):
+        """skip_first_n_tokens=3 fully masks the first three completion positions."""
+        K = 2
+        datum = _make_datum([10, 20], [30, 40, 50, 60, 70])
+        teacher_prompt = tinker.ModelInput.from_ints([100])
+
+        mock_topk = [None] + [
+            [(30, -0.5), (31, -1.5)],
+            [(40, -0.5), (41, -1.5)],
+            [(50, -0.5), (51, -1.5)],
+            [(60, -0.5), (61, -1.5)],
+            [(70, -0.5), (71, -1.5)],
+        ]
+        mock_response = MagicMock()
+        mock_response.topk_prompt_logprobs = mock_topk
+        mock_client = AsyncMock()
+        mock_client.sample_async = AsyncMock(return_value=mock_response)
+
+        rev_datums, _ = await build_reverse_kl_datums(
+            data_D=[datum],
+            metadata_D=[{"group_idx": 0, "traj_idx": 0}],
+            teacher_client=mock_client,
+            teacher_prompts_P=[teacher_prompt],
+            topk=K,
+            skip_first_n_tokens=3,
+        )
+        weights = rev_datums[0].loss_fn_inputs["weights"].to_torch()
+        # Of model_input length 6, only 2 positions should have any positive weight.
+        active_positions = (weights > 0).any(dim=-1).sum().item()
+        assert active_positions == 2
+
+
+class TestReverseKLCustomLoss:
+    def _make_rev_datum(
+        self,
+        N: int,
+        K: int,
+        teacher_log_renorm_NK: torch.Tensor,
+        position_mask_N: torch.Tensor,
+        k_valid_N: torch.Tensor,
+    ) -> tinker.Datum:
+        weights = _pack_weights(teacher_log_renorm_NK, position_mask_N, k_valid_N)
+        return tinker.Datum(
+            model_input=tinker.ModelInput.from_ints([0] * N),
+            loss_fn_inputs={
+                "target_tokens": tinker.TensorData.from_torch(torch.zeros(N, K, dtype=torch.long)),
+                "weights": tinker.TensorData.from_torch(weights),
+            },
+        )
+
+    def test_zero_when_distributions_equal(self):
+        """L_rev ≈ 0 when student (after renorm) matches teacher."""
+        N, K = 4, 3
+        raw = torch.tensor([0.2, -0.1, 0.5])
+        teacher_log_renorm = (raw - torch.logsumexp(raw, dim=0)).unsqueeze(0).repeat(N, 1)
+        position_mask = torch.tensor([0.0, 1.0, 1.0, 1.0])
+        k_valid = torch.tensor([K, K, K, K], dtype=torch.long)
+
+        student_logp = raw.unsqueeze(0).repeat(N, 1).clone().requires_grad_(True)
+
+        datum = self._make_rev_datum(N, K, teacher_log_renorm, position_mask, k_valid)
+        loss, metrics = reverse_kl_custom_loss([datum], [student_logp])
+
+        assert abs(loss.item()) < 1e-6
+        assert metrics["sdft/reverse_kl_mean"] < 1e-6
+        assert metrics["sdft/reverse_kl_positions"] == 3.0
+
+    def test_positive_kl_and_gradient(self):
+        """L_rev > 0 when p ≠ q, and gradient flows through student logits."""
+        N, K = 2, 3
+        teacher_raw = torch.tensor([0.0, -2.0, -4.0])
+        teacher_log_renorm = (teacher_raw - torch.logsumexp(teacher_raw, dim=0))
+        teacher_log_renorm_NK = teacher_log_renorm.unsqueeze(0).repeat(N, 1)
+
+        student_logp = torch.tensor([[-4.0, -2.0, 0.0], [-4.0, -2.0, 0.0]], requires_grad=True)
+
+        position_mask = torch.tensor([1.0, 1.0])
+        k_valid = torch.tensor([K, K], dtype=torch.long)
+        datum = self._make_rev_datum(N, K, teacher_log_renorm_NK, position_mask, k_valid)
+
+        loss, metrics = reverse_kl_custom_loss([datum], [student_logp])
+        assert loss.item() > 0.1
+
+        p_renorm = torch.log_softmax(student_logp, dim=-1).exp()
+        kl_full = (
+            p_renorm
+            * (torch.log_softmax(student_logp, dim=-1) - teacher_log_renorm_NK)
+        ).sum()
+        assert abs(metrics["sdft/reverse_kl_mean"] * 2 - kl_full.item()) < 1e-4
+
+        loss.backward()
+        assert student_logp.grad is not None
+        assert student_logp.grad.abs().sum().item() > 0.0
+
+    def test_position_mask_zeros_contribution(self):
+        """Position-mask=0 fully excludes a position from the loss and metrics."""
+        N, K = 2, 2
+        teacher_log_renorm_NK = torch.tensor(
+            [[-0.1, -2.5], [-0.1, -2.5]], dtype=torch.float32
+        )
+        student_logp = torch.tensor([[2.0, -2.0], [2.0, -2.0]], requires_grad=True)
+        position_mask = torch.tensor([0.0, 1.0])
+        k_valid = torch.tensor([K, K], dtype=torch.long)
+        datum = self._make_rev_datum(N, K, teacher_log_renorm_NK, position_mask, k_valid)
+
+        loss_masked, metrics_masked = reverse_kl_custom_loss([datum], [student_logp])
+        datum_all = self._make_rev_datum(
+            N, K, teacher_log_renorm_NK, torch.tensor([1.0, 1.0]), k_valid
+        )
+        student_logp2 = torch.tensor([[2.0, -2.0], [2.0, -2.0]], requires_grad=True)
+        loss_all, _ = reverse_kl_custom_loss([datum_all], [student_logp2])
+        assert abs(loss_masked.item() * 2 - loss_all.item()) < 1e-5
+        assert metrics_masked["sdft/reverse_kl_positions"] == 1.0

--- a/tinker_cookbook/recipes/sdft/train.py
+++ b/tinker_cookbook/recipes/sdft/train.py
@@ -63,6 +63,7 @@ class CLIConfig:
 
     # SDFT-specific
     topk: int = 20
+    reverse: bool = False
     teacher_sync_every: int | None = None
     max_context_length: int = 32768
 
@@ -146,6 +147,7 @@ async def cli_main(cli_config: CLIConfig) -> None:
         max_tokens=cli_config.max_tokens,
         temperature=cli_config.temperature,
         topk=cli_config.topk,
+        reverse=cli_config.reverse,
         teacher_sync_every=cli_config.teacher_sync_every,
         max_context_length=cli_config.max_context_length,
         num_substeps=cli_config.num_substeps,


### PR DESCRIPTION
Adds a `reverse` knob to SDFT (default False) that, when True with topk>0, trains against an analytical reverse-KL objective rather than the legacy single-sample importance-sampling approximation.

With p = student, q = teacher, 𝒯 = usable completion positions, and S_t = teacher's top-K at position t (both distributions renormalized over S_t):

    L_rev = Σ_{t∈𝒯} Σ_{k∈S_t} p_renorm(x_k|t) · sg[log p_renorm − log q_renorm]

Implemented via `forward_backward_custom_async` (renormalized teacher probs shipped in `weights` with 0 as the mask sentinel, matching the forward-KL CE encoding). Gradient flows only through the outer `p_renorm` weight — the bracketed advantage is detached.

Also marks the topk=0 branch as deprecated; it's superseded by `topk>0, reverse=True` and kept only for backward compat.

Verified on Qwen/Qwen3.5-35B-A3B, LoRA 64, lr=5e-4, 30 steps, ToolAlpaca:
- SDFT topk=0 (old single-sample IS): 58.76%
- SDFT reverse=True (new):             63.92%  (+5.2pp)
- Base model (published):              61.86%
- SDFT forward KL (published, full):   65.98%