### PR TITLE
Revert Kimi K2.6 tokenizer workaround after Moonshot's revert

### DIFF
--- a/tinker_cookbook/image_processing_utils.py
+++ b/tinker_cookbook/image_processing_utils.py
@@ -38,7 +38,7 @@ def get_image_processor(model_name: str) -> ImageProcessor:
         kwargs["revision"] = "3367c8d1c68584429fab7faf845a32d5195b6ac1"
     elif model_name == "moonshotai/Kimi-K2.6":
         kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "81bcaaa7947338ce2641983d98947bca0cc1a4d4"
+        kwargs["revision"] = "b5aabbfb20227ed42becbf5541dbffd213942c58"
 
     processor = AutoImageProcessor.from_pretrained(model_name, **kwargs)
 

--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -142,41 +142,24 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
         kwargs["revision"] = "2426b45b6af0da48d0dcce71bbce6225e5c73adc"
     elif model_name == "moonshotai/Kimi-K2.6":
         kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "81bcaaa7947338ce2641983d98947bca0cc1a4d4"
+        kwargs["revision"] = "b5aabbfb20227ed42becbf5541dbffd213942c58"
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
 
-    # Kimi models require the custom TikTokenTokenizer{,Fast} class which overrides
-    # apply_chat_template to format tool declarations as TypeScript. On some platforms
-    # (x86_64 + transformers >=5.5), AutoTokenizer resolves to TokenizersBackend
-    # instead. Bypass AutoTokenizer and directly load the custom class in that case.
+    # Kimi models require the custom TikTokenTokenizer which overrides apply_chat_template
+    # to format tool declarations as TypeScript. On some platforms (x86_64 + transformers
+    # >=5.5), AutoTokenizer resolves to TokenizersBackend instead. Bypass AutoTokenizer
+    # and directly load the custom class in that case.
     if (
         model_name.startswith("moonshotai/Kimi-K2")
         and "apply_chat_template" not in type(tokenizer).__dict__
     ):
-        from huggingface_hub import try_to_load_from_cache
         from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
         revision = kwargs.get("revision")
-        if model_name == "moonshotai/Kimi-K2.6":
-            # K2.6's main branch was rewritten to a tokenizer.json + PreTrainedTokenizerFast
-            # subclass; the slow TikTokenTokenizer module no longer exists upstream.
-            class_ref = "tokenization_kimi_fast.TikTokenTokenizerFast"
-            # TikTokenTokenizerFast.__init__ expects model_root to be a local directory
-            # containing tokenizer.json + tiktoken.model. AutoTokenizer above downloads
-            # tokenizer.json but not tiktoken.model, so fetch that explicitly.
-            from transformers.utils import cached_file
-
-            cached_file(model_name, "tiktoken.model", revision=revision)
-            tokenizer_json = try_to_load_from_cache(model_name, "tokenizer.json", revision=revision)
-            assert isinstance(tokenizer_json, str), (
-                f"tokenizer.json not in cache for {model_name}@{revision}"
-            )
-            cls = get_class_from_dynamic_module(class_ref, model_name, revision=revision)
-            tokenizer = cls.from_pretrained(os.path.dirname(tokenizer_json))
-        else:
-            class_ref = "tokenization_kimi.TikTokenTokenizer"
-            cls = get_class_from_dynamic_module(class_ref, model_name, revision=revision)
-            tokenizer = cls.from_pretrained(model_name, revision=revision)
+        cls = get_class_from_dynamic_module(
+            "tokenization_kimi.TikTokenTokenizer", model_name, revision=revision
+        )
+        tokenizer = cls.from_pretrained(model_name, revision=revision)
 
     return tokenizer


### PR DESCRIPTION
Moonshot reverted the upstream `use-fast-tokenizer` change on Kimi-K2.6 (`b5aabbf`), so main is back to the old `tokenization_kimi.py` + `tiktoken.model` layout. Bumping our pin to `b5aabbf` restores the simpler workaround used across K2/K2.5/K2-Thinking.

See Huggingface: https://huggingface.co/moonshotai/Kimi-K2.6/commits/main

(Net diff vs the state before #700: just the revision strings)