### PR TITLE
Fix plugin.json skills field validation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,5 +10,5 @@
   "repository": "https://github.com/thinking-machines-lab/tinker-cookbook",
   "license": "MIT",
   "keywords": ["tinker", "fine-tuning", "rl", "sft", "dpo", "llm"],
-  "skills": "skills/"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
Plugin install fails with `skills: Invalid input` because the manifest validator requires relative paths to start with `./`. Changes `"skills": "skills/"` → `"skills": "./skills/"`.