### PR TITLE
HarborReward._upload_tests: recurse into nested fixture dirs

### DIFF
--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -88,13 +88,18 @@ class HarborReward:
             return 0.0, {"reward": 0.0, "test_passed": 0.0, "grading_error": 1.0}
 
     async def _upload_tests(self) -> None:
-        """Upload test files from local tests_dir to /tests/ in sandbox."""
+        """Upload test files from local tests_dir to /tests/ in sandbox.
+
+        Walks ``tests_dir`` recursively so nested fixture trees (e.g. a
+        ``tests/repo_overlay/`` directory copied into the workspace by
+        ``test.sh``) are preserved. ``Path.iterdir`` would silently drop them.
+        """
         await self.sandbox.run_command("mkdir -p /tests", workdir="/")
-        for file_path in self.tests_dir.iterdir():
+        for file_path in self.tests_dir.rglob("*"):
             if not file_path.is_file():
                 continue
             content = file_path.read_text()
-            target = f"/tests/{file_path.name}"
+            target = f"/tests/{file_path.relative_to(self.tests_dir)}"
             await self.sandbox.write_file(target, content, executable=(file_path.suffix == ".sh"))
 
     async def _parse_reward(self) -> float:

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
@@ -131,10 +131,13 @@ class TestHarborReward:
         assert info["grading_error"] == 1.0
 
     def test_upload_tests(self, tmp_path: Path) -> None:
-        """Files are uploaded; .sh files marked executable; subdirs skipped."""
+        """Files are uploaded recursively; .sh files marked executable."""
         (tmp_path / "test.sh").write_text("#!/bin/bash\necho ok")
         (tmp_path / "helper.py").write_text("print('hi')")
-        (tmp_path / "subdir").mkdir()
+        (tmp_path / "fixtures").mkdir()
+        (tmp_path / "fixtures" / "expected.txt").write_text("expected")
+        (tmp_path / "fixtures" / "nested").mkdir()
+        (tmp_path / "fixtures" / "nested" / "deep.py").write_text("# deep")
 
         sandbox = FakeSandbox()
         sandbox.files["/logs/verifier/reward.txt"] = "1.0"
@@ -144,10 +147,11 @@ class TestHarborReward:
 
         assert "/tests/test.sh" in sandbox.files
         assert "/tests/helper.py" in sandbox.files
+        assert "/tests/fixtures/expected.txt" in sandbox.files
+        assert "/tests/fixtures/nested/deep.py" in sandbox.files
         assert "/tests/test.sh" in sandbox.executable_files
         assert "/tests/helper.py" not in sandbox.executable_files
-        # subdir should not be uploaded
-        assert not any("subdir" in p for p in sandbox.files if p.startswith("/tests/"))
+        assert "/tests/fixtures/expected.txt" not in sandbox.executable_files
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Path.iterdir silently skips directories, so test fixtures placed in subdirs of `tests_dir` (e.g. `tests/repo_overlay/`) never get uploaded into the sandbox. `test.sh` scripts that do `cp -r /tests/repo_overlay/. /repo/` then become no-ops and grading fails for reasons that are not visible in per-task logs.

Switch to `rglob` and preserve the relative path. `modal_sandbox.write_file` already `mkdir -p`s the parent directory, so nested target paths just work. Test updated to assert recursive upload and that nested files are not marked executable.