### PR TITLE
Align Kimi K2.6 revision pin

### DIFF
--- a/tinker_cookbook/image_processing_utils.py
+++ b/tinker_cookbook/image_processing_utils.py
@@ -38,7 +38,7 @@ def get_image_processor(model_name: str) -> ImageProcessor:
         kwargs["revision"] = "3367c8d1c68584429fab7faf845a32d5195b6ac1"
     elif model_name == "moonshotai/Kimi-K2.6":
         kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "2b2b88e33c96d813ebb4c83a740252fe08018e3a"
+        kwargs["revision"] = "5a49d036ab7472b7d5912ded487150ec1358c11d"
 
     processor = AutoImageProcessor.from_pretrained(model_name, **kwargs)
 

--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -142,7 +142,7 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
         kwargs["revision"] = "2426b45b6af0da48d0dcce71bbce6225e5c73adc"
     elif model_name == "moonshotai/Kimi-K2.6":
         kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "2b2b88e33c96d813ebb4c83a740252fe08018e3a"
+        kwargs["revision"] = "5a49d036ab7472b7d5912ded487150ec1358c11d"
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
 


### PR DESCRIPTION
## Summary
- Align the Kimi K2.6 tokenizer revision pin with the Tinker SDK.
- Use the same K2.6 revision for image processor loading to keep cookbook model support consistent.

## Test plan
- uv run pytest tinker_cookbook/tokenizer_utils_test.py tinker_cookbook/image_processing_utils_test.py


Made with [Cursor](https://cursor.com)