### PR TITLE
Shrink `test_lifecycle` base model to `Qwen3.5-4B`

### DIFF
--- a/tests/weights/test_lifecycle.py
+++ b/tests/weights/test_lifecycle.py
@@ -30,8 +30,8 @@ from tinker_cookbook.weights import build_hf_model, download
 class TestFullLifecycle:
     """Train 1 step → save → download → build merged HF model."""
 
-    MODEL_NAME = "Qwen/Qwen3-8B"
-    RENDERER_NAME = "qwen3"
+    MODEL_NAME = "Qwen/Qwen3.5-4B"
+    RENDERER_NAME = "qwen3_5"
     BATCH_SIZE = 4
     MAX_LENGTH = 512
     LORA_RANK = 8


### PR DESCRIPTION
The previous `Qwen3-8B` base (~16GB bf16) plus the merged HF output fit poorly on the ~14GB GitHub-hosted runner disk, causing flaky "No space left on device" failures from the snapshot_download step. `Qwen3.5-4B` exercises the same save → download → merge plumbing at roughly half the disk footprint.

See the test failure here: https://github.com/thinking-machines-lab/tinker-cookbook/actions/runs/25929209539/job/76218477990