### PR TITLE
[checkpoint] add options for saving every N tokens or M seconds

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -566,6 +567,8 @@ class CheckpointManager:
         service_client: tinker.ServiceClient,
         log_path: str,
         save_every: int = 0,
+        save_every_tokens: int = 0,
+        save_every_seconds: float = 0.0,
         ttl_seconds: int | None = 604800,
         rolling_save_every: int = 0,
         rolling_ttl_seconds: int = 7200,
@@ -576,6 +579,8 @@ class CheckpointManager:
         self._service_client = service_client
         self._log_path = log_path
         self._save_every = save_every
+        self._save_every_tokens = save_every_tokens
+        self._save_every_seconds = save_every_seconds
         self._ttl_seconds = ttl_seconds
         self._rolling_save_every = rolling_save_every
         self._rolling_ttl_seconds = rolling_ttl_seconds
@@ -586,13 +591,30 @@ class CheckpointManager:
         self._pending_periodic_task: asyncio.Task[dict[str, str]] | None = None
         self._prev_state_path: str | None = None
 
+        self._last_saved_tokens: int = 0
+        self._last_saved_wall_time: float = time.perf_counter()
+
     # ------------------------------------------------------------------
     # Periodic checkpoints
     # ------------------------------------------------------------------
 
-    def should_save_periodic(self, step: int) -> bool:
-        """Return True if *step* warrants a periodic checkpoint."""
-        return self._save_every > 0 and step > 0 and step % self._save_every == 0
+    def restore_last_saved_tokens(self, last_saved_tokens: int) -> None:
+        self._last_saved_tokens = last_saved_tokens
+
+    def should_save_periodic(self, step: int, *, elapsed_tokens: int = 0) -> bool:
+        """Return True if *step*, *elapsed_tokens*, or *elapsed_seconds* warrants a periodic checkpoint."""
+        if step <= 0:
+            return False
+        _save_on_step = self._save_every > 0 and step % self._save_every == 0
+        _save_on_tokens = (
+            self._save_every_tokens > 0
+            and elapsed_tokens - self._last_saved_tokens >= self._save_every_tokens
+        )
+        _save_on_seconds = (
+            self._save_every_seconds > 0
+            and time.perf_counter() - self._last_saved_wall_time >= self._save_every_seconds
+        )
+        return _save_on_step or _save_on_tokens or _save_on_seconds
 
     async def save_periodic_async(self, step: int, loop_state: dict[str, Any]) -> dict[str, str]:
         """Save a periodic checkpoint (state + sampler) and return paths.
@@ -672,7 +694,11 @@ class CheckpointManager:
     # ------------------------------------------------------------------
 
     async def maybe_save_async(
-        self, step: int, loop_state: dict[str, Any]
+        self,
+        step: int,
+        loop_state: dict[str, Any],
+        *,
+        elapsed_tokens: int = 0,
     ) -> dict[str, str] | None:
         """Save periodic checkpoint if due, then fire rolling save if due.
 
@@ -685,7 +711,7 @@ class CheckpointManager:
         the same point (SL, DPO).
         """
         result: dict[str, str] | None = None
-        if self.should_save_periodic(step):
+        if self.should_save_periodic(step, elapsed_tokens=elapsed_tokens):
             if self._async_periodic_saves:
                 await self._resolve_pending_periodic_async()
                 self._pending_periodic_task = asyncio.create_task(
@@ -694,14 +720,24 @@ class CheckpointManager:
                 )
             else:
                 result = await self.save_periodic_async(step, loop_state)
+            self._last_saved_tokens = elapsed_tokens
+            self._last_saved_wall_time = time.perf_counter()
         await self.maybe_save_rolling_async(step, loop_state)
         return result
 
-    def maybe_save(self, step: int, loop_state: dict[str, Any]) -> dict[str, str] | None:
+    def maybe_save(
+        self,
+        step: int,
+        loop_state: dict[str, Any],
+        *,
+        elapsed_tokens: int = 0,
+    ) -> dict[str, str] | None:
         """Synchronous version of :meth:`maybe_save_async`."""
         result: dict[str, str] | None = None
-        if self.should_save_periodic(step):
+        if self.should_save_periodic(step, elapsed_tokens=elapsed_tokens):
             result = self.save_periodic(step, loop_state)
+            self._last_saved_tokens = elapsed_tokens
+            self._last_saved_wall_time = time.perf_counter()
         self.maybe_save_rolling(step, loop_state)
         return result
 

--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -602,7 +602,7 @@ class CheckpointManager:
         self._last_saved_tokens = last_saved_tokens
 
     def should_save_periodic(self, step: int, *, elapsed_tokens: int = 0) -> bool:
-        """Return True if *step*, *elapsed_tokens*, or *elapsed_seconds* warrants a periodic checkpoint."""
+        """Return True if *step*, *elapsed_tokens*, or time since last save warrants a periodic checkpoint."""
         if step <= 0:
             return False
         _save_on_step = self._save_every > 0 and step % self._save_every == 0

--- a/tinker_cookbook/checkpoint_utils_test.py
+++ b/tinker_cookbook/checkpoint_utils_test.py
@@ -2,6 +2,7 @@
 
 import json
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -253,6 +254,61 @@ class TestCheckpointManagerShouldSavePeriodic:
         assert mgr.should_save_periodic(1)
         assert mgr.should_save_periodic(2)
         assert mgr.should_save_periodic(3)
+
+
+class TestCheckpointManagerCadences:
+    """Tests for token- and seconds-based cadence support in should_save_periodic."""
+
+    def _make_mgr(
+        self,
+        save_every: int = 0,
+        save_every_tokens: int = 0,
+        save_every_seconds: float = 0.0,
+    ) -> CheckpointManager:
+        return CheckpointManager(
+            training_client=MagicMock(),
+            service_client=MagicMock(),
+            log_path="/tmp/unused",
+            save_every=save_every,
+            save_every_tokens=save_every_tokens,
+            save_every_seconds=save_every_seconds,
+        )
+
+    def test_token_cadence_fires_on_threshold_crossing(self):
+        """Token cadence fires when (elapsed_tokens - last_saved_tokens) >= threshold."""
+        mgr = self._make_mgr(save_every_tokens=1_000_000)
+        assert not mgr.should_save_periodic(1, elapsed_tokens=999_999)
+        assert mgr.should_save_periodic(1, elapsed_tokens=1_000_000)
+        assert mgr.should_save_periodic(1, elapsed_tokens=1_500_000)
+
+    def test_token_cadence_resets_after_save(self):
+        """After a save, last_saved_tokens advances → next save needs another full delta."""
+        mgr = self._make_mgr(save_every_tokens=1_000_000)
+        # Token threshold reached → fires.
+        assert mgr.should_save_periodic(1, elapsed_tokens=1_000_000)
+        # Simulate post-save bookkeeping (what maybe_save_async does internally).
+        mgr._last_saved_tokens = 1_000_000
+        # Another 999_999 tokens isn't enough.
+        assert not mgr.should_save_periodic(2, elapsed_tokens=1_999_999)
+        # 1M past last save → fires again.
+        assert mgr.should_save_periodic(2, elapsed_tokens=2_000_000)
+
+    def test_token_cadence_resume_anchor(self):
+        """restore_last_saved_tokens shifts the cadence anchor to match the loaded value."""
+        mgr = self._make_mgr(save_every_tokens=1_000_000)
+        mgr.restore_last_saved_tokens(5_000_000)
+        # delta = 5_000_500 - 5_000_000 = 500 < threshold
+        assert not mgr.should_save_periodic(1, elapsed_tokens=5_000_500)
+        # delta = 6_000_000 - 5_000_000 = 1M ≥ threshold
+        assert mgr.should_save_periodic(1, elapsed_tokens=6_000_000)
+
+    def test_seconds_cadence_fires(self):
+        """Seconds cadence fires when (now - last_saved_wall_time) >= threshold."""
+        mgr = self._make_mgr(save_every_seconds=0.05)
+        # Just constructed; wall_time was set to now → not yet 50ms past.
+        assert not mgr.should_save_periodic(1)
+        time.sleep(0.06)
+        assert mgr.should_save_periodic(1)
 
 
 def _make_save_state_mock(paths: list[str]) -> AsyncMock:

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -125,7 +125,12 @@ class Config:
     # Checkpointing and evaluation (0 = disabled for *_every fields)
     evaluator_builders: list[EvaluatorBuilder] = chz.field(default_factory=list)
     infrequent_evaluator_builders: list[EvaluatorBuilder] = chz.field(default_factory=list)
+    # Step-based periodic checkpoint cadence
     save_every: int = 20
+    # Token-based periodic checkpoint cadence
+    save_every_tokens: int = 0
+    # Wall-clock periodic checkpoint cadence in seconds
+    save_every_seconds: float = 0.0
     eval_every: int = 10
     infrequent_eval_every: int = 100
     # Periodic checkpoints use this TTL; the final checkpoint is kept indefinitely.
@@ -195,6 +200,8 @@ class SubmittedBatch:
     batch_idx: int
     eval_metrics: dict[str, float] | None = None
     infrequent_eval_metrics: dict[str, float] | None = None
+    # Sum of `datum.model_input.length` across this batch's data
+    num_tokens: int = 0
 
 
 async def run_evals(
@@ -279,9 +286,11 @@ async def main(config: Config):
     if resume_info:
         start_epoch = resume_info.epoch or 0
         start_batch = resume_info.batch
+        resumed_elapsed_tokens: int = int(resume_info.get("elapsed_tokens", 0))
     else:
         start_epoch = 0
         start_batch = 0
+        resumed_elapsed_tokens = 0
     # (start_epoch, start_batch) now represent the next batch to execute if resuming.
 
     ml_logger = ml_log.setup_logging(
@@ -344,12 +353,16 @@ async def main(config: Config):
         service_client=service_client,
         log_path=config.log_path,
         save_every=config.save_every,
+        save_every_tokens=config.save_every_tokens,
+        save_every_seconds=config.save_every_seconds,
         ttl_seconds=config.ttl_seconds,
         rolling_save_every=config.rolling_save_every,
         rolling_ttl_seconds=config.rolling_ttl_seconds,
         store=store,
         async_periodic_saves=config.async_periodic_saves,
     )
+    checkpoint_mgr.restore_last_saved_tokens(resumed_elapsed_tokens)
+    elapsed_tokens: int = resumed_elapsed_tokens
 
     dataset, maybe_test_dataset = config.dataset_builder()
     n_batches = len(dataset)
@@ -425,18 +438,26 @@ async def main(config: Config):
             batch_idx=batch_idx,
             eval_metrics=eval_metrics,
             infrequent_eval_metrics=infrequent_eval_metrics,
+            num_tokens=sum(datum.model_input.length for datum in data),
         )
 
     @trace.scope
     async def finish_batch(submitted: SubmittedBatch):
+        nonlocal elapsed_tokens
         trace.update_scope_context({"step": submitted.step})
 
         metrics = submitted.metrics
         metrics["progress"] = min((submitted.step + 1) / progress_denominator, 1.0)
 
+        elapsed_tokens += submitted.num_tokens
         await checkpoint_mgr.maybe_save_async(
             step=submitted.step,
-            loop_state={"epoch": submitted.epoch_idx, "batch": submitted.batch_idx},
+            loop_state={
+                "epoch": submitted.epoch_idx,
+                "batch": submitted.batch_idx,
+                "elapsed_tokens": elapsed_tokens,
+            },
+            elapsed_tokens=elapsed_tokens,
         )
 
         async with trace.scope_span("step"):
@@ -452,7 +473,7 @@ async def main(config: Config):
 
         metrics.update(
             num_sequences=len(submitted.data),
-            num_tokens=sum(datum.model_input.length for datum in submitted.data),
+            num_tokens=submitted.num_tokens,
             num_loss_tokens=sum(
                 sum(datum.loss_fn_inputs["weights"].data) for datum in submitted.data
             ),
@@ -534,7 +555,11 @@ async def main(config: Config):
     )
     if did_train:
         await checkpoint_mgr.save_final_async(
-            loop_state={"epoch": config.num_epochs, "batch": 0},
+            loop_state={
+                "epoch": config.num_epochs,
+                "batch": 0,
+                "elapsed_tokens": elapsed_tokens,
+            },
         )
     else:
         logger.info("Training was already complete; nothing to do")


### PR DESCRIPTION
Adds the ability to specify `save_every_tokens` or `save_every_seconds`, which do as they describe: save checkpoints after a certain amount of tokens or seconds. can be combined with `save_every` to save as frequently as one desires