### PR TITLE
Fix flaky `test_quantize_dequantize_roundtrip`

### DIFF
--- a/tinker_cookbook/weights/merge_test.py
+++ b/tinker_cookbook/weights/merge_test.py
@@ -1764,6 +1764,10 @@ class TestPackedInt4:
         # empirical max-error across 10k random seeds was 0.7461; atol=0.75 keeps
         # the structural-correctness check while making flakes < 1 in 10,000.
         assert torch.allclose(tensor.float(), dequantized.float(), atol=0.75)
+        # Tighter body-of-distribution check: 95% of the 512 values should be
+        # within 0.5 of the original. Worst p95 across 10k seeds was 0.4531.
+        diffs = (tensor.float() - dequantized.float()).abs()
+        assert torch.quantile(diffs.flatten(), 0.95).item() < 0.5
 
     def test_dequantize_known_values(self):
         """Dequantize hand-crafted values to verify math."""

--- a/tinker_cookbook/weights/merge_test.py
+++ b/tinker_cookbook/weights/merge_test.py
@@ -1760,8 +1760,10 @@ class TestPackedInt4:
         assert scale.shape == (8, 2)  # 64 / 32
         dequantized = dequantize_int4_group(packed, scale, (8, 64), group_size=32)
         assert dequantized.shape == (8, 64)
-        # INT4 quantization is lossy but should be reasonably close
-        assert torch.allclose(tensor.float(), dequantized.float(), atol=0.5)
+        # INT4 group quant has per-value error ~group_max/14. For std=2 inputs the
+        # empirical max-error across 10k random seeds was 0.7461; atol=0.75 keeps
+        # the structural-correctness check while making flakes < 1 in 10,000.
+        assert torch.allclose(tensor.float(), dequantized.float(), atol=0.75)
 
     def test_dequantize_known_values(self):
         """Dequantize hand-crafted values to verify math."""


### PR DESCRIPTION
The INT4 group-quant roundtrip test used `atol=0.5` on unseeded random input, but for `std=2` inputs over groups of 32 the theoretical max per-value error (~group_max/14) routinely lands around 0.55-0.65 on the tail. Observed flake rate on main: ~17% across 10k seeds (in particular, it failed for me on https://github.com/thinking-machines-lab/tinker-cookbook/pull/710 twice in a row).

Loosen atol to 0.75. Empirical max-error across 10k seeds was 0.7461, so flakes drop to < 1 in 10,000. Test intent (quant/dequant is its own inverse to bounded error) is preserved; the precision floor is checked separately by `test_dequantize_known_values`.

Also assert that the 95th percentile is less than 0.5, which empirically has a < 1 in 10,000 chance of flakes as well.