### PR TITLE
AGENTS: add section on finding supported models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ Agents often struggle with the nested type hierarchy.
 
 ---
 
+## Finding supported models
+
+For an identifier to pass to the SDK, call `service_client.get_server_capabilities().supported_models` — authoritative, includes `:peft:` long-context variants, but requires `TINKER_API_KEY`. For a read-only lookup with pricing and context length (no auth), browse <https://tinker-docs.thinkingmachines.ai/tinker/models/>.
+
+---
+
 ## Common Pitfalls
 
 1. **Sequential API calls:** The #1 performance mistake. Always use `_async` variants and submit calls back-to-back before awaiting. Use `asyncio.gather` for concurrent evaluation — never sequential loops over API calls.


### PR DESCRIPTION
## Summary

Adds a short section to AGENTS.md telling coding agents where to find the list of supported Tinker model identifiers:

- **Runtime, authoritative:** \`service_client.get_server_capabilities().supported_models\` — includes \`:peft:\` long-context variants but requires \`TINKER_API_KEY\`.
- **No-auth fallback:** the public Models page on tinker-docs, useful when an agent just wants to look up an identifier (with pricing and context length) before writing code.

CLAUDE.md is a symlink to AGENTS.md so it picks up the change automatically.

## Motivation

The existing pitfall #4 points agents at \`model_info.get_recommended_renderer_name()\` for renderers but doesn't say where to find the model identifiers themselves. Agents have been guessing or hardcoding stale IDs.