### PR TITLE
Add 'Public-repo discipline' section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,13 @@ Quick reference for agents working on `tinker-cookbook`. Detailed guidance is in
 Agents often struggle with the nested type hierarchy.
 
 **Core types:**
+
 - `Datum` = `model_input` (ModelInput) + `loss_fn_inputs` (dict of TensorData)
 - `ModelInput` = list of chunks (EncodedTextChunk, ImageChunk)
 - `TensorData` = wrapper for numpy/torch arrays with shape info
 
 **Helper functions** (use these instead of manual construction):
+
 - `datum_from_model_input_weights(model_input, weights, max_length)` - SL datum creation (`supervised/common.py`)
 - `conversation_to_datum(messages, renderer, max_length, train_on_what)` - Full pipeline (`supervised/data.py`)
 - `renderer.build_supervised_example(messages)` - Returns (ModelInput, weights)
@@ -29,6 +31,7 @@ Agents often struggle with the nested type hierarchy.
 **Builder pattern:** Config objects are `chz` dataclasses (SupervisedDatasetBuilder, RLDatasetBuilder, EnvGroupBuilder). They expose `.build()`/`__call__()` returning runtime objects.
 
 **Key code locations:**
+
 - SL: `tinker_cookbook/supervised/train.py`
 - RL: `tinker_cookbook/rl/train.py`
 - DPO: `tinker_cookbook/preference/train_dpo.py`
@@ -48,12 +51,19 @@ Agents often struggle with the nested type hierarchy.
 **Subscript suffixes** for tensor names: `_P` (problems), `_G` (groups), `_T` (tokens), `_D` (datums). Example: `tokens_P_G_T[p][g][t]`
 
 **Code style:**
+
 - Explicit typing; avoid `Any` / `type: ignore`
 - Use `safezip`, `timed`, `scope` helpers
 - `@chz.chz` decorator for config serialization
 - `ml_log.log_metrics` for metrics; `logtree` for transcripts
 
 **Env lifecycle:** `Env` objects are single-use (no reset). Create via `EnvGroupBuilder`.
+
+---
+
+## Public-repo discipline
+
+`tinker-cookbook` is a public repository. Keep internal context out of commits (even intermediate commits), and write with an external audience in mind.
 
 ---
 


### PR DESCRIPTION
Reminds agents working in `tinker-cookbook` to keep internal context out of commits (including intermediate commits) and to write with an external audience in mind.