### PR TITLE
Clarify Tinker concurrency guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ For an identifier to pass to the SDK, call `service_client.get_server_capabiliti
 
 ## Common Pitfalls
 
-1. **Sequential API calls:** The #1 performance mistake. Always use `_async` variants and submit calls back-to-back before awaiting. Use `asyncio.gather` for concurrent evaluation — never sequential loops over API calls.
+1. **Sequential API calls:** The #1 performance mistake. Always use `_async` variants and submit calls back-to-back before awaiting. Use `asyncio.gather` for concurrent evaluation — never sequential loops over API calls. Tinker is designed for high request concurrency from a single Python process; when exact limits matter, check the current SDK/client configuration rather than inventing small caps. For very high parallelism, shard work across multiple Python processes and pass pickled sampling clients where appropriate.
 
 2. **Sampler desync:** Create a **new** sampling client after saving weights. A stale client silently samples from old weights.
 


### PR DESCRIPTION
## Summary
- Clarify that agents should not invent small Tinker request concurrency caps.
- Point agents toward current SDK/client configuration for exact limits and process sharding for very high parallelism.

## Test plan
- Not run; docs-only change.


Made with [Cursor](https://cursor.com)