### PR TITLE
Fix verifiers integration recipe

### DIFF
--- a/tinker_cookbook/recipes/verifiers_rl/train.py
+++ b/tinker_cookbook/recipes/verifiers_rl/train.py
@@ -17,7 +17,7 @@ from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
     VerifiersRLDatasetBuilder,
     convert_states_to_trajectory_group,
 )
-from tinker_cookbook.rl import train
+from tinker_cookbook.rl import rollouts, train
 from tinker_cookbook.rl.types import EnvGroupBuilder, TrajectoryGroup
 from tinker_cookbook.tokenizer_utils import Tokenizer, get_tokenizer
 
@@ -76,9 +76,17 @@ async def cli_main(cli_config: CLIConfig, env: Any | None):
     local_tokenizer: Tokenizer | None = None
 
     async def custom_do_group_rollout(
-        builder: EnvGroupBuilder, policy: TokenCompleter
+        builder: EnvGroupBuilder,
+        policy: TokenCompleter,
+        strategy: rollouts.RolloutStrategy | None = None,
     ) -> TrajectoryGroup:
         nonlocal shared_client, shared_renderer, local_tokenizer
+
+        if strategy is not None and not isinstance(strategy, rollouts.FailFast):
+            logger.warning(
+                "custom_do_group_rollout (verifiers) received unsupported strategy=%s",
+                type(strategy).__name__,
+            )
 
         # initialize tokenizer and renderer lazily
         if local_tokenizer is None:
@@ -115,8 +123,9 @@ async def cli_main(cli_config: CLIConfig, env: Any | None):
 
         return convert_states_to_trajectory_group(states)
 
-    # override do_group_rollout function inside rl.train
-    train.do_group_rollout = custom_do_group_rollout
+    # override do_group_rollout function inside rl.rollouts
+    assert hasattr(rollouts, "do_group_rollout"), "verifiers monkeypatch site missing"
+    rollouts.do_group_rollout = custom_do_group_rollout
 
     dataset_builder = VerifiersRLDatasetBuilder(
         vf_env_id=cli_config.vf_env_id,

--- a/tinker_cookbook/rl/rollouts.py
+++ b/tinker_cookbook/rl/rollouts.py
@@ -200,6 +200,7 @@ async def do_single_rollout(policy: TokenCompleter, env: Env) -> Trajectory:
     return Trajectory(transitions=transitions, final_ob=ob)
 
 
+# NOTE: this function is monkeypatched by verifiers (recipes/verifiers_rl/train.py)
 @logtree.scope_header_decorator("Group Rollout")
 async def do_group_rollout(
     env_group_builder: EnvGroupBuilder,

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -52,7 +52,6 @@ from tinker_cookbook.rl.rollout_strategy import (
 )
 from tinker_cookbook.rl.rollouts import (
     RolloutErrorCounter,
-    do_group_rollout,  # noqa: F401 — re-exported for verifiers monkey-patching
     do_group_rollout_and_filter_constant_reward,
     set_rollout_executor,
 )


### PR DESCRIPTION
The refactor in #425 accidentally broke the `verifiers` integration in `recipes/verifiers_rl/train.py` - after `do_group_rollout` was moved to `rollouts`, the verifiers monkeypatch reassigning it in `train` did nothing, just changed an unused module attribute. I fixed up the integration by changing the monkeypatch point, and also added a comment and `hasattr(rollouts, "do_group_rollout")` assert so future refactors hopefully don't unknowingly break it again.

(Though it might be better if there was an official way to plug in an alternate rollout group execution function, along the lines of the existing `rollouts::{get,set}_rollout_executor`.)

I didn't attempt to add support for the new `rollouts.RolloutStrategy.` Instead, we just warn when the user attempts to use the verifiers recipe with a RolloutStrategy. To get my run working, I also had to wrap `vf_builder.vf_env.run_group` in an `await asyncio.wait_for(..., timeout=1800)` because the sampling API was occasionally hanging, but I didn't want to upstream that hack and I wasn't sure how to integrate `RolloutStrategy` with `verifiers` rollout logic without invasive code changes.

cc @willccbb 