### PR TITLE
feat(rl): opt-in async eval scheduling

### DIFF
--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Callable, Coroutine, Iterable, Iterator, Sequence
 from concurrent.futures import Executor
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -501,6 +502,22 @@ class Config:
     stream_minibatch_config: StreamMinibatchConfig | None = None
     # Optional service base URL override (primarily internal/dev use).
     base_url: str | None = None
+    # When True, evaluators are scheduled as fire-and-forget asyncio Tasks instead
+    # of awaited inline by the train loop. Each evaluator's metrics are logged
+    # asynchronously via ml_logger when it finishes, keyed to the iteration step
+    # at which the eval was scheduled (not the step at which it completes). Useful
+    # when an eval pass is comparable in wall-clock to a training step — e.g. long
+    # CoT eval on hundreds of problems — and you'd rather not block training.
+    # Tradeoffs:
+    #   * Eval rollouts compete with training rollouts for Tinker's per-account
+    #     sampling concurrency. Heavy evals may slow training.
+    #   * W&B receives retroactive step writes (well-supported but worth noting
+    #     when reading chart hover values).
+    #   * Pending evals are awaited up to `async_eval_drain_timeout_s` at shutdown.
+    async_eval: bool = False
+    # Maximum seconds to wait for pending async evals at shutdown. None = wait
+    # indefinitely. Only consulted when ``async_eval=True``.
+    async_eval_drain_timeout_s: float | None = 600.0
 
     # -------------------------------------------------------------------------
     # Checkpoint retention and logging detail (advanced)
@@ -578,6 +595,93 @@ async def run_single_evaluation(
         return eval_metrics
 
 
+_async_eval_dispatcher: ContextVar["_AsyncEvalDispatcher | None"] = ContextVar(
+    "async_eval_dispatcher", default=None
+)
+
+
+def get_async_eval_dispatcher() -> "_AsyncEvalDispatcher | None":
+    """Return the currently installed async-eval dispatcher (or ``None``)."""
+    return _async_eval_dispatcher.get()
+
+
+def set_async_eval_dispatcher(dispatcher: "_AsyncEvalDispatcher | None") -> None:
+    """Install (or clear) the async-eval dispatcher in the current context."""
+    _async_eval_dispatcher.set(dispatcher)
+
+
+class _AsyncEvalDispatcher:
+    """Holds state for ``Config.async_eval=True``: scheduling and shutdown drain.
+
+    When installed (via :func:`set_async_eval_dispatcher`), :func:`run_evaluations_parallel`
+    consults it instead of awaiting evaluators inline. Each evaluator is fired as an
+    ``asyncio.Task`` whose result is logged via ``ml_logger.log_metrics(metrics,
+    step=i_batch_when_scheduled)`` when it finishes. The train loop receives only
+    sentinel metrics at the time of the schedule call.
+    """
+
+    def __init__(self, ml_logger: ml_log.Logger):
+        self._ml_logger = ml_logger
+        self._pending: set[asyncio.Task] = set()
+
+    def schedule(
+        self,
+        evaluators: list[SamplingClientEvaluator],
+        sampling_client: tinker.SamplingClient,
+        config: "Config",
+        i_batch: int,
+        store: TrainingRunStore | None = None,
+    ) -> dict[str, Any]:
+        """Fire one ``asyncio.Task`` per evaluator. Return sentinel metrics."""
+        sentinel: dict[str, Any] = {}
+        captured_step = int(i_batch)
+        for i, evaluator in enumerate(evaluators):
+            ev_name = _get_evaluator_name(evaluator)
+            evaluator_label = _sanitize_filename_component(ev_name or str(i))
+            task = asyncio.create_task(
+                self._run_and_log(
+                    evaluator, config, captured_step, sampling_client, evaluator_label, store
+                ),
+                name=f"async_eval_{evaluator_label}_iter_{captured_step:06d}",
+            )
+            self._pending.add(task)
+            task.add_done_callback(self._pending.discard)
+            sentinel[f"async_eval/{evaluator_label}/scheduled"] = 1.0
+        sentinel["async_eval/in_flight"] = float(len(self._pending))
+        return sentinel
+
+    async def _run_and_log(
+        self,
+        evaluator: SamplingClientEvaluator,
+        config: "Config",
+        i_batch: int,
+        sampling_client: tinker.SamplingClient,
+        evaluator_label: str,
+        store: TrainingRunStore | None,
+    ) -> None:
+        try:
+            metrics = await run_single_evaluation(
+                evaluator, config, i_batch, sampling_client, evaluator_label, store=store
+            )
+            self._ml_logger.log_metrics(metrics, step=i_batch)
+            logger.info("Async eval %s at iter=%d completed.", evaluator_label, i_batch)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Async eval %s at iter=%d failed: %s", evaluator_label, i_batch, e
+            )
+
+    async def drain(self, timeout: float | None = None) -> None:
+        """Await all pending eval tasks. No-op when none are in flight."""
+        if not self._pending:
+            return
+        logger.info(
+            "Draining %d pending async eval task(s) (timeout=%s)...",
+            len(self._pending),
+            timeout,
+        )
+        await asyncio.wait(list(self._pending), timeout=timeout)
+
+
 @trace.scope
 async def run_evaluations_parallel(
     evaluators: list[SamplingClientEvaluator],
@@ -591,6 +695,12 @@ async def run_evaluations_parallel(
     Each evaluator is launched as an independent ``asyncio.Task``. Results
     are gathered and merged into a single metrics dictionary.
 
+    When :func:`get_async_eval_dispatcher` returns a dispatcher (installed via
+    ``Config.async_eval=True`` in :func:`main`), evaluators are scheduled
+    fire-and-forget instead and the returned dict contains only sentinel keys.
+    The real metrics get logged retroactively via the dispatcher's
+    ``ml_logger`` reference at the captured iteration step.
+
     Args:
         evaluators (list[SamplingClientEvaluator]): Evaluators to execute.
         sampling_client (tinker.SamplingClient): Sampling client with the
@@ -599,8 +709,15 @@ async def run_evaluations_parallel(
         i_batch (int): Current training iteration index.
 
     Returns:
-        dict[str, Any]: Merged metrics from all evaluators.
+        dict[str, Any]: Merged metrics from all evaluators, OR sentinel metrics
+            when async eval is enabled.
     """
+
+    dispatcher = get_async_eval_dispatcher()
+    if dispatcher is not None:
+        return dispatcher.schedule(
+            evaluators, sampling_client, config, i_batch, store=store
+        )
 
     # Create tasks for all evaluators with names for better traceability
     tasks = []
@@ -1850,6 +1967,10 @@ async def main(
         config=config,
         wandb_name=config.wandb_name,
     )
+    async_eval_dispatcher: _AsyncEvalDispatcher | None = None
+    if config.async_eval:
+        async_eval_dispatcher = _AsyncEvalDispatcher(ml_logger=ml_logger)
+        set_async_eval_dispatcher(async_eval_dispatcher)
     store = ml_logger.store
     if config.enable_trace:
         # Get and rename the current (main) task
@@ -1982,6 +2103,9 @@ async def main(
         await checkpoint_mgr.finalize_async()
 
     # Cleanup
+    if async_eval_dispatcher is not None:
+        await async_eval_dispatcher.drain(timeout=config.async_eval_drain_timeout_s)
+        set_async_eval_dispatcher(None)
     if rollout_executor is not None:
         rollout_executor.shutdown(wait=True)
         set_rollout_executor(None)

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -595,17 +595,17 @@ async def run_single_evaluation(
         return eval_metrics
 
 
-_async_eval_dispatcher: ContextVar["_AsyncEvalDispatcher | None"] = ContextVar(
+_async_eval_dispatcher: ContextVar[_AsyncEvalDispatcher | None] = ContextVar(
     "async_eval_dispatcher", default=None
 )
 
 
-def get_async_eval_dispatcher() -> "_AsyncEvalDispatcher | None":
+def get_async_eval_dispatcher() -> _AsyncEvalDispatcher | None:
     """Return the currently installed async-eval dispatcher (or ``None``)."""
     return _async_eval_dispatcher.get()
 
 
-def set_async_eval_dispatcher(dispatcher: "_AsyncEvalDispatcher | None") -> None:
+def set_async_eval_dispatcher(dispatcher: _AsyncEvalDispatcher | None) -> None:
     """Install (or clear) the async-eval dispatcher in the current context."""
     _async_eval_dispatcher.set(dispatcher)
 
@@ -628,7 +628,7 @@ class _AsyncEvalDispatcher:
         self,
         evaluators: list[SamplingClientEvaluator],
         sampling_client: tinker.SamplingClient,
-        config: "Config",
+        config: Config,
         i_batch: int,
         store: TrainingRunStore | None = None,
     ) -> dict[str, Any]:
@@ -653,7 +653,7 @@ class _AsyncEvalDispatcher:
     async def _run_and_log(
         self,
         evaluator: SamplingClientEvaluator,
-        config: "Config",
+        config: Config,
         i_batch: int,
         sampling_client: tinker.SamplingClient,
         evaluator_label: str,
@@ -665,10 +665,8 @@ class _AsyncEvalDispatcher:
             )
             self._ml_logger.log_metrics(metrics, step=i_batch)
             logger.info("Async eval %s at iter=%d completed.", evaluator_label, i_batch)
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                "Async eval %s at iter=%d failed: %s", evaluator_label, i_batch, e
-            )
+        except Exception as e:
+            logger.warning("Async eval %s at iter=%d failed: %s", evaluator_label, i_batch, e)
 
     async def drain(self, timeout: float | None = None) -> None:
         """Await all pending eval tasks. No-op when none are in flight."""
@@ -715,9 +713,7 @@ async def run_evaluations_parallel(
 
     dispatcher = get_async_eval_dispatcher()
     if dispatcher is not None:
-        return dispatcher.schedule(
-            evaluators, sampling_client, config, i_batch, store=store
-        )
+        return dispatcher.schedule(evaluators, sampling_client, config, i_batch, store=store)
 
     # Create tasks for all evaluators with names for better traceability
     tasks = []

--- a/tinker_cookbook/rl/train_async_eval_test.py
+++ b/tinker_cookbook/rl/train_async_eval_test.py
@@ -30,9 +30,7 @@ async def test_schedule_returns_sentinel_immediately():
         return {"score": 0.5}
 
     with patch("tinker_cookbook.rl.train.run_single_evaluation", side_effect=slow_run):
-        sentinel = dispatcher.schedule(
-            [MagicMock(name="ev")], MagicMock(), MagicMock(), i_batch=7
-        )
+        sentinel = dispatcher.schedule([MagicMock(name="ev")], MagicMock(), MagicMock(), i_batch=7)
         # schedule() must return immediately. The eval coroutine may or may not have
         # actually started yet (it's a freshly-created task).
         assert sentinel.get("async_eval/in_flight") == 1.0

--- a/tinker_cookbook/rl/train_async_eval_test.py
+++ b/tinker_cookbook/rl/train_async_eval_test.py
@@ -1,0 +1,133 @@
+"""Tests for the async-eval dispatcher in ``rl/train.py``."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tinker_cookbook.rl.train import (
+    _AsyncEvalDispatcher,
+    get_async_eval_dispatcher,
+    run_evaluations_parallel,
+    set_async_eval_dispatcher,
+)
+
+
+@pytest.mark.asyncio
+async def test_schedule_returns_sentinel_immediately():
+    """schedule() must return a sentinel dict without awaiting the evaluator."""
+    ml_logger = MagicMock()
+    dispatcher = _AsyncEvalDispatcher(ml_logger=ml_logger)
+
+    started_event = asyncio.Event()
+    release_event = asyncio.Event()
+
+    async def slow_run(evaluator, config, i_batch, sampling_client, label, store=None):
+        started_event.set()
+        await release_event.wait()
+        return {"score": 0.5}
+
+    with patch("tinker_cookbook.rl.train.run_single_evaluation", side_effect=slow_run):
+        sentinel = dispatcher.schedule(
+            [MagicMock(name="ev")], MagicMock(), MagicMock(), i_batch=7
+        )
+        # schedule() must return immediately. The eval coroutine may or may not have
+        # actually started yet (it's a freshly-created task).
+        assert sentinel.get("async_eval/in_flight") == 1.0
+        assert any(k.endswith("/scheduled") for k in sentinel)
+        ml_logger.log_metrics.assert_not_called()
+
+        release_event.set()
+        await dispatcher.drain(timeout=5.0)
+
+    ml_logger.log_metrics.assert_called_once()
+    call = ml_logger.log_metrics.call_args
+    assert call.args[0] == {"score": 0.5}
+    assert call.kwargs.get("step") == 7
+
+
+@pytest.mark.asyncio
+async def test_drain_awaits_pending_tasks_and_logs_at_captured_step():
+    """drain() must wait for in-flight evals and log each at the captured i_batch."""
+    ml_logger = MagicMock()
+    dispatcher = _AsyncEvalDispatcher(ml_logger=ml_logger)
+
+    captured_steps: list[int] = []
+
+    async def quick_run(evaluator, config, i_batch, sampling_client, label, store=None):
+        captured_steps.append(i_batch)
+        await asyncio.sleep(0)
+        return {"score": float(i_batch)}
+
+    with patch("tinker_cookbook.rl.train.run_single_evaluation", side_effect=quick_run):
+        # Schedule three batches at different steps.
+        dispatcher.schedule([MagicMock()], MagicMock(), MagicMock(), i_batch=10)
+        dispatcher.schedule([MagicMock()], MagicMock(), MagicMock(), i_batch=20)
+        dispatcher.schedule([MagicMock()], MagicMock(), MagicMock(), i_batch=30)
+        assert len(dispatcher._pending) == 3
+        await dispatcher.drain()
+
+    assert sorted(captured_steps) == [10, 20, 30]
+    assert ml_logger.log_metrics.call_count == 3
+    logged_steps = {c.kwargs["step"] for c in ml_logger.log_metrics.call_args_list}
+    assert logged_steps == {10, 20, 30}
+
+
+@pytest.mark.asyncio
+async def test_run_evaluations_parallel_routes_through_dispatcher_when_installed():
+    """When a dispatcher is installed via the ContextVar, run_evaluations_parallel
+    must consult it instead of awaiting evaluators inline."""
+    ml_logger = MagicMock()
+    dispatcher = _AsyncEvalDispatcher(ml_logger=ml_logger)
+    set_async_eval_dispatcher(dispatcher)
+
+    try:
+        # If the dispatcher wasn't consulted, run_single_evaluation would be awaited
+        # immediately and ml_logger would NOT be called (since it's only called from
+        # inside the dispatcher's done-callback).
+        async def slow_run(*args, **kwargs):
+            await asyncio.sleep(60)
+            return {}
+
+        with patch("tinker_cookbook.rl.train.run_single_evaluation", side_effect=slow_run):
+            result = await run_evaluations_parallel(
+                [MagicMock()], MagicMock(), MagicMock(), i_batch=3
+            )
+        # Sentinel keys mean we went through the dispatcher.
+        assert "async_eval/in_flight" in result
+        assert len(dispatcher._pending) == 1
+        for task in list(dispatcher._pending):
+            task.cancel()
+    finally:
+        set_async_eval_dispatcher(None)
+
+
+@pytest.mark.asyncio
+async def test_get_set_dispatcher_round_trip():
+    """ContextVar install/clear works."""
+    assert get_async_eval_dispatcher() is None
+    dispatcher = _AsyncEvalDispatcher(ml_logger=MagicMock())
+    set_async_eval_dispatcher(dispatcher)
+    try:
+        assert get_async_eval_dispatcher() is dispatcher
+    finally:
+        set_async_eval_dispatcher(None)
+    assert get_async_eval_dispatcher() is None
+
+
+@pytest.mark.asyncio
+async def test_eval_failure_is_swallowed_with_warning():
+    """A failing evaluator must not kill training: the exception is logged, not raised."""
+    ml_logger = MagicMock()
+    dispatcher = _AsyncEvalDispatcher(ml_logger=ml_logger)
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("simulated failure")
+
+    with patch("tinker_cookbook.rl.train.run_single_evaluation", side_effect=boom):
+        dispatcher.schedule([MagicMock()], MagicMock(), MagicMock(), i_batch=1)
+        await dispatcher.drain()
+    # ml_logger never received a real metric write
+    ml_logger.log_metrics.assert_not_called()


### PR DESCRIPTION
## Summary

Adds `Config.async_eval: bool = False` (default off — no behavior change). When enabled, `run_evaluations_parallel` schedules each evaluator as a fire-and-forget `asyncio.Task` instead of awaiting them inline. Eval metrics are logged asynchronously via `ml_logger.log_metrics(metrics, step=i_batch_when_scheduled)` when each evaluator finishes; pending tasks are awaited up to `async_eval_drain_timeout_s` (default 600s) at shutdown.

## Motivation

In long-CoT RL training (e.g. `max_tokens=24576` against hundreds of LiveCodeBench-style problems), a single eval pass can take minutes — comparable to a training step. With the current sync-await pattern at `train.py:692`, `train.py:1225`, `train.py:1694`, training stalls for the entire eval. Even though evaluators internally use `asyncio.gather`, the train loop awaits the whole gather before the next step.

`set_rollout_executor(ProcessPoolExecutor(...))` is the cookbook's existing scale-out path, but it parallelizes *within* an eval rather than overlapping eval with training. This PR adds the missing overlap by making the schedule fire-and-forget.

I was running this pattern as an out-of-tree wrapper around `RLTestSetEvaluator` for our own training and it cleanly cut the eval-induced stall to zero, so figured it might be worth upstreaming as a built-in opt-in.

## Design

| | |
|---|---|
| Backward compat | Off by default. `Config.async_eval=False` → existing behavior, byte-for-byte. |
| Wiring | New `_AsyncEvalDispatcher` class + `ContextVar` (`_async_eval_dispatcher`). Pattern mirrors the existing `_rollout_executor` ContextVar in `rl/rollouts.py`. |
| Signature change | None. `run_evaluations_parallel` consults `get_async_eval_dispatcher()` at the top of the function. |
| Metric logging | When async, each eval's metrics are written via `ml_logger.log_metrics(metrics, step=i_batch_when_scheduled)` after the task completes. W&B accepts retroactive step writes. |
| Shutdown | `main()` awaits `dispatcher.drain(timeout=config.async_eval_drain_timeout_s)` before `ml_logger.close()`. Set timeout to `None` for unbounded. |

## Tradeoffs (documented in the Config docstring)

* Eval rollouts compete with training rollouts for per-account Tinker sampling concurrency. Heavy evals may slow training.
* W&B charts will show retroactive step writes — well-supported but worth knowing when reading hover values.
* Evaluator exceptions are swallowed with a warning rather than raised (a flaky eval shouldn't kill training).

## Tests

Adds `tinker_cookbook/rl/train_async_eval_test.py` (5 tests, no API or network):

- `test_schedule_returns_sentinel_immediately` — schedule returns without awaiting the underlying evaluator
- `test_drain_awaits_pending_tasks_and_logs_at_captured_step` — multiple scheduled evals all log via ml_logger at their captured i_batch
- `test_run_evaluations_parallel_routes_through_dispatcher_when_installed` — ContextVar-based dispatch works at the public API boundary
- `test_get_set_dispatcher_round_trip` — ContextVar install/clear
- `test_eval_failure_is_swallowed_with_warning` — exception in evaluator does not propagate

All 5 pass.

I also ran `pytest tinker_cookbook/rl/` (full RL test suite): **108 passed, 3 skipped**. One pre-existing failure unrelated to this change (`rollout_logging_test::test_write_rollout_summaries_jsonl_handles_numpy_scalars` — a deprecation that should have been removed in 0.4.0 per its own message; reproduces on `main` without this PR).

## Test plan

- [x] New unit tests added and passing
- [x] Existing `tinker_cookbook/rl/` tests still pass (one pre-existing unrelated failure on main)
- [ ] Smoke test the cookbook-internal `Config(async_eval=True)` path against a real Tinker RL run (I've validated the same approach via an external wrapper; haven't yet run with the in-cookbook `Config.async_eval=True` flag wired end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)