### PR TITLE
feat: add support for Qwen3.6-27B

### DIFF
--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -115,6 +115,7 @@ def _get_hidden_size(model_name: str) -> int:
         "Qwen/Qwen3.5-27B": 5120,
         "Qwen/Qwen3.5-4B": 2560,
         # Qwen3.6 (same architecture family as Qwen3.5, hidden_size under text_config)
+        "Qwen/Qwen3.6-27B": 5120,
         "Qwen/Qwen3.6-35B-A3B": 2048,
         # OpenAI
         "openai/gpt-oss-120b": 2880,

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -113,8 +113,8 @@ def get_qwen_info() -> dict[str, ModelAttributes]:
         "Qwen3.5-35B-A3B": ModelAttributes(org, "3.5", "35B-A3B", True, _QWEN3_5, is_vl=True),
         "Qwen3.5-397B-A17B": ModelAttributes(org, "3.5", "397B-A17B", True, _QWEN3_5, is_vl=True),
         # Qwen3.6 reuses the Qwen3.5 renderer: identical tokenizer, special tokens,
-        # preprocessor, and chat template (same architectures=Qwen3_5MoeForConditionalGeneration
-        # and model_type=qwen3_5_moe), so renderer/merge/export code paths are shared.
+        # preprocessor, and chat template (same qwen3_5 / qwen3_5_moe model_type),
+        # so renderer/merge/export code paths are shared.
         "Qwen3.6-27B": ModelAttributes(org, "3.6", "27B", True, _QWEN3_5, is_vl=True),
         "Qwen3.6-35B-A3B": ModelAttributes(org, "3.6", "35B-A3B", True, _QWEN3_5, is_vl=True),
     }

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -115,6 +115,7 @@ def get_qwen_info() -> dict[str, ModelAttributes]:
         # Qwen3.6 reuses the Qwen3.5 renderer: identical tokenizer, special tokens,
         # preprocessor, and chat template (same architectures=Qwen3_5MoeForConditionalGeneration
         # and model_type=qwen3_5_moe), so renderer/merge/export code paths are shared.
+        "Qwen3.6-27B": ModelAttributes(org, "3.6", "27B", True, _QWEN3_5, is_vl=True),
         "Qwen3.6-35B-A3B": ModelAttributes(org, "3.6", "35B-A3B", True, _QWEN3_5, is_vl=True),
     }
 

--- a/tinker_cookbook/model_info_test.py
+++ b/tinker_cookbook/model_info_test.py
@@ -14,25 +14,16 @@ class TestQwen3_6:
     counterparts (same tokenizer, chat template, and ``qwen3_5`` /
     ``qwen3_5_moe`` model_type) and therefore reuse the qwen3_5 renderer."""
 
-    def test_qwen3_6_27b_uses_qwen3_5_renderer(self):
-        assert get_recommended_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_5"
+    @pytest.mark.parametrize("size_str", ["27B", "35B-A3B"])
+    def test_qwen3_6_uses_qwen3_5_renderer(self, size_str: str):
+        assert get_recommended_renderer_name(f"Qwen/Qwen3.6-{size_str}") == "qwen3_5"
 
-    def test_qwen3_6_27b_attributes(self):
-        attrs = get_model_attributes("Qwen/Qwen3.6-27B")
+    @pytest.mark.parametrize("size_str", ["27B", "35B-A3B"])
+    def test_qwen3_6_attributes(self, size_str: str):
+        attrs = get_model_attributes(f"Qwen/Qwen3.6-{size_str}")
         assert attrs.organization == "Qwen"
         assert attrs.version_str == "3.6"
-        assert attrs.size_str == "27B"
-        assert attrs.is_chat is True
-        assert attrs.is_vl is True
-
-    def test_qwen3_6_35b_a3b_uses_qwen3_5_renderer(self):
-        assert get_recommended_renderer_name("Qwen/Qwen3.6-35B-A3B") == "qwen3_5"
-
-    def test_qwen3_6_35b_a3b_attributes(self):
-        attrs = get_model_attributes("Qwen/Qwen3.6-35B-A3B")
-        assert attrs.organization == "Qwen"
-        assert attrs.version_str == "3.6"
-        assert attrs.size_str == "35B-A3B"
+        assert attrs.size_str == size_str
         assert attrs.is_chat is True
         assert attrs.is_vl is True
 

--- a/tinker_cookbook/model_info_test.py
+++ b/tinker_cookbook/model_info_test.py
@@ -10,9 +10,20 @@ from tinker_cookbook.model_info import (
 
 
 class TestQwen3_6:
-    """Qwen3.6-35B-A3B is architecturally identical to Qwen3.5-35B-A3B
-    (same tokenizer, chat template, and ``qwen3_5_moe`` model_type) and
-    therefore reuses the qwen3_5 renderer."""
+    """Qwen3.6 models are architecturally identical to their Qwen3.5
+    counterparts (same tokenizer, chat template, and ``qwen3_5`` /
+    ``qwen3_5_moe`` model_type) and therefore reuse the qwen3_5 renderer."""
+
+    def test_qwen3_6_27b_uses_qwen3_5_renderer(self):
+        assert get_recommended_renderer_name("Qwen/Qwen3.6-27B") == "qwen3_5"
+
+    def test_qwen3_6_27b_attributes(self):
+        attrs = get_model_attributes("Qwen/Qwen3.6-27B")
+        assert attrs.organization == "Qwen"
+        assert attrs.version_str == "3.6"
+        assert attrs.size_str == "27B"
+        assert attrs.is_chat is True
+        assert attrs.is_vl is True
 
     def test_qwen3_6_35b_a3b_uses_qwen3_5_renderer(self):
         assert get_recommended_renderer_name("Qwen/Qwen3.6-35B-A3B") == "qwen3_5"

--- a/tinker_cookbook/weights/_merge_qwen3_5.py
+++ b/tinker_cookbook/weights/_merge_qwen3_5.py
@@ -6,7 +6,7 @@ Tinker trains separate ``in_proj_q/k/v`` LoRA adapters. All Qwen3.5 models
 are vision-language with the ``model.language_model.*`` key prefix.
 
 Supported models: Qwen3.5-4B, Qwen3.5-27B, Qwen3.5-35B-A3B, Qwen3.5-397B-A17B,
-Qwen3.6-35B-A3B (same ``qwen3_5_moe`` architecture family).
+Qwen3.6-27B, Qwen3.6-35B-A3B (same ``qwen3_5`` / ``qwen3_5_moe`` architecture family).
 """
 
 from __future__ import annotations
@@ -47,7 +47,8 @@ def detect_profile(model_config: dict, model_state_keys: set[str]) -> MergeProfi
     are vision-language with the ``model.language_model.*`` key prefix.
 
     Supported models: Qwen3.5-4B, Qwen3.5-27B, Qwen3.5-35B-A3B,
-    Qwen3.5-397B-A17B, and Qwen3.6-35B-A3B (same ``qwen3_5_moe`` model_type).
+    Qwen3.5-397B-A17B, Qwen3.6-27B, and Qwen3.6-35B-A3B (same ``qwen3_5`` /
+    ``qwen3_5_moe`` model_type).
     """
     if model_config.get("model_type") not in ("qwen3_5", "qwen3_5_moe"):
         return None


### PR DESCRIPTION
## Summary
Adds support for Qwen3.6-27B by registering it in `model_info`, `hyperparam_utils`, and extending the Qwen3.5 merge profile docs/tests. This mirrors the Qwen3.6-35B-A3B addition in #674.

## Design
Qwen3.6-27B is architecturally identical to Qwen3.5-27B — same tokenizer, special tokens, chat template, and `qwen3_5` `model_type`. The renderer (`qwen3_5`) and weight-merge code path already handle both `qwen3_5` (dense) and `qwen3_5_moe` (MoE) `model_type`s in `detect_profile`, so only registration and metadata updates are needed:

- `model_info.py`: register `Qwen3.6-27B` with `_QWEN3_5` renderer, `is_vl=True`
- `hyperparam_utils.py`: hidden size 5120 (matches Qwen3.5-27B)
- `_merge_qwen3_5.py`: update module + `detect_profile` docstrings to list the new model
- `model_info_test.py`: add renderer + attributes tests

## Backward Compatibility
Fully backward-compatible. Only additions to lookup tables and docstrings — no existing model entries, renderers, or merge logic changed.

## Tests
- [x] `pytest tinker_cookbook/model_info_test.py` — 10/10 pass (4 Qwen3.6 tests + 6 pre-existing)
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — already formatted

## Additional Notes
Assumes Qwen3.6-27B is dense with `hidden_size=5120` like Qwen3.5-27B; worth confirming against the released HF config once available.