### PR TITLE
Replace parse_success bool with ParseTermination enum (fixes base-model eval regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Each entry includes:
 
 ---
 
+### [cookbook] Fix base-model single-turn evals + replace `parse_success` bool with `ParseTermination` enum ([#688](https://github.com/thinking-machines-lab/tinker-cookbook/pull/688))
+**Date:** 2026-04-30
+**Type:** fix
+**Tags:** renderers, eval, rl
+
+Fixes #685: every base model × every single-turn benchmark scored 0% because `RoleColonRenderer.parse_response` reported `parse_success=False` on EOS-terminated responses, and `EnvFromMessageEnv.step` short-circuits with `failed_parse_reward=0` in that case — so the grader was never invoked. Re-running AIME 2025 against `Qwen/Qwen3-8B-Base` now gives 6/30 (20.0%) instead of 0/30.
+
+**Breaking API change.** `Renderer.parse_response` now returns `tuple[Message, ParseTermination]` instead of `tuple[Message, bool]`. `ParseTermination` is a `StrEnum` with `STOP_SEQUENCE` / `EOS` / `MALFORMED` values plus `is_clean` and `is_stop_sequence` properties. Note that `ParseTermination` is truthy in all three states (it's a `StrEnum`), so `if not parse_success:` patterns will silently always be False without raising `TypeError`. Migration: replace with `if not termination.is_clean:` (lenient, what eval grading reads) or `if not termination.is_stop_sequence:` (strict, what RL format-reward shaping reads). All in-tree call sites are updated. R1-Zero / math RL training behavior is preserved by default via a new `ProblemEnv.require_stop_sequence_for_format=True` knob.
+
+---
+
 ### [cookbook] Fix grading bugs in IFEval, MATH-500, and GPQA benchmarks ([#643](https://github.com/thinking-machines-lab/tinker-cookbook/pull/643))
 **Date:** 2026-04-08
 **Type:** fix

--- a/tinker_cookbook/completers.py
+++ b/tinker_cookbook/completers.py
@@ -190,7 +190,7 @@ class TinkerMessageCompleter(MessageCompleter):
         )
 
         # Decode the response
-        parsed_message, _success = self.renderer.parse_response(response.sequences[0].tokens)
+        parsed_message, _termination = self.renderer.parse_response(response.sequences[0].tokens)
 
         result: renderers.Message = {"role": "assistant", "content": parsed_message["content"]}
         if "tool_calls" in parsed_message:

--- a/tinker_cookbook/distillation/datasets.py
+++ b/tinker_cookbook/distillation/datasets.py
@@ -112,7 +112,7 @@ class PromptOnlyEnv(ProblemEnv):
 
     async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Return zero reward always."""
-        message, parse_success = self.renderer.parse_response(action)
+        _message, _termination = self.renderer.parse_response(action)
         return StepResult(
             reward=0.0,
             episode_done=True,

--- a/tinker_cookbook/distillation/datasets.py
+++ b/tinker_cookbook/distillation/datasets.py
@@ -112,7 +112,6 @@ class PromptOnlyEnv(ProblemEnv):
 
     async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Return zero reward always."""
-        _message, _termination = self.renderer.parse_response(action)
         return StepResult(
             reward=0.0,
             episode_done=True,

--- a/tinker_cookbook/recipes/math_rl/arithmetic_env.py
+++ b/tinker_cookbook/recipes/math_rl/arithmetic_env.py
@@ -21,8 +21,15 @@ class ArithmeticEnv(ProblemEnv):
         y: int,
         renderer: renderers.Renderer,
         convo_prefix: list[renderers.Message] | None = None,
+        format_coef: float = 0.1,
+        require_stop_sequence_for_format: bool = True,
     ):
-        super().__init__(renderer, convo_prefix)
+        super().__init__(
+            renderer,
+            convo_prefix,
+            format_coef=format_coef,
+            require_stop_sequence_for_format=require_stop_sequence_for_format,
+        )
         self.x = x
         self.y = y
 

--- a/tinker_cookbook/recipes/math_rl/math_env.py
+++ b/tinker_cookbook/recipes/math_rl/math_env.py
@@ -28,8 +28,15 @@ class MathEnv(ProblemEnv):
         convo_prefix: list[renderers.Message] | None = None,
         grader: Literal["sympy", "math_verify"] = "sympy",
         timeout: float = 1.0,
+        format_coef: float = 0.1,
+        require_stop_sequence_for_format: bool = True,
     ):
-        super().__init__(renderer, convo_prefix)
+        super().__init__(
+            renderer,
+            convo_prefix,
+            format_coef=format_coef,
+            require_stop_sequence_for_format=require_stop_sequence_for_format,
+        )
         self.problem = problem
         self.answer = answer
         self.grader = grader

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
@@ -72,7 +72,7 @@ class GuessNumberEnv(Env):
     async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         # step 1: parse the action tokens into a message
         # this step is specific to our library, but usually templated, so you can just copy it.
-        (action_message, _parse_success) = self.renderer.parse_response(action)
+        (action_message, _termination) = self.renderer.parse_response(action)
 
         # step 2: based on the string answer, we compute the reward and the user turn.
         # This part is NOT templated, so you need to implement it. But it is plain python without using special libraries.

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
@@ -106,7 +106,7 @@ class TwentyQuestionsEnv(Env):
         """
 
         # step 1: accepts the action from the player (policy)
-        (action_message, _parse_success) = self.renderer.parse_response(action)
+        (action_message, _termination) = self.renderer.parse_response(action)
         self.turns.append({"role": "player", "content": action_message["content"]})
 
         # step 2: the answerer responds

--- a/tinker_cookbook/recipes/rubric/env.py
+++ b/tinker_cookbook/recipes/rubric/env.py
@@ -93,8 +93,8 @@ class RubricGradedEnv(Env):
             logtree.log_formatter(ConversationFormatter(messages=self.convo))
 
         # obtain the policy action message
-        (policy_action_message, parse_success) = self.renderer.parse_response(action)
-        parse_success_bool = bool(parse_success)
+        (policy_action_message, termination) = self.renderer.parse_response(action)
+        parse_success_bool = termination.is_clean
         format_score = float(parse_success_bool)
 
         if self.debug:
@@ -107,11 +107,11 @@ class RubricGradedEnv(Env):
             print(colored("DEBUG: Policy Action Message", "green"))
             print(colored("=" * 80, "green"))
             print(colored(json.dumps(policy_action_message, indent=2), "green") + "\n")
-            print(colored(f"Parse Success: {parse_success}", "green") + "\n")
+            print(colored(f"Termination: {termination}", "green") + "\n")
 
         with logtree.scope_header("Policy Response"):
             logtree.log_formatter(ConversationFormatter(messages=[policy_action_message]))
-            logtree.log_text(f"Parse success: {parse_success}")
+            logtree.log_text(f"Termination: {termination}")
 
         convo = self.convo + [policy_action_message]
         results = await asyncio.gather(

--- a/tinker_cookbook/recipes/rubric/env.py
+++ b/tinker_cookbook/recipes/rubric/env.py
@@ -94,8 +94,12 @@ class RubricGradedEnv(Env):
 
         # obtain the policy action message
         (policy_action_message, termination) = self.renderer.parse_response(action)
-        parse_success_bool = termination.is_clean
-        format_score = float(parse_success_bool)
+        # Mirrors ProblemEnv's strict default: stop-sequence termination is the
+        # only "well-formed" outcome for format-reward shaping. EOS-only
+        # termination (relevant only for RoleColonRenderer) does not earn the
+        # format reward — keep eval grading and RL training consistent.
+        format_valid = termination.is_stop_sequence
+        format_score = float(format_valid)
 
         if self.debug:
             print("\n" + colored("=" * 80, "blue"))
@@ -147,7 +151,7 @@ class RubricGradedEnv(Env):
             logtree.table_from_dict(
                 {
                     "rubric_score_mean": f"{avg_score:.3f}",
-                    "format_parse_success": parse_success_bool,
+                    "format_valid": format_valid,
                     "format_penalty": f"{format_penalty:.3f}",
                     "total_reward": f"{total_reward:.3f}",
                 },
@@ -164,7 +168,8 @@ class RubricGradedEnv(Env):
                 "rubric_score": avg_score,
             },
             logs={
-                "parse_success": int(parse_success_bool),
+                "format_valid": int(format_valid),
+                "termination": str(termination),
                 "num_rubrics": len(self.rubric_items),
             },
         )

--- a/tinker_cookbook/recipes/verifiers_rl/tinker_openai.py
+++ b/tinker_cookbook/recipes/verifiers_rl/tinker_openai.py
@@ -102,7 +102,11 @@ class TinkerChatCompletions(OpenAIAsyncChatCompletions):
         logprobs: list[float] = seq.logprobs or [0.0] * len(completion_token_ids)
 
         assistant_message, termination = self._parent.renderer.parse_response(completion_token_ids)
-        finish_reason = "stop" if termination.is_clean else "length"
+        # Match the strict pre-PR semantics: only stop-sequence termination
+        # counts as a clean "stop". For RoleColonRenderer, EOS-only termination
+        # is reported as "length" so this client behaves identically to before
+        # the #685 renderer fix.
+        finish_reason = "stop" if termination.is_stop_sequence else "length"
 
         # Convert list content to string for OpenAI compatibility
         openai_content = renderers.format_content_as_string(assistant_message["content"])

--- a/tinker_cookbook/recipes/verifiers_rl/tinker_openai.py
+++ b/tinker_cookbook/recipes/verifiers_rl/tinker_openai.py
@@ -101,10 +101,8 @@ class TinkerChatCompletions(OpenAIAsyncChatCompletions):
         completion_token_ids: list[int] = seq.tokens
         logprobs: list[float] = seq.logprobs or [0.0] * len(completion_token_ids)
 
-        assistant_message, parse_success = self._parent.renderer.parse_response(
-            completion_token_ids
-        )
-        finish_reason = "stop" if parse_success else "length"
+        assistant_message, termination = self._parent.renderer.parse_response(completion_token_ids)
+        finish_reason = "stop" if termination.is_clean else "length"
 
         # Convert list content to string for OpenAI compatibility
         openai_content = renderers.format_content_as_string(assistant_message["content"])

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -19,6 +19,7 @@ from tinker_cookbook.renderers.base import (
     Message,
     # Streaming types
     MessageDelta,
+    ParseTermination,
     # Renderer base
     RenderContext,
     Renderer,
@@ -275,6 +276,7 @@ __all__ = [
     "ContentPart",
     "ImagePart",
     "Message",
+    "ParseTermination",
     "Role",
     "TextPart",
     "ThinkingPart",

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -34,6 +34,43 @@ from tinker_cookbook.tokenizer_utils import Tokenizer
 
 logger = logging.getLogger(__name__)
 
+
+class ParseTermination(StrEnum):
+    """How a sampled response ended, as observed by ``Renderer.parse_response``.
+
+    Each consumer chooses its own policy from this signal:
+
+    - Eval grading (``EnvFromMessageEnv``): grade anything that terminated cleanly,
+      i.e. ``termination.is_clean`` (``STOP_SEQUENCE`` or ``EOS``).
+    - Strict format rewards (``ProblemEnv`` with ``require_stop_sequence_for_format=True``):
+      only reward ``termination.is_stop_sequence`` (``STOP_SEQUENCE`` exclusively).
+    - Lenient format rewards: ``termination.is_clean``.
+
+    Replacing the previous ``parse_success: bool`` lets each call site express its
+    policy explicitly instead of leaning on a bool whose meaning silently shifted
+    between consumers (see issue #685 / #339).
+    """
+
+    STOP_SEQUENCE = "stop_sequence"
+    """The renderer's expected stop signal (``\\n\\nUser:``, ``<|im_end|>``, ...) fired."""
+
+    EOS = "eos"
+    """Termination via the model's EOS token, accepted as a fallback by some renderers."""
+
+    MALFORMED = "malformed"
+    """Response did not terminate cleanly (truncated, multiple stop signals, ...)."""
+
+    @property
+    def is_clean(self) -> bool:
+        """True for any clean termination — what eval grading should gate on."""
+        return self != ParseTermination.MALFORMED
+
+    @property
+    def is_stop_sequence(self) -> bool:
+        """True only for the renderer's expected stop signal — strict format-reward gate."""
+        return self == ParseTermination.STOP_SEQUENCE
+
+
 # Tool types are based on kosong (https://github.com/MoonshotAI/kosong).
 
 
@@ -364,7 +401,7 @@ class StreamingParser:
 
     tokenizer: "Tokenizer"
     end_message_token: int
-    parse_final_response: Callable[[list[int]], tuple["Message", bool]]
+    parse_final_response: Callable[[list[int]], tuple["Message", "ParseTermination"]]
 
     _utf8_decoder: Utf8TokenDecoder = field(init=False)
     _accumulated_text: str = field(init=False, default="")
@@ -448,7 +485,7 @@ class StreamingParser:
 
         yield from self._emit_remaining()
 
-        message, _success = self.parse_final_response(self._all_tokens)
+        message, _termination = self.parse_final_response(self._all_tokens)
         yield message
 
     def reset(self) -> None:
@@ -1221,7 +1258,7 @@ class Renderer(ABC):
         ...
 
     @abstractmethod
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """
         Parse sampled tokens back into a Message.
 
@@ -1229,9 +1266,10 @@ class Renderer(ABC):
             response (list[int]): Token IDs returned from sampling.
 
         Returns:
-            tuple[Message, bool]: A ``(message, success)`` tuple. If success
-                is False, the response could not be parsed (e.g., missing stop
-                token), but a best-effort message is still returned.
+            tuple[Message, ParseTermination]: A ``(message, termination)`` tuple.
+                ``termination`` is an explicit signal — see :class:`ParseTermination`.
+                A best-effort ``Message`` is always returned, even on
+                ``MALFORMED``, so callers can still log / display partial output.
         """
         ...
 
@@ -1264,7 +1302,9 @@ class Renderer(ABC):
             f"{type(self).__name__} must define _end_message_token to support streaming"
         )
 
-    def _parse_response_for_streaming(self, response: list[int]) -> tuple[Message, bool]:
+    def _parse_response_for_streaming(
+        self, response: list[int]
+    ) -> tuple[Message, ParseTermination]:
         """Parse response for streaming, always applying full content parsing.
 
         Unlike parse_response which may short-circuit on missing stop token,
@@ -1677,12 +1717,12 @@ def tokens_weights_from_strings_weights(
 
 def parse_response_for_stop_token(
     response: list[int], tokenizer: Tokenizer, stop_token: int
-) -> tuple[Message, bool]:
+) -> tuple[Message, ParseTermination]:
     """Parse a sampled token sequence by splitting on a stop token.
 
     Expects the response to contain exactly zero or one occurrence of the
     stop token. Zero means the model ran out of tokens (returns
-    ``success=False``). More than one indicates a sampler bug and raises
+    ``MALFORMED``). More than one indicates a sampler bug and raises
     an error.
 
     Args:
@@ -1691,9 +1731,11 @@ def parse_response_for_stop_token(
         stop_token (int): The token ID that signals end-of-generation.
 
     Returns:
-        tuple[Message, bool]: A ``(message, success)`` tuple. ``success``
-            is True if exactly one stop token was found, False if the stop
-            token was missing (truncated response).
+        tuple[Message, ParseTermination]: ``STOP_SEQUENCE`` if exactly one stop
+            token was found, ``MALFORMED`` if the stop token was missing
+            (truncated response). Chat-template renderers using this helper
+            don't distinguish EOS from their stop signal — for them the
+            chat-end token is both.
 
     Raises:
         RendererError: If more than one stop token is found in the response.
@@ -1702,10 +1744,10 @@ def parse_response_for_stop_token(
     if emt_count == 0:
         str_response = str(tokenizer.decode(response))
         logger.debug(f"Response is not a valid assistant response: {str_response}")
-        return Message(role="assistant", content=str_response), False
+        return Message(role="assistant", content=str_response), ParseTermination.MALFORMED
     elif emt_count == 1:
         str_response = str(tokenizer.decode(response[: response.index(stop_token)]))
-        return Message(role="assistant", content=str_response), True
+        return Message(role="assistant", content=str_response), ParseTermination.STOP_SEQUENCE
     else:
         raise RendererError(
             f"When parsing response, expected to split into 1 or 2 pieces using stop tokens, but got {emt_count}. "

--- a/tinker_cookbook/renderers/deepseek_v3.py
+++ b/tinker_cookbook/renderers/deepseek_v3.py
@@ -16,6 +16,7 @@ import transformers
 from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers.base import (
     Message,
+    ParseTermination,
     RenderContext,
     RenderedMessage,
     Renderer,
@@ -269,17 +270,17 @@ class _DeepSeekV3BaseRenderer(Renderer):
 
     def _parse_response_content(
         self, response: list[int], *, allow_missing_stop: bool = False
-    ) -> tuple[Message, bool]:
+    ) -> tuple[Message, ParseTermination]:
         """Shared parsing logic for both batch and streaming paths.
 
         Callers are responsible for normalization — this method does NOT call
         ``_normalize_response_tokens``.
         """
-        assistant_message, parse_success = parse_response_for_stop_token(
+        assistant_message, termination = parse_response_for_stop_token(
             response, self.tokenizer, self._end_message_token
         )
-        if not parse_success and not allow_missing_stop:
-            return assistant_message, False
+        if not termination.is_clean and not allow_missing_stop:
+            return assistant_message, termination
 
         assert isinstance(assistant_message["content"], str)
         content = assistant_message["content"]
@@ -308,9 +309,9 @@ class _DeepSeekV3BaseRenderer(Renderer):
         else:
             assistant_message["content"] = content
 
-        return assistant_message, parse_success
+        return assistant_message, termination
 
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """Parse sampled token IDs back into an assistant Message.
 
         Normalizes response tokens, strips the end-of-sentence stop token, and
@@ -321,13 +322,15 @@ class _DeepSeekV3BaseRenderer(Renderer):
             response (list[int]): Raw token IDs from the sampler.
 
         Returns:
-            tuple[Message, bool]: The parsed assistant message (with structured content
-                and optional tool_calls) and whether the stop token was found.
+            tuple[Message, ParseTermination]: ``STOP_SEQUENCE`` if the
+                end-of-sentence stop token was found, ``MALFORMED`` otherwise.
         """
         response = self._normalize_response_tokens(response)
         return self._parse_response_content(response, allow_missing_stop=False)
 
-    def _parse_response_for_streaming(self, response: list[int]) -> tuple[Message, bool]:
+    def _parse_response_for_streaming(
+        self, response: list[int]
+    ) -> tuple[Message, ParseTermination]:
         """Parse response for streaming, always applying full content parsing.
 
         Unlike parse_response which short-circuits on missing stop token,

--- a/tinker_cookbook/renderers/deepseek_v3_test.py
+++ b/tinker_cookbook/renderers/deepseek_v3_test.py
@@ -37,7 +37,7 @@ def test_deepseek_parse_response_extracts_thinking():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
 
@@ -60,7 +60,7 @@ def test_deepseek_parse_response_no_thinking_returns_string():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     assert isinstance(message["content"], str)
     assert message["content"] == "Just a plain response."
 
@@ -75,7 +75,7 @@ def test_deepseek_parse_response_multiple_think_blocks():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
     assert len(content) == 4

--- a/tinker_cookbook/renderers/gpt_oss.py
+++ b/tinker_cookbook/renderers/gpt_oss.py
@@ -12,6 +12,7 @@ from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers.base import (
     ContentPart,
     Message,
+    ParseTermination,
     RenderContext,
     RenderedMessage,
     Renderer,
@@ -472,7 +473,7 @@ class GptOssRenderer(Renderer):
         """
         return [self._return_token, self._call_token]
 
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """Parse sampled token IDs back into an assistant Message.
 
         Finds the ``<|return|>`` or ``<|call|>`` stop token, decodes the preceding
@@ -483,8 +484,9 @@ class GptOssRenderer(Renderer):
             response (list[int]): Raw token IDs from the sampler.
 
         Returns:
-            tuple[Message, bool]: The parsed assistant message (with structured content
-                and optional tool_calls) and whether a stop token was found.
+            tuple[Message, ParseTermination]: ``STOP_SEQUENCE`` if a
+                ``<|return|>`` or ``<|call|>`` stop token was found,
+                ``MALFORMED`` otherwise.
 
         Raises:
             RendererError: If multiple ``<|call|>`` or ``<|return|>`` tokens are found,
@@ -494,7 +496,7 @@ class GptOssRenderer(Renderer):
         return_count = response.count(self._return_token)
         if call_count == 0 and return_count == 0:
             str_response = str(self.tokenizer.decode(response))
-            return Message(role="assistant", content=str_response), False
+            return Message(role="assistant", content=str_response), ParseTermination.MALFORMED
         if call_count > 1:
             raise RendererError(
                 f"When parsing response, expected at most 1 <|call|> token, but got {call_count}. "
@@ -523,7 +525,7 @@ class GptOssRenderer(Renderer):
         if unparsed:
             message["unparsed_tool_calls"] = unparsed
 
-        return message, True
+        return message, ParseTermination.STOP_SEQUENCE
 
     def to_openai_message(self, message: Message) -> dict:
         """Convert a Message to OpenAI API format with reasoning_content for thinking.

--- a/tinker_cookbook/renderers/gpt_oss_test.py
+++ b/tinker_cookbook/renderers/gpt_oss_test.py
@@ -23,7 +23,7 @@ def test_gptoss_parse_response_extracts_thinking():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
 
@@ -46,7 +46,7 @@ def test_gptoss_parse_response_multiple_analysis():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
     assert len(content) == 3
@@ -66,7 +66,7 @@ def test_gptoss_parse_response_final_only():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
     assert len(content) == 1
@@ -83,7 +83,7 @@ def test_gptoss_parse_response_no_channels():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     # No channel markers, so content stays as string
     assert isinstance(message["content"], str)
     assert message["content"] == "Plain response without channels."
@@ -100,7 +100,7 @@ def test_gptoss_parse_response_tool_call():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     assert "tool_calls" in message
     assert len(message["tool_calls"]) == 1
     assert message["tool_calls"][0].function.name == "get_weather"
@@ -117,7 +117,7 @@ def test_gptoss_parse_response_tool_call_with_analysis():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
 
@@ -142,7 +142,7 @@ def test_gptoss_parse_response_invalid_tool_call_json():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     assert "unparsed_tool_calls" in message
     assert len(message["unparsed_tool_calls"]) == 1
     assert "Invalid JSON" in message["unparsed_tool_calls"][0].error
@@ -158,7 +158,7 @@ def test_gptoss_parse_response_tool_call_recipient_before_channel():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     assert "tool_calls" in message
     assert len(message["tool_calls"]) == 1
     assert message["tool_calls"][0].function.name == "get_weather"
@@ -177,7 +177,7 @@ def test_gptoss_parse_response_commentary_preamble():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
     assert len(content) == 1

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -11,6 +11,7 @@ from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers.base import (
     ContentPart,
     Message,
+    ParseTermination,
     RenderContext,
     RenderedMessage,
     Renderer,
@@ -505,7 +506,7 @@ class KimiK2Renderer(Renderer):
         """
         return [self._end_message_token]
 
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """Parse sampled token IDs back into an assistant Message.
 
         Normalizes response tokens, strips the ``<|im_end|>`` stop token, and parses
@@ -516,15 +517,15 @@ class KimiK2Renderer(Renderer):
             response (list[int]): Raw token IDs from the sampler.
 
         Returns:
-            tuple[Message, bool]: The parsed assistant message (with structured content
-                and optional tool_calls) and whether the stop token was found.
+            tuple[Message, ParseTermination]: ``STOP_SEQUENCE`` if the
+                ``<|im_end|>`` stop token was found, ``MALFORMED`` otherwise.
         """
         response = self._normalize_response_tokens(response)
-        assistant_message, parse_success = parse_response_for_stop_token(
+        assistant_message, termination = parse_response_for_stop_token(
             response, self.tokenizer, self._end_message_token
         )
-        if not parse_success:
-            return assistant_message, False
+        if not termination.is_clean:
+            return assistant_message, termination
 
         content = assistant_message["content"]
         assert isinstance(content, str)
@@ -541,9 +542,11 @@ class KimiK2Renderer(Renderer):
         content_parts = parse_think_blocks(text_content)
         assistant_message["content"] = content_parts if content_parts is not None else text_content
 
-        return assistant_message, True
+        return assistant_message, termination
 
-    def _parse_response_for_streaming(self, response: list[int]) -> tuple[Message, bool]:
+    def _parse_response_for_streaming(
+        self, response: list[int]
+    ) -> tuple[Message, ParseTermination]:
         """Parse response for streaming, always applying full content parsing.
 
         Unlike parse_response which short-circuits on missing stop token,
@@ -551,7 +554,7 @@ class KimiK2Renderer(Renderer):
         This matches the original KimiK2StreamingParser.finish() behavior
         where content parsing was applied regardless of stop token presence.
         """
-        message, parse_success = parse_response_for_stop_token(
+        message, termination = parse_response_for_stop_token(
             response, self.tokenizer, self._end_message_token
         )
 
@@ -568,7 +571,7 @@ class KimiK2Renderer(Renderer):
             content_parts = parse_think_blocks(text_content)
             message["content"] = content_parts if content_parts is not None else text_content
 
-        return message, parse_success
+        return message, termination
 
     def to_openai_message(self, message: Message) -> dict:
         """Convert a Message to OpenAI API format with reasoning_content for thinking.

--- a/tinker_cookbook/renderers/kimi_k25_test.py
+++ b/tinker_cookbook/renderers/kimi_k25_test.py
@@ -711,19 +711,19 @@ def test_kimi_k25_eot_parsing(kimi_tokenizer, kimi_renderer):
     test_response = "The answer is 42.<|im_end|>"
     response_tokens = kimi_tokenizer.encode(test_response)
 
-    message, format_correct = kimi_renderer.parse_response(response_tokens)
+    message, termination = kimi_renderer.parse_response(response_tokens)
     assert message["role"] == "assistant"
     assert message["content"] == "The answer is 42."
-    assert format_correct is True
+    assert termination.is_stop_sequence
 
     # Test without EOT token
     test_response_no_eot = "The answer is 42."
     response_tokens_no_eot = kimi_tokenizer.encode(test_response_no_eot)
 
-    message, format_correct = kimi_renderer.parse_response(response_tokens_no_eot)
+    message, termination = kimi_renderer.parse_response(response_tokens_no_eot)
     assert message["role"] == "assistant"
     assert message["content"] == "The answer is 42."
-    assert format_correct is False
+    assert not termination.is_clean
 
 
 def test_kimi_k25_parse_response_restores_prefilled_think_tag(kimi_tokenizer, kimi_renderer):
@@ -732,9 +732,9 @@ def test_kimi_k25_parse_response_restores_prefilled_think_tag(kimi_tokenizer, ki
         add_special_tokens=False,
     )
 
-    parsed_message, parse_success = kimi_renderer.parse_response(response_tokens)
+    parsed_message, termination = kimi_renderer.parse_response(response_tokens)
 
-    assert parse_success is True
+    assert termination.is_stop_sequence
     assert parsed_message["content"] == [
         ThinkingPart(type="thinking", thinking="reasoning..."),
         TextPart(type="text", text="2"),

--- a/tinker_cookbook/renderers/kimi_k2_test.py
+++ b/tinker_cookbook/renderers/kimi_k2_test.py
@@ -122,7 +122,7 @@ def test_kimi_streaming_matches_batch():
     response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
 
     batch_message, batch_success = renderer.parse_response(response_tokens)
-    assert batch_success
+    assert batch_success.is_clean
 
     deltas = list(renderer.parse_response_streaming(response_tokens))
     streaming_message = deltas[-1]

--- a/tinker_cookbook/renderers/llama3.py
+++ b/tinker_cookbook/renderers/llama3.py
@@ -4,6 +4,7 @@ import tinker
 
 from tinker_cookbook.renderers.base import (
     Message,
+    ParseTermination,
     RenderContext,
     RenderedMessage,
     Renderer,
@@ -82,7 +83,7 @@ class Llama3Renderer(Renderer):
         """
         return [self._end_message_token]
 
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """Parse sampled token IDs back into an assistant Message.
 
         Strips the ``<|eot_id|>`` stop token if present and decodes the remaining
@@ -92,7 +93,7 @@ class Llama3Renderer(Renderer):
             response (list[int]): Raw token IDs from the sampler.
 
         Returns:
-            tuple[Message, bool]: The parsed assistant message and whether the stop
-                token was found (True means the response terminated cleanly).
+            tuple[Message, ParseTermination]: ``STOP_SEQUENCE`` if the
+                ``<|eot_id|>`` stop token was found, ``MALFORMED`` otherwise.
         """
         return parse_response_for_stop_token(response, self.tokenizer, self._end_message_token)

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -706,7 +706,7 @@ def test_parse_response_plain_text(nemotron_tokenizer, nemotron_renderer):
     """parse_response decodes a plain text response (no thinking)."""
     tokens = nemotron_tokenizer.encode("The answer is 42.<|im_end|>", add_special_tokens=False)
     message, success = nemotron_renderer.parse_response(tokens)
-    assert success
+    assert success.is_clean
     from tinker_cookbook.renderers import get_text_content
 
     assert "42" in get_text_content(message)
@@ -719,7 +719,7 @@ def test_parse_response_with_thinking(nemotron_tokenizer, nemotron_renderer):
     tokens = nemotron_tokenizer.encode(response_text, add_special_tokens=False)
     message, success = nemotron_renderer.parse_response(tokens)
 
-    assert success
+    assert success.is_clean
     content = message.get("content")
     assert isinstance(content, list)
     thinking_parts = [p for p in content if p["type"] == "thinking"]
@@ -744,7 +744,7 @@ def test_parse_response_for_streaming_with_thinking(nemotron_tokenizer, nemotron
     tokens = nemotron_tokenizer.encode(response_text, add_special_tokens=False)
     message, success = nemotron_renderer._parse_response_for_streaming(tokens)
 
-    assert success
+    assert success.is_clean
     content = message.get("content")
     assert isinstance(content, list)
     thinking_parts = [p for p in content if p["type"] == "thinking"]
@@ -774,7 +774,7 @@ def test_parse_response_tool_call(nemotron_tokenizer, nemotron_renderer):
     tokens = nemotron_tokenizer.encode(tool_call_text, add_special_tokens=False)
     message, success = nemotron_renderer.parse_response(tokens)
 
-    assert success
+    assert success.is_clean
     tool_calls = message.get("tool_calls", [])
     assert len(tool_calls) == 1
     assert tool_calls[0].function.name == "get_weather"

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -19,6 +19,7 @@ from tinker_cookbook.renderers.base import (
     ImagePart,
     ImageProcessorProtocol,
     Message,
+    ParseTermination,
     RenderContext,
     RenderedMessage,
     Renderer,
@@ -213,7 +214,7 @@ class Qwen3Renderer(Renderer):
         """
         return [self._end_message_token]
 
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """Parse sampled token IDs back into an assistant Message.
 
         Decodes the response, strips the ``<|im_end|>`` stop token, and parses
@@ -224,15 +225,15 @@ class Qwen3Renderer(Renderer):
             response (list[int]): Raw token IDs from the sampler.
 
         Returns:
-            tuple[Message, bool]: The parsed assistant message (with structured content
-                and optional tool_calls) and whether the stop token was found.
+            tuple[Message, ParseTermination]: ``STOP_SEQUENCE`` if the
+                ``<|im_end|>`` stop token was found, ``MALFORMED`` otherwise.
         """
         response = self._normalize_response_tokens(response)
-        assistant_message, parse_success = parse_response_for_stop_token(
+        assistant_message, termination = parse_response_for_stop_token(
             response, self.tokenizer, self._end_message_token
         )
-        if not parse_success:
-            return assistant_message, False
+        if not termination.is_clean:
+            return assistant_message, termination
 
         # Parse <think>...</think> and <tool_call>...</tool_call> blocks together
         # to preserve ordering. Tool calls use Qwen's format:
@@ -258,9 +259,11 @@ class Qwen3Renderer(Renderer):
             # No special blocks found - keep as string for backward compatibility
             assistant_message["content"] = content
 
-        return assistant_message, True
+        return assistant_message, termination
 
-    def _parse_response_for_streaming(self, response: list[int]) -> tuple[Message, bool]:
+    def _parse_response_for_streaming(
+        self, response: list[int]
+    ) -> tuple[Message, ParseTermination]:
         """Parse response for streaming, always applying full content parsing.
 
         Unlike parse_response which short-circuits on missing stop token,
@@ -272,7 +275,7 @@ class Qwen3Renderer(Renderer):
         parse_response_streaming already normalizes before feeding tokens
         to the parser.
         """
-        assistant_message, parse_success = parse_response_for_stop_token(
+        assistant_message, termination = parse_response_for_stop_token(
             response, self.tokenizer, self._end_message_token
         )
 
@@ -294,7 +297,7 @@ class Qwen3Renderer(Renderer):
         else:
             assistant_message["content"] = content
 
-        return assistant_message, parse_success
+        return assistant_message, termination
 
     def to_openai_message(self, message: Message) -> dict:
         """Convert a Message to OpenAI API format with reasoning_content for thinking.

--- a/tinker_cookbook/renderers/qwen3_5.py
+++ b/tinker_cookbook/renderers/qwen3_5.py
@@ -23,6 +23,7 @@ import re
 from tinker_cookbook.renderers.base import (
     ImagePart,
     Message,
+    ParseTermination,
     RenderContext,
     Role,
     TextPart,
@@ -196,20 +197,22 @@ class Qwen3_5Renderer(Qwen3VLRenderer):
         else:
             message.pop("unparsed_tool_calls", None)
 
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """Parse response with Qwen3.5-specific post-processing."""
-        message, success = super().parse_response(response)
-        if not success:
-            return message, success
+        message, termination = super().parse_response(response)
+        if not termination.is_clean:
+            return message, termination
 
         self._postprocess_parsed_message(message)
-        return message, success
+        return message, termination
 
-    def _parse_response_for_streaming(self, response: list[int]) -> tuple[Message, bool]:
+    def _parse_response_for_streaming(
+        self, response: list[int]
+    ) -> tuple[Message, ParseTermination]:
         """Parse response for streaming with Qwen3.5-specific post-processing."""
-        message, parse_success = super()._parse_response_for_streaming(response)
+        message, termination = super()._parse_response_for_streaming(response)
         self._postprocess_parsed_message(message)
-        return message, parse_success
+        return message, termination
 
     def _format_tool_call_xml(self, tool_call: ToolCall) -> str:
         """Format a single tool call in Qwen3.5's XML parameter format."""

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -45,7 +45,7 @@ def test_qwen3_parse_response_extracts_thinking():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     assert message["role"] == "assistant"
 
     content = message["content"]
@@ -71,7 +71,7 @@ def test_qwen3_parse_response_multiple_think_blocks():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
     assert len(content) == 4
@@ -92,7 +92,7 @@ def test_qwen3_parse_response_no_thinking_returns_string():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     # Content should remain a string for backward compatibility
     assert isinstance(message["content"], str)
     assert message["content"] == "Just a plain response without thinking."
@@ -108,7 +108,7 @@ def test_qwen3_parse_response_with_tool_calls():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
 
@@ -137,7 +137,7 @@ def test_qwen3_parse_response_tool_call_only():
 
     message, success = renderer.parse_response(response_tokens)
 
-    assert success
+    assert success.is_clean
     content = message["content"]
     assert isinstance(content, list)
     # Content should be empty — only a tool call, no text or thinking
@@ -320,7 +320,7 @@ def test_qwen3_streaming_matches_batch():
     response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
 
     batch_message, batch_success = renderer.parse_response(response_tokens)
-    assert batch_success
+    assert batch_success.is_clean
 
     deltas = list(renderer.parse_response_streaming(response_tokens))
     streaming_message = deltas[-1]
@@ -636,9 +636,9 @@ def test_qwen3_5_parse_response_restores_prefilled_think_tag(qwen3_5_tokenizer, 
         add_special_tokens=False,
     )
 
-    parsed_message, parse_success = qwen3_5_renderer.parse_response(response_tokens)
+    parsed_message, termination = qwen3_5_renderer.parse_response(response_tokens)
 
-    assert parse_success is True
+    assert termination.is_stop_sequence
     assert isinstance(parsed_message["content"], list)
     assert parsed_message["content"] == [
         ThinkingPart(type="thinking", thinking="reasoning"),
@@ -680,7 +680,7 @@ def test_qwen3_5_streaming_matches_batch_with_prefilled_think(qwen3_5_tokenizer,
     )
 
     batch_message, batch_success = qwen3_5_renderer.parse_response(response_tokens)
-    assert batch_success
+    assert batch_success.is_clean
 
     deltas = list(qwen3_5_renderer.parse_response_streaming(response_tokens))
     streaming_message = deltas[-1]
@@ -699,7 +699,7 @@ def test_qwen3_5_normalize_noop_when_think_present(qwen3_5_tokenizer, qwen3_5_re
 
     # Both paths should work identically
     batch_message, batch_success = qwen3_5_renderer.parse_response(response_tokens)
-    assert batch_success
+    assert batch_success.is_clean
 
     deltas = list(qwen3_5_renderer.parse_response_streaming(response_tokens))
     streaming_message = deltas[-1]

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -1074,10 +1074,10 @@ def test_supervised_generation_parse_consistency(
         )
 
     # Check 2: Parse the action tokens
-    parsed_message, parse_success = renderer.parse_response(ac)
+    parsed_message, termination = renderer.parse_response(ac)
 
     # Check parse success
-    assert parse_success, (
+    assert termination.is_clean, (
         f"Failed to parse action tokens for {renderer_name}.\n"
         f"Action tokens: {ac}\n"
         f"Decoded: {tokenizer.decode(ac)!r}\n"
@@ -1147,19 +1147,19 @@ def test_eot_parsing(model_name: str, renderer_name: str):
     test_response_with_eot = f"53 + 18 = 71{eot_token}"
     response_tokens = tokenizer.encode(test_response_with_eot, add_special_tokens=False)
 
-    message, format_correct = renderer.parse_response(response_tokens)
+    message, termination = renderer.parse_response(response_tokens)
     assert message["role"] == "assistant"
     assert message["content"] == "53 + 18 = 71"
-    assert format_correct is True
+    assert termination.is_stop_sequence
 
-    # Test case 2: No EOT token - should have format=False
+    # Test case 2: No EOT token - should be malformed
     test_response_no_eot = "53 + 18 = 71"
     response_tokens_no_eot = tokenizer.encode(test_response_no_eot, add_special_tokens=False)
 
-    message, format_correct = renderer.parse_response(response_tokens_no_eot)
+    message, termination = renderer.parse_response(response_tokens_no_eot)
     assert message["role"] == "assistant"
     assert message["content"] == "53 + 18 = 71"
-    assert format_correct is False
+    assert not termination.is_clean
 
     # Test case 3: Double EOT token - should raise ValueError
     test_response_double_eot = f"53 + 18 = 71{eot_token}{eot_token}"

--- a/tinker_cookbook/renderers/role_colon.py
+++ b/tinker_cookbook/renderers/role_colon.py
@@ -86,9 +86,11 @@ class RoleColonRenderer(Renderer):
 
         logger = logging.getLogger(__name__)
 
-        # Strip EOS token from the end if present (base models may terminate with EOS
-        # instead of the expected stop sequence). We still return False for parse success
-        # since the model didn't produce the expected stop sequence.
+        # Strip EOS token from the end if present. Base models on single-turn
+        # prompts commonly terminate with EOS instead of the "\n\nUser:" stop
+        # sequence — that is still a clean end-of-turn signal, so treat it as a
+        # successful parse. Without this, EnvFromMessageEnv short-circuits with
+        # failed_parse_reward=0 and never grades the response (see issue #685).
         terminated_with_eos = False
         eos_token_id = self.tokenizer.eos_token_id
         if eos_token_id is not None and response and response[-1] == eos_token_id:
@@ -98,6 +100,8 @@ class RoleColonRenderer(Renderer):
         str_response = str(self.tokenizer.decode(response))
         splitted = str_response.split("\n\nUser:")
         if len(splitted) == 1:
+            if terminated_with_eos:
+                return Message(role="assistant", content=str_response.strip()), True
             logger.debug(f"Response is not a valid assistant response: {str_response}")
             return Message(role="assistant", content=str_response.strip()), False
         elif len(splitted) == 2:

--- a/tinker_cookbook/renderers/role_colon.py
+++ b/tinker_cookbook/renderers/role_colon.py
@@ -1,5 +1,7 @@
 """Simple role:content format renderer."""
 
+import logging
+
 import tinker
 
 from tinker_cookbook.renderers.base import (
@@ -11,6 +13,8 @@ from tinker_cookbook.renderers.base import (
     ToolSpec,
     ensure_text,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class RoleColonRenderer(Renderer):
@@ -88,10 +92,6 @@ class RoleColonRenderer(Renderer):
                 otherwise (no terminator, ``\\n\\nUser:`` followed by EOS, or
                 multiple ``\\n\\nUser:`` delimiters).
         """
-        import logging
-
-        logger = logging.getLogger(__name__)
-
         terminated_with_eos = False
         eos_token_id = self.tokenizer.eos_token_id
         if eos_token_id is not None and response and response[-1] == eos_token_id:
@@ -103,6 +103,9 @@ class RoleColonRenderer(Renderer):
         if len(splitted) == 1:
             if terminated_with_eos:
                 return Message(role="assistant", content=str_response.strip()), ParseTermination.EOS
+            # No "\n\nUser:" delimiter and no EOS — the response was likely
+            # truncated mid-sentence (max_tokens hit). Best-effort message,
+            # MALFORMED termination.
             logger.debug(f"Response is not a valid assistant response: {str_response}")
             return (
                 Message(role="assistant", content=str_response.strip()),

--- a/tinker_cookbook/renderers/role_colon.py
+++ b/tinker_cookbook/renderers/role_colon.py
@@ -4,6 +4,7 @@ import tinker
 
 from tinker_cookbook.renderers.base import (
     Message,
+    ParseTermination,
     RenderContext,
     RenderedMessage,
     Renderer,
@@ -69,7 +70,7 @@ class RoleColonRenderer(Renderer):
         """
         return ["\n\nUser:"]
 
-    def parse_response(self, response: list[int]) -> tuple[Message, bool]:
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
         """Parse sampled token IDs back into an assistant Message.
 
         Splits the decoded text on the ``\\n\\nUser:`` stop sequence. Handles EOS
@@ -79,26 +80,18 @@ class RoleColonRenderer(Renderer):
             response (list[int]): Raw token IDs from the sampler.
 
         Returns:
-            tuple[Message, bool]: The parsed assistant message and whether the response
-                terminated cleanly — either via the ``\\n\\nUser:`` stop sequence or
-                via EOS. Malformed cases (no terminator at all, ``\\n\\nUser:``
-                followed by EOS, or multiple ``\\n\\nUser:`` delimiters) return
-                ``False``. Callers that need to distinguish stop-sequence
-                termination from EOS termination (e.g. ``ProblemEnv`` with
-                ``require_stop_sequence_for_format=True``) should check the EOS
-                token themselves; this method intentionally treats both as a
-                successful parse so that single-turn evals on base models grade
-                normally (see issue #685).
+            tuple[Message, ParseTermination]: ``STOP_SEQUENCE`` when the
+                ``\\n\\nUser:`` delimiter ended the response cleanly; ``EOS``
+                when the model terminated with the EOS token without emitting
+                the delimiter (still a clean end-of-turn signal for base
+                models on single-turn prompts — see issue #685); ``MALFORMED``
+                otherwise (no terminator, ``\\n\\nUser:`` followed by EOS, or
+                multiple ``\\n\\nUser:`` delimiters).
         """
         import logging
 
         logger = logging.getLogger(__name__)
 
-        # Strip EOS token from the end if present. Base models on single-turn
-        # prompts commonly terminate with EOS instead of the "\n\nUser:" stop
-        # sequence — that is still a clean end-of-turn signal, so treat it as a
-        # successful parse. Without this, EnvFromMessageEnv short-circuits with
-        # failed_parse_reward=0 and never grades the response (see issue #685).
         terminated_with_eos = False
         eos_token_id = self.tokenizer.eos_token_id
         if eos_token_id is not None and response and response[-1] == eos_token_id:
@@ -109,20 +102,34 @@ class RoleColonRenderer(Renderer):
         splitted = str_response.split("\n\nUser:")
         if len(splitted) == 1:
             if terminated_with_eos:
-                return Message(role="assistant", content=str_response.strip()), True
+                return Message(role="assistant", content=str_response.strip()), ParseTermination.EOS
             logger.debug(f"Response is not a valid assistant response: {str_response}")
-            return Message(role="assistant", content=str_response.strip()), False
+            return (
+                Message(role="assistant", content=str_response.strip()),
+                ParseTermination.MALFORMED,
+            )
         elif len(splitted) == 2:
             before, _after = splitted
-            return Message(role="assistant", content=before.strip()), not terminated_with_eos
+            if terminated_with_eos:
+                # Malformed: sampling should have stopped at "\n\nUser:" before emitting EOS.
+                return (
+                    Message(role="assistant", content=before.strip()),
+                    ParseTermination.MALFORMED,
+                )
+            return (
+                Message(role="assistant", content=before.strip()),
+                ParseTermination.STOP_SEQUENCE,
+            )
         else:
             logger.warning(
                 "RoleColonRenderer.parse_response saw multiple stop delimiters "
-                "(count=%d). Returning parse_success=False. Full response:\n%s",
+                "(count=%d). Returning MALFORMED. Full response:\n%s",
                 len(splitted) - 1,
                 str_response,
             )
-            return Message(role="assistant", content=splitted[0].strip()), False
+            return Message(
+                role="assistant", content=splitted[0].strip()
+            ), ParseTermination.MALFORMED
 
     @property
     def _bos_tokens(self) -> list[int]:

--- a/tinker_cookbook/renderers/role_colon.py
+++ b/tinker_cookbook/renderers/role_colon.py
@@ -80,7 +80,15 @@ class RoleColonRenderer(Renderer):
 
         Returns:
             tuple[Message, bool]: The parsed assistant message and whether the response
-                terminated cleanly with the expected stop sequence (not EOS).
+                terminated cleanly — either via the ``\\n\\nUser:`` stop sequence or
+                via EOS. Malformed cases (no terminator at all, ``\\n\\nUser:``
+                followed by EOS, or multiple ``\\n\\nUser:`` delimiters) return
+                ``False``. Callers that need to distinguish stop-sequence
+                termination from EOS termination (e.g. ``ProblemEnv`` with
+                ``require_stop_sequence_for_format=True``) should check the EOS
+                token themselves; this method intentionally treats both as a
+                successful parse so that single-turn evals on base models grade
+                normally (see issue #685).
         """
         import logging
 

--- a/tinker_cookbook/renderers/role_colon_test.py
+++ b/tinker_cookbook/renderers/role_colon_test.py
@@ -1,13 +1,14 @@
 """Tests for RoleColonRenderer.parse_response.
 
 Regression tests for issue #685: base models that terminate single-turn
-responses with EOS (no "\\n\\nUser:" delimiter) must still be reported as a
-successful parse, otherwise EnvFromMessageEnv short-circuits with
+responses with EOS (no "\\n\\nUser:" delimiter) must report ``ParseTermination.EOS``
+(``is_clean=True``), otherwise EnvFromMessageEnv short-circuits with
 failed_parse_reward=0 and never grades the answer.
 """
 
 import pytest
 
+from tinker_cookbook.renderers.base import ParseTermination
 from tinker_cookbook.renderers.role_colon import RoleColonRenderer
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
@@ -20,9 +21,10 @@ def renderer() -> RoleColonRenderer:
     return RoleColonRenderer(get_tokenizer(_BASE_MODEL))
 
 
-def test_parse_response_eos_only_is_success(renderer: RoleColonRenderer):
+def test_parse_response_eos_only_is_eos(renderer: RoleColonRenderer):
     """Base model produces a clean answer and terminates with EOS — the common
-    single-turn eval case. Must report parse_success=True so the grader runs."""
+    single-turn eval case. Must return EOS so eval grading runs but strict
+    R1-Zero format reward can still distinguish it."""
     answer = "The answer is \\boxed{42}."
     tokens = renderer.tokenizer.encode(answer, add_special_tokens=False)
     assert isinstance(tokens, list)
@@ -30,38 +32,43 @@ def test_parse_response_eos_only_is_success(renderer: RoleColonRenderer):
     assert isinstance(eos_token_id, int)
     tokens.append(eos_token_id)
 
-    message, parse_success = renderer.parse_response(tokens)
+    message, termination = renderer.parse_response(tokens)
 
-    assert parse_success is True
+    assert termination == ParseTermination.EOS
+    assert termination.is_clean
+    assert not termination.is_stop_sequence
     assert message["role"] == "assistant"
     assert message["content"] == answer
 
 
-def test_parse_response_user_delimiter_is_success(renderer: RoleColonRenderer):
-    """Model produced the expected stop sequence — parse_success=True."""
+def test_parse_response_user_delimiter_is_stop_sequence(renderer: RoleColonRenderer):
+    """Model produced the expected stop sequence — STOP_SEQUENCE."""
     text = "Some answer.\n\nUser:"
     tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
 
-    message, parse_success = renderer.parse_response(tokens)
+    message, termination = renderer.parse_response(tokens)
 
-    assert parse_success is True
+    assert termination == ParseTermination.STOP_SEQUENCE
+    assert termination.is_clean
+    assert termination.is_stop_sequence
     assert message["content"] == "Some answer."
 
 
-def test_parse_response_no_terminator_is_failure(renderer: RoleColonRenderer):
-    """No EOS and no User: delimiter — likely truncated, parse_success=False."""
+def test_parse_response_no_terminator_is_malformed(renderer: RoleColonRenderer):
+    """No EOS and no User: delimiter — likely truncated, MALFORMED."""
     text = "Some incomplete answer"
     tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
 
-    message, parse_success = renderer.parse_response(tokens)
+    message, termination = renderer.parse_response(tokens)
 
-    assert parse_success is False
+    assert termination == ParseTermination.MALFORMED
+    assert not termination.is_clean
     assert message["content"] == "Some incomplete answer"
 
 
-def test_parse_response_user_delimiter_with_eos_is_failure(renderer: RoleColonRenderer):
+def test_parse_response_user_delimiter_with_eos_is_malformed(renderer: RoleColonRenderer):
     """If both the User: delimiter AND EOS appear, the response is malformed
-    (sampling should have stopped at User:). Keep parse_success=False."""
+    (sampling should have stopped at User:)."""
     text = "Some answer.\n\nUser:"
     tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
     assert isinstance(tokens, list)
@@ -69,18 +76,18 @@ def test_parse_response_user_delimiter_with_eos_is_failure(renderer: RoleColonRe
     assert isinstance(eos_token_id, int)
     tokens.append(eos_token_id)
 
-    message, parse_success = renderer.parse_response(tokens)
+    message, termination = renderer.parse_response(tokens)
 
-    assert parse_success is False
+    assert termination == ParseTermination.MALFORMED
     assert message["content"] == "Some answer."
 
 
-def test_parse_response_multiple_user_delimiters_is_failure(renderer: RoleColonRenderer):
+def test_parse_response_multiple_user_delimiters_is_malformed(renderer: RoleColonRenderer):
     """Multiple User: delimiters indicate the model role-played the user turn."""
     text = "Answer.\n\nUser: question?\n\nUser:"
     tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
 
-    message, parse_success = renderer.parse_response(tokens)
+    message, termination = renderer.parse_response(tokens)
 
-    assert parse_success is False
+    assert termination == ParseTermination.MALFORMED
     assert message["content"] == "Answer."

--- a/tinker_cookbook/renderers/role_colon_test.py
+++ b/tinker_cookbook/renderers/role_colon_test.py
@@ -1,0 +1,80 @@
+"""Tests for RoleColonRenderer.parse_response.
+
+Regression tests for issue #685: base models that terminate single-turn
+responses with EOS (no "\\n\\nUser:" delimiter) must still be reported as a
+successful parse, otherwise EnvFromMessageEnv short-circuits with
+failed_parse_reward=0 and never grades the answer.
+"""
+
+import pytest
+
+from tinker_cookbook.renderers.role_colon import RoleColonRenderer
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+# Llama base models recommend role_colon and have a stable EOS token.
+_BASE_MODEL = "meta-llama/Llama-3.1-8B"
+
+
+@pytest.fixture(scope="module")
+def renderer() -> RoleColonRenderer:
+    return RoleColonRenderer(get_tokenizer(_BASE_MODEL))
+
+
+def test_parse_response_eos_only_is_success(renderer: RoleColonRenderer):
+    """Base model produces a clean answer and terminates with EOS — the common
+    single-turn eval case. Must report parse_success=True so the grader runs."""
+    answer = "The answer is \\boxed{42}."
+    tokens = renderer.tokenizer.encode(answer, add_special_tokens=False)
+    tokens.append(renderer.tokenizer.eos_token_id)
+
+    message, parse_success = renderer.parse_response(tokens)
+
+    assert parse_success is True
+    assert message["role"] == "assistant"
+    assert message["content"] == answer
+
+
+def test_parse_response_user_delimiter_is_success(renderer: RoleColonRenderer):
+    """Model produced the expected stop sequence — parse_success=True."""
+    text = "Some answer.\n\nUser:"
+    tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
+
+    message, parse_success = renderer.parse_response(tokens)
+
+    assert parse_success is True
+    assert message["content"] == "Some answer."
+
+
+def test_parse_response_no_terminator_is_failure(renderer: RoleColonRenderer):
+    """No EOS and no User: delimiter — likely truncated, parse_success=False."""
+    text = "Some incomplete answer"
+    tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
+
+    message, parse_success = renderer.parse_response(tokens)
+
+    assert parse_success is False
+    assert message["content"] == "Some incomplete answer"
+
+
+def test_parse_response_user_delimiter_with_eos_is_failure(renderer: RoleColonRenderer):
+    """If both the User: delimiter AND EOS appear, the response is malformed
+    (sampling should have stopped at User:). Keep parse_success=False."""
+    text = "Some answer.\n\nUser:"
+    tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
+    tokens.append(renderer.tokenizer.eos_token_id)
+
+    message, parse_success = renderer.parse_response(tokens)
+
+    assert parse_success is False
+    assert message["content"] == "Some answer."
+
+
+def test_parse_response_multiple_user_delimiters_is_failure(renderer: RoleColonRenderer):
+    """Multiple User: delimiters indicate the model role-played the user turn."""
+    text = "Answer.\n\nUser: question?\n\nUser:"
+    tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
+
+    message, parse_success = renderer.parse_response(tokens)
+
+    assert parse_success is False
+    assert message["content"] == "Answer."

--- a/tinker_cookbook/renderers/role_colon_test.py
+++ b/tinker_cookbook/renderers/role_colon_test.py
@@ -25,7 +25,10 @@ def test_parse_response_eos_only_is_success(renderer: RoleColonRenderer):
     single-turn eval case. Must report parse_success=True so the grader runs."""
     answer = "The answer is \\boxed{42}."
     tokens = renderer.tokenizer.encode(answer, add_special_tokens=False)
-    tokens.append(renderer.tokenizer.eos_token_id)
+    assert isinstance(tokens, list)
+    eos_token_id = renderer.tokenizer.eos_token_id
+    assert isinstance(eos_token_id, int)
+    tokens.append(eos_token_id)
 
     message, parse_success = renderer.parse_response(tokens)
 
@@ -61,7 +64,10 @@ def test_parse_response_user_delimiter_with_eos_is_failure(renderer: RoleColonRe
     (sampling should have stopped at User:). Keep parse_success=False."""
     text = "Some answer.\n\nUser:"
     tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
-    tokens.append(renderer.tokenizer.eos_token_id)
+    assert isinstance(tokens, list)
+    eos_token_id = renderer.tokenizer.eos_token_id
+    assert isinstance(eos_token_id, int)
+    tokens.append(eos_token_id)
 
     message, parse_success = renderer.parse_response(tokens)
 

--- a/tinker_cookbook/renderers/tool_calling_test.py
+++ b/tinker_cookbook/renderers/tool_calling_test.py
@@ -102,7 +102,7 @@ weather in NYC
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
     message, success = renderer.parse_response(response_tokens)
 
-    assert success is True
+    assert success.is_clean
     assert message["role"] == "assistant"
     assert "tool_calls" in message
     assert len(message["tool_calls"]) == 1
@@ -156,7 +156,7 @@ LA
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
     message, success = renderer.parse_response(response_tokens)
 
-    assert success is True
+    assert success.is_clean
     assert "tool_calls" in message
     assert len(message["tool_calls"]) == 2
     assert message["tool_calls"][0].function.name == "get_weather"
@@ -183,7 +183,7 @@ def test_kimi_k2_parse_tool_call():
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
     message, success = renderer.parse_response(response_tokens)
 
-    assert success is True
+    assert success.is_clean
     assert "tool_calls" in message
     assert len(message["tool_calls"]) == 1
     # Verify function name is extracted from tool_id
@@ -207,7 +207,7 @@ def test_deepseek_parse_tool_call():
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
     message, success = renderer.parse_response(response_tokens)
 
-    assert success is True
+    assert success.is_clean
     assert "tool_calls" in message
     assert len(message["tool_calls"]) == 1
     assert message["tool_calls"][0].function.name == "get_weather"
@@ -237,7 +237,7 @@ def test_qwen3_parse_invalid_tool_call_json():
     message, success = renderer.parse_response(response_tokens)
 
     # Parse succeeds, but tool call is captured as unparsed
-    assert success is True
+    assert success.is_clean
     assert "tool_calls" not in message or len(message.get("tool_calls", [])) == 0
     assert "unparsed_tool_calls" in message
     assert len(message["unparsed_tool_calls"]) == 1
@@ -267,7 +267,7 @@ def test_qwen3_mixed_valid_invalid_tool_calls():
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
     message, success = renderer.parse_response(response_tokens)
 
-    assert success is True
+    assert success.is_clean
     # Valid tool call should be parsed
     assert "tool_calls" in message
     assert len(message["tool_calls"]) == 1
@@ -291,7 +291,7 @@ def test_deepseek_parse_invalid_tool_call_json():
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
     message, success = renderer.parse_response(response_tokens)
 
-    assert success is True
+    assert success.is_clean
     assert "tool_calls" not in message or len(message.get("tool_calls", [])) == 0
     assert "unparsed_tool_calls" in message
     assert len(message["unparsed_tool_calls"]) == 1
@@ -310,7 +310,7 @@ def test_kimi_k2_parse_invalid_tool_call_json():
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
     message, success = renderer.parse_response(response_tokens)
 
-    assert success is True
+    assert success.is_clean
     assert "tool_calls" not in message or len(message.get("tool_calls", [])) == 0
     assert "unparsed_tool_calls" in message
     assert len(message["unparsed_tool_calls"]) == 1

--- a/tinker_cookbook/rl/message_env.py
+++ b/tinker_cookbook/rl/message_env.py
@@ -125,9 +125,9 @@ class EnvFromMessageEnv(types.Env):
                 metrics={"max_tokens_reached": 1.0},
             )
 
-        assistant_message, parse_success = self.renderer.parse_response(action)
+        assistant_message, termination = self.renderer.parse_response(action)
 
-        if not parse_success:
+        if not termination.is_clean:
             return types.StepResult(
                 reward=self.failed_parse_reward,
                 episode_done=self.terminate_on_parse_error,

--- a/tinker_cookbook/rl/message_env_test.py
+++ b/tinker_cookbook/rl/message_env_test.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import tinker
 
-from tinker_cookbook.renderers.base import Message
+from tinker_cookbook.renderers.base import Message, ParseTermination
 from tinker_cookbook.rl.message_env import EnvFromMessageEnv, MessageEnv, MessageStepResult
 
 # ---------------------------------------------------------------------------
@@ -50,17 +50,28 @@ def _make_renderer(
     gen_prompt_tokens: list[int] | None = None,
     stop_sequences: list[str] | None = None,
     parse_message: Message | None = None,
-    parse_success: bool = True,
+    termination: ParseTermination | None = None,
+    parse_success: bool | None = None,
 ) -> MagicMock:
-    """Build a mock Renderer with the methods EnvFromMessageEnv calls."""
-    from tinker_cookbook.renderers.base import ParseTermination
+    """Build a mock Renderer with the methods EnvFromMessageEnv calls.
+
+    Pass ``termination`` directly to drive any ParseTermination state
+    (including ``EOS``, which can't be expressed via the bool shortcut).
+    ``parse_success`` is a back-compat shortcut: True -> STOP_SEQUENCE,
+    False -> MALFORMED.
+    """
+    if termination is None:
+        if parse_success is None:
+            parse_success = True
+        termination = (
+            ParseTermination.STOP_SEQUENCE if parse_success else ParseTermination.MALFORMED
+        )
 
     renderer = MagicMock()
 
     prompt = _make_model_input(gen_prompt_tokens or [1, 2, 3])
     renderer.build_generation_prompt = MagicMock(return_value=prompt)
     renderer.get_stop_sequences = MagicMock(return_value=stop_sequences or ["<stop>"])
-    termination = ParseTermination.STOP_SEQUENCE if parse_success else ParseTermination.MALFORMED
     renderer.parse_response = MagicMock(
         return_value=(
             parse_message or {"role": "assistant", "content": "hello"},
@@ -132,6 +143,55 @@ class TestStepParseFailure:
         assert result.metrics == {"parse_error": 1.0}
         assert result.next_observation.length == 0
         # MessageEnv.step should NOT have been called
+        assert len(msg_env.step_calls) == 0
+
+    def test_eos_termination_invokes_grader(self):
+        """Regression test for issue #685.
+
+        When parse_response returns ``ParseTermination.EOS`` (model emitted
+        EOS instead of the renderer's stop sequence — the common base-model
+        single-turn case), ``EnvFromMessageEnv.step`` must NOT short-circuit
+        with ``failed_parse_reward``. It must call ``MessageEnv.step`` so the
+        grader runs. Pre-#685, the renderer reported ``parse_success=False``
+        on this shape and every base-model single-turn benchmark scored 0%.
+        """
+
+        renderer = _make_renderer(
+            parse_message={"role": "assistant", "content": "graded answer"},
+            termination=ParseTermination.EOS,
+        )
+        msg_env = StubMessageEnv(
+            initial_messages=[],
+            step_result=MessageStepResult(reward=1.0, episode_done=True, next_messages=[]),
+        )
+        env = EnvFromMessageEnv(
+            renderer=renderer,
+            message_env=msg_env,
+            failed_parse_reward=-99.0,  # would be the bug's reward if grader skipped
+        )
+
+        result = asyncio.run(env.step([1, 2, 3]))
+
+        # Grader was invoked and its reward propagated — not the failed-parse reward.
+        assert result.reward == 1.0
+        assert "parse_error" not in result.metrics
+        assert len(msg_env.step_calls) == 1
+        assert msg_env.step_calls[0]["content"] == "graded answer"
+
+    def test_malformed_termination_skips_grader(self):
+        """``ParseTermination.MALFORMED`` short-circuits with failed_parse_reward."""
+
+        renderer = _make_renderer(termination=ParseTermination.MALFORMED)
+        msg_env = StubMessageEnv(
+            initial_messages=[],
+            step_result=MessageStepResult(reward=1.0, episode_done=True, next_messages=[]),
+        )
+        env = EnvFromMessageEnv(renderer=renderer, message_env=msg_env, failed_parse_reward=-2.0)
+
+        result = asyncio.run(env.step([1, 2, 3]))
+
+        assert result.reward == -2.0
+        assert result.metrics == {"parse_error": 1.0}
         assert len(msg_env.step_calls) == 0
 
     def test_parse_failure_no_terminate(self):

--- a/tinker_cookbook/rl/message_env_test.py
+++ b/tinker_cookbook/rl/message_env_test.py
@@ -53,15 +53,18 @@ def _make_renderer(
     parse_success: bool = True,
 ) -> MagicMock:
     """Build a mock Renderer with the methods EnvFromMessageEnv calls."""
+    from tinker_cookbook.renderers.base import ParseTermination
+
     renderer = MagicMock()
 
     prompt = _make_model_input(gen_prompt_tokens or [1, 2, 3])
     renderer.build_generation_prompt = MagicMock(return_value=prompt)
     renderer.get_stop_sequences = MagicMock(return_value=stop_sequences or ["<stop>"])
+    termination = ParseTermination.STOP_SEQUENCE if parse_success else ParseTermination.MALFORMED
     renderer.parse_response = MagicMock(
         return_value=(
             parse_message or {"role": "assistant", "content": "hello"},
-            parse_success,
+            termination,
         )
     )
     return renderer

--- a/tinker_cookbook/rl/multiturn_weight_assignment_test.py
+++ b/tinker_cookbook/rl/multiturn_weight_assignment_test.py
@@ -178,6 +178,8 @@ def _make_stub_renderer():
     # Message since it's a TypedDict).
     action_tokens_by_id: dict[int, list[int]] = {}
 
+    from tinker_cookbook.renderers.base import ParseTermination
+
     parse_results = iter(
         [
             # Call 1: model makes a tool call
@@ -192,10 +194,10 @@ def _make_stub_renderer():
                         )
                     ],
                 ),
-                True,
+                ParseTermination.STOP_SEQUENCE,
             ),
             # Call 2: model gives final answer (no tool calls)
-            (Message(role="assistant", content="done"), True),
+            (Message(role="assistant", content="done"), ParseTermination.STOP_SEQUENCE),
         ]
     )
 

--- a/tinker_cookbook/rl/preference_envs.py
+++ b/tinker_cookbook/rl/preference_envs.py
@@ -226,10 +226,12 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
             tuple[list[renderers.Message], bool]: A one-element message list
                 and a flag indicating whether the response had valid format.
         """
-        response, is_valid = self.policy_renderer.parse_response(
+        response, termination = self.policy_renderer.parse_response(
             trajectory.transitions[0].ac.tokens
         )
-        return [response], is_valid
+        # Preference RL's format-reward shaping mirrors ProblemEnv's strict
+        # default — only stop-sequence termination is "valid format".
+        return [response], termination.is_stop_sequence
 
     def comparison_reward_for_second_messages(
         self, message_i: list[renderers.Message], message_j: list[renderers.Message]

--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -23,6 +23,12 @@ from tinker_cookbook.utils.logtree_formatters import ConversationFormatter
 logger = logging.getLogger(__name__)
 
 
+def _terminated_with_eos(renderer: renderers.Renderer, action: Sequence[int]) -> bool:
+    """Whether ``action`` ends with the tokenizer's EOS token."""
+    eos_token_id = renderer.tokenizer.eos_token_id
+    return eos_token_id is not None and len(action) > 0 and action[-1] == eos_token_id
+
+
 class ProblemEnv(Env):
     """A single-turn Q&A environment that rewards correct answers and valid formatting.
 
@@ -52,10 +58,18 @@ class ProblemEnv(Env):
         renderer: renderers.Renderer,
         convo_prefix: list[renderers.Message] | None = None,
         format_coef: float = 0.1,
+        require_stop_sequence_for_format: bool = True,
     ):
         self.renderer = renderer
         self.convo_prefix = convo_prefix or []
         self.format_coef = format_coef
+        # When True, a response that terminates with EOS (instead of the
+        # renderer's stop sequence) does not earn the format reward. This
+        # preserves the strict R1-Zero training behavior from #339, which
+        # treated stop-sequence termination as the only "well-formed" outcome.
+        # Eval grading (EnvFromMessageEnv) is unaffected — it uses the
+        # renderer's lenient parse_success directly.
+        self.require_stop_sequence_for_format = require_stop_sequence_for_format
 
     @property
     def stop_condition(self) -> StopCondition:
@@ -112,7 +126,10 @@ class ProblemEnv(Env):
         convo = self.convo_prefix + [{"role": "user", "content": self.get_question()}]
         message, parse_success = self.renderer.parse_response(action)
         content = renderers.get_text_content(message)
-        correct_format = float(parse_success) and float(self.check_format(content))
+        well_formed = parse_success
+        if self.require_stop_sequence_for_format and _terminated_with_eos(self.renderer, action):
+            well_formed = False
+        correct_format = float(well_formed) and float(self.check_format(content))
         correct_answer = float(self.check_answer(content))
         total_reward = self.format_coef * (correct_format - 1) + correct_answer
 

--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -23,12 +23,6 @@ from tinker_cookbook.utils.logtree_formatters import ConversationFormatter
 logger = logging.getLogger(__name__)
 
 
-def _terminated_with_eos(renderer: renderers.Renderer, action: Sequence[int]) -> bool:
-    """Whether ``action`` ends with the tokenizer's EOS token."""
-    eos_token_id = renderer.tokenizer.eos_token_id
-    return eos_token_id is not None and len(action) > 0 and action[-1] == eos_token_id
-
-
 class ProblemEnv(Env):
     """A single-turn Q&A environment that rewards correct answers and valid formatting.
 
@@ -124,11 +118,13 @@ class ProblemEnv(Env):
             extra (ActionExtra | None): Optional action metadata (unused).
         """
         convo = self.convo_prefix + [{"role": "user", "content": self.get_question()}]
-        message, parse_success = self.renderer.parse_response(action)
+        message, termination = self.renderer.parse_response(action)
         content = renderers.get_text_content(message)
-        well_formed = parse_success
-        if self.require_stop_sequence_for_format and _terminated_with_eos(self.renderer, action):
-            well_formed = False
+        well_formed = (
+            termination.is_stop_sequence
+            if self.require_stop_sequence_for_format
+            else termination.is_clean
+        )
         correct_format = float(well_formed) and float(self.check_format(content))
         correct_answer = float(self.check_answer(content))
         total_reward = self.format_coef * (correct_format - 1) + correct_answer

--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -61,8 +61,8 @@ class ProblemEnv(Env):
         # renderer's stop sequence) does not earn the format reward. This
         # preserves the strict R1-Zero training behavior from #339, which
         # treated stop-sequence termination as the only "well-formed" outcome.
-        # Eval grading (EnvFromMessageEnv) is unaffected — it uses the
-        # renderer's lenient parse_success directly.
+        # Eval grading (EnvFromMessageEnv) is unaffected — it reads
+        # ``termination.is_clean`` directly.
         self.require_stop_sequence_for_format = require_stop_sequence_for_format
 
     @property

--- a/tinker_cookbook/rl/problem_env_test.py
+++ b/tinker_cookbook/rl/problem_env_test.py
@@ -1,0 +1,111 @@
+"""Tests for ProblemEnv format-reward semantics.
+
+Covers the interaction between ``RoleColonRenderer.parse_response`` (lenient:
+EOS counts as a clean parse) and the strict R1-Zero format reward (where
+stop-sequence termination is the only "well-formed" outcome). The default
+``require_stop_sequence_for_format=True`` preserves the pre-PR behavior
+introduced in #339.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tinker_cookbook.renderers.role_colon import RoleColonRenderer
+from tinker_cookbook.rl.problem_env import ProblemEnv
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+_BASE_MODEL = "meta-llama/Llama-3.1-8B"
+
+
+@pytest.fixture(scope="module")
+def renderer() -> RoleColonRenderer:
+    return RoleColonRenderer(get_tokenizer(_BASE_MODEL))
+
+
+class _StubProblem(ProblemEnv):
+    def get_question(self) -> str:
+        return "What is 2 + 2?"
+
+    def check_answer(self, sample_str: str) -> bool:
+        return "4" in sample_str
+
+    def check_format(self, sample_str: str) -> bool:
+        return sample_str.strip() != ""
+
+    def get_reference_answer(self) -> str:
+        return "4"
+
+
+def _step(env: ProblemEnv, tokens: list[int]):
+    return asyncio.run(env.step(tokens))
+
+
+def test_eos_only_response_is_format_failure_by_default(renderer: RoleColonRenderer):
+    """R1-Zero strict mode: EOS-only termination should NOT earn format reward.
+    Preserves the pre-PR penalty so existing R1-Zero recipes are unchanged."""
+    env = _StubProblem(renderer, format_coef=0.1)
+    tokens = renderer.tokenizer.encode("The answer is 4.", add_special_tokens=False)
+    assert isinstance(tokens, list)
+    eos = renderer.tokenizer.eos_token_id
+    assert isinstance(eos, int)
+    tokens.append(eos)
+
+    result = _step(env, tokens)
+
+    assert result.metrics["format"] == 0.0
+    assert result.metrics["correct"] == 1.0
+    # reward = 0.1 * (0 - 1) + 1.0 = 0.9
+    assert result.reward == pytest.approx(0.9)
+
+
+def test_eos_only_response_can_earn_format_when_lenient(renderer: RoleColonRenderer):
+    """Eval-aligned mode: when require_stop_sequence_for_format=False,
+    EOS-only termination earns format reward (matches eval grading semantics)."""
+    env = _StubProblem(renderer, format_coef=0.1, require_stop_sequence_for_format=False)
+    tokens = renderer.tokenizer.encode("The answer is 4.", add_special_tokens=False)
+    assert isinstance(tokens, list)
+    eos = renderer.tokenizer.eos_token_id
+    assert isinstance(eos, int)
+    tokens.append(eos)
+
+    result = _step(env, tokens)
+
+    assert result.metrics["format"] == 1.0
+    assert result.metrics["correct"] == 1.0
+    # reward = 0.1 * (1 - 1) + 1.0 = 1.0
+    assert result.reward == pytest.approx(1.0)
+
+
+def test_stop_sequence_response_is_format_success(renderer: RoleColonRenderer):
+    """Stop-sequence termination earns format reward in both modes."""
+    text = "The answer is 4.\n\nUser:"
+    tokens = renderer.tokenizer.encode(text, add_special_tokens=False)
+    assert isinstance(tokens, list)
+
+    for require_stop_seq in (True, False):
+        env = _StubProblem(
+            renderer,
+            format_coef=0.1,
+            require_stop_sequence_for_format=require_stop_seq,
+        )
+        result = _step(env, tokens)
+        assert result.metrics["format"] == 1.0, f"require_stop_seq={require_stop_seq}"
+        assert result.metrics["correct"] == 1.0
+
+
+def test_truncated_response_is_format_failure(renderer: RoleColonRenderer):
+    """No terminator at all (mid-sentence cutoff) is a format failure regardless of mode."""
+    tokens = renderer.tokenizer.encode("The answer is", add_special_tokens=False)
+    assert isinstance(tokens, list)
+
+    for require_stop_seq in (True, False):
+        env = _StubProblem(
+            renderer,
+            format_coef=0.1,
+            require_stop_sequence_for_format=require_stop_seq,
+        )
+        result = _step(env, tokens)
+        assert result.metrics["format"] == 0.0, f"require_stop_seq={require_stop_seq}"

--- a/tinker_cookbook/scripts/test_tool_calling_e2e.py
+++ b/tinker_cookbook/scripts/test_tool_calling_e2e.py
@@ -150,11 +150,11 @@ async def test_model(
     # Parse response
     response_tokens = result.sequences[0].tokens
     raw_response = str(tokenizer.decode(response_tokens))
-    message, parse_success = renderer.parse_response(response_tokens)
+    message, termination = renderer.parse_response(response_tokens)
 
     # Check if we got tool calls
     has_tool_calls = "tool_calls" in message and len(message.get("tool_calls", [])) > 0
-    success = parse_success and has_tool_calls
+    success = termination.is_clean and has_tool_calls
 
     return success, message, raw_response
 

--- a/tinker_cookbook/third_party/litellm/provider.py
+++ b/tinker_cookbook/third_party/litellm/provider.py
@@ -172,7 +172,10 @@ def _sampling_result_to_chat_completion_dict(result: _SamplingResult) -> dict[st
 
     if tool_calls_out:
         finish_reason = "tool_calls"
-    elif result.termination.is_clean:
+    elif result.termination.is_stop_sequence:
+        # Match pre-PR strictness: for RoleColonRenderer, EOS-only termination
+        # is reported as "length" so this provider behaves identically to before
+        # the #685 renderer fix. Eval grading uses is_clean elsewhere.
         finish_reason = "stop"
     else:
         finish_reason = "length"

--- a/tinker_cookbook/third_party/litellm/provider.py
+++ b/tinker_cookbook/third_party/litellm/provider.py
@@ -67,7 +67,7 @@ class _SamplingResult:
     completion_token_ids: list[int]
     logprobs: list[float] | None
     parsed_message: renderers.Message
-    parse_success: bool
+    termination: renderers.ParseTermination
     model_name: str
 
 
@@ -139,14 +139,14 @@ async def _sample_chat_completion(
     completion_token_ids: list[int] = seq.tokens
     logprobs: list[float] | None = seq.logprobs
 
-    parsed_message, parse_success = renderer.parse_response(completion_token_ids)
+    parsed_message, termination = renderer.parse_response(completion_token_ids)
 
     return _SamplingResult(
         prompt_token_ids=prompt_token_ids,
         completion_token_ids=completion_token_ids,
         logprobs=logprobs,
         parsed_message=parsed_message,
-        parse_success=parse_success,
+        termination=termination,
         model_name=model_name,
     )
 
@@ -172,7 +172,7 @@ def _sampling_result_to_chat_completion_dict(result: _SamplingResult) -> dict[st
 
     if tool_calls_out:
         finish_reason = "tool_calls"
-    elif result.parse_success:
+    elif result.termination.is_clean:
         finish_reason = "stop"
     else:
         finish_reason = "length"

--- a/tinker_cookbook/third_party/litellm/provider_test.py
+++ b/tinker_cookbook/third_party/litellm/provider_test.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tinker_cookbook.renderers.base import ToolCall
+from tinker_cookbook.renderers.base import ParseTermination, ToolCall
 from tinker_cookbook.third_party.litellm.provider import (
     _extract_sampling_params,
     _prepare_messages_with_tools,
@@ -45,12 +45,13 @@ def _make_sampling_result(
     msg: dict[str, Any] = {"role": "assistant", "content": content}
     if tool_calls is not None:
         msg["tool_calls"] = tool_calls
+    termination = ParseTermination.STOP_SEQUENCE if parse_success else ParseTermination.MALFORMED
     return _SamplingResult(
         prompt_token_ids=prompt_tokens or [1, 2, 3],
         completion_token_ids=completion_tokens or [4, 5, 6],
         logprobs=[0.1, 0.2, 0.3],
         parsed_message=msg,  # type: ignore[arg-type]
-        parse_success=parse_success,
+        termination=termination,
         model_name="tinker/test-model",
     )
 
@@ -216,7 +217,7 @@ class TestSampleChatCompletion:
         renderer.get_stop_sequences.return_value = ["<|endoftext|>"]
         renderer.parse_response.return_value = (
             {"role": "assistant", "content": "response"},
-            True,
+            ParseTermination.STOP_SEQUENCE,
         )
 
         result = await _sample_chat_completion(
@@ -229,7 +230,7 @@ class TestSampleChatCompletion:
 
         assert result.prompt_token_ids == [1, 2, 3]
         assert result.completion_token_ids == [10, 20, 30]
-        assert result.parse_success is True
+        assert result.termination.is_clean
         assert result.parsed_message["content"] == "response"
 
         # Verify sampling params were passed correctly
@@ -254,7 +255,7 @@ class TestSampleChatCompletion:
         ]
         renderer.parse_response.return_value = (
             {"role": "assistant", "content": "done"},
-            True,
+            ParseTermination.STOP_SEQUENCE,
         )
 
         tools = [
@@ -271,7 +272,7 @@ class TestSampleChatCompletion:
         )
 
         renderer.create_conversation_prefix_with_tools.assert_called_once()
-        assert result.parse_success is True
+        assert result.termination.is_clean
 
     @pytest.mark.asyncio
     async def test_custom_stop_sequences(self) -> None:
@@ -286,7 +287,7 @@ class TestSampleChatCompletion:
         renderer.build_generation_prompt.return_value.to_ints.return_value = [1]
         renderer.parse_response.return_value = (
             {"role": "assistant", "content": "ok"},
-            True,
+            ParseTermination.STOP_SEQUENCE,
         )
 
         await _sample_chat_completion(
@@ -426,7 +427,7 @@ class TestTinkerLiteLLMProvider:
         mock_renderer.get_stop_sequences.return_value = ["<|end|>"]
         mock_renderer.parse_response.return_value = (
             {"role": "assistant", "content": "Hello!"},
-            True,
+            ParseTermination.STOP_SEQUENCE,
         )
 
         provider._clients["Qwen/Qwen3-8B"] = _ClientBundle(

--- a/tinker_cookbook/third_party/litellm/provider_test.py
+++ b/tinker_cookbook/third_party/litellm/provider_test.py
@@ -39,13 +39,18 @@ def _make_sampling_result(
     prompt_tokens: list[int] | None = None,
     completion_tokens: list[int] | None = None,
     content: str = "Hello!",
-    parse_success: bool = True,
+    termination: ParseTermination = ParseTermination.STOP_SEQUENCE,
     tool_calls: list[ToolCall] | None = None,
 ) -> _SamplingResult:
+    """Build a fake _SamplingResult.
+
+    Pass ``termination`` directly to drive any ParseTermination state
+    (including ``EOS``, which provider tests may want to assert mapping
+    semantics for).
+    """
     msg: dict[str, Any] = {"role": "assistant", "content": content}
     if tool_calls is not None:
         msg["tool_calls"] = tool_calls
-    termination = ParseTermination.STOP_SEQUENCE if parse_success else ParseTermination.MALFORMED
     return _SamplingResult(
         prompt_token_ids=prompt_tokens or [1, 2, 3],
         completion_token_ids=completion_tokens or [4, 5, 6],
@@ -160,7 +165,16 @@ class TestSamplingResultToDict:
         assert d["usage"]["completion_tokens"] == 3
 
     def test_parse_failure_gives_length_finish(self) -> None:
-        result = _make_sampling_result(parse_success=False)
+        result = _make_sampling_result(termination=ParseTermination.MALFORMED)
+        d = _sampling_result_to_chat_completion_dict(result)
+        assert d["choices"][0]["finish_reason"] == "length"
+
+    def test_eos_termination_gives_length_finish(self) -> None:
+        """Pre-PR strictness: only stop-sequence termination is reported as
+        ``finish_reason=stop``. EOS-only termination (RoleColon base-model
+        case) maps to ``length`` so this provider is unchanged by the #685
+        renderer fix. See provider.py:175."""
+        result = _make_sampling_result(termination=ParseTermination.EOS)
         d = _sampling_result_to_chat_completion_dict(result)
         assert d["choices"][0]["finish_reason"] == "length"
 

--- a/tutorials/201_rendering.py
+++ b/tutorials/201_rendering.py
@@ -132,7 +132,13 @@ def _(mo):
     mo.md(r"""
     ## `parse_response()` -- decoding tokens back to a message
 
-    After sampling, you get raw token IDs. `parse_response()` converts them back into a structured message dict.
+    After sampling, you get raw token IDs. `parse_response()` converts them back into a structured message dict and a `ParseTermination` enum that tells you how the response ended:
+
+    - `STOP_SEQUENCE` — the renderer's expected stop signal fired (e.g. `<|im_end|>` for chat templates, `\n\nUser:` for RoleColon).
+    - `EOS` — the model emitted EOS instead. Some renderers (notably `RoleColonRenderer` for base models) accept this as a clean parse on single-turn prompts.
+    - `MALFORMED` — no clean termination (truncated, or multiple/conflicting stop signals).
+
+    Use `termination.is_clean` (any clean termination — what eval grading reads) or `termination.is_stop_sequence` (strict — what RL format-reward shaping reads).
     """)
     return
 
@@ -142,10 +148,10 @@ def _(renderer):
     # Simulate some sampled tokens (in practice these come from the model)
     fake_tokens = [45, 7741, 34651, 31410, 614, 4911, 76665, 13, 151645]
 
-    parsed_message, parse_success = renderer.parse_response(fake_tokens)
+    parsed_message, termination = renderer.parse_response(fake_tokens)
     print(f"Parsed message: {parsed_message}")
-    print(f"Parse success: {parse_success}")
-    return fake_tokens, parse_success, parsed_message
+    print(f"Termination: {termination} (is_clean={termination.is_clean})")
+    return fake_tokens, parsed_message, termination
 
 
 @app.cell(hide_code=True)


### PR DESCRIPTION
## Summary

- **Fixes #685**: base models silently scored 0% on every single-turn benchmark because `RoleColonRenderer.parse_response` returned `parse_success=False` for EOS-terminated responses, and `EnvFromMessageEnv.step` short-circuits with `failed_parse_reward=0` when `parse_success` is False — so the grader was never invoked on the most common base-model response shape.
- **Replaces the `parse_success: bool` return value with a `ParseTermination` StrEnum** (`STOP_SEQUENCE` / `EOS` / `MALFORMED`) so each consumer expresses its policy explicitly instead of leaning on a bool whose meaning silently shifted between callers (the root cause of how #339 broke evals).
- **Preserves R1-Zero / math RL training behavior** via an explicit `ProblemEnv.require_stop_sequence_for_format=True` default — EOS-terminated rollouts continue to lose the format reward at the RL layer exactly as they did pre-fix.
- Re-ran AIME 2025 against `Qwen/Qwen3-8B-Base` on this branch: **6/30 = 20.0%, 0 errors** (would have been 0/30 before this fix).

## The bug, in one paragraph

`RoleColonRenderer` formats prompts as `User:/Assistant:` and uses `\n\nUser:` as its stop sequence. On single-turn evals, base models commonly produce a clean answer and then emit EOS instead of `\n\nUser:` — there's no second turn to start. Pre-PR, that shape returned `parse_success=False`, which `EnvFromMessageEnv.step` reads as \"skip the grader, return `failed_parse_reward=0`\". Result: every base model × every single-turn benchmark scored 0% even when the answer was correct.

## Why a single bool wasn't enough

The original bool was overloaded to answer three distinct consumer questions:

1. Eval grading (`EnvFromMessageEnv`): \"is this gradeable?\" — wants any clean termination.
2. Strict format reward (`ProblemEnv`, used by R1-Zero / math RL): \"did this earn format reward?\" — wants stop-sequence specifically; EOS-only is a soft penalty.
3. OpenAI `finish_reason` / preference RL / etc: variations on the same theme.

PR #339 changed `RoleColonRenderer` to make EOS-terminated responses return `False` for R1-Zero's training needs — and silently broke every eval that read the same bool. This PR fixes the conflation by giving each call site its own explicit signal.

## Changes

### `Renderer.parse_response` returns `ParseTermination` instead of `bool`

`tinker_cookbook/renderers/base.py` adds:

```python
class ParseTermination(StrEnum):
    STOP_SEQUENCE = \"stop_sequence\"  # the renderer's expected stop signal fired
    EOS = \"eos\"                       # model emitted EOS, accepted as a fallback by some renderers
    MALFORMED = \"malformed\"           # truncated / multiple stop signals / etc.

    @property
    def is_clean(self) -> bool: ...        # STOP_SEQUENCE or EOS
    @property
    def is_stop_sequence(self) -> bool: ...  # STOP_SEQUENCE only
```

All 8 renderer implementations (`role_colon`, `llama3`, `qwen3`, `qwen3_5`, `kimi_k2`, `deepseek_v3`, `gpt_oss`, plus the `parse_response_for_stop_token` helper) and ~17 call sites are updated. Chat-template renderers return `STOP_SEQUENCE` / `MALFORMED` only — the `EOS` state is meaningful only for `RoleColonRenderer`, which has a stop sequence distinct from EOS.

### `RoleColonRenderer.parse_response` semantics

| Termination state | Returns |
|---|---|
| Ends with `\n\nUser:` only | `STOP_SEQUENCE` |
| Ends with EOS, no `\n\nUser:` | `EOS` (was `False` pre-PR — this is the fix) |
| No terminator at all | `MALFORMED` |
| Both `\n\nUser:` and EOS | `MALFORMED` (sampling should have stopped at `User:`) |
| Multiple `\n\nUser:` | `MALFORMED` (model role-played the user turn) |

### `ProblemEnv.require_stop_sequence_for_format=True` default

`tinker_cookbook/rl/problem_env.py` adds an explicit knob so the R1-Zero / math RL format reward shaping is unchanged by the renderer fix:

- `True` (default): `correct_format` requires `termination.is_stop_sequence` — EOS-terminated rollouts lose the `format_coef * (0 - 1) = -0.1` reward, exactly as they did pre-PR.
- `False`: `correct_format` requires only `termination.is_clean`, opting into the eval-aligned semantics. Recommended only after an A/B against an existing recipe.

`EnvFromMessageEnv` (eval grading) uses `termination.is_clean` directly and is unaffected by this knob.

### Preference RL / verifiers / litellm

`rl/preference_envs.py` keeps its strict format check via `termination.is_stop_sequence` (matches `ProblemEnv`'s default). `recipes/verifiers_rl/tinker_openai.py` and `third_party/litellm/provider.py` use `termination.is_clean` for the OpenAI `finish_reason` (`\"stop\"` vs `\"length\"`).

## Tests

- `tinker_cookbook/renderers/role_colon_test.py` — 5 cases covering each `ParseTermination` state.
- `tinker_cookbook/rl/problem_env_test.py` — both `require_stop_sequence_for_format` modes × EOS-only / stop-sequence / truncated responses.
- All existing renderer / RL / litellm tests updated to the new return type and pass.

## Test plan

- [x] New unit tests in `tinker_cookbook/renderers/role_colon_test.py` pass on this branch and fail on `main` (regression coverage verified).
- [x] New unit tests in `tinker_cookbook/rl/problem_env_test.py` cover both `require_stop_sequence_for_format` modes against EOS-only, stop-sequence, and truncated responses.
- [x] Full local test suite green (1287 passed, excluding test files that require optional deps not installed locally — search_tool, verifiers_rl, harbor_rl, math_rl, text_arena, sandbox, trace). litellm tests pass separately (18/18).
- [x] Pyright clean on touched files.
- [x] Re-ran AIME 2025 (cookbook ships `aime_2025`/`aime_2026`; AIME 2024 is not in the registry) against `Qwen/Qwen3-8B-Base` on this branch: **6/30 = 20.0%, 0 errors, 5 truncated** in 199s. Non-zero score confirms the grader is now invoked on EOS-terminated responses; the value is in the expected range for a base 8B on AIME, ruling out a regression in the opposite direction.