### PR TITLE
Update cookbook model lineup

### DIFF
--- a/tinker_cookbook/chat_app/README.md
+++ b/tinker_cookbook/chat_app/README.md
@@ -11,13 +11,13 @@ You can easily chat with any sampler checkpoint saved using **Tinker** by runnin
 ```bash
 python -m tinker_cookbook.chat_app.tinker_chat_cli \
     model_path=tinker://<unique_id>/sampler_weights/final \
-    base_model=meta-llama/Llama-3.1-8B
+    base_model=Qwen/Qwen3.5-9B-Base
 ```
 
 ### Arguments
 
 * **model_path**: Path to the trained Tinker sampler checkpoint. Example: `tinker://<unique_id>/sampler_weights/final`. Note that the Tinker chat CLI will not work with training weights which look like `tinker://<unique_id>/weights/final`. Make sure the checkpoint contains `sampler_weights`.
-* **base_model**: Hugging Face base model to use for inference. Example: `meta-llama/Llama-3.1-8B`
+* **base_model**: Hugging Face base model to use for inference. Example: `Qwen/Qwen3.5-9B-Base`
 
 ---
 
@@ -39,7 +39,7 @@ Example:
 ```bash
 python -m tinker_cookbook.chat_app.tinker_chat_cli \
     model_path=tinker://<unique_id>/sampler_weights/final \
-    base_model=meta-llama/Llama-3.1-8B \
+    base_model=Qwen/Qwen3.5-9B-Base \
     max_tokens=256 \
     temperature=0.8 \
     top_p=0.95

--- a/tinker_cookbook/chat_app/tinker_chat_cli.py
+++ b/tinker_cookbook/chat_app/tinker_chat_cli.py
@@ -26,7 +26,7 @@ logging.basicConfig(
 
 @chz.chz
 class Config:
-    base_model: str = "meta-llama/Llama-3.2-1B"
+    base_model: str = "Qwen/Qwen3.5-9B-Base"
     model_path: str | None = None
     max_tokens: int = 512
     temperature: float = 0.7

--- a/tinker_cookbook/distillation/__init__.py
+++ b/tinker_cookbook/distillation/__init__.py
@@ -21,7 +21,7 @@ point. Access them via the submodule to avoid naming conflicts::
     from tinker_cookbook.distillation import train_on_policy
 
     config = train_on_policy.Config(
-        model_name="Qwen/Qwen3.5-35B-A3B",
+        model_name="Qwen/Qwen3.6-35B-A3B",
         ...,
     )
     await train_on_policy.main(config)

--- a/tinker_cookbook/distillation/sdft.py
+++ b/tinker_cookbook/distillation/sdft.py
@@ -27,7 +27,7 @@ Example usage::
 
     # SDFT with top-K=20 distillation on tool-use data
     python -m tinker_cookbook.recipes.sdft.train \\
-        model_name=Qwen/Qwen3.5-35B-A3B \\
+        model_name=Qwen/Qwen3.6-35B-A3B \\
         dataset=toolalpaca \\
         toolalpaca_data_path=~/Self-Distillation/data/tooluse_data/train_data \\
         groups_per_batch=128 \\

--- a/tinker_cookbook/eval/README.md
+++ b/tinker_cookbook/eval/README.md
@@ -285,6 +285,8 @@ Treat these scores as reference points for a specific configuration, not definit
 Reference scores on **[Qwen3.5-35B-A3B](https://huggingface.co/Qwen/Qwen3.5-35B-A3B)** with `max_tokens=32768`, `temperature=0.6`.
 Official scores from the model card (which may use different settings).
 
+> **Note:** These historical scores used `Qwen3.5-35B-A3B`, which is deprecated. Rerun the benchmark suite with `Qwen/Qwen3.6-35B-A3B` before treating these results as current.
+
 **Stable benchmarks:**
 
 | Benchmark | Our Score | Official | Match? | Settings |
@@ -341,7 +343,8 @@ for a reference bash-only implementation that achieves 74%+ with frontier models
 ### Qwen3.5-35B-A3B (64K context)
 
 Model: ``Qwen/Qwen3.5-35B-A3B``. Renderer: ``qwen3_5``.
-Official scores from the [Qwen3.5-35B-A3B model card](https://huggingface.co/Qwen/Qwen3.5-35B-A3B).
+
+> **Note:** `Qwen/Qwen3.5-35B-A3B` is deprecated. Rerun these verified scores with `Qwen/Qwen3.6-35B-A3B`.
 
 | Benchmark | Raw | Completed | Official | Match? |
 |-----------|-----|-----------|----------|--------|

--- a/tinker_cookbook/eval/benchmarks/_types.py
+++ b/tinker_cookbook/eval/benchmarks/_types.py
@@ -112,29 +112,22 @@ _MODEL_EVAL_DEFAULTS: dict[str, dict[str, int | float]] = {
         "context_window": 262144,
         "timeout_seconds": 1800,
     },
-    "Qwen/Qwen3.5-35B-A3B": {"max_tokens": 65536, "context_window": 65536, "timeout_seconds": 1800},
-    "Qwen/Qwen3.5-27B": {"max_tokens": 65536, "context_window": 65536, "timeout_seconds": 1800},
+    "Qwen/Qwen3.6-35B-A3B": {"max_tokens": 65536, "context_window": 65536, "timeout_seconds": 1800},
+    "Qwen/Qwen3.6-27B": {"max_tokens": 65536, "context_window": 65536, "timeout_seconds": 1800},
+    "Qwen/Qwen3.5-35B-A3B-Base": {
+        "max_tokens": 65536,
+        "context_window": 65536,
+        "timeout_seconds": 1800,
+    },
+    "Qwen/Qwen3.5-9B": {"max_tokens": 65536, "context_window": 65536, "timeout_seconds": 300},
+    "Qwen/Qwen3.5-9B-Base": {
+        "max_tokens": 65536,
+        "context_window": 65536,
+        "timeout_seconds": 300,
+    },
     "Qwen/Qwen3.5-4B": {"max_tokens": 65536, "context_window": 65536, "timeout_seconds": 1800},
     # Qwen3 — Hybrid (thinking), 32K context
-    "Qwen/Qwen3-30B-A3B": {"max_tokens": 32768, "context_window": 32768, "timeout_seconds": 1800},
-    "Qwen/Qwen3-32B": {"max_tokens": 32768, "context_window": 32768, "timeout_seconds": 1800},
     "Qwen/Qwen3-8B": {"max_tokens": 32768, "context_window": 32768, "timeout_seconds": 1800},
-    # Qwen3 — Instruction (non-thinking), 32K context
-    "Qwen/Qwen3-235B-A22B-Instruct-2507": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
-    "Qwen/Qwen3-30B-A3B-Instruct-2507": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
-    "Qwen/Qwen3-4B-Instruct-2507": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
     # Nemotron — Hybrid (thinking), 64K context
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {
         "max_tokens": 65536,
@@ -166,54 +159,11 @@ _MODEL_EVAL_DEFAULTS: dict[str, dict[str, int | float]] = {
         "timeout_seconds": 1800,
     },
     # Kimi — Reasoning, 32K context
-    "moonshotai/Kimi-K2-Thinking": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 1800,
-    },
-    "moonshotai/Kimi-K2.5": {"max_tokens": 32768, "context_window": 32768, "timeout_seconds": 1800},
-    "moonshotai/Kimi-K2.5:peft:131072": {
-        "max_tokens": 131072,
-        "context_window": 131072,
-        "timeout_seconds": 1800,
-    },
     "moonshotai/Kimi-K2.6": {"max_tokens": 32768, "context_window": 32768, "timeout_seconds": 1800},
     "moonshotai/Kimi-K2.6:peft:131072": {
         "max_tokens": 131072,
         "context_window": 131072,
         "timeout_seconds": 1800,
-    },
-    # Llama — Instruction (non-thinking), 32K context
-    "meta-llama/Llama-3.3-70B-Instruct": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
-    "meta-llama/Llama-3.1-8B-Instruct": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
-    # Llama — Base, 32K context
-    "meta-llama/Llama-3.1-70B": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
-    "meta-llama/Llama-3.1-8B": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
-    "meta-llama/Llama-3.2-3B": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
-    },
-    "meta-llama/Llama-3.2-1B": {
-        "max_tokens": 32768,
-        "context_window": 32768,
-        "timeout_seconds": 300,
     },
 }
 
@@ -360,13 +310,13 @@ class BenchmarkConfig:
         Example::
 
             config = BenchmarkConfig.for_model(
-                "Qwen/Qwen3.5-35B-A3B",
+                "Qwen/Qwen3.6-35B-A3B",
                 save_dir="evals/my_model",
             )
             result = await run_benchmark("gsm8k", client, renderer, config)
 
         Args:
-            model_name: Model ID (e.g., ``"Qwen/Qwen3.5-35B-A3B"``).
+            model_name: Model ID (e.g., ``"Qwen/Qwen3.6-35B-A3B"``).
                 See https://tinker-docs.thinkingmachines.ai/tinker/models/
             **kwargs: Override any :class:`BenchmarkConfig` field.
 

--- a/tinker_cookbook/eval/custom_evaluators.py
+++ b/tinker_cookbook/eval/custom_evaluators.py
@@ -86,14 +86,12 @@ def grader_fn(response: str, target: str) -> bool:
 evaluator = CustomEvaluator(
     dataset=QA_DATASET,
     grader_fn=grader_fn,
-    renderer_name="llama3",
-    model_name="meta-llama/Llama-3.1-8B-Instruct",
+    renderer_name="qwen3_5_disable_thinking",
+    model_name="Qwen/Qwen3.5-9B",
 )
 
 service_client = tinker.ServiceClient()
-sampling_client = service_client.create_sampling_client(
-    base_model="meta-llama/Llama-3.1-8B-Instruct"
-)
+sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3.5-9B")
 
 
 async def main():

--- a/tinker_cookbook/eval/custom_inspect_task.py
+++ b/tinker_cookbook/eval/custom_inspect_task.py
@@ -6,7 +6,7 @@ python -m tinker_cookbook.eval.run_inspect_evals \
     model_path=tinker://your-model-path \
     tasks=tinker_cookbook.eval.custom_inspect_task:example_lm_as_judge \
     renderer_name=role_colon \
-    model_name=Qwen/Qwen3-8B-Base
+    model_name=Qwen/Qwen3.5-9B-Base
 """
 
 import tinker
@@ -34,13 +34,11 @@ QA_DATASET = MemoryDataset(
 )
 
 service_client = tinker.ServiceClient()
-sampling_client = service_client.create_sampling_client(
-    base_model="meta-llama/Llama-3.1-8B-Instruct"
-)
+sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3.5-9B")
 
 api = InspectAPIFromTinkerSampling(
-    renderer_name="llama3",  # pyright: ignore[reportCallIssue]
-    model_name="meta-llama/Llama-3.1-8B-Instruct",
+    renderer_name="qwen3_5_disable_thinking",  # pyright: ignore[reportCallIssue]
+    model_name="Qwen/Qwen3.5-9B",
     sampling_client=sampling_client,  # pyright: ignore[reportCallIssue]
     verbose=False,  # pyright: ignore[reportCallIssue]
 )

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -79,40 +79,22 @@ def get_lora_lr_over_full_finetune_lr(model_name: str, lora_alpha: int = 32) -> 
 def _get_hidden_size(model_name: str) -> int:
     # Known hidden sizes for models in the lineup. This avoids network lookups and
     # works around gated repos (Llama) and configs that nest hidden_size under
-    # text_config (Qwen3-VL, Qwen3.5, Kimi-K2.5).
+    # text_config (Qwen3-VL, Qwen3.5, Kimi-K2.6).
     _KNOWN_HIDDEN_SIZES: dict[str, int] = {
         # Llama-3 (gated — cannot fetch config without HF_TOKEN)
-        "meta-llama/Llama-3.2-1B": 2048,
         "meta-llama/Llama-3.2-1B-Instruct": 2048,
-        "meta-llama/Llama-3.2-3B": 3072,
         "meta-llama/Llama-3.2-3B-Instruct": 3072,
-        "meta-llama/Llama-3.1-8B": 4096,
-        "meta-llama/Llama-3.1-8B-Instruct": 4096,
-        "meta-llama/Llama-3.1-70B": 8192,
-        "meta-llama/Llama-3.3-70B-Instruct": 8192,
         # DeepSeek
         "deepseek-ai/DeepSeek-V3.1": 7168,
-        "deepseek-ai/DeepSeek-V3.1-Base": 7168,
         # Kimi
-        "moonshotai/Kimi-K2-Thinking": 7168,
-        "moonshotai/Kimi-K2.5": 7168,
         "moonshotai/Kimi-K2.6": 7168,
         # Qwen3 (text-only)
-        "Qwen/Qwen3-235B-A22B-Instruct-2507": 4096,
-        "Qwen/Qwen3-30B-A3B-Instruct-2507": 2048,
-        "Qwen/Qwen3-30B-A3B": 2048,
-        "Qwen/Qwen3-30B-A3B-Base": 2048,
-        "Qwen/Qwen3-32B": 5120,
         "Qwen/Qwen3-8B": 4096,
-        "Qwen/Qwen3-8B-Base": 4096,
-        "Qwen/Qwen3-4B-Instruct-2507": 2560,
-        # Qwen3-VL (config nests hidden_size under text_config)
-        "Qwen/Qwen3-VL-235B-A22B-Instruct": 4096,
-        "Qwen/Qwen3-VL-30B-A3B-Instruct": 2048,
         # Qwen3.5 (config nests hidden_size under text_config)
         "Qwen/Qwen3.5-397B-A17B": 4096,
-        "Qwen/Qwen3.5-35B-A3B": 2048,
-        "Qwen/Qwen3.5-27B": 5120,
+        "Qwen/Qwen3.5-35B-A3B-Base": 2048,
+        "Qwen/Qwen3.5-9B": 4096,
+        "Qwen/Qwen3.5-9B-Base": 4096,
         "Qwen/Qwen3.5-4B": 2560,
         # Qwen3.6 (same architecture family as Qwen3.5, hidden_size under text_config)
         "Qwen/Qwen3.6-27B": 5120,
@@ -154,36 +136,13 @@ def _get_hidden_size(model_name: str) -> int:
 # To refresh these counts (e.g., when a new model ships), ask a Tinker team
 # member to re-run the measurement script.
 _LORA_PARAMS_PER_RANK_BY_COMPONENT: dict[str, dict[str, int]] = {
-    "Qwen/Qwen3-235B-A22B-Instruct-2507": {
-        "mlp": 56_598_528,
-        "attn": 3_176_448,
-        "unembed": 156_032,
-    },
-    "Qwen/Qwen3-30B-A3B": {"mlp": 14_450_688, "attn": 835_584, "unembed": 153_984},
-    "Qwen/Qwen3-30B-A3B-Base": {"mlp": 14_450_688, "attn": 835_584, "unembed": 153_984},
-    "Qwen/Qwen3-30B-A3B-Instruct-2507": {"mlp": 14_450_688, "attn": 835_584, "unembed": 153_984},
-    "Qwen/Qwen3-32B": {"mlp": 5_898_240, "attn": 2_490_368, "unembed": 157_056},
-    "Qwen/Qwen3-4B-Instruct-2507": {"mlp": 1_327_104, "attn": 737_280, "unembed": 154_496},
     "Qwen/Qwen3-8B": {"mlp": 1_769_472, "attn": 958_464, "unembed": 156_032},
-    "Qwen/Qwen3-8B-Base": {"mlp": 1_769_472, "attn": 958_464, "unembed": 156_032},
-    "Qwen/Qwen3-VL-235B-A22B-Instruct": {"mlp": 56_598_528, "attn": 3_176_448, "unembed": 156_032},
-    "Qwen/Qwen3-VL-30B-A3B-Instruct": {"mlp": 14_450_688, "attn": 835_584, "unembed": 153_984},
-    "Qwen/Qwen3.5-27B": {"mlp": 4_325_376, "attn": 2_965_504, "unembed": 253_440},
-    "Qwen/Qwen3.5-35B-A3B": {"mlp": 16_281_600, "attn": 1_013_760, "unembed": 250_368},
     "Qwen/Qwen3.5-397B-A17B": {"mlp": 96_030_720, "attn": 2_841_600, "unembed": 252_416},
+    "Qwen/Qwen3.5-35B-A3B-Base": {"mlp": 16_281_600, "attn": 1_013_760, "unembed": 250_368},
     "Qwen/Qwen3.5-4B": {"mlp": 1_130_496, "attn": 897_024, "unembed": 250_880},
     "Qwen/Qwen3.6-27B": {"mlp": 4_325_376, "attn": 2_965_504, "unembed": 253_440},
     "Qwen/Qwen3.6-35B-A3B": {"mlp": 16_281_600, "attn": 1_013_760, "unembed": 250_368},
     "deepseek-ai/DeepSeek-V3.1": {"mlp": 94_307_328, "attn": 2_440_000, "unembed": 136_448},
-    "deepseek-ai/DeepSeek-V3.1-Base": {"mlp": 94_307_328, "attn": 2_440_000, "unembed": 136_448},
-    "meta-llama/Llama-3.1-70B": {"mlp": 8_847_360, "attn": 4_096_000, "unembed": 136_448},
-    "meta-llama/Llama-3.1-8B": {"mlp": 1_769_472, "attn": 851_968, "unembed": 132_352},
-    "meta-llama/Llama-3.1-8B-Instruct": {"mlp": 1_769_472, "attn": 851_968, "unembed": 132_352},
-    "meta-llama/Llama-3.2-1B": {"mlp": 491_520, "attn": 212_992, "unembed": 130_304},
-    "meta-llama/Llama-3.2-3B": {"mlp": 946_176, "attn": 573_440, "unembed": 131_328},
-    "meta-llama/Llama-3.3-70B-Instruct": {"mlp": 8_847_360, "attn": 4_096_000, "unembed": 136_448},
-    "moonshotai/Kimi-K2-Thinking": {"mlp": 144_583_680, "attn": 1_940_288, "unembed": 171_008},
-    "moonshotai/Kimi-K2.5": {"mlp": 144_583_680, "attn": 1_940_288, "unembed": 171_008},
     "moonshotai/Kimi-K2.6": {"mlp": 144_583_680, "attn": 1_940_288, "unembed": 171_008},
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {
         "mlp": 11_346_176,
@@ -263,11 +222,8 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
         exponent_model = 0.0775
     elif model_name in (
         "deepseek-ai/DeepSeek-V3.1",
-        "deepseek-ai/DeepSeek-V3.1-Base",
         "openai/gpt-oss-20b",
         "openai/gpt-oss-120b",
-        "moonshotai/Kimi-K2-Thinking",
-        "moonshotai/Kimi-K2.5",
         "moonshotai/Kimi-K2.6",
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
         "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",

--- a/tinker_cookbook/image_processing_utils.py
+++ b/tinker_cookbook/image_processing_utils.py
@@ -33,10 +33,7 @@ def get_image_processor(model_name: str) -> ImageProcessor:
     if os.environ.get("HF_TRUST_REMOTE_CODE", "").lower() in ("1", "true", "yes"):
         kwargs["trust_remote_code"] = True
 
-    if model_name == "moonshotai/Kimi-K2.5":
-        kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "3367c8d1c68584429fab7faf845a32d5195b6ac1"
-    elif model_name == "moonshotai/Kimi-K2.6":
+    if model_name == "moonshotai/Kimi-K2.6":
         kwargs["trust_remote_code"] = True
         kwargs["revision"] = "b5aabbfb20227ed42becbf5541dbffd213942c58"
 

--- a/tinker_cookbook/image_processing_utils_test.py
+++ b/tinker_cookbook/image_processing_utils_test.py
@@ -12,16 +12,16 @@ def _clear_cache() -> None:
 
 
 @patch("transformers.models.auto.image_processing_auto.AutoImageProcessor")
-def test_kimi_k25_trusts_remote_code_without_env(
+def test_kimi_k26_trusts_remote_code_without_env(
     mock_auto: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Hardcoded Kimi K2.5 should pass trust_remote_code=True without the env var."""
+    """Hardcoded Kimi K2.6 should pass trust_remote_code=True without the env var."""
     monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
-    get_image_processor("moonshotai/Kimi-K2.5")
+    get_image_processor("moonshotai/Kimi-K2.6")
     mock_auto.from_pretrained.assert_called_once_with(
-        "moonshotai/Kimi-K2.5",
+        "moonshotai/Kimi-K2.6",
         trust_remote_code=True,
-        revision="3367c8d1c68584429fab7faf845a32d5195b6ac1",
+        revision="b5aabbfb20227ed42becbf5541dbffd213942c58",
     )
 
 

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -59,18 +59,12 @@ def get_llama_info() -> dict[str, ModelAttributes]:
 
     Returns:
         dict[str, ModelAttributes]: Mapping from model version name
-            (e.g. ``"Llama-3.1-8B-Instruct"``) to its attributes.
+            (e.g. ``"Llama-3.2-1B-Instruct"``) to its attributes.
     """
     org = "meta-llama"
     return {
         "Llama-3.2-1B-Instruct": ModelAttributes(org, "3.2", "1B", True, _LLAMA3),
         "Llama-3.2-3B-Instruct": ModelAttributes(org, "3.2", "3B", True, _LLAMA3),
-        "Llama-3.1-8B-Instruct": ModelAttributes(org, "3.1", "8B", True, _LLAMA3),
-        "Llama-3.2-1B": ModelAttributes(org, "3.2", "1B", False, _ROLE_COLON),
-        "Llama-3.2-3B": ModelAttributes(org, "3.2", "3B", False, _ROLE_COLON),
-        "Llama-3.1-8B": ModelAttributes(org, "3.1", "8B", False, _ROLE_COLON),
-        "Llama-3.1-70B": ModelAttributes(org, "3.1", "70B", False, _ROLE_COLON),
-        "Llama-3.3-70B-Instruct": ModelAttributes(org, "3.3", "70B", True, _LLAMA3),
     }
 
 
@@ -86,31 +80,19 @@ def get_qwen_info() -> dict[str, ModelAttributes]:
     """
     org = "Qwen"
     return {
-        "Qwen3-VL-30B-A3B-Instruct": ModelAttributes(
-            org, "3", "30B-A3B", True, _QWEN3_VL_INSTRUCT, is_vl=True
-        ),
-        "Qwen3-VL-235B-A22B-Instruct": ModelAttributes(
-            org, "3", "235B-A22B", True, _QWEN3_VL_INSTRUCT, is_vl=True
-        ),
         "Qwen3-4B-Base": ModelAttributes(org, "3", "4B", False, _ROLE_COLON),
-        "Qwen3-8B-Base": ModelAttributes(org, "3", "8B", False, _ROLE_COLON),
         "Qwen3-14B-Base": ModelAttributes(org, "3", "14B", False, _ROLE_COLON),
-        "Qwen3-30B-A3B-Base": ModelAttributes(org, "3", "30B-A3B", False, _ROLE_COLON),
         "Qwen3-0.6B": ModelAttributes(org, "3", "0.6B", True, _QWEN3),
         "Qwen3-1.7B": ModelAttributes(org, "3", "1.7B", True, _QWEN3),
         "Qwen3-4B": ModelAttributes(org, "3", "4B", True, _QWEN3),
         "Qwen3-8B": ModelAttributes(org, "3", "8B", True, _QWEN3),
         "Qwen3-14B": ModelAttributes(org, "3", "14B", True, _QWEN3),
-        "Qwen3-32B": ModelAttributes(org, "3", "32B", True, _QWEN3),
-        "Qwen3-30B-A3B": ModelAttributes(org, "3", "30B-A3B", True, _QWEN3),
-        "Qwen3-4B-Instruct-2507": ModelAttributes(org, "3", "4B", True, _QWEN3_INSTRUCT),
-        "Qwen3-30B-A3B-Instruct-2507": ModelAttributes(org, "3", "30B-A3B", True, _QWEN3_INSTRUCT),
-        "Qwen3-235B-A22B-Instruct-2507": ModelAttributes(
-            org, "3", "235B-A22B", True, _QWEN3_INSTRUCT
-        ),
         "Qwen3.5-4B": ModelAttributes(org, "3.5", "4B", True, _QWEN3_5, is_vl=True),
-        "Qwen3.5-27B": ModelAttributes(org, "3.5", "27B", True, _QWEN3_5, is_vl=True),
-        "Qwen3.5-35B-A3B": ModelAttributes(org, "3.5", "35B-A3B", True, _QWEN3_5, is_vl=True),
+        "Qwen3.5-9B": ModelAttributes(org, "3.5", "9B", True, _QWEN3_5, is_vl=True),
+        "Qwen3.5-9B-Base": ModelAttributes(org, "3.5", "9B", False, _ROLE_COLON, is_vl=True),
+        "Qwen3.5-35B-A3B-Base": ModelAttributes(
+            org, "3.5", "35B-A3B", False, _ROLE_COLON, is_vl=True
+        ),
         "Qwen3.5-397B-A17B": ModelAttributes(org, "3.5", "397B-A17B", True, _QWEN3_5, is_vl=True),
         # Qwen3.6 reuses the Qwen3.5 renderer: identical tokenizer, special tokens,
         # preprocessor, and chat template (same qwen3_5 / qwen3_5_moe model_type),
@@ -131,7 +113,6 @@ def get_deepseek_info() -> dict[str, ModelAttributes]:
     org = "deepseek-ai"
     return {
         "DeepSeek-V3.1": ModelAttributes(org, "3", "671B-A37B", True, _DEEPSEEKV3),
-        "DeepSeek-V3.1-Base": ModelAttributes(org, "3", "671B-A37B", False, _ROLE_COLON),
     }
 
 
@@ -156,12 +137,10 @@ def get_moonshot_info() -> dict[str, ModelAttributes]:
 
     Returns:
         dict[str, ModelAttributes]: Mapping from model version name
-            (e.g. ``"Kimi-K2-Thinking"``) to its attributes.
+            (e.g. ``"Kimi-K2.6"``) to its attributes.
     """
     org = "moonshotai"
     return {
-        "Kimi-K2-Thinking": ModelAttributes(org, "K2", "1T-A32B", True, _KIMI_K2),
-        "Kimi-K2.5": ModelAttributes(org, "K2.5", "1T-A32B", True, _KIMI_K25, is_vl=True),
         "Kimi-K2.6": ModelAttributes(org, "K2.6", "1T-A32B", True, _KIMI_K26, is_vl=True),
     }
 
@@ -189,7 +168,7 @@ def get_model_attributes(model_name: str) -> ModelAttributes:
     """Get model metadata by name.
 
     Args:
-        model_name: HuggingFace model identifier (e.g. ``"meta-llama/Llama-3.1-8B"``).
+        model_name: HuggingFace model identifier (e.g. ``"Qwen/Qwen3.6-35B-A3B"``).
             An optional ``:checkpoint`` suffix is stripped before lookup.
 
     Returns:

--- a/tinker_cookbook/model_info_test.py
+++ b/tinker_cookbook/model_info_test.py
@@ -31,22 +31,20 @@ class TestQwen3_6:
 class TestWarnIfRendererNotRecommended:
     def test_no_warning_when_renderer_is_none(self, caplog: pytest.LogCaptureFixture):
         with caplog.at_level(logging.WARNING):
-            warn_if_renderer_not_recommended("Qwen/Qwen3-4B-Instruct-2507", None)
+            warn_if_renderer_not_recommended("Qwen/Qwen3.5-4B", None)
         assert caplog.text == ""
 
     def test_no_warning_when_renderer_is_recommended(self, caplog: pytest.LogCaptureFixture):
         with caplog.at_level(logging.WARNING):
-            warn_if_renderer_not_recommended("Qwen/Qwen3-4B-Instruct-2507", "qwen3_instruct")
+            warn_if_renderer_not_recommended("Qwen/Qwen3.5-4B", "qwen3_5_disable_thinking")
         assert caplog.text == ""
 
     def test_warning_when_renderer_not_recommended(self, caplog: pytest.LogCaptureFixture):
         with caplog.at_level(logging.WARNING):
-            warn_if_renderer_not_recommended(
-                "Qwen/Qwen3-4B-Instruct-2507", "qwen3_disable_thinking"
-            )
+            warn_if_renderer_not_recommended("Qwen/Qwen3.5-4B", "qwen3_instruct")
         assert "not recommended" in caplog.text
-        assert "qwen3_disable_thinking" in caplog.text
         assert "qwen3_instruct" in caplog.text
+        assert "qwen3_5_disable_thinking" in caplog.text
 
     def test_no_warning_for_unknown_model(self, caplog: pytest.LogCaptureFixture):
         with caplog.at_level(logging.WARNING):

--- a/tinker_cookbook/preference/comparison_policy_evaluator.py
+++ b/tinker_cookbook/preference/comparison_policy_evaluator.py
@@ -44,8 +44,8 @@ class ComparisonEvaluator(SamplingClientEvaluator):
         evaluator = ComparisonEvaluator(
             preference_model_builder=my_pm_builder,
             comparisons=test_comparisons,
-            renderer_name="llama3",
-            model_name_for_tokenizer="meta-llama/Llama-3.1-8B-Instruct",
+            renderer_name="qwen3_5_disable_thinking",
+            model_name_for_tokenizer="Qwen/Qwen3.5-9B",
         )
         metrics = await evaluator(sampling_client)
         print(metrics["win_rate"])

--- a/tinker_cookbook/preference/dpo_datasets.py
+++ b/tinker_cookbook/preference/dpo_datasets.py
@@ -34,8 +34,8 @@ class DPODatasetBuilderFromComparisons(ChatDatasetBuilder):
         builder = DPODatasetBuilderFromComparisons(
             comparison_builder=my_comparison_builder,
             common_config=ChatDatasetBuilderCommonConfig(
-                model_name_for_tokenizer="meta-llama/Llama-3.1-8B-Instruct",
-                renderer_name="llama3",
+                model_name_for_tokenizer="Qwen/Qwen3.5-9B",
+                renderer_name="qwen3_5_disable_thinking",
                 max_length=2048,
                 batch_size=8,
             ),

--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -77,7 +77,8 @@ class Config:
 
         config = Config(
             log_path="~/logs/dpo_run",
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_name="Qwen/Qwen3.5-9B",
+            renderer_name="qwen3_5_disable_thinking",
             dataset_builder=my_dpo_dataset_builder,
             dpo_beta=0.1,
             learning_rate=1e-5,

--- a/tinker_cookbook/preference/types.py
+++ b/tinker_cookbook/preference/types.py
@@ -300,8 +300,8 @@ class PreferenceModelBuilderFromChatRenderer(PreferenceModelBuilder):
     Example::
 
         builder = PreferenceModelBuilderFromChatRenderer(
-            renderer_name="llama3",
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            renderer_name="qwen3_5_disable_thinking",
+            model_name="Qwen/Qwen3.5-9B",
             rm_weights_path="path/to/rm_weights",
         )
         pref_model = builder()

--- a/tinker_cookbook/recipes/chat_sl/README.md
+++ b/tinker_cookbook/recipes/chat_sl/README.md
@@ -4,7 +4,7 @@
 
 ```bash
 python -m tinker_cookbook.recipes.chat_sl.train \
-    model_name=Qwen/Qwen3-8B-Base \
+    model_name=Qwen/Qwen3.5-9B-Base \
     dataset=no_robots \
     learning_rate=5e-4 \
     batch_size=64 \
@@ -20,7 +20,7 @@ After 140 steps of training, `test/nll` decreases to 1.788.
 
 ```bash
 python -m tinker_cookbook.recipes.chat_sl.train \
-    model_name=Qwen/Qwen3-8B-Base \
+    model_name=Qwen/Qwen3.5-9B-Base \
     dataset=tulu3 \
     learning_rate=5e-4 \
     batch_size=128 \

--- a/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
+++ b/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
@@ -11,6 +11,8 @@ Use these as a reference when choosing learning rate and LoRA rank for your mode
 
 > **Note:** Wall times are approximate and depend on server load at the time of the run. They may fluctuate significantly between runs.
 
+> **Rerun needed:** This historical report includes models that are now deprecated. Keep the original model names for traceability, but rerun affected sweeps with the recommended replacements before using these results as current guidance.
+
 ## Key Findings
 
 **Optimal learning rate is model-size dependent.** Across all models, the best LR per model breaks down as:

--- a/tinker_cookbook/recipes/chat_sl/sweep/launch_all.py
+++ b/tinker_cookbook/recipes/chat_sl/sweep/launch_all.py
@@ -81,9 +81,6 @@ def _cfg(
 
 # Models already swept (included for completeness, skipped by default)
 ALREADY_DONE: dict[str, ModelSweepConfig] = {
-    "deepseek-ai/DeepSeek-V3.1-Base": _cfg(
-        "deepseek-ai/DeepSeek-V3.1-Base", "large", "MoE, already swept"
-    ),
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": _cfg(
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "medium", "MoE, already swept"
     ),
@@ -96,33 +93,21 @@ ALREADY_DONE: dict[str, ModelSweepConfig] = {
 NEW_MODELS: list[ModelSweepConfig] = [
     # --- Large ---
     _cfg("Qwen/Qwen3.5-397B-A17B", "large", "MoE Hybrid+Vision"),
-    _cfg("Qwen/Qwen3-VL-235B-A22B-Instruct", "large", "MoE Vision"),
-    _cfg("Qwen/Qwen3-235B-A22B-Instruct-2507", "large", "MoE Instruction"),
     _cfg("deepseek-ai/DeepSeek-V3.1", "large", "MoE Hybrid", renderer_name="deepseekv3_thinking"),
-    _cfg("meta-llama/Llama-3.1-70B", "large", "Dense Base"),
-    _cfg("meta-llama/Llama-3.3-70B-Instruct", "large", "Dense Instruction"),
-    _cfg("moonshotai/Kimi-K2-Thinking", "large", "MoE Reasoning"),
-    _cfg("moonshotai/Kimi-K2.5", "large", "MoE Reasoning+Vision"),
+    _cfg("moonshotai/Kimi-K2.6", "large", "MoE Reasoning+Vision"),
     # --- Medium ---
-    _cfg("Qwen/Qwen3.5-35B-A3B", "medium", "MoE Hybrid+Vision"),
-    _cfg("Qwen/Qwen3.5-27B", "medium", "Dense Hybrid+Vision"),
-    _cfg("Qwen/Qwen3-VL-30B-A3B-Instruct", "medium", "MoE Vision"),
-    _cfg("Qwen/Qwen3-30B-A3B-Instruct-2507", "medium", "MoE Instruction"),
-    _cfg("Qwen/Qwen3-30B-A3B", "medium", "MoE Hybrid"),
-    _cfg("Qwen/Qwen3-30B-A3B-Base", "medium", "MoE Base"),
-    _cfg("Qwen/Qwen3-32B", "medium", "Dense Hybrid"),
+    _cfg("Qwen/Qwen3.6-35B-A3B", "medium", "MoE Hybrid+Vision"),
+    _cfg("Qwen/Qwen3.6-27B", "medium", "Dense Hybrid+Vision"),
+    _cfg("Qwen/Qwen3.5-35B-A3B-Base", "medium", "MoE Base"),
     _cfg("openai/gpt-oss-120b", "medium", "MoE Reasoning"),
     # --- Small ---
     _cfg("Qwen/Qwen3-8B", "small", "Dense Hybrid"),
-    _cfg("Qwen/Qwen3-8B-Base", "small", "Dense Base"),
+    _cfg("Qwen/Qwen3.5-9B-Base", "small", "Dense Base"),
+    _cfg("Qwen/Qwen3.5-9B", "small", "Dense Instruction", renderer_name="qwen3_5_disable_thinking"),
     _cfg("openai/gpt-oss-20b", "small", "MoE Reasoning"),
-    _cfg("meta-llama/Llama-3.1-8B", "small", "Dense Base"),
-    _cfg("meta-llama/Llama-3.1-8B-Instruct", "small", "Dense Instruction"),
     _cfg("Qwen/Qwen3.5-4B", "small", "Dense Hybrid+Vision"),
     # --- Compact ---
-    _cfg("Qwen/Qwen3-4B-Instruct-2507", "compact", "Dense Instruction"),
-    _cfg("meta-llama/Llama-3.2-3B", "compact", "Dense Base"),
-    _cfg("meta-llama/Llama-3.2-1B", "compact", "Dense Base"),
+    _cfg("Qwen/Qwen3.5-4B", "compact", "Dense Instruction", renderer_name="qwen3_5_disable_thinking"),
 ]
 
 

--- a/tinker_cookbook/recipes/chat_sl/train.py
+++ b/tinker_cookbook/recipes/chat_sl/train.py
@@ -21,7 +21,7 @@ from tinker_cookbook.utils.lr_scheduling import LRSchedule
 class CLIConfig:
     # Required parameters
     log_path: str | None = None
-    model_name: str = "meta-llama/Llama-3.1-8B"
+    model_name: str = "Qwen/Qwen3.5-9B-Base"
     load_checkpoint_path: str | None = None
     dataset: str = "no_robots"
 

--- a/tinker_cookbook/recipes/code_rl/README.md
+++ b/tinker_cookbook/recipes/code_rl/README.md
@@ -1,6 +1,6 @@
 # Replicating DeepCoder with Tinker
 
-Competitive programming problems are a common testbed for RL with LLMs. The recent [DeepCoder](https://pretty-radio-b75.notion.site/DeepCoder-A-Fully-Open-Source-14B-Coder-at-O3-mini-Level-1cf81902c14680b3bee5eb349a512a51) blog post introduces a dataset and training pipeline for this purpose. This recipe demonstrates a similar setup using `Qwen3-4B-Instruct-2507`.
+Competitive programming problems are a common testbed for RL with LLMs. The recent [DeepCoder](https://pretty-radio-b75.notion.site/DeepCoder-A-Fully-Open-Source-14B-Coder-at-O3-mini-Level-1cf81902c14680b3bee5eb349a512a51) blog post introduces a dataset and training pipeline for this purpose. This recipe demonstrates a similar setup using `Qwen3.5-4B` in non-thinking mode.
 
 ## Running This Demo
 
@@ -49,11 +49,12 @@ Optional environment variables for Modal:
 
 ### Example command
 
-Train a `Qwen3-4B-Instruct-2507` model with:
+Train a `Qwen3.5-4B` model in non-thinking mode with:
 
 ```bash
 python -m tinker_cookbook.recipes.code_rl.train \
-    model_name="Qwen/Qwen3-4B-Instruct-2507" \
+    model_name="Qwen/Qwen3.5-4B" \
+    renderer_name=qwen3_5_disable_thinking \
     group_size=8 groups_per_batch=128 \
     learning_rate=4e-5 \
     lora_rank=32 \
@@ -66,5 +67,7 @@ After 100 steps of training, you can expect the following performance on **LiveC
 |-------|--------|--------|
 | Qwen3-4B-Instruct-2507 (before training) | 33.8% | 44.3% |
 | Qwen3-4B-Instruct-2507 (after 100 steps) | 42.7% | 55.0% |
+
+> **Note:** `Qwen3-4B-Instruct-2507` is deprecated. Rerun this experiment with `Qwen/Qwen3.5-4B` using `qwen3_5_disable_thinking` before treating these numbers as current.
 
 [1] Luo, M., Tan, S., Huang, R., Patel, A., Ariyak, A., Wu, Q., Shi, X., Xin, R., Cai, C., Weber, M., Zhang, C., Li, L. E., Popa, R. A., & Stoica, I. (2025). DeepCoder: A fully open-source 14B coder at O3-mini level.

--- a/tinker_cookbook/recipes/code_rl/train.py
+++ b/tinker_cookbook/recipes/code_rl/train.py
@@ -18,9 +18,9 @@ class CLIConfig:
     """Command-line configuration for DeepCoder RL training."""
 
     # Model configuration
-    model_name: str = "meta-llama/Llama-3.1-8B-Instruct"
+    model_name: str = "Qwen/Qwen3.5-9B"
     lora_rank: int = 32
-    renderer_name: str | None = None
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     load_checkpoint_path: str | None = None
 
     # Data / environment configuration

--- a/tinker_cookbook/recipes/distillation/README.md
+++ b/tinker_cookbook/recipes/distillation/README.md
@@ -18,7 +18,7 @@ We observe an AIME'24 score of ~55% using a rank-128 LoRA after 3000 steps. We u
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.off_policy_reasoning \
-    model_name=Qwen/Qwen3-8B-Base \
+    model_name=Qwen/Qwen3.5-9B-Base \
     learning_rate=1e-3 \
     batch_size=128 \
     lora_rank=128 \
@@ -31,7 +31,7 @@ We observe an AIME'24 score of ~65% using a rank-128 LoRA after 100 steps. For o
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-    model_name=Qwen/Qwen3-8B-Base \
+    model_name=Qwen/Qwen3.5-9B-Base \
     load_checkpoint_path=tinker://4a1939e6-04be-5a77-9e4e-910ccff9f27e:train:0/weights/final \
     dataset=deepmath \
     learning_rate=1e-4 \
@@ -65,7 +65,7 @@ In our experiment, we saw [IF-eval](https://huggingface.co/datasets/google/IFEva
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-    model_name=Qwen/Qwen3-8B-Base \
+    model_name=Qwen/Qwen3.5-9B-Base \
     dataset=tulu3 \
     learning_rate=1e-4 \
     groups_per_batch=64 \
@@ -103,8 +103,8 @@ See `tinker_cookbook/recipes/harbor_rl/README.md` for full details on the Harbor
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation_harbor_multi_turn \
-    model_name=moonshotai/Kimi-K2-Thinking \
-    teacher_model=moonshotai/Kimi-K2-Thinking \
+    model_name=moonshotai/Kimi-K2.6 \
+    teacher_model=moonshotai/Kimi-K2.6 \
     max_turns=10 \
     group_size=4 \
     groups_per_batch=8 \
@@ -135,7 +135,7 @@ For every dataset, we can define a teacher model and batch size (`groups_per_bat
 {
     "dataset_builder": RLDatasetBuilder,
     "teacher_model": {
-        "base_model": str,  # e.g. "Qwen/Qwen3-32B"
+        "base_model": str,  # e.g. "Qwen/Qwen3.6-27B"
         "load_checkpoint_path": str | None  # e.g. "tinker://<unique_id>/sampler_weights/final
     },
     "groups_per_batch": int

--- a/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
+++ b/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
@@ -6,7 +6,7 @@ which contains reasoning traces with chain-of-thought style responses.
 
 Example usage:
     python -m tinker_cookbook.recipes.distillation.off_policy_reasoning \
-        model_name=Qwen/Qwen3-8B-Base \
+        model_name=Qwen/Qwen3.5-9B-Base \
         learning_rate=1e-4 \
         batch_size=128 \
         lora_rank=128 \
@@ -92,9 +92,9 @@ class CLIConfig:
     """Command-line configuration for SFT on OpenThoughts3."""
 
     # Model configuration
-    model_name: str = "Qwen/Qwen3-8B-Base"
+    model_name: str = "Qwen/Qwen3.5-9B-Base"
     lora_rank: int = 128
-    renderer_name: str | None = "qwen3"
+    renderer_name: str | None = "role_colon"
     load_checkpoint_path: str | None = None
 
     # Training hyperparameters

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -8,7 +8,7 @@ are used - only KL penalty provides supervision.
 Example usage:
     # For reasoning tasks (DeepMath)
     python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-        model_name=Qwen/Qwen3-8B-Base \
+        model_name=Qwen/Qwen3.5-9B-Base \
         dataset=deepmath \
         learning_rate=1e-4 \
         groups_per_batch=1024 \
@@ -17,7 +17,7 @@ Example usage:
 
     # For chat tasks (Tulu3)
     python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-        model_name=Qwen/Qwen3-8B-Base \
+        model_name=Qwen/Qwen3.5-9B-Base \
         dataset=tulu3 \
         learning_rate=1e-4 \
         groups_per_batch=1024 \
@@ -50,7 +50,7 @@ class CLIConfig:
     """Command-line configuration for on-policy distillation."""
 
     # Model configuration
-    model_name: str = "Qwen/Qwen3-8B-Base"  # Student model
+    model_name: str = "Qwen/Qwen3.5-9B-Base"  # Student model
     lora_rank: int = 128
     renderer_name: str | None = None
     load_checkpoint_path: str | None = None  # Student checkpoint

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation_harbor_multi_turn.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation_harbor_multi_turn.py
@@ -9,8 +9,8 @@ Environment responses are masked out; only student-generated tokens contribute.
 
 Example usage:
     python -m tinker_cookbook.recipes.distillation.on_policy_distillation_harbor_multi_turn \
-        model_name=moonshotai/Kimi-K2-Thinking \
-        teacher_model=moonshotai/Kimi-K2-Thinking \
+        model_name=moonshotai/Kimi-K2.6 \
+        teacher_model=moonshotai/Kimi-K2.6 \
         max_turns=10 \
         group_size=4 \
         groups_per_batch=8 \
@@ -57,13 +57,13 @@ class CLIConfig:
     """Command-line configuration for multi-turn harbor distillation."""
 
     # Student model
-    model_name: str = "moonshotai/Kimi-K2-Thinking"
+    model_name: str = "moonshotai/Kimi-K2.6"
     lora_rank: int = 32
     renderer_name: str | None = None
     load_checkpoint_path: str | None = None
 
     # Teacher model
-    teacher_model: str = "moonshotai/Kimi-K2-Thinking"
+    teacher_model: str = "moonshotai/Kimi-K2.6"
     teacher_checkpoint: str | None = None
 
     # Harbor environment

--- a/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
@@ -3,8 +3,8 @@ Multi-teacher on-policy distillation example.
 
 This script demonstrates on-policy distillation with multiple datasets and
 different teacher models for each dataset. It uses:
-- DeepMath dataset with Qwen3-32B as teacher
-- Tulu3 dataset with Qwen3-235B-A22B-Instruct-2507 as teacher
+- DeepMath dataset with Qwen3.6-27B as teacher
+- Tulu3 dataset with Qwen3.5-397B-A17B in non-thinking mode as teacher
 - Qwen3-8B as student model
 - qwen3_instruct renderer
 
@@ -48,9 +48,9 @@ class CLIConfig:
     load_checkpoint_path: str | None = None  # Student checkpoint
 
     # Teacher configurations
-    deepmath_teacher_model: str = "Qwen/Qwen3-32B"
+    deepmath_teacher_model: str = "Qwen/Qwen3.6-27B"
     deepmath_teacher_checkpoint: str | None = None
-    tulu3_teacher_model: str = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+    tulu3_teacher_model: str = "Qwen/Qwen3.5-397B-A17B"
     tulu3_teacher_checkpoint: str | None = None
 
     # Dataset configuration

--- a/tinker_cookbook/recipes/harbor_rl/README.md
+++ b/tinker_cookbook/recipes/harbor_rl/README.md
@@ -119,7 +119,7 @@ Key parameters in `EvalConfig`: `max_turns`, `max_tokens`, `temperature`.
 
 We evaluated SWE-Bench-Verified-1.0 and Terminal-Bench-2.0 at 32K context length and naive agent harness with no advanced features like context compatification that summarizes the tool calling history.
 
-### Results: Kimi-K2-Thinking (32K context, no compaction)
+### Results: Kimi-K2.6 (32K context, no compaction)
 
 | Benchmark | Total | PASS | FAIL | ERROR | Pass Rate |
 |-----------|-------|------|------|-------|-----------|

--- a/tinker_cookbook/recipes/harbor_rl/eval.py
+++ b/tinker_cookbook/recipes/harbor_rl/eval.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 class EvalConfig:
     """Configuration for Harbor evaluation."""
 
-    model_name: str = "moonshotai/Kimi-K2-Thinking"
+    model_name: str = "moonshotai/Kimi-K2.6"
     output_path: str = "tinker_cookbook/recipes/harbor_rl/scripts/results"
     max_turns: int = 10
     max_tokens: int = 2048

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
@@ -213,8 +213,8 @@ class TestHarborEnvGroupBuilderPickle:
         """HarborEnvGroupBuilder survives pickle/unpickle with default sandbox_factory."""
         builder = HarborEnvGroupBuilder(
             task=self._make_task(tmp_path),
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
-            renderer_name="llama3",
+            model_name="Qwen/Qwen3.5-9B",
+            renderer_name="qwen3_5_disable_thinking",
             max_turns=5,
             group_size=2,
         )
@@ -236,8 +236,8 @@ class TestHarborEnvGroupBuilderPickle:
         """Non-default scalar parameters survive pickle roundtrip."""
         builder = HarborEnvGroupBuilder(
             task=self._make_task(tmp_path),
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
-            renderer_name="llama3",
+            model_name="Qwen/Qwen3.5-9B",
+            renderer_name="qwen3_5_disable_thinking",
             max_turns=5,
             group_size=2,
             sandbox_timeout=300,

--- a/tinker_cookbook/recipes/harbor_rl/train.py
+++ b/tinker_cookbook/recipes/harbor_rl/train.py
@@ -21,7 +21,7 @@ class CLIConfig:
     """Command-line configuration for Harbor RL training."""
 
     # Model configuration
-    model_name: str = "moonshotai/Kimi-K2-Thinking"
+    model_name: str = "moonshotai/Kimi-K2.6"
     lora_rank: int = 32
     renderer_name: str | None = None
     load_checkpoint_path: str | None = None

--- a/tinker_cookbook/recipes/math_rl/README.md
+++ b/tinker_cookbook/recipes/math_rl/README.md
@@ -13,7 +13,7 @@ uv pip install 'tinker-cookbook[math-rl] @ git+https://github.com/thinking-machi
 Trivial, but runs fast enough that you can see it learn. Reward should go from 0.66 to 1 in the first few steps.
 
 ```bash
-python -m tinker_cookbook.recipes.math_rl.train model_name="meta-llama/Llama-3.2-1B" group_size=4 groups_per_batch=100 learning_rate=1e-4
+python -m tinker_cookbook.recipes.math_rl.train model_name="Qwen/Qwen3.5-9B-Base" group_size=4 groups_per_batch=100 learning_rate=1e-4
 ```
 
 ## RL on MATH dataset.
@@ -68,7 +68,7 @@ So the best possible is sum1=20 and sum2=21, product 420. So the maximum sum is 
 # RL on GSM8K
 
 ```bash
-python -m tinker_cookbook.recipes.math_rl.train env=gsm8k model_name="meta-llama/Llama-3.1-8B-Instruct" group_size=64 groups_per_batch=32 learning_rate=8e-5 max_tokens=1024
+python -m tinker_cookbook.recipes.math_rl.train env=gsm8k model_name="Qwen/Qwen3.5-9B" renderer_name=qwen3_5_disable_thinking group_size=64 groups_per_batch=32 learning_rate=8e-5 max_tokens=1024
 ```
 
 Generally, you should observe that training reward goes above 0.8 within a few steps. After 220 steps of training, we achieve `"test/env/all/correct": 0.9090`. A smaller group_size (8) and larger `groups_per_batch` (64) will achieve `0.8824` accuracy in around a quarter of the time.

--- a/tinker_cookbook/recipes/math_rl/train.py
+++ b/tinker_cookbook/recipes/math_rl/train.py
@@ -22,9 +22,9 @@ class CLIConfig:
     """Simple command-line configuration for RL training."""
 
     # Model configuration
-    model_name: str = "meta-llama/Llama-3.1-8B-Instruct"
+    model_name: str = "Qwen/Qwen3.5-9B"
     lora_rank: int = 32
-    renderer_name: str | None = None
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     load_checkpoint_path: str | None = None
 
     # Environment configuration

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/train.py
@@ -10,8 +10,8 @@ from tinker_cookbook.rl import train
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     group_size: int = 8
     batch_size: int = 32
     learning_rate: float = 3e-5

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/README.md
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/README.md
@@ -53,7 +53,7 @@ The default of 80 steps avoids the collapse while capturing the performance plat
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `model_name` | `Qwen/Qwen3-4B-Instruct-2507` | Base model to train |
+| `model_name` | `Qwen/Qwen3.5-4B` | Base model to train in non-thinking mode |
 | `batch_size` | `512` | Trajectories per training step |
 | `num_train_datapoints` | `40960` | Total training trajectories (~80 steps) |
 | `learning_rate` | `3e-5` | Adam learning rate |

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/play.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/play.py
@@ -124,8 +124,8 @@ async def eval_model(
 @chz.chz
 class PlayConfig:
     checkpoint_path: str
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     game_name: str = "TicTacToe-v0"
     mode: Literal["human_vs_model", "eval"] = "human_vs_model"
     opponent: OpponentType = "random"

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/train.py
@@ -11,8 +11,8 @@ from tinker_cookbook.rl import train
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     game_name: str = "TicTacToe-v0"
     test_opponent: OpponentType = "base_model"
     batch_size: int = 512

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
@@ -15,7 +15,6 @@ from tinker_cookbook.completers import (
     StopCondition,
     TinkerMessageCompleter,
 )
-from tinker_cookbook.model_info import get_recommended_renderer_name
 from tinker_cookbook.renderers import Message, Renderer, get_renderer, get_text_content
 from tinker_cookbook.rl.types import (
     Action,
@@ -203,7 +202,7 @@ class TwentyQuestionsDatasetBuilder(RLDatasetBuilder):
     base_url: str | None = None
     num_epochs: int = 1
     test_group_size: int = 32
-    answerer_base_model: str = "meta-llama/Llama-3.1-8B-Instruct"
+    answerer_base_model: str = "Qwen/Qwen3.5-9B"
 
     async def __call__(self) -> tuple[RLDataset, RLDataset]:
         service_client = tinker.ServiceClient(base_url=self.base_url)
@@ -230,7 +229,9 @@ class TwentyQuestionsDatasetBuilder(RLDatasetBuilder):
         return training_dataset, test_dataset
 
     def _construct_answer_completer(self, service_client: tinker.ServiceClient) -> MessageCompleter:
-        if self.answerer_base_model.startswith("Qwen/Qwen3"):
+        if self.answerer_base_model.startswith("Qwen/Qwen3.5"):
+            answerer_renderer_name = "qwen3_5_disable_thinking"
+        elif self.answerer_base_model.startswith("Qwen/Qwen3"):
             answerer_renderer_name = "qwen3_disable_thinking"
         else:
             answerer_renderer_name = model_info.get_recommended_renderer_name(
@@ -256,19 +257,19 @@ class TwentyQuestionsDatasetBuilder(RLDatasetBuilder):
 
 
 def construct_minimal_20q_env(answer: str) -> TwentyQuestionsEnv:
-    answerer_model = "meta-llama/Llama-3.1-8B-Instruct"
+    answerer_model = "Qwen/Qwen3.5-9B"
 
     service_client = tinker.ServiceClient()
     answerer_sampling_client = service_client.create_sampling_client(base_model=answerer_model)
     answerer = TinkerMessageCompleter(
         sampling_client=answerer_sampling_client,
         renderer=get_renderer(
-            get_recommended_renderer_name(answerer_model), get_tokenizer(answerer_model)
+            "qwen3_5_disable_thinking", get_tokenizer(answerer_model)
         ),
         max_tokens=5,
     )
     policy_renderer = get_renderer(
-        get_recommended_renderer_name(answerer_model), get_tokenizer(answerer_model)
+        "qwen3_5_disable_thinking", get_tokenizer(answerer_model)
     )  # this argument is not actually used and is a placeholder
     env = TwentyQuestionsEnv(answerer, answer, policy_renderer)
     return env

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/train.py
@@ -12,8 +12,8 @@ from tinker_cookbook.rl import train
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     group_size: int = 8
     num_epochs: int = 100
     batch_size: int = 64

--- a/tinker_cookbook/recipes/preference/dpo/README.md
+++ b/tinker_cookbook/recipes/preference/dpo/README.md
@@ -6,7 +6,7 @@ Here is an example command:
 ```
 python -m tinker_cookbook.recipes.preference.dpo.train \
     log_path=/tmp/dpo-hhh-experiment \
-    model_name=meta-llama/Llama-3.2-1B \
+    model_name=Qwen/Qwen3.5-9B-Base \
     dataset=hhh \
     renderer_name=role_colon \
     learning_rate=1e-5 \

--- a/tinker_cookbook/recipes/preference/dpo/train.py
+++ b/tinker_cookbook/recipes/preference/dpo/train.py
@@ -22,7 +22,7 @@ from tinker_cookbook.utils.lr_scheduling import LRSchedule
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "meta-llama/Llama-3.2-1B"
+    model_name: str = "Qwen/Qwen3.5-9B-Base"
     dataset: str = "hhh"  # or path like tinker_cookbook.preference.preference_datasets:HHHBuilder
     load_checkpoint_path: str | None = None
     renderer_name: str | None = None

--- a/tinker_cookbook/recipes/preference/rlhf/rlhf_pipeline.py
+++ b/tinker_cookbook/recipes/preference/rlhf/rlhf_pipeline.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 @chz.chz
 class CLIConfig:
-    base_model: str = "meta-llama/Llama-3.2-3B"
-    short_name: str = "llama3b"
+    base_model: str = "Qwen/Qwen3.5-9B-Base"
+    short_name: str = "qwen9b"
     run_sft: bool = True
     run_rm: bool = True
     run_rl: bool = True

--- a/tinker_cookbook/recipes/preference/shorter/train.py
+++ b/tinker_cookbook/recipes/preference/shorter/train.py
@@ -14,8 +14,8 @@ from tinker_cookbook.rl.preference_envs import PairwisePreferenceRLDatasetBuilde
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
 
     # Training parameters
     batch_size: int = 32

--- a/tinker_cookbook/recipes/prompt_distillation/README.md
+++ b/tinker_cookbook/recipes/prompt_distillation/README.md
@@ -26,7 +26,7 @@ ar (Arabic), de (German), el (Greek), en (English), es (Spanish), fr (French), h
 
 The recipe in [`create_data.py`](create_data.py) also includes handling strategies for inputs containing code, numerical content, or multiple languages.
 
-In the example below, the same model (`Qwen/Qwen3-30B-A3B`) is used as both teacher and student, though in general they need not be identical.
+In the example below, the same model (`Qwen/Qwen3.6-35B-A3B`) is used as both teacher and student, though in general they need not be identical.
 
 ---
 

--- a/tinker_cookbook/recipes/prompt_distillation/create_data.py
+++ b/tinker_cookbook/recipes/prompt_distillation/create_data.py
@@ -89,9 +89,9 @@ def setup_clients():
     print("Creating service client")
     service_client = tinker.ServiceClient()
     print("Creating sampling client")
-    sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3-30B-A3B")
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
-    renderer = renderers.get_renderer("qwen3", tokenizer)
+    sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3.6-35B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3.6-35B-A3B")
+    renderer = renderers.get_renderer("qwen3_5", tokenizer)
 
     return sampling_client, tokenizer, renderer
 

--- a/tinker_cookbook/recipes/prompt_distillation/train.py
+++ b/tinker_cookbook/recipes/prompt_distillation/train.py
@@ -21,7 +21,7 @@ class CLIConfig:
     # Required parameters
     file_path: str = "/tmp/tinker-datasets/prompt_distillation_lang.jsonl"
     log_path: str | None = None
-    model_name: str = "Qwen/Qwen3-30B-A3B"
+    model_name: str = "Qwen/Qwen3.6-35B-A3B"
     load_checkpoint_path: str | None = None
 
     # Training parameters

--- a/tinker_cookbook/recipes/rl_basic.py
+++ b/tinker_cookbook/recipes/rl_basic.py
@@ -9,7 +9,7 @@ from tinker_cookbook.rl import train
 
 
 def build_config_blueprint() -> chz.Blueprint[train.Config]:
-    model_name = "meta-llama/Llama-3.1-8B"
+    model_name = "Qwen/Qwen3.5-9B-Base"
     renderer_name = model_info.get_recommended_renderer_name(model_name)
     builder = Gsm8kDatasetBuilder(
         batch_size=128,

--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -37,7 +37,7 @@ logging.getLogger("httpx").setLevel(logging.WARN)
 class Config:
     base_url: str | None = None
     log_path: str = "/tmp/tinker-examples/rl-loop"
-    model_name: str = "meta-llama/Llama-3.1-8B"
+    model_name: str = "Qwen/Qwen3.5-9B-Base"
     batch_size: int = 128
     group_size: int = 16
     learning_rate: float = 4e-5

--- a/tinker_cookbook/recipes/rubric/debug_env.py
+++ b/tinker_cookbook/recipes/rubric/debug_env.py
@@ -2,7 +2,6 @@ import asyncio
 
 import tinker
 
-from tinker_cookbook import model_info
 from tinker_cookbook.completers import TinkerMessageCompleter, TinkerTokenCompleter
 from tinker_cookbook.recipes.rubric.env import Rubric, RubricBasedDatapoint, RubricGradedEnv
 from tinker_cookbook.renderers import get_renderer
@@ -36,8 +35,8 @@ def get_prometheus_datapoint() -> RubricBasedDatapoint:
 
 async def main(datapoint: RubricBasedDatapoint):
     # Configuration parameters
-    policy_name = "meta-llama/Llama-3.1-8B-Instruct"
-    grader_name = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+    policy_name = "Qwen/Qwen3.5-9B"
+    grader_name = "Qwen/Qwen3.6-35B-A3B"
     policy_max_tokens = 64
     grader_max_tokens = 64
 
@@ -46,13 +45,11 @@ async def main(datapoint: RubricBasedDatapoint):
         sampling_client=service_client.create_sampling_client(base_model=policy_name),
         max_tokens=policy_max_tokens,
     )
-    policy_renderer = get_renderer(
-        model_info.get_recommended_renderer_name(policy_name), get_tokenizer(policy_name)
-    )
+    policy_renderer = get_renderer("qwen3_5_disable_thinking", get_tokenizer(policy_name))
     grader = TinkerMessageCompleter(
         sampling_client=service_client.create_sampling_client(base_model=grader_name),
         renderer=get_renderer(
-            model_info.get_recommended_renderer_name(grader_name), get_tokenizer(grader_name)
+            "qwen3_5_disable_thinking", get_tokenizer(grader_name)
         ),
         max_tokens=grader_max_tokens,
     )

--- a/tinker_cookbook/recipes/rubric/env.py
+++ b/tinker_cookbook/recipes/rubric/env.py
@@ -8,7 +8,6 @@ import tinker
 from termcolor import colored
 from tinker.types import ModelInput
 
-from tinker_cookbook import model_info
 from tinker_cookbook.completers import MessageCompleter, StopCondition, TinkerMessageCompleter
 from tinker_cookbook.recipes.rubric.data import (
     Conversation,
@@ -229,12 +228,12 @@ class RubricGradedDatasetBuilder(RLDatasetBuilder):
     test_datapoint_list_builder: RubricDatapointListBuilder | None = None
 
     base_url: str | None = None
-    grader_llm_name: str = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+    grader_llm_name: str = "Qwen/Qwen3.6-35B-A3B"
+    grader_renderer_name: str = "qwen3_5_disable_thinking"
 
     def _get_grader_llm(self) -> MessageCompleter:
         tokenizer = get_tokenizer(self.grader_llm_name)
-        renderer_name = model_info.get_recommended_renderer_name(self.grader_llm_name)
-        renderer = get_renderer(name=renderer_name, tokenizer=tokenizer)
+        renderer = get_renderer(name=self.grader_renderer_name, tokenizer=tokenizer)
         service_client = tinker.ServiceClient(base_url=self.base_url)
         sampling_client = service_client.create_sampling_client(base_model=self.grader_llm_name)
         return TinkerMessageCompleter(

--- a/tinker_cookbook/recipes/rubric/prometheus_experimental.py
+++ b/tinker_cookbook/recipes/rubric/prometheus_experimental.py
@@ -16,9 +16,9 @@ class CLIConfig:
     """Simple command-line configuration for RL training."""
 
     # Model configuration
-    model_name: str = "meta-llama/Llama-3.1-8B-Instruct"
+    model_name: str = "Qwen/Qwen3.5-9B"
     lora_rank: int = 32
-    renderer_name: str | None = None
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     load_checkpoint_path: str | None = None
 
     seed: int = 0  # Random seed for data shuffling
@@ -31,7 +31,7 @@ class CLIConfig:
     max_tokens: int = 5
     temperature: float = 1.0
     kl_penalty_coef: float = 0.0
-    grader_llm_name: str = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+    grader_llm_name: str = "Qwen/Qwen3.6-35B-A3B"
     # Number of optimizer steps per training iteration.
     # Useful for very large batch sizes.
     num_substeps: int = 1

--- a/tinker_cookbook/recipes/rubric/train.py
+++ b/tinker_cookbook/recipes/rubric/train.py
@@ -16,9 +16,9 @@ class CLIConfig:
     """Simple command-line configuration for RL training."""
 
     # Model configuration
-    model_name: str = "meta-llama/Llama-3.1-8B-Instruct"
+    model_name: str = "Qwen/Qwen3.5-9B"
     lora_rank: int = 32
-    renderer_name: str | None = None
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     load_checkpoint_path: str | None = None
 
     seed: int = 0  # Random seed for data shuffling
@@ -31,7 +31,7 @@ class CLIConfig:
     max_tokens: int = 5
     temperature: float = 1.0
     kl_penalty_coef: float = 0.0
-    grader_llm_name: str = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+    grader_llm_name: str = "Qwen/Qwen3.6-35B-A3B"
     train_jsonl_path: str = "tinker_cookbook/example_data/example_rubric_train.jsonl"
     test_jsonl_path: str = "tinker_cookbook/example_data/example_rubric_test.jsonl"
 

--- a/tinker_cookbook/recipes/sdft/README.md
+++ b/tinker_cookbook/recipes/sdft/README.md
@@ -46,6 +46,8 @@ We verified both design choices by running ablations on the [official SDFT codeb
 
 We also confirmed our Tinker implementation produces identical results to the reference on the same model (`Qwen/Qwen3-4B-Instruct-2507`): both get 56.70% tooluse accuracy with top-K=20 and static teacher.
 
+> **Note:** The historical result above used a deprecated model. Rerun it with `Qwen/Qwen3.5-4B` using `qwen3_5_disable_thinking` before treating the number as current.
+
 ## Setup
 
 ### 1. Download the data
@@ -70,7 +72,7 @@ export TINKER_API_KEY=<your-key>
 ```bash
 # SDFT on tool-use (top-K distillation, K=20)
 python -m tinker_cookbook.recipes.sdft.train \
-    model_name=Qwen/Qwen3.5-35B-A3B \
+    model_name=Qwen/Qwen3.6-35B-A3B \
     dataset=toolalpaca \
     toolalpaca_data_path=Self-Distillation/data/tooluse_data/train_data \
     groups_per_batch=128 \
@@ -85,7 +87,7 @@ The key experiment: train sequentially on two tasks and measure retention.
 
 ```bash
 python -m tinker_cookbook.recipes.sdft.run_continual_learning \
-    model_name=Qwen/Qwen3.5-35B-A3B \
+    model_name=Qwen/Qwen3.6-35B-A3B \
     data_dir=Self-Distillation/data \
     methods=sft,sdft_topk \
     learning_rates=5e-4 \
@@ -99,7 +101,7 @@ python -m tinker_cookbook.recipes.sdft.run_continual_learning \
 
 ```bash
 python -m tinker_cookbook.recipes.sdft.train \
-    model_name=Qwen/Qwen3.5-35B-A3B \
+    model_name=Qwen/Qwen3.6-35B-A3B \
     dataset=sciknoweval \
     groups_per_batch=4 \
     max_tokens=256 \
@@ -116,7 +118,7 @@ python -m tinker_cookbook.recipes.sdft.train \
 | `topk` | `20` | Top-K tokens for distillation (0 = importance sampling fallback) |
 | `learning_rate` | `2e-5` | Adam learning rate. For LoRA, use 5e-4 to 1e-3 |
 | `groups_per_batch` | `32` | Problems per training batch |
-| `lora_rank` | `128` | LoRA adapter rank (64 for `Qwen/Qwen3.5-35B-A3B`) |
+| `lora_rank` | `128` | LoRA adapter rank (64 for `Qwen/Qwen3.6-35B-A3B`) |
 | `max_tokens` | `2048` | Max completion length |
 | `thinking_format` | `false` | Convert data for thinking models (e.g., Qwen3.5) |
 | `teacher_sync_every` | `None` | Optional periodic teacher weight sync |
@@ -124,6 +126,8 @@ python -m tinker_cookbook.recipes.sdft.train \
 ## Results
 
 ### Continual Learning: `Qwen/Qwen3.5-35B-A3B` (Tinker, LoRA 64)
+
+> **Note:** These historical results used `Qwen/Qwen3.5-35B-A3B`, which is deprecated. Rerun the experiment with `Qwen/Qwen3.6-35B-A3B` before treating these numbers as current.
 
 **Stage 1: Train on tool-use, evaluate both tasks**
 

--- a/tinker_cookbook/recipes/sdft/run_continual_learning.py
+++ b/tinker_cookbook/recipes/sdft/run_continual_learning.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 Method = Literal["sft", "sdft_is", "sdft_topk", "sdft_hybrid"]
 
-MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+MODEL_NAME = "Qwen/Qwen3.5-4B"
 DATA_DIR = "~/Self-Distillation/data"
 LORA_RANK = 128
 BATCH_SIZE = 128

--- a/tinker_cookbook/recipes/sdft/sdft_test.py
+++ b/tinker_cookbook/recipes/sdft/sdft_test.py
@@ -31,8 +31,8 @@ from tinker_cookbook.recipes.sdft.eval import (
 from tinker_cookbook.renderers import get_renderer
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
-MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
-RENDERER_NAME = "qwen3_instruct"
+MODEL_NAME = "Qwen/Qwen3.5-4B"
+RENDERER_NAME = "qwen3_5_disable_thinking"
 
 
 @pytest.fixture

--- a/tinker_cookbook/recipes/search_tool/README.md
+++ b/tinker_cookbook/recipes/search_tool/README.md
@@ -2,7 +2,7 @@
 
 [Search-R1](https://arxiv.org/pdf/2503.09516) is a recent paper that showcases tool-use RL for multi-hop QA on Wikipedia.
 It provides a clean setup for testing tool-use RL and also released their training and evaluation data.
-In this demo, we demonstrate similar experiments using `Qwen3-4B-Instruct-2507`, and we include our replication results using `Qwen/Qwen2.5-7B-Instruct` at the end.
+In this demo, we demonstrate similar experiments using `Qwen3.5-4B` in non-thinking mode, and we include our replication results using `Qwen/Qwen2.5-7B-Instruct` at the end.
 
 ## Running This Demo
 
@@ -25,7 +25,7 @@ If you launch the chroma service locally, you generally need 160+ GB RAM to load
 
 ### Example command
 
-This default command trains a `Qwen3-4B-Instruct-2507` with reasonable hyperparameters.
+This default command trains `Qwen3.5-4B` in non-thinking mode with reasonable hyperparameters.
 
 ```bash
 python -m tinker_cookbook.recipes.search_tool.train
@@ -35,6 +35,8 @@ With the default hyperparameters, you can expect performance like:
 | | Natural Questions | Trivia QA | HotpotQA | 2WikiMultihopQA |
 |---|---|---|---|---|
 | Qwen3-4B-Instruct-2507 | 51.8 | 70.2 | 52.0 | 47.7 |
+
+> **Note:** `Qwen3-4B-Instruct-2507` is deprecated. Rerun this experiment with `Qwen/Qwen3.5-4B` using `qwen3_5_disable_thinking` before treating these numbers as current.
 
 A successful run generally learns multi-turn search within 10-25 steps, which can be monitored by checking if `env/all/turns_per_episode` has increased over 2 turns.
 

--- a/tinker_cookbook/recipes/search_tool/offline_eval.py
+++ b/tinker_cookbook/recipes/search_tool/offline_eval.py
@@ -37,7 +37,7 @@ class CLIConfig:
     split: Literal["train", "test"] = chz.field(default="test", doc="Dataset split to use")
 
     # Model parameters
-    base_model: str = chz.field(default="Qwen/Qwen3-4B-Instruct-2507", doc="Base model to use")
+    base_model: str = chz.field(default="Qwen/Qwen3.5-4B", doc="Base model to use")
     tinker_checkpoint_url: str = chz.field(doc="Tinker checkpoint URL (required)")
     max_tokens: int = chz.field(default=1024, doc="Maximum number of tokens to generate")
 

--- a/tinker_cookbook/recipes/search_tool/train.py
+++ b/tinker_cookbook/recipes/search_tool/train.py
@@ -18,9 +18,9 @@ from tinker_cookbook.rl import train
 @chz.chz
 class CLIConfig:
     # Model parameters
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
+    model_name: str = "Qwen/Qwen3.5-4B"
     lora_rank: int = 32
-    renderer_name: str | None = None
+    renderer_name: str | None = "qwen3_5_disable_thinking"
 
     # Training parameters
     learning_rate: float = 4e-5

--- a/tinker_cookbook/recipes/sl_basic.py
+++ b/tinker_cookbook/recipes/sl_basic.py
@@ -12,7 +12,7 @@ from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
 
 
 def build_config_blueprint() -> chz.Blueprint[train.Config]:
-    model_name = "meta-llama/Llama-3.1-8B"
+    model_name = "Qwen/Qwen3.5-9B-Base"
     renderer_name = model_info.get_recommended_renderer_name(model_name)
     common_config = ChatDatasetBuilderCommonConfig(
         model_name_for_tokenizer=model_name,

--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -24,7 +24,7 @@ logging.getLogger("httpx").setLevel(logging.WARN)
 class Config:
     base_url: str | None = None
     log_path: str = "/tmp/tinker-examples/sl-loop"
-    model_name: str = "meta-llama/Llama-3.1-8B"
+    model_name: str = "Qwen/Qwen3.5-9B-Base"
     batch_size: int = 128
     learning_rate: float = 1e-4
     max_length: int = 32768

--- a/tinker_cookbook/recipes/true_thinking_score/README.md
+++ b/tinker_cookbook/recipes/true_thinking_score/README.md
@@ -163,7 +163,7 @@ python -m tinker_cookbook.recipes.true_thinking_score.analyze \
 
 ```bash
 python -m tinker_cookbook.recipes.true_thinking_score.analyze \
-    dataset=gsm8k model_name=Qwen/Qwen3.5-27B n_problems=50
+    dataset=gsm8k model_name=Qwen/Qwen3.6-27B n_problems=50
 ```
 
 Results are saved to `/tmp/tinker-examples/tts/<run-name>/`:
@@ -231,6 +231,8 @@ pytest tinker_cookbook/recipes/true_thinking_score/tts_test.py -v
 | SV steps | — | 115 | 110 | 113 |
 | SV decorative | 12-21% | 56.5% | 49.1% | **36.3%** |
 | Accuracy | — | 58% | 62% | **70%** |
+
+> **Note:** These historical results include `Qwen3.5-27B`, which is deprecated. Rerun that column with `Qwen/Qwen3.6-27B` before treating the comparison as current.
 
 ### Findings
 

--- a/tinker_cookbook/recipes/true_thinking_score/analyze.py
+++ b/tinker_cookbook/recipes/true_thinking_score/analyze.py
@@ -16,7 +16,7 @@ Usage:
 
     # GSM8K, larger model
     python -m tinker_cookbook.recipes.true_thinking_score.analyze \
-        dataset=gsm8k model_name=Qwen/Qwen3.5-27B n_problems=50
+        dataset=gsm8k model_name=Qwen/Qwen3.6-27B n_problems=50
 
     # Full MATH-500
     python -m tinker_cookbook.recipes.true_thinking_score.analyze \

--- a/tinker_cookbook/recipes/verifiers_rl/train.py
+++ b/tinker_cookbook/recipes/verifiers_rl/train.py
@@ -27,8 +27,9 @@ logger = logging.getLogger(__name__)
 @chz.chz
 class CLIConfig:
     # model configuration
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
+    model_name: str = "Qwen/Qwen3.5-4B"
     lora_rank: int = 32
+    renderer_name: str = "qwen3_5_disable_thinking"
 
     # environment configuration
     vf_env_id: str = "reverse-text"

--- a/tinker_cookbook/recipes/vlm_classifier/README.md
+++ b/tinker_cookbook/recipes/vlm_classifier/README.md
@@ -9,11 +9,11 @@ python -m tinker_cookbook.recipes.vlm_classifier.train \
     experiment_dir=./vlm_classifier \
     wandb_project=vlm-classifier \
     dataset=caltech101 \
-    renderer_name=qwen3_vl \
-    model_name=Qwen/Qwen3-VL-30B-A3B-Instruct
+    renderer_name=qwen3_5 \
+    model_name=Qwen/Qwen3.6-35B-A3B
 ```
 
-Currently, the qwen series of VLMs are supported. Running the above script after installing tinker-cookbook will fine-tune `Qwen/Qwen3-VL-30B-A3B-Instruct` on the `caltech101` as an example.
+Currently, the qwen series of VLMs are supported. Running the above script after installing tinker-cookbook will fine-tune `Qwen/Qwen3.6-35B-A3B` on the `caltech101` as an example.
 
 ### Evaluation
 
@@ -23,8 +23,8 @@ Once trained, you can evaluate the class predictions from your VLM as follows:
 python -m tinker_cookbook.recipes.vlm_classifier.eval \
     dataset=caltech101 \
     model_path=$YOUR_MODEL_PATH \
-    model_name=Qwen/Qwen3-VL-30B-A3B-Instruct \
-    renderer_name=qwen3_vl
+    model_name=Qwen/Qwen3.6-35B-A3B \
+    renderer_name=qwen3_5
 ```
 
 This will print the test accuracy of your model.

--- a/tinker_cookbook/recipes/vlm_classifier/eval_sweep.py
+++ b/tinker_cookbook/recipes/vlm_classifier/eval_sweep.py
@@ -71,7 +71,7 @@ def parse_hyperparams_from_experiment_name(experiment_name: str) -> dict[str, An
     Experiment names follow the format from sweep.py:
     {dataset}-{model_name}-{lora_rank}rank-{learning_rate}lr-{batch_size}batch-{examples_per_class}shot-seed{subset_seed}-{date}
 
-    Example: caltech101-Qwen-Qwen3-VL-235B-A22B-Instruct-32rank-0.0005lr-32batch-4shot-seed0-2025-11-26
+    Example: caltech101-Qwen-Qwen3.5-397B-A17B-32rank-0.0005lr-32batch-4shot-seed0-2025-11-26
     """
 
     hyperparams: dict[str, Any] = {}
@@ -115,8 +115,8 @@ class EvalConfig:
     experiment_dir: str
     output_file: str
 
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     # Infrastructure parameters
     base_url: str | None = None

--- a/tinker_cookbook/recipes/vlm_classifier/sweep.py
+++ b/tinker_cookbook/recipes/vlm_classifier/sweep.py
@@ -5,7 +5,7 @@
 Launcher for training image classifiers based on VLMs.
 
 ```bash
-python -m tinker_cookbook.recipes.vlm_classifier.sweep experiment_dir=./sweep model_name=Qwen/Qwen3-VL-30B-A3B-Instruct
+python -m tinker_cookbook.recipes.vlm_classifier.sweep experiment_dir=./sweep model_name=Qwen/Qwen3.6-35B-A3B renderer_name=qwen3_5
 ```
 
 """
@@ -35,8 +35,8 @@ class ExperimentConfig:
     experiment_dir: str
 
     dataset: str = "caltech101"
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     # Infrastructure parameters
     base_url: str | None = None
@@ -158,8 +158,8 @@ class SweepConfig:
 
     experiment_dir: str
 
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     datasets: list[str] = chz.field(default_factory=lambda: ["caltech101"])
     examples_per_class: list[int] = chz.field(default_factory=lambda: [1, 2, 4, 8, 16])

--- a/tinker_cookbook/recipes/vlm_classifier/train.py
+++ b/tinker_cookbook/recipes/vlm_classifier/train.py
@@ -36,8 +36,8 @@ class ExperimentConfig:
 
     dataset: str = "caltech101"
 
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     # Infrastructure parameters
     base_url: str | None = None

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -135,8 +135,8 @@ def get_renderer(
             - ``"deepseekv3_disable_thinking"``: DeepSeek V3 non-thinking (alias)
             - ``"deepseekv3_thinking"``: DeepSeek V3 thinking mode
             - ``"kimi_k2"``: Kimi K2 Thinking format
-            - ``"kimi_k25"``: Kimi K2.5 with thinking enabled
-            - ``"kimi_k25_disable_thinking"``: Kimi K2.5 with thinking disabled
+            - ``"kimi_k25"``: Kimi K2.6-compatible renderer with thinking enabled
+            - ``"kimi_k25_disable_thinking"``: Kimi K2.6-compatible renderer with thinking disabled
             - ``"kimi_k26"``: Kimi K2.6 with thinking enabled (HF default — same token output as ``kimi_k25``)
             - ``"kimi_k26_disable_thinking"``: Kimi K2.6 with thinking disabled
             - ``"kimi_k26_preserve_thinking"``: Kimi K2.6 with thinking enabled and historical ``<think>...</think>`` blocks preserved (HF ``preserve_thinking=true``); use for long-horizon agents / multi-turn RL

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1762,7 +1762,7 @@ class ImageProcessorProtocol(Protocol):
     """Protocol for image processors used by vision-language renderers.
 
     Implementations must provide either ``get_number_of_image_patches`` (used
-    by Qwen3-VL style processors) or ``get_resize_config`` (used by Kimi-K2.5
+    by Qwen3-VL style processors) or ``get_resize_config`` (used by Kimi-K2.6
     style processors) to compute the number of image tokens an image will
     produce after preprocessing.
 

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -115,7 +115,7 @@ def _parse_tool_calls_section(
 
 class KimiK2Renderer(Renderer):
     """
-    Format for moonshotai/Kimi-K2-Thinking:
+    Format for Kimi K2-style thinking models:
         <|im_system|>system<|im_middle|>You are Kimi, an AI assistant created by Moonshot AI.<|im_end|>
         <|im_user|>user<|im_middle|>What can you help me with?<|im_end|>
         <|im_assistant|>assistant<|im_middle|><think>reasoning</think>I can help you with...<|im_end|>
@@ -631,7 +631,7 @@ class KimiK2Renderer(Renderer):
         If no system_prompt is provided, uses the default system prompt to match
         HuggingFace chat template behavior.
 
-        Reference: https://huggingface.co/moonshotai/Kimi-K2-Thinking/blob/main/chat_template.jinja
+        Reference: Kimi K2 chat_template.jinja
         """
         messages: list[Message] = []
 

--- a/tinker_cookbook/renderers/kimi_k25.py
+++ b/tinker_cookbook/renderers/kimi_k25.py
@@ -1,4 +1,4 @@
-"""Renderer for Moonshot AI's Kimi K2.5 models."""
+"""Renderer for Moonshot AI's Kimi K2.6 models using the ``kimi_k25`` architecture."""
 
 from typing import cast
 
@@ -21,7 +21,7 @@ from tinker_cookbook.tokenizer_utils import Tokenizer
 
 class KimiK25Renderer(KimiK2Renderer):
     """
-    Renderer for Kimi K2.5 with thinking enabled (default).
+    Renderer for Kimi K2.6 with thinking enabled (default).
 
     Key differences from KimiK2Renderer:
     1. Generation prompt prefill: Appends `<think>` (open tag) to enable thinking mode
@@ -46,7 +46,7 @@ class KimiK25Renderer(KimiK2Renderer):
         image_processor: ImageProcessor | None = None,
         strip_thinking_from_history: bool = True,
     ):
-        """Initialize the Kimi K2.5 renderer.
+        """Initialize the Kimi K2.6 renderer.
 
         Args:
             tokenizer (Tokenizer): The tokenizer to use for encoding.
@@ -130,7 +130,7 @@ class KimiK25Renderer(KimiK2Renderer):
     ) -> list[Message]:
         """Create system messages with TypeScript-style tool specifications.
 
-        Per the HuggingFace chat template, Kimi K2.5 uses TypeScript-style tool
+        Per the HuggingFace chat template, Kimi K2.6 uses TypeScript-style tool
         declarations instead of JSON format. The tool_declare message comes BEFORE
         the regular system message.
 
@@ -142,7 +142,7 @@ class KimiK25Renderer(KimiK2Renderer):
         Returns:
             list[Message]: Messages to prepend to conversations (tool_declare + system).
 
-        Reference: kimi-k2.5-hf-tokenizer/chat_template.jinja
+        Reference: Kimi K2.6 chat_template.jinja
         """
         messages: list[Message] = []
 
@@ -161,7 +161,7 @@ class KimiK25Renderer(KimiK2Renderer):
 
 class KimiK25DisableThinkingRenderer(KimiK25Renderer):
     """
-    Renderer for Kimi K2.5 with thinking disabled.
+    Renderer for Kimi K2.6 with thinking disabled.
 
     Uses `<think></think>` prefill instead of `<think>` to disable thinking mode.
 

--- a/tinker_cookbook/renderers/kimi_k25_test.py
+++ b/tinker_cookbook/renderers/kimi_k25_test.py
@@ -1,5 +1,5 @@
 """
-Tests for Kimi K2.5 renderer.
+Tests for the Kimi K2.6 renderer path backed by KimiK25Renderer.
 
 Tests verify that the KimiK25Renderer produces correct output:
 1. Generation prompt includes `<think>` prefill (thinking enabled)
@@ -29,7 +29,7 @@ from tinker_cookbook.renderers.kimi_k2_5_tool_declaration_ts import encode_tools
 from tinker_cookbook.renderers.testing_utils import extract_token_ids
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
-KIMI_K25_MODEL = "moonshotai/Kimi-K2.5"
+KIMI_K25_MODEL = "moonshotai/Kimi-K2.6"
 
 
 # =============================================================================
@@ -39,24 +39,24 @@ KIMI_K25_MODEL = "moonshotai/Kimi-K2.5"
 
 @pytest.fixture(scope="module")
 def kimi_tokenizer():
-    """Get the Kimi K2.5 tokenizer (cached per module)."""
+    """Get the Kimi K2.6 tokenizer (cached per module)."""
     try:
         return get_tokenizer(KIMI_K25_MODEL)
     except ModuleNotFoundError as e:
         if "Kimi-K2" in str(e):
-            pytest.skip(f"K2.5 tokenizer has HF module import bug: {e}")
+            pytest.skip(f"K2.6 tokenizer has HF module import bug: {e}")
         raise
 
 
 @pytest.fixture(scope="module")
 def kimi_renderer(kimi_tokenizer):
-    """Get the Kimi K2.5 renderer (cached per module)."""
+    """Get the Kimi K2.6-compatible renderer (cached per module)."""
     return get_renderer("kimi_k25", kimi_tokenizer)
 
 
 @pytest.fixture(scope="module")
 def kimi_renderer_disable_thinking(kimi_tokenizer):
-    """Get the Kimi K2.5 disable-thinking renderer (cached per module)."""
+    """Get the Kimi K2.6-compatible disable-thinking renderer (cached per module)."""
     return get_renderer("kimi_k25_disable_thinking", kimi_tokenizer)
 
 
@@ -557,7 +557,7 @@ def test_kimi_k25_multi_step_tool_calls_matches_hf(
 
 
 def test_kimi_k25_tool_declaration_is_typescript(kimi_renderer):
-    """Test that K2.5 uses TypeScript-style tool declarations."""
+    """Test that Kimi K2.6 uses TypeScript-style tool declarations."""
     tools = [get_tool_spec()]
     prefix_messages = kimi_renderer.create_conversation_prefix_with_tools(tools)
 
@@ -706,7 +706,7 @@ def test_kimi_k25_thinking_stripped_in_history(build_mode: str, kimi_tokenizer, 
 
 
 def test_kimi_k25_eot_parsing(kimi_tokenizer, kimi_renderer):
-    """Test EOT token parsing for K2.5 renderer."""
+    """Test EOT token parsing for the Kimi K2.6 renderer."""
     # Test with EOT token
     test_response = "The answer is 42.<|im_end|>"
     response_tokens = kimi_tokenizer.encode(test_response)
@@ -773,7 +773,7 @@ def test_kimi_k25_parse_response_streaming_restores_prefilled_think_tag(
     "image_dimensions_and_expected_tokens", [(2048, 1365, 3626), (17, 64, 3), (5000, 6000, 4189)]
 )
 def test_kimi_k25_image_content(image_dimensions_and_expected_tokens: tuple[int, int, int]):
-    """Test that image-content is encoded properly for kimi2.5"""
+    """Test that image-content is encoded properly for Kimi K2.6."""
     width, height, expected_tokens = image_dimensions_and_expected_tokens
     dummy_image = Image.new("RGB", (width, height))
     messages = [

--- a/tinker_cookbook/renderers/kimi_k26.py
+++ b/tinker_cookbook/renderers/kimi_k26.py
@@ -1,7 +1,7 @@
 """Renderer for Moonshot AI's Kimi K2.6 models.
 
-K2.6 is a near-drop-in replacement for K2.5 at the renderer level — the
-only template difference is the new opt-in ``preserve_thinking`` flag.
+K2.6 reuses the existing ``kimi_k25`` renderer implementation; the only
+template difference is the new opt-in ``preserve_thinking`` flag.
 The ``kimi_k26`` and ``kimi_k26_disable_thinking`` renderer names
 therefore dispatch directly to ``KimiK25Renderer`` /
 ``KimiK25DisableThinkingRenderer`` in the factory; only the
@@ -19,7 +19,7 @@ class KimiK26PreserveThinkingRenderer(KimiK25Renderer):
     Matches the K2.6 HF chat template rendered with
     ``preserve_thinking=true``: every historical assistant turn keeps its
     full ``<think>...</think>`` reasoning block, instead of the default
-    K2.5/K2.6 behavior that collapses prior reasoning to empty
+    default K2.6 behavior that collapses prior reasoning to empty
     ``<think></think>`` and preserves only the current turn's thinking.
 
     Use this variant when reasoning traces on prior turns are load-bearing

--- a/tinker_cookbook/renderers/kimi_k2_5_tool_declaration_ts.py
+++ b/tinker_cookbook/renderers/kimi_k2_5_tool_declaration_ts.py
@@ -1,7 +1,7 @@
 """
 Encode structured tool declaration to typescript style string.
 
-Copied from kimi-k2.5-hf-tokenizer/tool_declaration_ts.py for Kimi K2.5 support.
+TypeScript-style tool declaration encoder used by Kimi K2.6-compatible renderers.
 """
 
 import dataclasses

--- a/tinker_cookbook/renderers/kimi_k2_test.py
+++ b/tinker_cookbook/renderers/kimi_k2_test.py
@@ -72,7 +72,7 @@ def _get_tool_call_conversation() -> list[Message]:
 
 def test_kimi_streaming_simple_text():
     """Test streaming parsing of simple text response."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "Hello, world!<|im_end|>"
@@ -92,7 +92,7 @@ def test_kimi_streaming_simple_text():
 
 def test_kimi_streaming_with_thinking():
     """Test streaming parsing with thinking blocks."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "<think>Let me reason about this.</think>The answer is 42.<|im_end|>"
@@ -115,7 +115,7 @@ def test_kimi_streaming_with_thinking():
 
 def test_kimi_streaming_matches_batch():
     """Test that streaming parse produces same final message as batch parse."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "<think>Step 1: Analyze.\nStep 2: Compute.</think>The result is 123.<|im_end|>"
@@ -134,7 +134,7 @@ def test_kimi_streaming_matches_batch():
 
 def test_kimi_streaming_content_index_increments():
     """Test that content_index increments when switching content types."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "<think>thinking</think>text<|im_end|>"
@@ -151,7 +151,7 @@ def test_kimi_streaming_content_index_increments():
 
 def test_kimi_streaming_multiple_think_blocks():
     """Test streaming with multiple interleaved think blocks."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "<think>first thought</think>partial<think>second thought</think>final<|im_end|>"
@@ -176,7 +176,7 @@ def test_kimi_streaming_multiple_think_blocks():
 
 def test_kimi_streaming_empty_response():
     """Test streaming parsing of empty/minimal response."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "<|im_end|>"
@@ -190,7 +190,7 @@ def test_kimi_streaming_empty_response():
 
 def test_kimi_streaming_no_unnecessary_buffering():
     """Test that we don't buffer more than necessary when no tag prefix matches."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "Hello world<|im_end|>"
@@ -204,7 +204,7 @@ def test_kimi_streaming_no_unnecessary_buffering():
 
 def test_kimi_streaming_with_emoji():
     """Test that streaming parser handles emoji correctly."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
     renderer = KimiK2Renderer(tokenizer)
 
     response_str = "<think>Let me think 🤔</think>Here's a party 🎉!<|im_end|>"
@@ -287,7 +287,7 @@ class TestKimiK2StreamingBatchEquivalence:
 
     @pytest.fixture
     def renderer(self):
-        tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+        tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
         return KimiK2Renderer(tokenizer)
 
     def test_simple_text(self, renderer):
@@ -450,7 +450,7 @@ def test_kimi_k2_thinking_stripped_when_no_suffix_messages():
     Kimi K2 should preserve thinking only after the last non-tool-call assistant.
     This test checks that the history thinking is stripped with the presence of a non-tool-call assistant.
     """
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
     renderer = get_renderer("kimi_k2", tokenizer)
 
@@ -502,7 +502,7 @@ def test_kimi_k2_thinking_preserved_in_suffix_after_last_non_tool_call():
     Suffix thinking is preserved but history thinking is stripped relative to the
     position of the last non-tool-call assistant.
     """
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
     renderer = get_renderer("kimi_k2", tokenizer)
 
@@ -554,7 +554,7 @@ def test_kimi_k2_thinking_preserved_when_no_non_tool_call_assistant():
     """
     When no non-tool-call assistant exists, all thinking should be preserved.
     """
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
     renderer = get_renderer("kimi_k2", tokenizer)
 
@@ -590,7 +590,7 @@ def test_kimi_k2_thinking_preserved_when_no_non_tool_call_assistant():
 
 
 def test_kimi_k2_build_supervised_examples_last_assistant_matches():
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
     renderer: KimiK2Renderer = get_renderer("kimi_k2", tokenizer)  # type: ignore
 
@@ -608,7 +608,7 @@ def test_kimi_k2_build_supervised_examples_last_assistant_matches():
 
 
 def test_kimi_k2_build_supervised_examples_all_assistant_matches():
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
     renderer: KimiK2Renderer = get_renderer("kimi_k2", tokenizer)  # type: ignore
 
@@ -650,7 +650,7 @@ def test_kimi_k2_build_supervised_examples_all_assistant_matches():
 
 
 def test_kimi_k2_build_supervised_examples_warns_on_non_assistant_mode():
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
     renderer: KimiK2Renderer = get_renderer("kimi_k2", tokenizer)  # type: ignore
 
@@ -681,7 +681,7 @@ def test_kimi_k2_build_supervised_examples_warns_on_non_assistant_mode():
 
 
 def test_kimi_k2_build_supervised_examples_all_assistant_matches_with_tool_calls():
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
     renderer: KimiK2Renderer = get_renderer("kimi_k2", tokenizer)  # type: ignore
 

--- a/tinker_cookbook/renderers/kimi_k2_tool_declaration_test.py
+++ b/tinker_cookbook/renderers/kimi_k2_tool_declaration_test.py
@@ -1,4 +1,4 @@
-"""Tests for Kimi K2 tool declaration rendering."""
+"""Tests for Kimi K2.6 tool declaration rendering."""
 
 import json
 
@@ -49,8 +49,8 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
 )
 def test_tool_declaration_message_order(tools, expected_order):
     """Test that tool_declare message comes before system message."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
-    renderer = get_renderer("kimi_k2", tokenizer)
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
+    renderer = get_renderer("kimi_k26", tokenizer)
 
     messages = renderer.create_conversation_prefix_with_tools(tools, "")
 
@@ -63,8 +63,8 @@ def test_tool_declaration_message_order(tools, expected_order):
 
 def test_tool_declaration_no_duplicate_system():
     """Test that tool declaration doesn't result in duplicate system messages."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
-    renderer = get_renderer("kimi_k2", tokenizer)
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
+    renderer = get_renderer("kimi_k26", tokenizer)
 
     tools: list[ToolSpec] = [
         {"name": "test", "description": "Test", "parameters": {"type": "object", "properties": {}}}
@@ -86,8 +86,8 @@ def test_tool_declaration_no_duplicate_system():
 
 def test_tool_json_keys_are_sorted():
     """Test that tool declaration JSON has sorted keys at all nesting levels."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
-    renderer = get_renderer("kimi_k2", tokenizer)
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
+    renderer = get_renderer("kimi_k26", tokenizer)
 
     tools: list[ToolSpec] = [
         {
@@ -160,14 +160,16 @@ def test_tool_declaration_matches_hf_tokens():
     messages: list[Message] = [{"role": "user", "content": "What's the weather in SF?"}]
 
     # Tinker-cookbook approach
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
-    renderer = get_renderer("kimi_k2", tokenizer)
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
+    renderer = get_renderer("kimi_k26", tokenizer)
     convo = renderer.create_conversation_prefix_with_tools(tools_toolspec, "") + messages
     cookbook_tokens = renderer.build_generation_prompt(convo).to_ints()
 
     # HuggingFace approach (pass OpenAI format to match tinker-cookbook's output)
     hf_tokenizer = AutoTokenizer.from_pretrained(
-        "moonshotai/Kimi-K2-Thinking", trust_remote_code=True
+        "moonshotai/Kimi-K2.6",
+        trust_remote_code=True,
+        revision="b5aabbfb20227ed42becbf5541dbffd213942c58",
     )
     hf_tokens = extract_token_ids(
         hf_tokenizer.apply_chat_template(
@@ -204,15 +206,17 @@ def test_tool_declaration_string_matches_hf():
     messages_list: list[Message] = [{"role": "user", "content": "Test"}]
 
     # Tinker-cookbook
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
-    renderer = get_renderer("kimi_k2", tokenizer)
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
+    renderer = get_renderer("kimi_k26", tokenizer)
     convo = renderer.create_conversation_prefix_with_tools(tools_toolspec, "") + messages_list
     cookbook_prompt = renderer.build_generation_prompt(convo)
     cookbook_str = tokenizer.decode(cookbook_prompt.to_ints())
 
     # HuggingFace (pass OpenAI format)
     hf_tokenizer = AutoTokenizer.from_pretrained(
-        "moonshotai/Kimi-K2-Thinking", trust_remote_code=True
+        "moonshotai/Kimi-K2.6",
+        trust_remote_code=True,
+        revision="b5aabbfb20227ed42becbf5541dbffd213942c58",
     )
     hf_str = hf_tokenizer.apply_chat_template(
         messages_list, tools=tools_openai, tokenize=False, add_generation_prompt=True
@@ -227,8 +231,8 @@ def test_tool_declaration_string_matches_hf():
 
 def test_empty_tools_list():
     """Test that empty tools list doesn't cause issues."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
-    renderer = get_renderer("kimi_k2", tokenizer)
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
+    renderer = get_renderer("kimi_k26", tokenizer)
 
     messages = renderer.create_conversation_prefix_with_tools([], "")
 
@@ -239,8 +243,8 @@ def test_empty_tools_list():
 
 def test_custom_system_prompt_with_tools():
     """Test that custom system prompt is preserved when using tools."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
-    renderer = get_renderer("kimi_k2", tokenizer)
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
+    renderer = get_renderer("kimi_k26", tokenizer)
 
     tools: list[ToolSpec] = [
         {"name": "test", "description": "Test", "parameters": {"type": "object", "properties": {}}}

--- a/tinker_cookbook/renderers/parsing_test.py
+++ b/tinker_cookbook/renderers/parsing_test.py
@@ -23,7 +23,6 @@ from tinker_cookbook.renderers.deepseek_v3 import (
     DeepSeekV3ThinkingRenderer,
 )
 from tinker_cookbook.renderers.gpt_oss import GptOssRenderer
-from tinker_cookbook.renderers.kimi_k2 import KimiK2Renderer
 from tinker_cookbook.renderers.kimi_k25 import KimiK25Renderer
 from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
 from tinker_cookbook.renderers.qwen3_5 import Qwen3_5DisableThinkingRenderer, Qwen3_5Renderer
@@ -253,7 +252,7 @@ def test_utf8_decoder_with_real_tokenizer_ascii():
     However, for ASCII text (single-byte UTF-8), there's no splitting issue,
     so the decoder should work correctly.
     """
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
 
     # ASCII-only text won't have UTF-8 splitting issues
     test_str = "Hello World! How are you today?"
@@ -284,7 +283,7 @@ def test_utf8_decoder_handles_replacement_chars():
     for incomplete UTF-8 instead of raising exceptions. The decoder detects these
     and buffers tokens until the sequence completes.
     """
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
 
     # The emoji 🎉 is encoded as multiple tokens
     test_str = "🎉"
@@ -318,7 +317,7 @@ def test_utf8_decoder_handles_replacement_chars():
 
 def test_utf8_decoder_mixed_ascii_and_emoji():
     """Test streaming with mixed ASCII and multi-byte Unicode."""
-    tokenizer = get_tokenizer("moonshotai/Kimi-K2-Thinking")
+    tokenizer = get_tokenizer("moonshotai/Kimi-K2.6")
 
     # Mix of ASCII and emoji
     test_str = "Hello 🎉 World 🌍!"
@@ -356,11 +355,10 @@ def test_utf8_decoder_mixed_ascii_and_emoji():
             GptOssRenderer,
             {"use_system_prompt": True, "reasoning_effort": "medium"},
         ),
-        ("Qwen/Qwen3-30B-A3B", Qwen3Renderer, {}),
-        ("Qwen/Qwen3.5-35B-A3B", Qwen3_5Renderer, {}),
-        ("Qwen/Qwen3.5-35B-A3B", Qwen3_5DisableThinkingRenderer, {}),
-        ("moonshotai/Kimi-K2-Thinking", KimiK2Renderer, {}),
-        ("moonshotai/Kimi-K2.5", KimiK25Renderer, {}),
+        ("Qwen/Qwen3-8B", Qwen3Renderer, {}),
+        ("Qwen/Qwen3.6-35B-A3B", Qwen3_5Renderer, {}),
+        ("Qwen/Qwen3.6-35B-A3B", Qwen3_5DisableThinkingRenderer, {}),
+        ("moonshotai/Kimi-K2.6", KimiK25Renderer, {}),
     ],
 )
 def test_thinking_generation_parse_correspondence(model_name, renderer_cls, renderer_kwargs):

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -37,7 +37,7 @@ def _is_message(obj) -> TypeGuard[Message]:
 
 def test_qwen3_parse_response_extracts_thinking():
     """Test Qwen3Renderer.parse_response extracts thinking to ThinkingPart."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<think>Let me reason about this.</think>The answer is 42.<|im_end|>"
@@ -63,7 +63,7 @@ def test_qwen3_parse_response_extracts_thinking():
 
 def test_qwen3_parse_response_multiple_think_blocks():
     """Test Qwen3Renderer.parse_response handles multiple interleaved think blocks."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<think>step 1</think>partial answer<think>step 2</think>final answer<|im_end|>"
@@ -84,7 +84,7 @@ def test_qwen3_parse_response_multiple_think_blocks():
 
 def test_qwen3_parse_response_no_thinking_returns_string():
     """Test Qwen3Renderer.parse_response returns string when no thinking."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "Just a plain response without thinking.<|im_end|>"
@@ -100,7 +100,7 @@ def test_qwen3_parse_response_no_thinking_returns_string():
 
 def test_qwen3_parse_response_with_tool_calls():
     """Test Qwen3Renderer.parse_response puts tool calls in message['tool_calls'], not content."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = '<think>Let me search</think>I will search for that.<tool_call>{"name": "web_search", "arguments": {"query": "weather"}}</tool_call><|im_end|>'
@@ -127,7 +127,7 @@ def test_qwen3_parse_response_with_tool_calls():
 
 def test_qwen3_parse_response_tool_call_only():
     """Test Qwen3Renderer.parse_response with only a tool call."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = (
@@ -270,7 +270,7 @@ def test_qwen3_disable_thinking_4turn():
 
 def test_qwen3_streaming_simple_text():
     """Test streaming parsing of simple text response without thinking."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "Hello, world!<|im_end|>"
@@ -290,7 +290,7 @@ def test_qwen3_streaming_simple_text():
 
 def test_qwen3_streaming_with_thinking():
     """Test streaming parsing with thinking blocks."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<think>Let me reason about this.</think>The answer is 42.<|im_end|>"
@@ -313,7 +313,7 @@ def test_qwen3_streaming_with_thinking():
 
 def test_qwen3_streaming_matches_batch():
     """Test that streaming parse produces same final message as batch parse."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<think>Step 1: Analyze.\nStep 2: Compute.</think>The result is 123.<|im_end|>"
@@ -332,7 +332,7 @@ def test_qwen3_streaming_matches_batch():
 
 def test_qwen3_streaming_content_index_increments():
     """Test that content_index increments when switching content types."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<think>thinking</think>text<|im_end|>"
@@ -349,7 +349,7 @@ def test_qwen3_streaming_content_index_increments():
 
 def test_qwen3_streaming_empty_response():
     """Test streaming parsing of empty/minimal response."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<|im_end|>"
@@ -363,7 +363,7 @@ def test_qwen3_streaming_empty_response():
 
 def test_qwen3_streaming_multiple_think_blocks():
     """Test streaming with multiple interleaved think blocks."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<think>first thought</think>partial<think>second thought</think>final<|im_end|>"
@@ -388,7 +388,7 @@ def test_qwen3_streaming_multiple_think_blocks():
 
 def test_qwen3_streaming_no_unnecessary_buffering():
     """Test that we don't buffer more than necessary when no tag prefix matches."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "Hello world<|im_end|>"
@@ -402,7 +402,7 @@ def test_qwen3_streaming_no_unnecessary_buffering():
 
 def test_qwen3_streaming_with_emoji():
     """Test that streaming parser handles multi-byte UTF-8 (emoji) correctly."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = Qwen3Renderer(tokenizer)
 
     response_str = "<think>Let me think 🤔</think>Here's a party 🎉!<|im_end|>"
@@ -426,7 +426,7 @@ def test_qwen3_streaming_with_emoji():
 )
 def test_qwen3_streaming_supported_by_text_variants(renderer_name):
     """All text-only Qwen3 renderer variants support streaming."""
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
     renderer = get_renderer(renderer_name, tokenizer)
 
     response_str = "<think>reasoning</think>answer<|im_end|>"
@@ -488,7 +488,7 @@ class TestQwen3StreamingBatchEquivalence:
 
     @pytest.fixture
     def renderer(self):
-        tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
+        tokenizer = get_tokenizer("Qwen/Qwen3-8B")
         return Qwen3Renderer(tokenizer)
 
     def test_simple_text(self, renderer):
@@ -620,7 +620,7 @@ class TestQwen3StreamingBatchEquivalence:
 
 @pytest.fixture
 def qwen3_5_tokenizer():
-    return get_tokenizer("Qwen/Qwen3.5-35B-A3B")
+    return get_tokenizer("Qwen/Qwen3.6-35B-A3B")
 
 
 @pytest.fixture

--- a/tinker_cookbook/renderers/qwen3_tool_declaration_test.py
+++ b/tinker_cookbook/renderers/qwen3_tool_declaration_test.py
@@ -17,14 +17,13 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
 
 # Qwen3 models use JSON tool calls with OpenAI-style tool wrapper in tool declarations.
 QWEN3_MODELS = [
-    ("Qwen/Qwen3-30B-A3B", "qwen3"),
-    ("Qwen/Qwen3-30B-A3B-Instruct-2507", "qwen3_instruct"),
+    ("Qwen/Qwen3-8B", "qwen3"),
 ]
 
-# Qwen3.5 models use XML tool calls and raw function specs in tool declarations.
+# Qwen3.5/Qwen3.6 models use XML tool calls and raw function specs in tool declarations.
 QWEN3_5_MODELS = [
-    ("Qwen/Qwen3.5-35B-A3B", "qwen3_5"),
-    ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking"),
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
 ]
 
 ALL_QWEN_MODELS = QWEN3_MODELS + QWEN3_5_MODELS

--- a/tinker_cookbook/renderers/renderer_pickle_test.py
+++ b/tinker_cookbook/renderers/renderer_pickle_test.py
@@ -16,8 +16,8 @@ from tinker_cookbook.tokenizer_utils import Tokenizer, get_tokenizer
 # Models that don't require special access / are commonly available in CI.
 # Each entry is (renderer_name, model_name).
 _TEXT_RENDERERS = [
-    ("role_colon", "meta-llama/Llama-3.1-8B-Instruct"),
-    ("llama3", "meta-llama/Llama-3.1-8B-Instruct"),
+    ("role_colon", "Qwen/Qwen3.5-9B-Base"),
+    ("llama3", "meta-llama/Llama-3.2-1B-Instruct"),
     ("qwen3", "Qwen/Qwen3-8B"),
     ("qwen3_disable_thinking", "Qwen/Qwen3-8B"),
     ("qwen3_instruct", "Qwen/Qwen3-8B"),
@@ -58,7 +58,7 @@ class TestRendererPickle:
 
     def test_pickle_without_metadata_raises(self) -> None:
         """Renderers created directly (not via get_renderer()) raise on pickle."""
-        tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
+        tokenizer = get_tokenizer("meta-llama/Llama-3.2-1B-Instruct")
 
         from tinker_cookbook.renderers.llama3 import Llama3Renderer
 
@@ -69,13 +69,13 @@ class TestRendererPickle:
 
     def test_pickle_with_manual_metadata(self) -> None:
         """Manually setting pickle metadata works for direct-constructed renderers."""
-        tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
+        tokenizer = get_tokenizer("meta-llama/Llama-3.2-1B-Instruct")
 
         from tinker_cookbook.renderers.llama3 import Llama3Renderer
 
         renderer = Llama3Renderer(tokenizer)
         renderer._renderer_name = "llama3"
-        renderer._model_name = "meta-llama/Llama-3.1-8B-Instruct"
+        renderer._model_name = "meta-llama/Llama-3.2-1B-Instruct"
         renderer._has_image_processor = False
 
         restored = pickle.loads(pickle.dumps(renderer))
@@ -96,14 +96,14 @@ class TestRendererPickle:
 
     def test_pickle_with_explicit_model_name(self) -> None:
         """The model_name param in get_renderer() overrides tokenizer.name_or_path."""
-        tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
+        tokenizer = get_tokenizer("meta-llama/Llama-3.2-1B-Instruct")
         # tokenizer.name_or_path is remapped, but we can override it
-        renderer = get_renderer("llama3", tokenizer, model_name="meta-llama/Llama-3.1-8B-Instruct")
+        renderer = get_renderer("llama3", tokenizer, model_name="meta-llama/Llama-3.2-1B-Instruct")
 
-        assert renderer._model_name == "meta-llama/Llama-3.1-8B-Instruct"
+        assert renderer._model_name == "meta-llama/Llama-3.2-1B-Instruct"
 
         restored = pickle.loads(pickle.dumps(renderer))
-        assert restored._model_name == "meta-llama/Llama-3.1-8B-Instruct"
+        assert restored._model_name == "meta-llama/Llama-3.2-1B-Instruct"
         assert type(restored) is type(renderer)
 
     def test_pickle_custom_registered_renderer(self) -> None:
@@ -115,7 +115,7 @@ class TestRendererPickle:
 
         register_renderer("test_custom_pickle", my_factory)
         try:
-            tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
+            tokenizer = get_tokenizer("meta-llama/Llama-3.2-1B-Instruct")
             renderer = get_renderer("test_custom_pickle", tokenizer)
 
             assert renderer._renderer_name == "test_custom_pickle"
@@ -133,7 +133,7 @@ class TestMessageCompleterPickle:
 
         We test the Renderer part here; SamplingClient has its own __reduce__ in the SDK.
         """
-        tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
+        tokenizer = get_tokenizer("meta-llama/Llama-3.2-1B-Instruct")
         renderer = get_renderer("llama3", tokenizer)
 
         # Just verify the renderer component pickles fine when it would be inside a completer

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -54,7 +54,6 @@ from tinker_cookbook.renderers.base import (
     format_content_as_string,
 )
 from tinker_cookbook.renderers.deepseek_v3 import DeepSeekV3ThinkingRenderer
-from tinker_cookbook.renderers.kimi_k2 import KimiK2Renderer
 from tinker_cookbook.renderers.kimi_k25 import KimiK25Renderer
 from tinker_cookbook.renderers.nemotron3 import Nemotron3Renderer
 from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
@@ -458,13 +457,11 @@ CONVERSATION_REGISTRY: dict[str, tuple[Callable[[], list[Message]], str, bool]] 
 
 # Models that support tool calling in their renderers
 TOOL_CAPABLE_MODELS = {
-    "Qwen/Qwen3-30B-A3B",
-    "Qwen/Qwen3-30B-A3B-Instruct-2507",
-    "Qwen/Qwen3-VL-30B-A3B-Instruct",
-    "Qwen/Qwen3.5-35B-A3B",
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3.6-35B-A3B",
     "meta-llama/Llama-3.2-1B-Instruct",
     "deepseek-ai/DeepSeek-V3.1",
-    "moonshotai/Kimi-K2-Thinking",
+    "moonshotai/Kimi-K2.6",
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     "openai/gpt-oss-20b",
 }
@@ -482,15 +479,13 @@ TOOL_CAPABLE_MODELS = {
 # - hf_kwargs: Extra kwargs to pass to apply_chat_template (e.g., {"thinking": True})
 _HF_TEST_MODELS = [
     ("meta-llama/Llama-3.2-1B-Instruct", None, {}),
-    ("Qwen/Qwen3-30B-A3B", None, {}),
-    ("Qwen/Qwen3-30B-A3B-Instruct-2507", None, {}),
+    ("Qwen/Qwen3-8B", None, {}),
     ("deepseek-ai/DeepSeek-V3.1", None, {}),  # non-thinking (default)
     ("deepseek-ai/DeepSeek-V3.1", "deepseekv3_thinking", {"thinking": True}),  # thinking mode
     ("openai/gpt-oss-20b", None, {}),
-    ("moonshotai/Kimi-K2-Thinking", None, {}),
-    ("Qwen/Qwen3-VL-30B-A3B-Instruct", None, {}),
-    ("Qwen/Qwen3.5-35B-A3B", None, {}),
-    ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking", {"enable_thinking": False}),
+    ("moonshotai/Kimi-K2.6", None, {}),
+    ("Qwen/Qwen3.6-35B-A3B", None, {}),
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking", {"enable_thinking": False}),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", None, {}),
     (
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -504,12 +499,10 @@ _HF_TEST_MODELS = [
 # - Llama3: see llama3.py docstring (double-encoding, assistant content handling)
 # - gpt-oss: no HF template
 _HF_TOOL_COMPATIBLE_MODELS = {
-    "Qwen/Qwen3-30B-A3B",
-    "Qwen/Qwen3-30B-A3B-Instruct-2507",
-    "Qwen/Qwen3-VL-30B-A3B-Instruct",
-    "Qwen/Qwen3.5-35B-A3B",
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3.6-35B-A3B",
     "deepseek-ai/DeepSeek-V3.1",
-    "moonshotai/Kimi-K2-Thinking",
+    "moonshotai/Kimi-K2.6",
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
 }
 
@@ -607,17 +600,15 @@ def test_generation_against_hf_chat_templates(
 # Models for supervised tests
 # Excluded:
 # - gpt-oss: analysis channel diverges from HF template
-# - Qwen/Qwen3-30B-A3B: HF template adds empty <think> blocks to non-thinking messages
+# - Qwen/Qwen3-8B: HF template adds empty <think> blocks to non-thinking messages
 # Format: (model_name, renderer_override, hf_kwargs) - same as _HF_TEST_MODELS
 _SUPERVISED_TEST_MODELS = [
     ("meta-llama/Llama-3.2-1B-Instruct", None, {}),
-    ("Qwen/Qwen3-30B-A3B-Instruct-2507", None, {}),
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking", {"enable_thinking": False}),
     ("deepseek-ai/DeepSeek-V3.1", None, {}),  # non-thinking (default)
     ("deepseek-ai/DeepSeek-V3.1", "deepseekv3_thinking", {"thinking": True}),  # thinking mode
-    ("moonshotai/Kimi-K2-Thinking", None, {}),
-    ("Qwen/Qwen3-VL-30B-A3B-Instruct", None, {}),
-    ("Qwen/Qwen3.5-35B-A3B", None, {}),
-    ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking", {"enable_thinking": False}),
+    ("moonshotai/Kimi-K2.6", None, {}),
+    ("Qwen/Qwen3.6-35B-A3B", None, {}),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", None, {}),
     (
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
@@ -709,7 +700,7 @@ def test_supervised_example_against_hf_chat_templates(
 @pytest.mark.parametrize(
     "model_name",
     [
-        "Qwen/Qwen3-30B-A3B",
+        "Qwen/Qwen3-8B",
     ],
 )
 def test_tokenization_boundary_with_whitespace(model_name: str):
@@ -756,11 +747,11 @@ def test_tokenization_boundary_with_whitespace(model_name: str):
 @pytest.mark.parametrize(
     "model_name",
     [
-        "Qwen/Qwen3-30B-A3B",
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3-8B",
+        "Qwen/Qwen3.6-35B-A3B",
         # Llama3 does not support tool calling - see llama3.py docstring
         "deepseek-ai/DeepSeek-V3.1",
-        "moonshotai/Kimi-K2-Thinking",
+        "moonshotai/Kimi-K2.6",
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
         "openai/gpt-oss-20b",
     ],
@@ -817,10 +808,9 @@ def test_tool_call_supervised_rendering(model_name: str):
     "model_name,renderer_class",
     [
         ("Qwen/Qwen3-8B", Qwen3Renderer),
-        ("Qwen/Qwen3.5-35B-A3B", Qwen3_5Renderer),
+        ("Qwen/Qwen3.6-35B-A3B", Qwen3_5Renderer),
         ("deepseek-ai/DeepSeek-V3.1", DeepSeekV3ThinkingRenderer),
-        ("moonshotai/Kimi-K2-Thinking", KimiK2Renderer),
-        ("moonshotai/Kimi-K2.5", KimiK25Renderer),
+        ("moonshotai/Kimi-K2.6", KimiK25Renderer),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", Nemotron3Renderer),
     ],
 )
@@ -849,10 +839,9 @@ def test_strip_thinking_from_history_default(model_name: str, renderer_class):
     "model_name,renderer_class",
     [
         ("Qwen/Qwen3-8B", Qwen3Renderer),
-        ("Qwen/Qwen3.5-35B-A3B", Qwen3_5Renderer),
+        ("Qwen/Qwen3.6-35B-A3B", Qwen3_5Renderer),
         ("deepseek-ai/DeepSeek-V3.1", DeepSeekV3ThinkingRenderer),
-        ("moonshotai/Kimi-K2-Thinking", KimiK2Renderer),
-        ("moonshotai/Kimi-K2.5", KimiK25Renderer),
+        ("moonshotai/Kimi-K2.6", KimiK25Renderer),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", Nemotron3Renderer),
     ],
 )
@@ -935,12 +924,12 @@ _CONSISTENCY_RENDERERS = [
     ("Qwen/Qwen3-8B", "qwen3"),
     ("Qwen/Qwen3-8B", "qwen3_disable_thinking"),
     ("Qwen/Qwen3-8B", "qwen3_instruct"),
-    ("Qwen/Qwen3.5-35B-A3B", "qwen3_5"),
-    ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking"),
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
     ("deepseek-ai/DeepSeek-V3.1", "deepseekv3"),
     ("deepseek-ai/DeepSeek-V3.1", "deepseekv3_thinking"),
     ("openai/gpt-oss-20b", "gpt_oss_medium_reasoning"),
-    ("moonshotai/Kimi-K2-Thinking", "kimi_k2"),
+    ("moonshotai/Kimi-K2.6", "kimi_k26"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3_disable_thinking"),
 ]
@@ -1103,16 +1092,16 @@ def test_supervised_generation_parse_consistency(
 @pytest.mark.parametrize(
     "model_name,renderer_name",
     [
-        ("Qwen/Qwen3-30B-A3B", "qwen3"),
+        ("Qwen/Qwen3-8B", "qwen3"),
         ("Qwen/Qwen3-8B", "qwen3_disable_thinking"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
         ("meta-llama/Llama-3.2-1B-Instruct", "llama3"),
         # deepseekv3 defaults to non-thinking, deepseekv3_thinking is thinking mode
         ("deepseek-ai/DeepSeek-V3.1", "deepseekv3"),
         ("deepseek-ai/DeepSeek-V3.1", "deepseekv3_thinking"),
         ("openai/gpt-oss-20b", "gpt_oss_medium_reasoning"),
-        ("moonshotai/Kimi-K2-Thinking", "kimi_k2"),
+        ("moonshotai/Kimi-K2.6", "kimi_k26"),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3"),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3_disable_thinking"),
     ],
@@ -1181,8 +1170,8 @@ def test_eot_parsing(model_name: str, renderer_name: str):
     [
         ("meta-llama/Llama-3.2-1B-Instruct", "llama3"),
         ("Qwen/Qwen3-8B", "qwen3"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
         ("deepseek-ai/DeepSeek-V3.1", "deepseekv3"),
     ],
 )
@@ -1313,14 +1302,14 @@ _EXTENSION_PROPERTY_TEST_PARAMS = [
     ),
     # Qwen3.5 with strip_thinking_from_history=False (preserves thinking)
     (
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.6-35B-A3B",
         Qwen3_5Renderer,
         {"strip_thinking_from_history": False},
         get_multiturn_thinking_conversation,
     ),
     # Qwen3.5 disable thinking with strip_thinking_from_history=False (preserves thinking)
     (
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.6-35B-A3B",
         Qwen3_5DisableThinkingRenderer,
         {"strip_thinking_from_history": False},
         get_multiturn_thinking_conversation,

--- a/tinker_cookbook/renderers/role_colon_test.py
+++ b/tinker_cookbook/renderers/role_colon_test.py
@@ -12,8 +12,8 @@ from tinker_cookbook.renderers.base import ParseTermination
 from tinker_cookbook.renderers.role_colon import RoleColonRenderer
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
-# Llama base models recommend role_colon and have a stable EOS token.
-_BASE_MODEL = "meta-llama/Llama-3.1-8B"
+# Qwen base models recommend role_colon and have a stable EOS token.
+_BASE_MODEL = "Qwen/Qwen3.5-9B-Base"
 
 
 @pytest.fixture(scope="module")

--- a/tinker_cookbook/renderers/tool_calling_test.py
+++ b/tinker_cookbook/renderers/tool_calling_test.py
@@ -24,9 +24,8 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
     "model_name,renderer_name",
     [
         ("Qwen/Qwen3-8B", "qwen3"),
-        ("Qwen/Qwen3-30B-A3B-Instruct-2507", "qwen3_instruct"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3"),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3_disable_thinking"),
     ],
@@ -72,9 +71,8 @@ def test_qwen3_tool_response_rendering(model_name: str, renderer_name: str):
     "model_name,renderer_name",
     [
         ("Qwen/Qwen3-8B", "qwen3"),
-        ("Qwen/Qwen3-30B-A3B-Instruct-2507", "qwen3_instruct"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5_disable_thinking"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3"),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3_disable_thinking"),
     ],
@@ -116,7 +114,7 @@ weather in NYC
     "model_name,renderer_name",
     [
         ("Qwen/Qwen3-8B", "qwen3"),
-        ("Qwen/Qwen3.5-35B-A3B", "qwen3_5"),
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
         ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3"),
     ],
 )
@@ -166,15 +164,15 @@ LA
     assert "LA" in message["tool_calls"][1].function.arguments
 
 
-def test_kimi_k2_parse_tool_call():
-    """Test parsing tool call from Kimi K2 response.
+def test_kimi_k26_parse_tool_call():
+    """Test parsing tool call from Kimi K2.6 response.
 
-    Kimi K2 uses tool_id format "functions.{name}:{idx}", and the function
+    Kimi K2.6 uses tool_id format "functions.{name}:{idx}", and the function
     name should be extracted correctly.
     """
-    model_name = "moonshotai/Kimi-K2-Thinking"
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
-    renderer = get_renderer("kimi_k2", tokenizer)
+    renderer = get_renderer("kimi_k26", tokenizer)
 
     # Simulate model response with tool call (Kimi K2 format)
     response_text = """<think></think>I'll search for that.
@@ -298,11 +296,11 @@ def test_deepseek_parse_invalid_tool_call_json():
     assert "Invalid JSON" in message["unparsed_tool_calls"][0].error
 
 
-def test_kimi_k2_parse_invalid_tool_call_json():
-    """Test that invalid JSON in Kimi K2 tool call is captured as unparsed."""
-    model_name = "moonshotai/Kimi-K2-Thinking"
+def test_kimi_k26_parse_invalid_tool_call_json():
+    """Test that invalid JSON in Kimi K2.6 tool call is captured as unparsed."""
+    model_name = "moonshotai/Kimi-K2.6"
     tokenizer = get_tokenizer(model_name)
-    renderer = get_renderer("kimi_k2", tokenizer)
+    renderer = get_renderer("kimi_k26", tokenizer)
 
     response_text = """<think></think>I'll search.
 <|tool_calls_section_begin|><|tool_call_begin|>functions.search:0<|tool_call_argument_begin|>{invalid}<|tool_call_end|><|tool_calls_section_end|><|im_end|>"""

--- a/tinker_cookbook/rl/builder_pickle_test.py
+++ b/tinker_cookbook/rl/builder_pickle_test.py
@@ -29,8 +29,8 @@ class TestProblemGroupBuilderPickle:
         )
         MathEnv = math_env_mod.MathEnv
 
-        tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
-        renderer = get_renderer("llama3", tokenizer)
+        tokenizer = get_tokenizer("Qwen/Qwen3.5-9B")
+        renderer = get_renderer("qwen3_5_disable_thinking", tokenizer)
 
         builder = ProblemGroupBuilder(
             env_thunk=partial(MathEnv, "What is 2+2?", "4", renderer),
@@ -43,7 +43,7 @@ class TestProblemGroupBuilderPickle:
         assert restored.num_envs == 4
         assert restored.dataset_name == "test_math"
         # Verify the renderer inside the partial survived
-        assert restored.env_thunk.args[2]._renderer_name == "llama3"
+        assert restored.env_thunk.args[2]._renderer_name == "qwen3_5_disable_thinking"
 
     def test_pickle_with_convo_prefix(self) -> None:
         """ProblemGroupBuilder with convo_prefix in the partial survives pickle."""
@@ -54,8 +54,8 @@ class TestProblemGroupBuilderPickle:
         )
         MathEnv = math_env_mod.MathEnv
 
-        tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
-        renderer = get_renderer("llama3", tokenizer)
+        tokenizer = get_tokenizer("Qwen/Qwen3.5-9B")
+        renderer = get_renderer("qwen3_5_disable_thinking", tokenizer)
         convo_prefix: list[Message] = [{"role": "system", "content": "You are helpful."}]
 
         builder = ProblemGroupBuilder(
@@ -77,8 +77,8 @@ class TestRolloutTask:
         )
         MathEnv = math_env_mod.MathEnv
 
-        tokenizer = get_tokenizer("meta-llama/Llama-3.1-8B-Instruct")
-        renderer = get_renderer("llama3", tokenizer)
+        tokenizer = get_tokenizer("Qwen/Qwen3.5-9B")
+        renderer = get_renderer("qwen3_5_disable_thinking", tokenizer)
 
         builder = ProblemGroupBuilder(
             env_thunk=partial(MathEnv, "What is 2+2?", "4", renderer),

--- a/tinker_cookbook/rl/problem_env_test.py
+++ b/tinker_cookbook/rl/problem_env_test.py
@@ -17,7 +17,7 @@ from tinker_cookbook.renderers.role_colon import RoleColonRenderer
 from tinker_cookbook.rl.problem_env import ProblemEnv
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
-_BASE_MODEL = "meta-llama/Llama-3.1-8B"
+_BASE_MODEL = "Qwen/Qwen3.5-9B-Base"
 
 
 @pytest.fixture(scope="module")

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -1835,7 +1835,8 @@ async def main(
         config = Config(
             learning_rate=1e-5,
             dataset_builder=my_dataset_builder,
-            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            model_name="Qwen/Qwen3.5-9B",
+            renderer_name="qwen3_5_disable_thinking",
             max_tokens=2048,
             log_path="./logs/my_rl_run",
         )

--- a/tinker_cookbook/scripts/test_tool_calling_e2e.py
+++ b/tinker_cookbook/scripts/test_tool_calling_e2e.py
@@ -62,20 +62,20 @@ MODEL_CONFIGS = [
         "renderer_name": "qwen3",
     },
     {
-        "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
-        "renderer_name": "qwen3_instruct",
+        "model_name": "Qwen/Qwen3.6-35B-A3B",
+        "renderer_name": "qwen3_5_disable_thinking",
     },
     {
-        "model_name": "meta-llama/Llama-3.1-8B-Instruct",
-        "renderer_name": "llama3",
+        "model_name": "Qwen/Qwen3.5-9B",
+        "renderer_name": "qwen3_5_disable_thinking",
     },
     {
         "model_name": "deepseek-ai/DeepSeek-V3.1",
         "renderer_name": "deepseekv3",
     },
     {
-        "model_name": "moonshotai/Kimi-K2-Thinking",
-        "renderer_name": "kimi_k2",
+        "model_name": "moonshotai/Kimi-K2.6",
+        "renderer_name": "kimi_k26",
     },
     {
         "model_name": "openai/gpt-oss-20b",

--- a/tinker_cookbook/stores/training_store_test.py
+++ b/tinker_cookbook/stores/training_store_test.py
@@ -22,7 +22,7 @@ def run_dir(tmp_path: Path) -> Path:
     (d / "config.json").write_text(
         json.dumps(
             {
-                "model_name": "Llama-3.1-8B",
+                "model_name": "Qwen3.5-9B-Base",
                 "learning_rate": 1e-4,
                 "loss_fn": "importance_sampling",
                 "lora_rank": 32,
@@ -120,7 +120,7 @@ class TestTrainingRunStore:
         store = TrainingRunStore(LocalStorage(run_dir))
         config = store.read_config()
         assert config is not None
-        assert config["model_name"] == "Llama-3.1-8B"
+        assert config["model_name"] == "Qwen3.5-9B-Base"
 
     def test_config_cached(self, run_dir: Path) -> None:
         store = TrainingRunStore(LocalStorage(run_dir))
@@ -199,7 +199,7 @@ class TestTrainingRunStore:
         restored = pickle.loads(pickle.dumps(store))
         config = restored.read_config()
         assert config is not None
-        assert config["model_name"] == "Llama-3.1-8B"
+        assert config["model_name"] == "Qwen3.5-9B-Base"
 
     def test_nonexistent(self, tmp_path: Path) -> None:
         store = TrainingRunStore(LocalStorage(tmp_path), "nonexistent")
@@ -348,7 +348,7 @@ class TestRunRegistry:
         store = registry.get_training_store(run_id)
         config = store.read_config()
         assert config is not None
-        assert config["model_name"] == "Llama-3.1-8B"
+        assert config["model_name"] == "Qwen3.5-9B-Base"
 
     def test_multi_storage(self, tmp_path: Path) -> None:
         # Create two storage roots with different runs

--- a/tinker_cookbook/supervised/interleaved_test.py
+++ b/tinker_cookbook/supervised/interleaved_test.py
@@ -53,8 +53,8 @@ class TestInterleavedChatDatasetBuilder:
             test_size=test_size,
             stopping_strategy=stopping_strategy,
             common_config=ChatDatasetBuilderCommonConfig(
-                model_name_for_tokenizer="meta-llama/Llama-3.1-8B",
-                renderer_name="llama3",
+                model_name_for_tokenizer="Qwen/Qwen3.5-9B-Base",
+                renderer_name="role_colon",
                 max_length=128,
                 batch_size=batch_size,
             ),

--- a/tinker_cookbook/supervised/resume_test.py
+++ b/tinker_cookbook/supervised/resume_test.py
@@ -57,7 +57,7 @@ def checkpoint_resume():
         os.makedirs(log_path, exist_ok=True)
 
         # Use the real NoRobots dataset with a small batch size
-        model_name = "meta-llama/Llama-3.2-1B"
+        model_name = "Qwen/Qwen3.5-9B-Base"
         common_config = ChatDatasetBuilderCommonConfig(
             model_name_for_tokenizer=model_name,
             renderer_name="role_colon",

--- a/tinker_cookbook/supervised/viz_sft_dataset.py
+++ b/tinker_cookbook/supervised/viz_sft_dataset.py
@@ -17,7 +17,7 @@ from tinker_cookbook.utils.misc_utils import lookup_func
 
 @chz.chz
 class Config:
-    model_name: str = "meta-llama/Llama-3.1-8B"  # just for tokenizer
+    model_name: str = "Qwen/Qwen3.5-9B-Base"  # just for tokenizer
     dataset_path: str = "Tulu3Builder"
     renderer_name: str | None = None
     max_length: int | None = None

--- a/tinker_cookbook/third_party/litellm/README.md
+++ b/tinker_cookbook/third_party/litellm/README.md
@@ -35,7 +35,7 @@ register_litellm_provider()
 response = await litellm.acompletion(
     model="tinker/my-label",
     messages=[{"role": "user", "content": "Hello!"}],
-    base_model="Qwen/Qwen3-4B-Instruct-2507",
+    base_model="Qwen/Qwen3.5-4B",
     temperature=0.7,
     max_tokens=256,
 )
@@ -49,9 +49,9 @@ LiteLLM uses the `model` parameter to decide which provider handles the request.
 
 The actual model is determined by `base_model`, which is passed directly to Tinker's `ServiceClient.create_sampling_client(base_model=...)`. This must be a model name from Tinker's [model lineup](https://tinker-docs.thinkingmachines.ai/tinker/models/), e.g.:
 
-- `Qwen/Qwen3-4B-Instruct-2507`
-- `meta-llama/Llama-3.1-8B-Instruct`
-- `moonshotai/Kimi-K2.5`
+- `Qwen/Qwen3.5-4B`
+- `Qwen/Qwen3.5-9B`
+- `moonshotai/Kimi-K2.6`
 
 You can list available models with:
 
@@ -87,7 +87,7 @@ provider.set_client(sampler)
 response = await litellm.acompletion(
     model="tinker/my-finetuned",
     messages=[{"role": "user", "content": "Hello!"}],
-    base_model="Qwen/Qwen3-4B-Instruct-2507",
+    base_model="Qwen/Qwen3.5-4B",
 )
 ```
 
@@ -112,7 +112,7 @@ The key feature of this integration is token-level access for training workflows
 response = await litellm.acompletion(
     model="tinker/my-label",
     messages=messages,
-    base_model="Qwen/Qwen3-4B-Instruct-2507",
+    base_model="Qwen/Qwen3.5-4B",
 )
 
 # Raw token IDs are in provider_specific_fields
@@ -138,13 +138,13 @@ completion_token_ids = fields["completion_token_ids"]  # list[int]
 
 ## Tool calling
 
-Tool declarations are supported for models whose renderers implement `create_conversation_prefix_with_tools` (Qwen3, DeepSeek V3, Kimi K2/K2.5, GPT-OSS):
+Tool declarations are supported for models whose renderers implement `create_conversation_prefix_with_tools` (Qwen3, DeepSeek V3, Kimi K2/K2.6, GPT-OSS):
 
 ```python
 response = await litellm.acompletion(
     model="tinker/my-agent",
     messages=[{"role": "user", "content": "What's the weather in SF?"}],
-    base_model="Qwen/Qwen3-4B-Instruct-2507",
+    base_model="Qwen/Qwen3.5-4B",
     tools=[{
         "type": "function",
         "function": {

--- a/tinker_cookbook/third_party/litellm/provider.py
+++ b/tinker_cookbook/third_party/litellm/provider.py
@@ -14,7 +14,7 @@ Usage::
     response = await litellm.acompletion(
         model="tinker/my-model",
         messages=[{"role": "user", "content": "Hello!"}],
-        base_model="Qwen/Qwen3-4B-Instruct-2507",
+        base_model="Qwen/Qwen3.5-4B",
     )
 
     # Access raw tokens for training
@@ -395,7 +395,7 @@ class TinkerLiteLLMProvider(CustomLLM):
         if not base_model:
             raise ValueError(
                 "base_model is required for the Tinker provider. "
-                "Pass it as: litellm.acompletion(..., base_model='Qwen/Qwen3-4B-Instruct-2507')"
+                "Pass it as: litellm.acompletion(..., base_model='Qwen/Qwen3.5-4B')"
             )
 
         bundle = self._get_or_create_client(base_model)
@@ -438,7 +438,7 @@ class TinkerLiteLLMProvider(CustomLLM):
         if not base_model:
             raise ValueError(
                 "base_model is required for the Tinker provider. "
-                "Pass it as: litellm.completion(..., base_model='Qwen/Qwen3-4B-Instruct-2507')"
+                "Pass it as: litellm.completion(..., base_model='Qwen/Qwen3.5-4B')"
             )
 
         bundle = self._get_or_create_client(base_model)

--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -134,13 +134,7 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
     if os.environ.get("HF_TRUST_REMOTE_CODE", "").lower() in ("1", "true", "yes"):
         kwargs["trust_remote_code"] = True
 
-    if model_name == "moonshotai/Kimi-K2-Thinking":
-        kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55"
-    elif model_name == "moonshotai/Kimi-K2.5":
-        kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "2426b45b6af0da48d0dcce71bbce6225e5c73adc"
-    elif model_name == "moonshotai/Kimi-K2.6":
+    if model_name == "moonshotai/Kimi-K2.6":
         kwargs["trust_remote_code"] = True
         kwargs["revision"] = "b5aabbfb20227ed42becbf5541dbffd213942c58"
 

--- a/tinker_cookbook/tokenizer_utils_test.py
+++ b/tinker_cookbook/tokenizer_utils_test.py
@@ -12,30 +12,16 @@ def _clear_cache() -> None:
 
 
 @patch("transformers.models.auto.tokenization_auto.AutoTokenizer")
-def test_kimi_k2_thinking_trusts_remote_code_without_env(
+def test_kimi_k26_trusts_remote_code_without_env(
     mock_auto: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Hardcoded Kimi models should pass trust_remote_code=True without the env var."""
+    """Hardcoded Kimi K2.6 should pass trust_remote_code=True without the env var."""
     monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
-    _get_hf_tokenizer("moonshotai/Kimi-K2-Thinking")
+    _get_hf_tokenizer("moonshotai/Kimi-K2.6")
     mock_auto.from_pretrained.assert_called_once_with(
-        "moonshotai/Kimi-K2-Thinking",
+        "moonshotai/Kimi-K2.6",
         trust_remote_code=True,
-        revision="a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55",
-    )
-
-
-@patch("transformers.models.auto.tokenization_auto.AutoTokenizer")
-def test_kimi_k25_trusts_remote_code_without_env(
-    mock_auto: MagicMock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Hardcoded Kimi K2.5 should pass trust_remote_code=True without the env var."""
-    monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
-    _get_hf_tokenizer("moonshotai/Kimi-K2.5")
-    mock_auto.from_pretrained.assert_called_once_with(
-        "moonshotai/Kimi-K2.5",
-        trust_remote_code=True,
-        revision="2426b45b6af0da48d0dcce71bbce6225e5c73adc",
+        revision="b5aabbfb20227ed42becbf5541dbffd213942c58",
     )
 
 

--- a/tinker_cookbook/weights/README.md
+++ b/tinker_cookbook/weights/README.md
@@ -25,7 +25,7 @@ Two build paths for trained LoRA adapters:
 | **Qwen3.5 MoE** (35B-A3B, 397B-A17B) | ✅ | ✅ | bf16 | Split QKV + fused experts; vLLM MoE LoRA experimental |
 | **GPT-OSS** (20B, 120B) | ✅ | ✅ | bf16 | `.attn` → `.self_attn` remap; interleaved expert layout |
 | **Kimi-K2** (~1T-A32B) | ✅ | ✅ | INT4 pack-quantized | DeepSeek arch; separate experts; shard-by-shard dequant/merge/requant |
-| **Kimi-K2.5** (~1T-A32B) | ✅ | ✅ | INT4 pack-quantized | VL model; `language_model.model.*` prefix; vLLM LoRA not yet supported |
+| **Kimi-K2.6** (~1T-A32B) | ✅ | ✅ | INT4 pack-quantized | VL model; `language_model.model.*` prefix; vLLM LoRA not yet supported |
 | **DeepSeek V3 / V3.1** | ✅ | ❌ | bf16 or native FP8 | vLLM/SGLang don't support DeepSeek LoRA |
 | **Nemotron-3** (Nano 30B, Super 120B) | ✅ | ✅ | bf16 | `backbone.*` weight prefix (handled automatically) |
 
@@ -46,7 +46,7 @@ Use `hyperparam_utils.get_lr(model_name)` when available. LoRA training typicall
 | **Qwen3** (all sizes) | `get_lr(model_name)` | `get_lr(model_name, is_lora=False)` | Calibrated; scales with hidden size |
 | **Llama 3.x** (all sizes) | `get_lr(model_name)` | `get_lr(model_name, is_lora=False)` | Calibrated; scales with hidden size |
 | **Kimi-K2** | ~5e-4 | ~5e-5 | Not yet calibrated in `get_lr`; start with 5e-4 for LoRA |
-| **Kimi-K2.5** | ~5e-4 | ~5e-5 | Same as K2 (same hidden size / architecture) |
+| **Kimi-K2.6** | ~5e-4 | ~5e-5 | Same as K2 (same hidden size / architecture) |
 | **DeepSeek V3 / V3.1** | ~5e-4 | ~5e-5 | Not yet calibrated; similar architecture to Kimi |
 | **GPT-OSS** | ~5e-4 | ~5e-5 | Not yet calibrated |
 | **Nemotron-3** | ~5e-4 | ~5e-5 | Not yet calibrated |
@@ -69,7 +69,7 @@ Default settings that work well across models:
 | `"auto"` / `"shard"` (default) | Large models, quantized checkpoints | ~1 shard (~10 GB) |
 | `"full"` | Small models, need specific output dtype | Full model size |
 
-For Kimi K2/K2.5 (595 GB–1 TB), always use the default shard strategy. The shard path automatically handles INT4 dequant → LoRA merge → INT4 requant for packed expert weights.
+For Kimi K2/K2.6 (595 GB–1 TB), always use the default shard strategy. The shard path automatically handles INT4 dequant → LoRA merge → INT4 requant for packed expert weights.
 
 Wall time depends on I/O bandwidth and service load (multiple concurrent jobs share the storage). Expect ~30–60 minutes for a 600 GB model on NFS, faster on local SSD.
 
@@ -81,11 +81,11 @@ MoE models store expert weights in different layouts. The merge/adapter code han
 
 | Layout | Models | Structure |
 |---|---|---|
-| **Separate** | DeepSeek, Kimi-K2, Kimi-K2.5, Qwen3 MoE (transformers 4.x) | Individual `experts.{i}.gate_proj.weight` per expert |
+| **Separate** | DeepSeek, Kimi-K2, Kimi-K2.6, Qwen3 MoE (transformers 4.x) | Individual `experts.{i}.gate_proj.weight` per expert |
 | **Fused concatenated** | Qwen3 MoE (transformers 5.x), Qwen3.5 MoE, Qwen3-VL MoE | Single `experts.gate_up_proj` with `[gate \| up]` layout |
 | **Fused interleaved** | GPT-OSS | Single `experts.gate_up_proj` with `[g0, u0, g1, u1, ...]` layout |
 
-### INT4 Pack-Quantized Experts (Kimi K2, K2.5)
+### INT4 Pack-Quantized Experts (Kimi K2, K2.6)
 
 Kimi models on HuggingFace use compressed-tensors `pack-quantized` format for routed expert weights:
 
@@ -115,7 +115,7 @@ Qwen3.5 linear attention layers use a fused `in_proj_qkv` weight, but Tinker tra
 | `base_model.model.` prefix strip | All models | Tinker adapter prefix → HF parameter names |
 | `unembed_tokens` → `lm_head` (or `embed_tokens`) | All models | Tinker naming → HF naming; tied embeddings use `embed_tokens` |
 | `model.*` → `model.language_model.*` | Qwen3.5 VL, Qwen3-VL | Inner `language_model` prefix for standard VL models |
-| `model.*` → `language_model.model.*` | Kimi-K2.5 | Outer `language_model.` prefix (different from Qwen pattern) |
+| `model.*` → `language_model.model.*` | Kimi-K2.6 | Outer `language_model.` prefix (different from Qwen pattern) |
 | `.attn` → `.self_attn` | GPT-OSS | Tinker internal naming → HF naming |
 | `w1/w2/w3` → `gate_proj/down_proj/up_proj` | MoE expert keys | Tinker expert naming → HF naming |
 
@@ -129,7 +129,7 @@ Qwen3.5 linear attention layers use a fused `in_proj_qkv` weight, but Tinker tra
 
 **Unblock when:** vLLM adds DeepSeek V3 LoRA support.
 
-### Kimi-K2.5 (`model_type=kimi_k25`)
+### Kimi-K2.6 (`model_type=kimi_k25`)
 
 **Status:** Adapter conversion works, but vLLM 0.18 does not implement `SupportsLoRA` for `KimiK25ForConditionalGeneration`.
 
@@ -146,11 +146,11 @@ Adapter serving has been verified end-to-end with vLLM 0.18:
 | Model | vLLM LoRA | Status |
 |---|---|---|
 | Qwen3-8B (dense) | Full support | ✅ Verified |
-| Qwen3-30B-A3B (MoE) | Experimental | ✅ Verified (requires all 3 expert projections) |
+| Qwen3.6-35B-A3B (MoE) | Experimental | ✅ Verified (requires all 3 expert projections) |
 | Qwen3.5-4B (split QKV) | Full support | ✅ Verified (split in_proj_q/k/v works) |
 | GPT-OSS-20B | Full support | ⚠️ Conversion verified; serving blocked by mxfp4+LoRA incompatibility |
 | Kimi-K2 | Supported (DeepSeekV2) | ⚠️ Conversion verified; model too large (~1TB) for routine e2e testing |
-| Kimi-K2.5 | Not supported | ⚠️ Conversion verified; vLLM 0.18 lacks LoRA for `KimiK25ForConditionalGeneration` |
+| Kimi-K2.6 | Not supported | ⚠️ Conversion verified; vLLM 0.18 lacks LoRA for `KimiK25ForConditionalGeneration` |
 | DeepSeek V3/V3.1 | Not supported | ❌ Adapter conversion blocked |
 | Nemotron-3-Nano (30B-A3B) | Full support (vLLM) | ✅ Verified (`backbone.*` → `model.*` remap, TP=2) |
 | Nemotron-3-Super (120B-A12B) | Full support (vLLM) | ✅ Verified (`backbone.*` → `model.*` remap, TP=4) |

--- a/tinker_cookbook/weights/__init__.py
+++ b/tinker_cookbook/weights/__init__.py
@@ -19,7 +19,7 @@ Example — merged model::
         output_dir="./adapter",
     )
     weights.build_hf_model(
-        base_model="Qwen/Qwen3.5-35B-A3B",
+        base_model="Qwen/Qwen3.6-35B-A3B",
         adapter_path=adapter_dir,
         output_path="./model",
     )

--- a/tinker_cookbook/weights/_export/__init__.py
+++ b/tinker_cookbook/weights/_export/__init__.py
@@ -62,7 +62,7 @@ def build_hf_model(
     or any HuggingFace-compatible inference framework.
 
     Args:
-        base_model: HuggingFace model name (e.g. ``"Qwen/Qwen3.5-35B-A3B"``)
+        base_model: HuggingFace model name (e.g. ``"Qwen/Qwen3.6-35B-A3B"``)
             or local path to a saved HuggingFace model.
         adapter_path: Local path to the Tinker adapter directory. Must contain
             ``adapter_model.safetensors`` and ``adapter_config.json``.

--- a/tinker_cookbook/weights/_export/_quant_format.py
+++ b/tinker_cookbook/weights/_export/_quant_format.py
@@ -4,7 +4,7 @@ Defines two protocols that plug into :func:`run_shard_merge`:
 
 - :class:`ShardHooks` — for models with pre-quantized weights on disk that
   need dequant → merge → requant as an atomic per-key operation (e.g. INT4
-  packed format for Kimi K2/K2.5).
+  packed format for Kimi K2/K2.6).
 
 - :class:`QuantizationFormat` — for post-merge quantization where the output
   model needs selected weights quantized after LoRA merge (e.g. FP8 blockwise

--- a/tinker_cookbook/weights/_export/_shard.py
+++ b/tinker_cookbook/weights/_export/_shard.py
@@ -4,7 +4,7 @@ Processes one safetensors shard at a time, keeping peak memory proportional to
 the largest shard rather than the full model. Produces output identical to the
 full-model path.
 
-Model-specific shard processing (e.g. INT4 dequant/requant for Kimi K2.5)
+Model-specific shard processing (e.g. INT4 dequant/requant for Kimi K2.6)
 lives in dedicated ``_shard_<model>.py`` modules and is invoked via hooks
 that this file dispatches to based on the detected merge profile.
 """
@@ -67,7 +67,7 @@ def _build_shard_hooks(
 
     Detection is config-driven via ``quantization_config``:
 
-    - ``format: pack-quantized`` → INT4 packed (Kimi K2, K2.5)
+    - ``format: pack-quantized`` → INT4 packed (Kimi K2, Kimi K2.6)
     - ``quant_method: mxfp4 | mxfp8`` → MX block format (GPT-OSS)
 
     Other quantized formats (DeepSeek native FP8) are NOT matched —

--- a/tinker_cookbook/weights/_export/_shard_packed_int4.py
+++ b/tinker_cookbook/weights/_export/_shard_packed_int4.py
@@ -2,7 +2,7 @@
 
 Provides the shard processing hooks used by the shard engine
 (:mod:`_shard_engine`) when processing checkpoints with INT4 quantized
-expert weights (e.g. Kimi K2, K2.5). This keeps all INT4 dequant/merge/
+expert weights (e.g. Kimi K2, Kimi K2.6). This keeps all INT4 dequant/merge/
 requant logic isolated so it cannot affect other model families.
 
 The :class:`PackedInt4ShardHooks` class implements the
@@ -186,7 +186,7 @@ def get_int4_group_size(config_dict: dict) -> int:
 
 class PackedInt4ShardHooks:
     """Hooks for models with compressed-tensors ``pack-quantized`` format
-    (e.g. Kimi K2, K2.5): dequant INT4 → merge LoRA → requant INT4.
+    (e.g. Kimi K2, Kimi K2.6): dequant INT4 → merge LoRA → requant INT4.
 
     Implements the :class:`~._quant_format.ShardHooks` protocol.
     """

--- a/tinker_cookbook/weights/_merge_kimi_k25.py
+++ b/tinker_cookbook/weights/_merge_kimi_k25.py
@@ -1,6 +1,6 @@
-"""Kimi K2.5 merge planning.
+"""Kimi K2.6 merge planning for the ``kimi_k25`` model type.
 
-Kimi K2.5 is a vision-language model (``model_type=kimi_k25``) wrapping a
+Kimi K2.6 is a vision-language model (``model_type=kimi_k25``) wrapping a
 Kimi-K2 / DeepSeek-style text backbone.  It differs from other VL models in
 two ways that require a dedicated merge module:
 
@@ -35,15 +35,15 @@ from tinker_cookbook.weights._merge_utils import (
 
 
 def detect_profile(model_config: dict, model_state_keys: set[str]) -> MergeProfile | None:
-    """Detect Kimi K2.5 from ``model_type``.
+    """Detect Kimi K2.6 from ``model_type``.
 
-    K2.5 uses DeepSeek-style separate per-expert weights and a non-standard
+    Kimi K2.6 uses DeepSeek-style separate per-expert weights and a non-standard
     VL prefix (``language_model.model.*``).  We set
     ``has_language_model_prefix=False`` because the default name-remap logic
     assumes the *inner* prefix pattern — this module provides its own
     remapping in :func:`plan_merge_ops`.
 
-    Returns ``None`` for non-K2.5 models so the detector chain continues.
+    Returns ``None`` for non-``kimi_k25`` models so the detector chain continues.
     """
     if model_config.get("model_type") != "kimi_k25":
         return None
@@ -61,7 +61,7 @@ def detect_profile(model_config: dict, model_state_keys: set[str]) -> MergeProfi
 
 
 def _build_kimi_k25_name_remaps() -> list[tuple[str, str]]:
-    """Build name remaps for Kimi K2.5's ``language_model.model.*`` prefix.
+    """Build name remaps for Kimi K2.6's ``language_model.model.*`` prefix.
 
     Remap order matters — applied sequentially via ``str.replace``:
 
@@ -110,9 +110,9 @@ def plan_merge_ops(
     model_state_keys: set[str],
     profile: MergeProfile,
 ) -> dict[str, list[MergeOp]]:
-    """Plan merge ops for Kimi K2.5.
+    """Plan merge ops for Kimi K2.6.
 
-    Uses K2.5-specific name remapping (``language_model.model.*`` prefix)
+    Uses ``kimi_k25``-specific name remapping (``language_model.model.*`` prefix)
     and separate per-expert expansion.  The ``model_state_keys`` should
     already include virtual ``.weight`` entries from
     :func:`create_virtual_weight_keys`.

--- a/tinker_cookbook/weights/_merge_qwen3_5.py
+++ b/tinker_cookbook/weights/_merge_qwen3_5.py
@@ -5,7 +5,7 @@ fused ``in_proj_qkv`` weight (Q‖K‖V, with potentially unequal dims), but
 Tinker trains separate ``in_proj_q/k/v`` LoRA adapters. All Qwen3.5 models
 are vision-language with the ``model.language_model.*`` key prefix.
 
-Supported models: Qwen3.5-4B, Qwen3.5-27B, Qwen3.5-35B-A3B, Qwen3.5-397B-A17B,
+Supported models: Qwen3.5-4B, Qwen3.5-9B, Qwen3.5-397B-A17B,
 Qwen3.6-27B, Qwen3.6-35B-A3B (same ``qwen3_5`` / ``qwen3_5_moe`` architecture family).
 """
 
@@ -46,7 +46,7 @@ def detect_profile(model_config: dict, model_state_keys: set[str]) -> MergeProfi
     Tinker trains separate ``in_proj_q/k/v`` LoRA adapters. All Qwen3.5 models
     are vision-language with the ``model.language_model.*`` key prefix.
 
-    Supported models: Qwen3.5-4B, Qwen3.5-27B, Qwen3.5-35B-A3B,
+    Supported models: Qwen3.5-4B, Qwen3.5-9B,
     Qwen3.5-397B-A17B, Qwen3.6-27B, and Qwen3.6-35B-A3B (same ``qwen3_5`` /
     ``qwen3_5_moe`` model_type).
     """
@@ -87,7 +87,7 @@ def build_qwen3_5_name_remaps(
             k == "lm_head.weight" or k.startswith("lm_head.") for k in model_state_keys
         )
         if has_top_level_lm_head:
-            # Non-tied (e.g. Qwen3.5-27B): lm_head stored at top level
+            # Non-tied (e.g. Qwen3.6-27B): lm_head stored at top level
             remaps.append(("model.language_model.unembed_tokens", "lm_head"))
         else:
             # Tied (e.g. Qwen3.5-4B): no separate lm_head; merge into embed_tokens

--- a/tinker_cookbook/weights/_merge_utils.py
+++ b/tinker_cookbook/weights/_merge_utils.py
@@ -406,7 +406,7 @@ def create_virtual_weight_keys(
 ) -> tuple[set[str], dict[str, str]]:
     """Add virtual ``.weight`` keys for compressed-tensors packed weights.
 
-    Some model checkpoints (e.g. Kimi K2, K2.5) store routed expert weights
+    Some model checkpoints (e.g. Kimi K2, Kimi K2.6) store routed expert weights
     in the compressed-tensors ``pack-quantized`` format: ``weight_packed``,
     ``weight_scale``, ``weight_shape``.  LoRA merge planning targets plain
     ``.weight`` keys, so we create virtual entries for the planner.
@@ -462,7 +462,7 @@ def create_virtual_weight_shapes(
 def find_quantization_config(config_dict: dict) -> dict | None:
     """Find the ``quantization_config`` dict, checking both top-level and ``text_config``.
 
-    Vision-language models (e.g. Kimi K2.5) nest quantization config under
+    Vision-language models (e.g. Kimi K2.6) nest quantization config under
     ``text_config``, while standard models have it at the top level.
 
     Returns the first ``quantization_config`` dict found, or ``None``.
@@ -479,7 +479,7 @@ def find_quantization_config(config_dict: dict) -> dict | None:
 def is_pack_quantized(config_dict: dict) -> bool:
     """Check if the model uses compressed-tensors ``pack-quantized`` format.
 
-    This format (used by Kimi K2, K2.5) stores quantized weights as
+    This format (used by Kimi K2, Kimi K2.6) stores quantized weights as
     ``weight_packed`` / ``weight_scale`` / ``weight_shape`` triplets.
     Detection is based on the explicit ``format: pack-quantized`` field
     in ``quantization_config``, not on weight key heuristics.

--- a/tinker_cookbook/weights/_packed_int4.py
+++ b/tinker_cookbook/weights/_packed_int4.py
@@ -1,7 +1,7 @@
 """INT4 group-quantized weight packing and unpacking.
 
 Supports the compressed-tensors ``pack-quantized`` format used by models like
-Kimi K2.5.  In this format, eight 4-bit signed integers (range [−8, 7]) are
+Kimi K2.6.  In this format, eight 4-bit signed integers (range [−8, 7]) are
 packed into a single ``int32`` from LSB to MSB.
 
 Key conventions (matching compressed-tensors / vLLM):

--- a/tinker_cookbook/weights/merge_test.py
+++ b/tinker_cookbook/weights/merge_test.py
@@ -1539,12 +1539,12 @@ class TestUnembedTokensVisionRemap:
 
 
 # ---------------------------------------------------------------------------
-# Kimi K2.5 — profile detection, name remapping, INT4 pack/unpack
+# Kimi K2.6 / kimi_k25 — profile detection, name remapping, INT4 pack/unpack
 # ---------------------------------------------------------------------------
 
 
 class TestKimiK25ProfileDetection:
-    """Profile detection for Kimi K2.5 (model_type=kimi_k25)."""
+    """Profile detection for Kimi K2.6 (model_type=kimi_k25)."""
 
     def test_detects_kimi_k25(self):
         config = {"model_type": "kimi_k25", "architectures": ["KimiK25ForConditionalGeneration"]}
@@ -1566,7 +1566,7 @@ class TestKimiK25ProfileDetection:
         assert profile.model_family == "kimi_k25"
 
     def test_kimi_k2_falls_through_to_default(self):
-        """Kimi-K2 (model_type=kimi_k2) should NOT match K2.5 detector."""
+        """Kimi-K2 (model_type=kimi_k2) should NOT match the kimi_k25 detector."""
         config = {"model_type": "kimi_k2"}
         keys = {"model.layers.0.self_attn.q_a_proj.weight"}
         profile = detect_merge_profile(config, keys)
@@ -1574,7 +1574,7 @@ class TestKimiK25ProfileDetection:
 
 
 class TestKimiK25NameRemapping:
-    """Name remapping for K2.5's language_model.model.* prefix."""
+    """Name remapping for the kimi_k25 language_model.model.* prefix."""
 
     HIDDEN = 64
     RANK = 1
@@ -1711,7 +1711,7 @@ class TestIsPackQuantizedGuard:
         assert is_pack_quantized(self._PACK_QUANTIZED_CONFIG)
 
     def test_kimi_k25_triggers_via_text_config(self):
-        """Kimi K2.5 nests quantization_config under text_config."""
+        """Kimi K2.6 nests quantization_config under text_config."""
         config = {"model_type": "kimi_k25", "text_config": self._PACK_QUANTIZED_CONFIG}
         assert is_pack_quantized(config)
 

--- a/tinker_cookbook/xmux/examples/async_rl_sweep.py
+++ b/tinker_cookbook/xmux/examples/async_rl_sweep.py
@@ -18,7 +18,7 @@ def json_already_exists(log_relpath: str) -> bool:
 
 
 def build_rl_basic_config(max_steps_off_policy: int, name: str) -> rl_train.Config:
-    model_name = "meta-llama/Llama-3.1-8B"
+    model_name = "Qwen/Qwen3.5-9B-Base"
     renderer_name = model_info.get_recommended_renderer_name(model_name)
     builder = Gsm8kDatasetBuilder(
         batch_size=128,


### PR DESCRIPTION
## Summary
- Cherry-picks `3cd853c` to refresh cookbook model metadata, defaults, and examples for the current model lineup.
- Updates Qwen/Kimi model names, renderer references, benchmark defaults, hyperparameter metadata, recipes, docs, and related tests.
- Removes deprecated model entries from the local model info and LoRA parameter tables.

## Test plan
- `uv run pytest tinker_cookbook/` fails during collection because optional extras are not installed locally: `modal` for Harbor and math-rl dependencies for `math_env_test.py`.
- `uv run pytest tinker_cookbook/model_info_test.py tinker_cookbook/image_processing_utils_test.py tinker_cookbook/tokenizer_utils_test.py tinker_cookbook/renderers tinker_cookbook/rl/builder_pickle_test.py tinker_cookbook/rl/problem_env_test.py tinker_cookbook/stores/training_store_test.py tinker_cookbook/supervised/interleaved_test.py tinker_cookbook/supervised/resume_test.py tinker_cookbook/weights/merge_test.py` fails with 24 renderer/HF-template expectation failures for Kimi K2.6 and Qwen3.6; 560 passed, 46 skipped.

Made with [Cursor](https://cursor.com)