### PR TITLE
feat: add Daytona sandbox support for cloud-based execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ math-rl = [
 modal = [
     "modal>=1.0.0",
 ]
+daytona = [
+    "daytona>=0.168.0",
+]
 multiplayer-rl = [
     "textarena>=0.7.4",
 ]
@@ -124,6 +127,7 @@ all = [
     "tinker_cookbook[eval]",
     "tinker_cookbook[math-rl]",
     "tinker_cookbook[modal]",
+    "tinker_cookbook[daytona]",
     "tinker_cookbook[multiplayer-rl]",
     "tinker_cookbook[vector-search]",
     "tinker_cookbook[wandb]",

--- a/tests/test_daytona_sandbox.py
+++ b/tests/test_daytona_sandbox.py
@@ -1,0 +1,208 @@
+"""Smoke tests for DaytonaSandbox.
+
+Require Daytona authentication and network access; skipped when no
+``DAYTONA_API_KEY`` or ``DAYTONA_JWT_TOKEN`` is set in the environment.
+
+Covers the SandboxInterface contract (run_command state persistence,
+write/read round-trip, heartbeat, idempotent cleanup, SandboxTerminatedError
+after cleanup) plus the stateless grading helper and a ``write_file``
+latency bound to catch future performance regressions.
+"""
+
+import os
+import time
+
+import pytest
+import pytest_asyncio
+
+from tinker_cookbook.sandbox.daytona_sandbox import (
+    DaytonaSandbox,
+    run_code_in_daytona,
+)
+from tinker_cookbook.sandbox.sandbox_interface import SandboxTerminatedError
+
+_has_daytona_auth = bool(os.environ.get("DAYTONA_API_KEY") or os.environ.get("DAYTONA_JWT_TOKEN"))
+
+requires_daytona = pytest.mark.skipif(
+    not _has_daytona_auth,
+    reason="Daytona not configured (set DAYTONA_API_KEY or DAYTONA_JWT_TOKEN)",
+)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def sandbox():
+    """Shared Daytona sandbox for persistent-state tests in this module."""
+    sb = await DaytonaSandbox.create(timeout=300)
+    yield sb
+    await sb.cleanup()
+
+
+async def _timed(coro):
+    """Await a coroutine and return (result, elapsed_seconds)."""
+    start = time.monotonic()
+    result = await coro
+    return result, time.monotonic() - start
+
+
+# ---------------------------------------------------------------------------
+# Core SandboxInterface contract
+# ---------------------------------------------------------------------------
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_run_command_basic(sandbox):
+    """run_command returns structured stdout/exit_code."""
+    result = await sandbox.run_command("echo hello")
+    assert result.exit_code == 0, f"stderr: {result.stderr}"
+    assert "hello" in result.stdout
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_run_command_state_persists(sandbox):
+    """Shell state (cwd) persists across run_command calls via the session."""
+    cd_result = await sandbox.run_command("cd /tmp")
+    assert cd_result.exit_code == 0
+
+    pwd_result = await sandbox.run_command("pwd")
+    assert pwd_result.exit_code == 0
+    assert "/tmp" in pwd_result.stdout
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_filesystem_round_trip(sandbox):
+    """write_file then read_file returns the same content."""
+    content = "hello from tinker-cookbook\n"
+    write_result = await sandbox.write_file("/tmp/probe.txt", content)
+    assert write_result.exit_code == 0, f"stderr: {write_result.stderr}"
+
+    read_result = await sandbox.read_file("/tmp/probe.txt")
+    assert read_result.exit_code == 0
+    assert read_result.stdout == content
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_write_file_executable(sandbox):
+    """write_file(executable=True) makes the file executable."""
+    script = "#!/bin/bash\necho ran from script\n"
+    write_result = await sandbox.write_file("/tmp/probe.sh", script, executable=True)
+    assert write_result.exit_code == 0, f"stderr: {write_result.stderr}"
+
+    stat_result = await sandbox.run_command("test -x /tmp/probe.sh && echo yes")
+    assert stat_result.stdout.strip() == "yes"
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+async def test_send_heartbeat(sandbox):
+    """send_heartbeat succeeds on a live sandbox."""
+    await sandbox.send_heartbeat()
+
+
+# ---------------------------------------------------------------------------
+# write_file latency — catches broad performance regressions
+# ---------------------------------------------------------------------------
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_write_file_latency(sandbox):
+    """write_file should complete in seconds, not minutes.
+
+    The Daytona SDK's ``fs.upload_files`` is a multipart HTTP POST — no
+    stdin piping — so the specific drain-hang that bit ModalSandbox does
+    not apply here. This test is a generous upper bound (15s) to catch
+    future regressions of any cause.
+    """
+    content = "#!/bin/bash\necho hello world\n"
+    result, elapsed = await _timed(
+        sandbox.write_file("/tmp/latency_probe.sh", content, executable=True, timeout=30)
+    )
+    assert result.exit_code == 0, f"write_file failed: {result.stderr}"
+    assert elapsed < 15, f"write_file took {elapsed:.1f}s (expected <15s)"
+
+
+# ---------------------------------------------------------------------------
+# Cleanup idempotency and post-cleanup behavior
+# ---------------------------------------------------------------------------
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_cleanup_is_idempotent():
+    """Calling cleanup twice on the same sandbox does not raise."""
+    sb = await DaytonaSandbox.create(timeout=120)
+
+    await sb.cleanup()
+    # Second call must be a no-op, not raise.
+    await sb.cleanup()
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_command_after_cleanup_raises_terminated():
+    """run_command after cleanup surfaces SandboxTerminatedError."""
+    sb = await DaytonaSandbox.create(timeout=120)
+    await sb.cleanup()
+
+    with pytest.raises(SandboxTerminatedError):
+        await sb.run_command("echo should not run")
+
+
+# ---------------------------------------------------------------------------
+# Stateless grading helper (code_rl path)
+# ---------------------------------------------------------------------------
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(180)
+async def test_run_code_in_daytona_success():
+    """run_code_in_daytona returns (True, {...stdout...}) on a working program."""
+    success, response = await run_code_in_daytona(
+        code="print(2 + 2)",
+        files={},
+        timeout=60,
+    )
+    assert success is True, f"response: {response}"
+    assert "4" in response["stdout"]
+    assert response["exit_code"] == 0
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(180)
+async def test_run_code_in_daytona_failure():
+    """run_code_in_daytona returns (False, {...}) when the program raises."""
+    success, response = await run_code_in_daytona(
+        code="raise ValueError('boom from test')",
+        files={},
+        timeout=60,
+    )
+    assert success is False
+    assert response.get("exit_code", 1) != 0 or "error" in response
+
+
+@requires_daytona
+@pytest.mark.asyncio
+@pytest.mark.timeout(180)
+async def test_run_code_in_daytona_with_files():
+    """run_code_in_daytona uploads supporting files alongside the entry point."""
+    success, response = await run_code_in_daytona(
+        code="print(open('data.txt').read().strip())",
+        files={"data.txt": "tinker-cookbook was here"},
+        timeout=60,
+    )
+    assert success is True, f"response: {response}"
+    assert "tinker-cookbook was here" in response["stdout"]

--- a/tinker_cookbook/recipes/code_rl/README.md
+++ b/tinker_cookbook/recipes/code_rl/README.md
@@ -6,7 +6,7 @@ Competitive programming problems are a common testbed for RL with LLMs. The rece
 
 ### Sandboxing
 
-Sandboxing is essential for safely executing generated code during training and evaluation. Two sandbox backends are supported:
+Sandboxing is essential for safely executing generated code during training and evaluation. Three sandbox backends are supported:
 
 #### SandboxFusion (Default)
 
@@ -46,6 +46,25 @@ python -m tinker_cookbook.recipes.code_rl.train \
 Optional environment variables for Modal:
 - `MODAL_POOL_SIZE`: Number of concurrent sandboxes (default: 32)
 - `MODAL_CREATION_RATE_LIMIT`: Max sandboxes created per second (default: 4)
+
+#### Daytona (Alternative)
+
+[Daytona](https://www.daytona.io) provides cloud-based sandboxed execution without local Docker setup. To use Daytona:
+
+1. Install the daytona extra and set your API key:
+```bash
+uv pip install 'tinker-cookbook[daytona] @ git+https://github.com/thinking-machines-lab/tinker-cookbook.git@nightly'
+export DAYTONA_API_KEY="***"
+```
+
+2. Set the sandbox backend in your training command:
+```bash
+python -m tinker_cookbook.recipes.code_rl.train \
+    sandbox_backend=daytona \
+    ...
+```
+
+Optional: set `DAYTONA_SNAPSHOT` to a pre-created Daytona snapshot name to skip image builds entirely. Not required — Daytona caches image builds across sandboxes automatically.
 
 ### Example command
 

--- a/tinker_cookbook/recipes/code_rl/code_grading.py
+++ b/tinker_cookbook/recipes/code_rl/code_grading.py
@@ -1,9 +1,10 @@
 """
 Code grading utilities for RL training.
 
-Supports two execution backends:
+Supports three execution backends:
 - sandboxfusion: Local Docker-based sandbox (default)
 - modal: Cloud-based Modal sandbox
+- daytona: Cloud-based Daytona sandbox
 """
 
 from __future__ import annotations
@@ -116,6 +117,27 @@ async def _check_with_modal(
     }
 
 
+async def _check_with_daytona(
+    test_cases: dict[str, str],
+    generation: str,
+    timeout: int,
+    total_timeout: int,
+) -> tuple[bool, dict[str, Any]]:
+    """Execute tests using Daytona sandbox."""
+    # Lazy-import so users without the [daytona] extra are unaffected.
+    from tinker_cookbook.sandbox.daytona_sandbox import run_code_in_daytona
+
+    return await run_code_in_daytona(
+        code=TEST_CODE % {"timeout": timeout},
+        files={
+            "test_cases.txt": json.dumps(test_cases),
+            "code.py": generation,
+            "testing_util.py": TEST_UTIL,
+        },
+        timeout=total_timeout,
+    )
+
+
 async def sandbox_check_correctness(
     sample: list[dict[str, Any]],
     generation: str,
@@ -146,6 +168,8 @@ async def sandbox_check_correctness(
 
         if use_backend == SandboxBackend.MODAL:
             return await _check_with_modal(test_cases, generation, timeout, total_timeout)
+        elif use_backend == SandboxBackend.DAYTONA:
+            return await _check_with_daytona(test_cases, generation, timeout, total_timeout)
         elif use_backend == SandboxBackend.SANDBOXFUSION:
             return await _check_with_sandboxfusion(test_cases, generation, timeout, total_timeout)
         else:

--- a/tinker_cookbook/recipes/harbor_rl/README.md
+++ b/tinker_cookbook/recipes/harbor_rl/README.md
@@ -85,6 +85,25 @@ The first argument is the task's `environment/` directory (containing a Dockerfi
 
 `cli_main()` accepts an optional `sandbox_factory` parameter. When `None`, it falls back to `default_sandbox_factory` (Modal). The factory flows through: `cli_main` -> `HarborDatasetBuilder` -> `HarborEnvGroupBuilder.make_envs()`.
 
+### Daytona backend (alternative)
+
+A Daytona factory with the same signature is also available:
+
+```python
+from tinker_cookbook.sandbox.daytona_sandbox import daytona_sandbox_factory
+
+cli_main(sandbox_factory=daytona_sandbox_factory, ...)
+```
+
+Install the extra and set your API key:
+
+```bash
+uv pip install 'tinker-cookbook[daytona] @ git+https://github.com/thinking-machines-lab/tinker-cookbook.git@nightly'
+export DAYTONA_API_KEY="***"
+```
+
+Each task's `environment/Dockerfile` is built into a Daytona image via `Image.from_dockerfile(...)`. Daytona caches image builds by content hash, so rebuilding across a sweep of rollouts is automatic. For further cold-start savings, pre-create a named snapshot with `daytona.snapshot.create(...)` and set `DAYTONA_SNAPSHOT`.
+
 ## Running
 
 First, download the Terminal-Bench tasks:

--- a/tinker_cookbook/sandbox/README.md
+++ b/tinker_cookbook/sandbox/README.md
@@ -2,7 +2,7 @@
 
 This directory contains code execution backends for sandboxed evaluation (e.g., grading code in RL environments).
 
-There are currently two available backends: SandboxFusion for local execution and Modal for cloud execution.
+There are currently three available backends: SandboxFusion for local execution, and Modal or Daytona for cloud execution.
 
 ## Backends
 
@@ -65,3 +65,48 @@ print(result.stdout)
 Environment variables:
 
 - `MODAL_POOL_SIZE`: Number of sandboxes in the pool (default: 32)
+
+### Daytona (cloud)
+
+[Daytona Sandboxes](https://www.daytona.io) provide cloud-based isolated execution environments. Requires `DAYTONA_API_KEY` (or `DAYTONA_JWT_TOKEN` + `DAYTONA_ORGANIZATION_ID`).
+
+Install the extra:
+
+```bash
+uv pip install 'tinker-cookbook[daytona] @ git+https://github.com/thinking-machines-lab/tinker-cookbook.git@nightly'
+```
+
+Example usage (stateful, implements `SandboxInterface`):
+
+```python
+from tinker_cookbook.sandbox.daytona_sandbox import DaytonaSandbox
+
+sandbox = await DaytonaSandbox.create()
+await sandbox.write_file("/workspace/code.py", "print('hello')")
+result = await sandbox.run_command("python /workspace/code.py", workdir="/workspace")
+print(result.stdout)
+await sandbox.cleanup()
+```
+
+Example usage (stateless grading, drop-in for `code_rl`):
+
+```python
+from tinker_cookbook.sandbox.daytona_sandbox import run_code_in_daytona
+
+success, response = await run_code_in_daytona(
+    code="print(2 + 2)",
+    files={"data.txt": "some content"},
+    timeout=30,
+)
+```
+
+Harbor-style per-task Dockerfiles (drop-in for `harbor_rl`):
+
+```python
+from tinker_cookbook.sandbox.daytona_sandbox import daytona_sandbox_factory
+
+# Pass to cli_main(sandbox_factory=daytona_sandbox_factory) or the
+# HarborDatasetBuilder / HarborEnvGroupBuilder constructors.
+```
+
+Optional: set `DAYTONA_SNAPSHOT` to a pre-created snapshot name to skip image builds. Not required — image builds are cached automatically across sandboxes.

--- a/tinker_cookbook/sandbox/__init__.py
+++ b/tinker_cookbook/sandbox/__init__.py
@@ -19,6 +19,7 @@ from tinker_cookbook.sandbox.sandboxfusion import SandboxFusionClient
 class SandboxBackend(StrEnum):
     SANDBOXFUSION = "sandboxfusion"
     MODAL = "modal"
+    DAYTONA = "daytona"
 
 
 __all__ = [

--- a/tinker_cookbook/sandbox/daytona_sandbox.py
+++ b/tinker_cookbook/sandbox/daytona_sandbox.py
@@ -1,0 +1,427 @@
+"""
+Thin wrapper around Daytona Sandbox API.
+
+Daytona provides cloud-based sandboxed execution environments.
+Requires Daytona authentication: ``export DAYTONA_API_KEY=...``
+(or ``DAYTONA_JWT_TOKEN`` + ``DAYTONA_ORGANIZATION_ID``).
+
+Supports two usage modes:
+
+- Stateful: a persistent sandbox where shell state (cwd, env, variables)
+  carries across calls. Used for multi-turn agentic workloads.
+- Stateless: an ephemeral sandbox per call, for one-shot code grading.
+
+Configuration via environment variables:
+    DAYTONA_API_URL: API endpoint (default: https://app.daytona.io/api)
+    DAYTONA_TARGET: Target region for sandbox placement
+    DAYTONA_SNAPSHOT: Pre-created snapshot name. Not required —
+        image builds are content-hashed and cached across sandboxes
+        automatically. Use this only to pin a specific pre-built snapshot.
+
+See: https://www.daytona.io
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+try:
+    from daytona import (
+        AsyncDaytona,
+        CreateSandboxFromImageParams,
+        CreateSandboxFromSnapshotParams,
+        DaytonaConfig,
+        DaytonaNotFoundError,
+        FileUpload,
+        Image,
+        SessionExecuteRequest,
+    )
+except ImportError:
+    raise ImportError(
+        "daytona is required for DaytonaSandbox. "
+        "Install it with: uv pip install 'tinker-cookbook[daytona] @ "
+        "git+https://github.com/thinking-machines-lab/tinker-cookbook.git@nightly'"
+    ) from None
+
+from tinker_cookbook.sandbox.sandbox_interface import (
+    SandboxInterface,
+    SandboxResult,
+    SandboxTerminatedError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _cap_output(text: str, max_bytes: int) -> str:
+    """Cap a string to *max_bytes* bytes of UTF-8, decoding safely at the boundary."""
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[:max_bytes].decode("utf-8", errors="replace")
+
+
+# 15-minute auto-stop matches the Daytona SDK default; 30-minute auto-delete
+# ensures a crashed rollout or forgotten ``cleanup()`` call does not leak the
+# sandbox indefinitely. Both are overridable via ``DaytonaSandbox.create``.
+_DEFAULT_AUTO_STOP_MINUTES = 15
+_DEFAULT_AUTO_DELETE_MINUTES = 30
+_DEFAULT_MAX_OUTPUT_BYTES = 128 * 1024
+_SESSION_ID = "tinker-cookbook-shell"
+
+
+class DaytonaSandbox(SandboxInterface):
+    """
+    Persistent Daytona sandbox that implements :class:`SandboxInterface`.
+
+    State persists across ``run_command`` calls via a long-running background
+    session (``sandbox.process.create_session`` + ``execute_session_command``).
+
+    For stateless per-call grading, prefer :func:`run_code_in_daytona`.
+
+    Usage:
+        sandbox = await DaytonaSandbox.create()
+        await sandbox.write_file("/workspace/code.py", "print('hello')")
+        result = await sandbox.run_command("python /workspace/code.py")
+        print(result.stdout)
+        await sandbox.cleanup()
+    """
+
+    def __init__(
+        self,
+        *,
+        client: AsyncDaytona,
+        sandbox: Any,  # daytona.AsyncSandbox — Any to avoid a hard dep at module import
+        max_stream_output_bytes: int,
+        owns_client: bool,
+    ) -> None:
+        self._client = client
+        self._sandbox = sandbox
+        self._max_stream_output_bytes = max_stream_output_bytes
+        self._owns_client = owns_client
+        self._session_ready = False
+        self._session_lock = asyncio.Lock()
+        self._cleaned_up = False
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        image: Image | str | None = None,
+        snapshot: str | None = None,
+        timeout: int = 600,
+        auto_stop_minutes: int | None = None,
+        auto_delete_minutes: int | None = None,
+        labels: dict[str, str] | None = None,
+        env_vars: dict[str, str] | None = None,
+        target: str | None = None,
+        max_stream_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES,
+        client: AsyncDaytona | None = None,
+    ) -> DaytonaSandbox:
+        """Create a new Daytona sandbox.
+
+        Args:
+            image: Image to use. Mutually exclusive with *snapshot*. If
+                both are ``None`` (and ``DAYTONA_SNAPSHOT`` is unset),
+                defaults to ``Image.debian_slim()``. Image builds are
+                cached by Daytona across sandboxes, so passing the same
+                image repeatedly does not re-build.
+            snapshot: Name of a pre-created Daytona snapshot. Mutually
+                exclusive with *image*. Falls back to ``DAYTONA_SNAPSHOT``
+                env var if unset.
+            timeout: Max wait time in seconds for sandbox creation.
+            auto_stop_minutes: Minutes of inactivity before auto-stop.
+                ``0`` disables. Defaults to 15.
+            auto_delete_minutes: Minutes after stopping before auto-delete.
+                ``0`` means delete immediately, negative disables. Defaults
+                to 30. Leak protection if ``cleanup()`` is skipped.
+            labels: Custom labels attached to the sandbox.
+            env_vars: Environment variables set inside the sandbox.
+            target: Target region for sandbox placement.
+            max_stream_output_bytes: Cap per-stream output at this many
+                bytes. Defaults to 128 KB.
+            client: Existing ``AsyncDaytona`` client to reuse. If ``None``,
+                a new client is created and owned by this sandbox.
+        """
+        if image is not None and snapshot is not None:
+            raise ValueError("Provide either image or snapshot, not both.")
+
+        resolved_auto_stop = (
+            auto_stop_minutes if auto_stop_minutes is not None else _DEFAULT_AUTO_STOP_MINUTES
+        )
+        resolved_auto_delete = (
+            auto_delete_minutes if auto_delete_minutes is not None else _DEFAULT_AUTO_DELETE_MINUTES
+        )
+
+        owns_client = client is None
+        if owns_client:
+            config = DaytonaConfig(target=target) if target is not None else DaytonaConfig()
+            client = AsyncDaytona(config)
+        assert client is not None  # for type checker
+
+        try:
+            resolved_snapshot = snapshot if snapshot is not None else os.getenv("DAYTONA_SNAPSHOT")
+            if resolved_snapshot:
+                params: CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams = (
+                    CreateSandboxFromSnapshotParams(
+                        snapshot=resolved_snapshot,
+                        auto_stop_interval=resolved_auto_stop,
+                        auto_delete_interval=resolved_auto_delete,
+                        labels=labels,
+                        env_vars=env_vars,
+                    )
+                )
+            else:
+                resolved_image: Image | str = image if image is not None else Image.debian_slim()
+                params = CreateSandboxFromImageParams(
+                    image=resolved_image,
+                    auto_stop_interval=resolved_auto_stop,
+                    auto_delete_interval=resolved_auto_delete,
+                    labels=labels,
+                    env_vars=env_vars,
+                )
+            sandbox = await client.create(params, timeout=float(timeout))
+        except Exception:
+            if owns_client:
+                # Best-effort close of the HTTP session we just opened.
+                with contextlib.suppress(Exception):
+                    await client.close()
+            raise
+
+        return cls(
+            client=client,
+            sandbox=sandbox,
+            max_stream_output_bytes=max_stream_output_bytes,
+            owns_client=owns_client,
+        )
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._sandbox.id
+
+    async def _ensure_session(self) -> None:
+        """Lazily create the shared background session used by ``run_command``."""
+        if self._session_ready:
+            return
+        async with self._session_lock:
+            if self._session_ready:
+                return
+            try:
+                await self._sandbox.process.create_session(_SESSION_ID)
+                self._session_ready = True
+            except DaytonaNotFoundError as e:
+                raise SandboxTerminatedError(str(e)) from e
+
+    async def send_heartbeat(self, timeout: int = 30) -> None:
+        try:
+            await asyncio.wait_for(self._sandbox.refresh_activity(), timeout=timeout)
+        except DaytonaNotFoundError as e:
+            raise SandboxTerminatedError(str(e)) from e
+
+    async def run_command(
+        self,
+        command: str,
+        workdir: str | None = None,
+        timeout: int = 60,
+        max_output_bytes: int | None = None,
+    ) -> SandboxResult:
+        """Run a shell command in the sandbox.
+
+        Uses a persistent session so state (cwd, env, shell variables)
+        carries across calls. A ``workdir`` argument is prepended as
+        ``cd <workdir> &&`` for per-call scoping without mutating
+        long-term session state.
+        """
+        cap = max_output_bytes if max_output_bytes is not None else self._max_stream_output_bytes
+
+        await self._ensure_session()
+
+        full_command = f"cd {shlex.quote(workdir)} && {command}" if workdir else command
+        try:
+            response = await self._sandbox.process.execute_session_command(
+                _SESSION_ID,
+                SessionExecuteRequest(command=full_command),
+                timeout=timeout,
+            )
+        except DaytonaNotFoundError as e:
+            raise SandboxTerminatedError(str(e)) from e
+        except Exception as e:
+            return SandboxResult(stdout="", stderr=str(e), exit_code=-1)
+
+        exit_code = response.exit_code if response.exit_code is not None else -1
+        stdout = response.stdout or ""
+        stderr = response.stderr or ""
+        return SandboxResult(
+            stdout=_cap_output(stdout, cap),
+            stderr=_cap_output(stderr, cap),
+            exit_code=exit_code,
+        )
+
+    async def read_file(
+        self, path: str, max_bytes: int | None = None, timeout: int = 60
+    ) -> SandboxResult:
+        """Read a file from the sandbox via the Daytona filesystem API."""
+        try:
+            content = await asyncio.wait_for(self._sandbox.fs.download_file(path), timeout=timeout)
+        except DaytonaNotFoundError as e:
+            raise SandboxTerminatedError(str(e)) from e
+        except Exception as e:
+            return SandboxResult(stdout="", stderr=str(e), exit_code=-1)
+
+        if max_bytes is not None and len(content) > max_bytes:
+            content = content[:max_bytes]
+        return SandboxResult(
+            stdout=content.decode("utf-8", errors="replace"),
+            stderr="",
+            exit_code=0,
+        )
+
+    async def write_file(
+        self,
+        path: str,
+        content: str | bytes = "",
+        executable: bool = False,
+        timeout: int = 60,
+    ) -> SandboxResult:
+        """Write content to a file in the sandbox."""
+        if isinstance(content, str):
+            content = content.encode()
+
+        try:
+            await asyncio.wait_for(
+                self._sandbox.fs.upload_files([FileUpload(source=content, destination=path)]),
+                timeout=timeout,
+            )
+        except DaytonaNotFoundError as e:
+            raise SandboxTerminatedError(str(e)) from e
+        except Exception as e:
+            return SandboxResult(stdout="", stderr=str(e), exit_code=-1)
+
+        if executable:
+            chmod = await self.run_command(f"chmod +x {shlex.quote(path)}", timeout=timeout)
+            if chmod.exit_code != 0:
+                return chmod
+        return SandboxResult(stdout="", stderr="", exit_code=0)
+
+    async def cleanup(self) -> None:
+        """Delete the sandbox and close the owned Daytona client, idempotently."""
+        if self._cleaned_up:
+            return
+        self._cleaned_up = True
+
+        # Both steps are best-effort so a double-cleanup or a sandbox that
+        # Daytona already auto-reaped does not surface as an exception.
+        with contextlib.suppress(Exception):
+            await self._client.delete(self._sandbox)
+
+        if self._owns_client:
+            with contextlib.suppress(Exception):
+                await self._client.close()
+
+
+# ---------------------------------------------------------------------------
+# Harbor RL factory
+# ---------------------------------------------------------------------------
+
+
+async def daytona_sandbox_factory(env_dir: Path, timeout: int) -> DaytonaSandbox:
+    """Create a Daytona sandbox from a Harbor task environment directory.
+
+    Signature matches ``harbor_env.SandboxFactory``.
+
+    Args:
+        env_dir: Path to the task's ``environment/`` directory (must
+            contain a ``Dockerfile``).
+        timeout: Max wait time in seconds for sandbox creation.
+    """
+    dockerfile_path = env_dir / "Dockerfile"
+    image = Image.from_dockerfile(dockerfile_path)
+    return await DaytonaSandbox.create(image=image, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Stateless code grading helper (for code_rl)
+# ---------------------------------------------------------------------------
+
+
+async def run_code_in_daytona(
+    code: str,
+    files: dict[str, str],
+    timeout: float,
+    language: str = "python",
+    snapshot: str | None = None,
+) -> tuple[bool, dict[str, Any]]:
+    """Execute code in an ephemeral Daytona sandbox for stateless grading.
+
+    Return shape matches :meth:`SandboxFusionClient.run` so this slots
+    into ``code_rl.code_grading`` as a peer backend without re-shaping
+    the caller.
+
+    Args:
+        code: Main code to execute (entry point — written as ``run.py``).
+        files: Additional files to include ``{filename: content}``.
+        timeout: Execution timeout in seconds.
+        language: Programming language (default: ``python``).
+        snapshot: Optional pre-created Daytona snapshot name for fast cold
+            start. Falls back to ``DAYTONA_SNAPSHOT`` env var, then to
+            ``Image.debian_slim()``.
+
+    Returns:
+        Tuple of ``(success: bool, response: dict)``. ``success`` is True
+        only when the process exited with code 0. ``response`` contains
+        ``exit_code``, ``stdout``, ``stderr``.
+    """
+    if language != "python":
+        return False, {"error": f"Unsupported language for Daytona grading: {language!r}"}
+
+    sandbox: DaytonaSandbox | None = None
+    try:
+        # Allow a generous creation budget on top of the execution timeout
+        # so a slow first-time image build does not kill the sandbox before
+        # the user's code starts.
+        #
+        # The default image installs numpy because the code_rl test harness
+        # (`testing_util.py`) imports it. Users passing a custom `snapshot=`
+        # are responsible for providing the runtime deps they need.
+        image: Image | None = None
+        if snapshot is None and not os.getenv("DAYTONA_SNAPSHOT"):
+            image = Image.debian_slim().pip_install("numpy")
+        sandbox = await DaytonaSandbox.create(
+            image=image, snapshot=snapshot, timeout=int(timeout) + 60
+        )
+
+        all_files = [
+            ("/workspace/run.py", code),
+            *[(f"/workspace/{name}", content) for name, content in files.items()],
+        ]
+        await asyncio.gather(*(sandbox.write_file(path, content) for path, content in all_files))
+
+        result = await sandbox.run_command(
+            "python run.py",
+            workdir="/workspace",
+            timeout=int(timeout),
+        )
+    except Exception as e:
+        return False, {"error": str(e)}
+    finally:
+        if sandbox is not None:
+            await sandbox.cleanup()
+
+    success = result.exit_code == 0
+    return success, {
+        "exit_code": result.exit_code,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+__all__ = [
+    "DaytonaSandbox",
+    "daytona_sandbox_factory",
+    "run_code_in_daytona",
+]


### PR DESCRIPTION
## Summary
Adds Daytona as a third sandbox backend alongside Modal and SandboxFusion. Supports both stateful and stateless execution. 

## Code Changes
- `DaytonaSandbox` — implements `SandboxInterface`; persistent session carries shell state (cwd, env) across `run_command` calls. Used by `harbor_rl` and sandbox-gated eval benchmarks (`_swe_bench`, `_terminal_bench`, `_tau2_bench`).
- `daytona_sandbox_factory(env_dir, timeout)` — wraps `DaytonaSandbox.create` in the signature Harbor's `SandboxFactory` expects. Drop-in for `cli_main(sandbox_factory=...)`.
- `run_code_in_daytona(code, files, timeout, language, snapshot)` — stateless grading helper with the same return shape as `SandboxFusionClient.run`. Used by `code_rl` under `sandbox_backend=daytona`.

    Optional extra: `tinker-cookbook[daytona]` (pins `daytona>=0.168.0`). Lazy-imported at module level.

    `SandboxBackend.DAYTONA = "daytona"` added to the enum; `chz` coerces the CLI string automatically. No other wiring changes.

## Usage

`code_rl`:
```bash
export DAYTONA_API_KEY="***"
python -m tinker_cookbook.recipes.code_rl.train sandbox_backend=daytona ...
```

`harbor_rl`:
```python
from tinker_cookbook.sandbox.daytona_sandbox import daytona_sandbox_factory
cli_main(sandbox_factory=daytona_sandbox_factory, ...)
```

Eval benchmarks:
```python
from tinker_cookbook.sandbox.daytona_sandbox import DaytonaSandbox
config = BenchmarkConfig(sandbox_factory=DaytonaSandbox.create, ...)
```

Optional `DAYTONA_SNAPSHOT` env var pins a pre-built snapshot for cold-start amortization. Not required. Daytona content-hashes image builds and caches them across sandboxes automatically.

Defaults: `auto_stop_interval=15m`, `auto_delete_interval=30m` so crashed rollouts or skipped `cleanup()` calls don't leak paid resources. Both overridable via `DaytonaSandbox.create(auto_stop_minutes=..., auto_delete_minutes=...)`.

## Testing

### Smoke tests
`tests/test_daytona_sandbox.py` — 11 tests, gated on `DAYTONA_API_KEY`. Covers `SandboxInterface` contract + stateless grading helper + `write_file` latency bound.

```bash
DAYTONA_API_KEY=*** pytest tests/test_daytona_sandbox.py -v
```

### Integration Tests
Each of the three call-sites exercised against real Daytona sandboxes. Exports `DAYTONA_API_KEY` first.

**1. `code_rl` grading path via `SandboxBackend.DAYTONA`**

```python
import asyncio
from tinker_cookbook.recipes.code_rl.code_grading import sandbox_check_correctness
from tinker_cookbook.sandbox import SandboxBackend

sample = [{
    "input": "5\n",
    "output": "25\n",
    "testtype": "stdin_stdout",
    "metadata": {},
}]
correct = "n = int(input())\nprint(n * n)\n"
wrong   = "n = int(input())\nprint(n + n)\n"

async def main():
    ok_c, resp_c = await sandbox_check_correctness(sample, correct, backend=SandboxBackend.DAYTONA)
    ok_w, resp_w = await sandbox_check_correctness(sample, wrong,   backend=SandboxBackend.DAYTONA)
    print("correct ->", ok_c, resp_c)
    print("wrong   ->", ok_w, resp_w)
    assert ok_c is True and ok_w is False

asyncio.run(main())
```

Result:
```
correct -> True  {'exit_code': 0,   'stdout': '', 'stderr': ''}
wrong   -> False {'exit_code': 255, 'stdout': "{'output': '10\\n', 'expected': '25\\n', 'inputs': '5\\n', 'error_code': -2, 'error_message': 'Wrong Answer'}\n", 'stderr': ''}
```

**2. `harbor_rl` path via `daytona_sandbox_factory`**

Harbor-style task fixture:

```bash
mkdir -p /tmp/harbor_fixture/environment /tmp/harbor_fixture/tests

cat > /tmp/harbor_fixture/environment/Dockerfile <<'EOF'
FROM python:3.12-slim
RUN apt-get update && apt-get install -y --no-install-recommends bash && rm -rf /var/lib/apt/lists/*
WORKDIR /app
RUN echo 'print("hello from harbor-style task")' > /app/solution.py
EOF

cat > /tmp/harbor_fixture/tests/test.sh <<'EOF'
#!/bin/bash
set -e
output=$(python /app/solution.py)
if [[ "$output" == *"harbor-style task"* ]]; then
  echo "PASS"; exit 0
else
  echo "FAIL: got $output"; exit 1
fi
EOF
```

Factory run:

```python
import asyncio
from pathlib import Path
from tinker_cookbook.sandbox.daytona_sandbox import daytona_sandbox_factory

TASK_DIR = Path("/tmp/harbor_fixture")

async def main():
    sandbox = await daytona_sandbox_factory(TASK_DIR / "environment", timeout=600)
    try:
        test_script = (TASK_DIR / "tests" / "test.sh").read_text()
        await sandbox.write_file("/app/run_tests.sh", test_script, executable=True)

        r = await sandbox.run_command("bash /app/run_tests.sh", timeout=60)
        print("bundled solution ->", r.exit_code, repr(r.stdout))

        await sandbox.write_file("/app/solution.py", "print('agent scrambled the answer')")
        r = await sandbox.run_command("bash /app/run_tests.sh", timeout=60)
        print("agent overwrote  ->", r.exit_code, repr(r.stdout))
    finally:
        await sandbox.cleanup()

asyncio.run(main())
```

Result:
```
bundled solution -> 0 'PASS\n'
agent overwrote  -> 1 'FAIL: got agent scrambled the answer\n'
```

**3. `BenchmarkConfig(sandbox_factory=DaytonaSandbox.create)` injection**

```python
import asyncio
from tinker_cookbook.eval.benchmarks._common import get_sandbox_factory
from tinker_cookbook.eval.benchmarks._types import BenchmarkConfig
from tinker_cookbook.sandbox.daytona_sandbox import DaytonaSandbox

async def main():
    config = BenchmarkConfig(sandbox_factory=DaytonaSandbox.create)
    factory = get_sandbox_factory(config)
    assert factory.__func__ is DaytonaSandbox.create.__func__, "Modal fallback won"

    sandbox = await factory()
    try:
        r = await sandbox.run_command("uname -a && echo marker-$RANDOM")
        print(r.exit_code, r.stdout.strip())
    finally:
        await sandbox.cleanup()

asyncio.run(main())
```

Result:
```
0 Linux <sandbox-id> 6.14.0-1018-oracle ... x86_64 GNU/Linux
  marker-5980
```

## Checks
- `ruff check` clean
- `ruff format` clean
- `pyright tinker_cookbook` — 0 errors
- `pre-commit run --all-files` — all hooks pass