### PR TITLE
[ckpt] Support fire-and-forget periodic checkpoints

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -527,13 +527,17 @@ class CheckpointManager:
     Manages three kinds of checkpoints:
 
     * **Periodic** – full checkpoints (state + sampler weights) saved every
-      ``save_every`` steps with a configurable TTL.
+      ``save_every`` steps with a configurable TTL.  When
+      ``async_periodic_saves=True``, these run as fire-and-forget background
+      tasks so the training loop is not blocked; the checkpoint record is
+      written to ``checkpoints.jsonl`` once the background save completes.
     * **Rolling** – cheap resume-only checkpoints (state only, no sampler
       export) saved every ``rolling_save_every`` steps.  After each save the
       previous rolling checkpoint is deleted to bound storage.  A short TTL
       acts as a safety net if deletion fails.
     * **Final** – a permanent checkpoint saved at the end of training with no
-      TTL, followed by cleanup of any remaining rolling checkpoint.
+      TTL, followed by cleanup of any remaining rolling checkpoint.  The final
+      checkpoint always blocks (never fire-and-forget).
 
     For training loops where periodic and rolling saves happen at the same
     point, use :meth:`maybe_save_async` / :meth:`maybe_save` which handles
@@ -566,6 +570,7 @@ class CheckpointManager:
         rolling_save_every: int = 0,
         rolling_ttl_seconds: int = 7200,
         store: "TrainingRunStore | None" = None,
+        async_periodic_saves: bool = False,
     ) -> None:
         self._training_client = training_client
         self._service_client = service_client
@@ -575,8 +580,10 @@ class CheckpointManager:
         self._rolling_save_every = rolling_save_every
         self._rolling_ttl_seconds = rolling_ttl_seconds
         self._store = store
+        self._async_periodic_saves = async_periodic_saves
 
-        self._pending_task: asyncio.Task[None] | None = None
+        self._pending_rolling_task: asyncio.Task[None] | None = None
+        self._pending_periodic_task: asyncio.Task[dict[str, str]] | None = None
         self._prev_state_path: str | None = None
 
     # ------------------------------------------------------------------
@@ -637,12 +644,12 @@ class CheckpointManager:
         The save runs as a background ``asyncio.Task`` so it overlaps with the
         next training step.
         """
-        await self._resolve_pending_async()
+        await self._resolve_pending_rolling_async()
 
         if not self._should_save_rolling(step):
             return
 
-        self._pending_task = asyncio.create_task(
+        self._pending_rolling_task = asyncio.create_task(
             self._do_rolling_save_async(step, loop_state),
             name=f"rolling_checkpoint_{step:06d}",
         )
@@ -669,13 +676,24 @@ class CheckpointManager:
     ) -> dict[str, str] | None:
         """Save periodic checkpoint if due, then fire rolling save if due.
 
-        Returns the periodic checkpoint path dict if a periodic save happened,
-        otherwise ``None``.  Suitable for training loops where periodic and
-        rolling saves happen at the same point (SL, DPO).
+        Returns the periodic checkpoint path dict if a periodic save happened
+        synchronously, otherwise ``None``.  When ``async_periodic_saves`` is
+        enabled, periodic saves run as background tasks and this always returns
+        ``None``.
+
+        Suitable for training loops where periodic and rolling saves happen at
+        the same point (SL, DPO).
         """
         result: dict[str, str] | None = None
         if self.should_save_periodic(step):
-            result = await self.save_periodic_async(step, loop_state)
+            if self._async_periodic_saves:
+                await self._resolve_pending_periodic_async()
+                self._pending_periodic_task = asyncio.create_task(
+                    self.save_periodic_async(step, loop_state),
+                    name=f"periodic_checkpoint_{step:06d}",
+                )
+            else:
+                result = await self.save_periodic_async(step, loop_state)
         await self.maybe_save_rolling_async(step, loop_state)
         return result
 
@@ -699,6 +717,9 @@ class CheckpointManager:
         deleted so that the last entry in ``checkpoints.jsonl`` always points
         to valid server-side data.
         """
+        # Drain any in-flight periodic save so its record lands in
+        # checkpoints.jsonl *before* the final record.
+        await self._resolve_pending_periodic_async()
         paths = await save_checkpoint_async(
             training_client=self._training_client,
             name="final",
@@ -730,12 +751,13 @@ class CheckpointManager:
     # ------------------------------------------------------------------
 
     async def finalize_async(self) -> None:
-        """Await any pending rolling save, then delete the last rolling checkpoint.
+        """Await any pending saves, then delete the last rolling checkpoint.
 
         Called automatically by :meth:`save_final_async`.  Can also be called
         directly if the final checkpoint is saved through other means.
         """
-        await self._resolve_pending_async()
+        await self._resolve_pending_periodic_async()
+        await self._resolve_pending_rolling_async()
         await self._delete_prev_async()
 
     def finalize(self) -> None:
@@ -752,14 +774,23 @@ class CheckpointManager:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _resolve_pending_async(self) -> None:
-        if self._pending_task is None:
+    async def _resolve_pending_rolling_async(self) -> None:
+        if self._pending_rolling_task is None:
             return
         try:
-            await self._pending_task
+            await self._pending_rolling_task
         except Exception:
             logger.warning("Rolling checkpoint save failed", exc_info=True)
-        self._pending_task = None
+        self._pending_rolling_task = None
+
+    async def _resolve_pending_periodic_async(self) -> None:
+        if self._pending_periodic_task is None:
+            return
+        try:
+            await self._pending_periodic_task
+        except Exception:
+            logger.warning("Background periodic checkpoint save failed", exc_info=True)
+        self._pending_periodic_task = None
 
     async def _do_rolling_save_async(self, step: int, loop_state: dict[str, Any]) -> None:
         name = f"{step:06d}"

--- a/tinker_cookbook/checkpoint_utils_test.py
+++ b/tinker_cookbook/checkpoint_utils_test.py
@@ -422,3 +422,197 @@ async def test_delete_failure_is_swallowed():
 
         # Should not raise — delete failure is swallowed
         assert mock_rest_client.delete_checkpoint_from_tinker_path_async.called
+
+
+# ---------------------------------------------------------------------------
+# Async periodic saves tests
+# ---------------------------------------------------------------------------
+
+
+def _make_both_save_mocks(
+    state_paths: list[str], sampler_paths: list[str]
+) -> tuple[AsyncMock, AsyncMock]:
+    """Create mocks for save_state_async and save_weights_for_sampler_async."""
+    state_mock = _make_save_state_mock(state_paths)
+
+    sampler_idx = 0
+
+    async def _save_sampler_async(name: str, ttl_seconds: int | None = None) -> MagicMock:
+        nonlocal sampler_idx
+        path = sampler_paths[sampler_idx % len(sampler_paths)]
+        sampler_idx += 1
+        future = MagicMock()
+        result = MagicMock()
+        result.path = path
+        future.result_async = AsyncMock(return_value=result)
+        return future
+
+    return state_mock, AsyncMock(side_effect=_save_sampler_async)
+
+
+@pytest.mark.asyncio
+async def test_async_periodic_saves_fire_and_forget():
+    """Periodic saves should run as background tasks when async_periodic_saves=True."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_training_client = MagicMock()
+        state_mock, sampler_mock = _make_both_save_mocks(
+            ["tinker://run/state/000005"], ["tinker://run/sampler/000005"]
+        )
+        mock_training_client.save_state_async = state_mock
+        mock_training_client.save_weights_for_sampler_async = sampler_mock
+
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=MagicMock(),
+            log_path=tmpdir,
+            save_every=5,
+            async_periodic_saves=True,
+        )
+
+        # Steps 1-4: no periodic save
+        for step in range(1, 5):
+            result = await mgr.maybe_save_async(step=step, loop_state={"batch": step})
+            assert result is None
+            mock_training_client.save_state_async.assert_not_called()
+
+        # Step 5: triggers periodic save, but async — returns None immediately
+        result = await mgr.maybe_save_async(step=5, loop_state={"batch": 5})
+        assert result is None  # async mode returns None
+        assert mgr._pending_periodic_task is not None
+
+        # Resolve by calling finalize
+        await mgr.finalize_async()
+        assert mgr._pending_periodic_task is None
+
+        # Verify checkpoints.jsonl was written with both state and sampler paths
+        ckpts = [
+            CheckpointRecord.from_dict(json.loads(line))
+            for line in (Path(tmpdir) / "checkpoints.jsonl").read_text().strip().split("\n")
+        ]
+        assert len(ckpts) == 1
+        assert ckpts[0].state_path == "tinker://run/state/000005"
+        assert ckpts[0].sampler_path == "tinker://run/sampler/000005"
+
+
+@pytest.mark.asyncio
+async def test_async_periodic_saves_resolves_before_next():
+    """A pending async periodic save should resolve before the next one fires."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_training_client = MagicMock()
+        state_mock, sampler_mock = _make_both_save_mocks(
+            ["tinker://run/state/000005", "tinker://run/state/000010"],
+            ["tinker://run/sampler/000005", "tinker://run/sampler/000010"],
+        )
+        mock_training_client.save_state_async = state_mock
+        mock_training_client.save_weights_for_sampler_async = sampler_mock
+
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=MagicMock(),
+            log_path=tmpdir,
+            save_every=5,
+            async_periodic_saves=True,
+        )
+
+        # Step 5: fires first periodic save
+        await mgr.maybe_save_async(step=5, loop_state={"batch": 5})
+        assert mgr._pending_periodic_task is not None
+
+        # Step 10: should resolve step 5 first, then fire step 10
+        await mgr.maybe_save_async(step=10, loop_state={"batch": 10})
+        # step 5 resolved, step 10 is now pending
+        assert mgr._pending_periodic_task is not None
+
+        await mgr.finalize_async()
+
+        ckpts = [
+            CheckpointRecord.from_dict(json.loads(line))
+            for line in (Path(tmpdir) / "checkpoints.jsonl").read_text().strip().split("\n")
+        ]
+        assert len(ckpts) == 2
+        assert ckpts[0].name == "000005"
+        assert ckpts[1].name == "000010"
+
+
+@pytest.mark.asyncio
+async def test_async_periodic_save_final_ordering():
+    """Final checkpoint record should always appear after any pending periodic save."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_training_client = MagicMock()
+        state_mock, sampler_mock = _make_both_save_mocks(
+            ["tinker://run/state/000005", "tinker://run/state/final"],
+            ["tinker://run/sampler/000005", "tinker://run/sampler/final"],
+        )
+        mock_training_client.save_state_async = state_mock
+        mock_training_client.save_weights_for_sampler_async = sampler_mock
+
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=MagicMock(),
+            log_path=tmpdir,
+            save_every=5,
+            async_periodic_saves=True,
+        )
+
+        # Fire a background periodic save at step 5
+        await mgr.maybe_save_async(step=5, loop_state={"batch": 5})
+        assert mgr._pending_periodic_task is not None
+
+        # save_final_async should drain the pending periodic save first
+        await mgr.save_final_async(loop_state={"epoch": 1, "batch": 0})
+
+        ckpts = [
+            CheckpointRecord.from_dict(json.loads(line))
+            for line in (Path(tmpdir) / "checkpoints.jsonl").read_text().strip().split("\n")
+        ]
+        assert len(ckpts) == 2
+        assert ckpts[0].name == "000005"
+        assert ckpts[1].name == "final"
+
+
+@pytest.mark.asyncio
+async def test_async_periodic_save_failure_is_swallowed():
+    """A failed async periodic save should be logged but not raise."""
+    mock_training_client = MagicMock()
+    mock_training_client.save_state_async = AsyncMock(side_effect=RuntimeError("server error"))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=MagicMock(),
+            log_path=tmpdir,
+            save_every=5,
+            async_periodic_saves=True,
+        )
+
+        # Step 5: fires periodic save that will fail
+        await mgr.maybe_save_async(step=5, loop_state={"batch": 5})
+
+        # Finalize should not raise
+        await mgr.finalize_async()
+
+
+@pytest.mark.asyncio
+async def test_sync_periodic_saves_still_work():
+    """With async_periodic_saves=False (default), saves block and return paths."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_training_client = MagicMock()
+        state_mock, sampler_mock = _make_both_save_mocks(
+            ["tinker://run/state/000005"], ["tinker://run/sampler/000005"]
+        )
+        mock_training_client.save_state_async = state_mock
+        mock_training_client.save_weights_for_sampler_async = sampler_mock
+
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=MagicMock(),
+            log_path=tmpdir,
+            save_every=5,
+            async_periodic_saves=False,
+        )
+
+        result = await mgr.maybe_save_async(step=5, loop_state={"batch": 5})
+        assert result is not None
+        assert result["state_path"] == "tinker://run/state/000005"
+        assert result["sampler_path"] == "tinker://run/sampler/000005"
+        assert mgr._pending_periodic_task is None

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -81,6 +81,11 @@ class Config:
             (0 disables).
         max_steps (int | None): Hard cap on training steps.  ``None`` trains
             for ``num_epochs * n_batches``.
+        async_periodic_saves (bool): When ``True``, periodic checkpoint saves
+            run as fire-and-forget background tasks instead of blocking the
+            training loop.  The checkpoint record is written to
+            ``checkpoints.jsonl`` once the save completes.  The final
+            checkpoint always blocks.  Default ``False``.
         submit_ahead (int): How many batches to submit ahead of the one being
             waited on.  ``1`` (default) matches the historical single-lookahead
             behavior; ``0`` disables pipelining entirely; higher values deepen
@@ -130,6 +135,10 @@ class Config:
     rolling_save_every: int = 0
     # TTL for rolling checkpoints; short to auto-clean if explicit deletion fails.
     rolling_ttl_seconds: int = 7200  # 2 hours
+    # When True, periodic checkpoint saves run as background asyncio tasks
+    # (fire-and-forget) instead of blocking the training loop. The final
+    # checkpoint always blocks regardless of this setting.
+    async_periodic_saves: bool = False
 
     # Adam optimizer parameters
     adam_beta1: float = 0.9
@@ -339,6 +348,7 @@ async def main(config: Config):
         rolling_save_every=config.rolling_save_every,
         rolling_ttl_seconds=config.rolling_ttl_seconds,
         store=store,
+        async_periodic_saves=config.async_periodic_saves,
     )
 
     dataset, maybe_test_dataset = config.dataset_builder()


### PR DESCRIPTION
When set, periodic checkpoints no longer block the training loop. This helps reduce bubbles, improving MFU and wall clock performance.