### PR TITLE
ci: disable reportPrivateImportUsage to fix type-check failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,10 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-timeout>=2.0.0",
     "ruff>=0.4.0",
-    "pyright>=1.1.300",
+    # Pinned below 1.1.409: that release introduced a regression that flags
+    # attribute access like torch.allclose / torch.zeros as
+    # reportPrivateImportUsage because those names are not in torch.__all__.
+    "pyright>=1.1.300,<1.1.409",
 ]
 math-rl = [
     "math-verify>=0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,7 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-timeout>=2.0.0",
     "ruff>=0.4.0",
-    # Pinned below 1.1.409: that release introduced a regression that flags
-    # attribute access like torch.allclose / torch.zeros as
-    # reportPrivateImportUsage because those names are not in torch.__all__.
-    "pyright>=1.1.300,<1.1.409",
+    "pyright>=1.1.300",
 ]
 math-rl = [
     "math-verify>=0.5.0",
@@ -209,3 +206,8 @@ exclude = [
     # Vendored from HuggingFace, kept identical to upstream
     "kimi-k2.5-hf-tokenizer/tool_declaration_ts.py",
 ]
+# Disabled because pyright 1.1.409+ flags attribute access like torch.zeros /
+# torch.allclose as private, since PyTorch does not list these names in
+# torch.__all__ (neither do numpy, pandas, and similar scientific libs). The
+# rule's signal is dominated by these false positives for our codebase.
+reportPrivateImportUsage = "none"


### PR DESCRIPTION
## Summary
Pyright 1.1.409 flags attribute access like `torch.allclose`, `torch.zeros`, and `torch.ones` as `reportPrivateImportUsage` because those names are not listed in `torch.__all__`. This produces ~774 false-positive errors (concentrated in `weights/` but spread across 16 files) and fails the `type-check` CI job on every new PR.

Observed on PR #681 (pyright 1.1.409, failed). PR #677 had used pyright 1.1.408 and passed.

## Design
Disable `reportPrivateImportUsage` in `[tool.pyright]`. PyTorch (and numpy/pandas/etc.) do not maintain `__all__` rigorously enough for this rule to be useful — its signal for our codebase is dominated by false positives on idiomatic attribute access. Since the repo previously passed with the rule enabled (on 1.1.408, which evaluated it more leniently), disabling it costs no real signal.

Alternatives considered and rejected:
- **Pin `pyright<1.1.409`**: blocks us from tracking pyright upstream. First approach on this PR, reverted in favor of the current one.
- **Rewrite `torch.X` to `from torch import X`**: invasive churn across 511 occurrences in 16 files, idiomatic PyTorch code.
- **Per-site `# pyright: ignore` comments**: 511 comment additions, ugly.

## Backward Compatibility
Fully backward-compatible. Config change only, no source changes.

## Tests
- [x] `uv sync --all-extras && uv run pyright tinker_cookbook` with `pyright==1.1.409` — 0 errors locally (matches the CI invocation in `.github/workflows/pyright.yaml`)
- [x] Without the disable, the same command reproduces the ~774 errors