### PR TITLE
Update distillation recipes for Qwen3.5 reruns

### DIFF
--- a/tinker_cookbook/recipes/distillation/README.md
+++ b/tinker_cookbook/recipes/distillation/README.md
@@ -14,11 +14,11 @@ Our results can be reproduced by running:
 
 ### Supervised fine-tuning
 
-We observe an AIME'24 score of ~55% using a rank-128 LoRA after 3000 steps. We use a learning rate of 1e-3 with LoRA and 1e-4 with full fine-tuning.
+We observe an AIME'24 score of ~65% using a rank-128 LoRA after 3000 steps. We use a learning rate of 1e-3 with LoRA and 1e-4 with full fine-tuning.
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.off_policy_reasoning \
-    model_name=Qwen/Qwen3-8B-Base \
+    model_name=Qwen/Qwen3.5-9B-Base \
     learning_rate=1e-3 \
     batch_size=128 \
     lora_rank=128 \
@@ -27,20 +27,24 @@ python -m tinker_cookbook.recipes.distillation.off_policy_reasoning \
 
 ### On-policy distillation
 
-We observe an AIME'24 score of ~65% using a rank-128 LoRA after 100 steps. For on-policy distillation experiments, we use a learning rate of 1e-4 with LoRA and 5e-5 with full fine-tuning.
+We observe an AIME'24 score of ~76.7% using a rank-128 LoRA after 200 steps with 16k-token rollouts. For on-policy distillation experiments, we use a learning rate of 1e-4 with LoRA and 5e-5 with full fine-tuning.
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-    model_name=Qwen/Qwen3-8B-Base \
-    load_checkpoint_path=tinker://4a1939e6-04be-5a77-9e4e-910ccff9f27e:train:0/weights/final \
+    model_name=Qwen/Qwen3.5-9B-Base \
+    teacher_model=Qwen/Qwen3.5-9B \
+    load_checkpoint_path=tinker://b89f6676-49c4-53ed-9788-2e0c81a9eabf:train:0/weights/final \
     dataset=deepmath \
     learning_rate=1e-4 \
     groups_per_batch=512 \
     lora_rank=128 \
+    max_tokens=16384 \
     wandb_project=cookbook_distillation
 ```
 
 This script can also be used to replicate the experiments in our Discussion section, after you have run RL to obtain an appropriate checkpoint for the teacher model.
+
+The AIME'24 scores above were evaluated with `temperature=1.0`, `top_p=1.0`, `top_k=-1`, and `max_tokens=64000`.
 
 ### Checkpoints
 
@@ -48,8 +52,8 @@ The results of running the above scripts with various LoRA ranks can be found he
 
 | Stage | Rank 8 | Rank 32 | Rank 128 |
 |-------|--------|---------|----------|
-| Supervised fine-tuning (SFT) | `tinker://c15f09f1-f225-5f98-bab1-ec8dfac5da2a:train:0/weights/final` | `tinker://b9190d16-c849-51d5-a690-1b5de146a284:train:0/weights/final` | `tinker://4a1939e6-04be-5a77-9e4e-910ccff9f27e:train:0/weights/final` |
-| On-policy distillation | `tinker://4a97bc02-f4d0-5ecd-888a-3e8cc5b0f7f6:train:0/sampler_weights/000080` | `tinker://bfffa2b2-a78f-59be-a2ef-cc9188bfce7e:train:0/sampler_weights/000080` | `tinker://1dd8de47-be86-54d3-9355-ebf80827be26:train:0/sampler_weights/000080` |
+| Supervised fine-tuning (SFT) | `tinker://414d30d0-3b63-5596-919d-647960d156c2:train:0/weights/final` | `tinker://1a32513a-6177-5642-bebd-ecc8e255d4a7:train:0/weights/final` | `tinker://b89f6676-49c4-53ed-9788-2e0c81a9eabf:train:0/weights/final` |
+| On-policy distillation | `tinker://52f1ee62-da13-547e-a3c0-708d7a680bb0:train:0/sampler_weights/final` | `tinker://00a05e59-9fc3-5f99-ba72-f28ca69c9894:train:0/sampler_weights/final` | `tinker://de58946a-6bfd-5ab2-821f-03b61d237b5b:train:0/sampler_weights/final` |
 
 See the on-policy distillation launch command above for an example of how to load the checkpoint path.
 
@@ -65,7 +69,9 @@ In our experiment, we saw [IF-eval](https://huggingface.co/datasets/google/IFEva
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-    model_name=Qwen/Qwen3-8B-Base \
+    model_name=Qwen/Qwen3.5-9B-Base \
+    teacher_model=Qwen/Qwen3.5-9B \
+    load_checkpoint_path=tinker://YOUR_SFT_INITIALIZATION \
     dataset=tulu3 \
     learning_rate=1e-4 \
     groups_per_batch=64 \
@@ -103,8 +109,8 @@ See `tinker_cookbook/recipes/harbor_rl/README.md` for full details on the Harbor
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation_harbor_multi_turn \
-    model_name=moonshotai/Kimi-K2-Thinking \
-    teacher_model=moonshotai/Kimi-K2-Thinking \
+    model_name=moonshotai/Kimi-K2.6 \
+    teacher_model=moonshotai/Kimi-K2.6 \
     max_turns=10 \
     group_size=4 \
     groups_per_batch=8 \
@@ -135,7 +141,7 @@ For every dataset, we can define a teacher model and batch size (`groups_per_bat
 {
     "dataset_builder": RLDatasetBuilder,
     "teacher_model": {
-        "base_model": str,  # e.g. "Qwen/Qwen3-32B"
+        "base_model": str,  # e.g. "Qwen/Qwen3.6-27B"
         "load_checkpoint_path": str | None  # e.g. "tinker://<unique_id>/sampler_weights/final
     },
     "groups_per_batch": int
@@ -146,6 +152,7 @@ The trainer will then sample from each configuration, and concatenate all the in
 
 ```bash
 python -m tinker_cookbook.recipes.distillation.on_policy_multi_teacher \
+    model_name=Qwen/Qwen3.5-9B \
     learning_rate=1e-4 \
     deepmath_groups_per_batch=256 \
     tulu3_groups_per_batch=256 \

--- a/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
+++ b/tinker_cookbook/recipes/distillation/off_policy_reasoning.py
@@ -6,7 +6,7 @@ which contains reasoning traces with chain-of-thought style responses.
 
 Example usage:
     python -m tinker_cookbook.recipes.distillation.off_policy_reasoning \
-        model_name=Qwen/Qwen3-8B-Base \
+        model_name=Qwen/Qwen3.5-9B-Base \
         learning_rate=1e-4 \
         batch_size=128 \
         lora_rank=128 \
@@ -92,9 +92,9 @@ class CLIConfig:
     """Command-line configuration for SFT on OpenThoughts3."""
 
     # Model configuration
-    model_name: str = "Qwen/Qwen3-8B-Base"
+    model_name: str = "Qwen/Qwen3.5-9B-Base"
     lora_rank: int = 128
-    renderer_name: str | None = "qwen3"
+    renderer_name: str | None = "qwen3_5"
     load_checkpoint_path: str | None = None
 
     # Training hyperparameters

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -8,7 +8,8 @@ are used - only KL penalty provides supervision.
 Example usage:
     # For reasoning tasks (DeepMath)
     python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-        model_name=Qwen/Qwen3-8B-Base \
+        model_name=Qwen/Qwen3.5-9B-Base \
+        teacher_model=Qwen/Qwen3.5-9B \
         dataset=deepmath \
         learning_rate=1e-4 \
         groups_per_batch=1024 \
@@ -17,7 +18,8 @@ Example usage:
 
     # For chat tasks (Tulu3)
     python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
-        model_name=Qwen/Qwen3-8B-Base \
+        model_name=Qwen/Qwen3.5-9B-Base \
+        teacher_model=Qwen/Qwen3.5-9B \
         dataset=tulu3 \
         learning_rate=1e-4 \
         groups_per_batch=1024 \
@@ -50,13 +52,13 @@ class CLIConfig:
     """Command-line configuration for on-policy distillation."""
 
     # Model configuration
-    model_name: str = "Qwen/Qwen3-8B-Base"  # Student model
+    model_name: str = "Qwen/Qwen3.5-9B-Base"  # Student model
     lora_rank: int = 128
     renderer_name: str | None = None
     load_checkpoint_path: str | None = None  # Student checkpoint
 
     # Teacher configuration
-    teacher_model: str = "Qwen/Qwen3-8B"
+    teacher_model: str = "Qwen/Qwen3.5-9B"
     teacher_checkpoint: str | None = None
 
     # Dataset configuration
@@ -150,10 +152,10 @@ async def cli_main(cli_config: CLIConfig):
 
     # Create full config
     config = train_on_policy.Config(
+        recipe_name="recipe_distillation_on_policy",
         learning_rate=cli_config.learning_rate,
         dataset_configs=[dataset_config],
         model_name=cli_config.model_name,
-        recipe_name="recipe_distillation_on_policy",
         renderer_name=renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation_harbor_multi_turn.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation_harbor_multi_turn.py
@@ -9,8 +9,8 @@ Environment responses are masked out; only student-generated tokens contribute.
 
 Example usage:
     python -m tinker_cookbook.recipes.distillation.on_policy_distillation_harbor_multi_turn \
-        model_name=moonshotai/Kimi-K2-Thinking \
-        teacher_model=moonshotai/Kimi-K2-Thinking \
+        model_name=moonshotai/Kimi-K2.6 \
+        teacher_model=moonshotai/Kimi-K2.6 \
         max_turns=10 \
         group_size=4 \
         groups_per_batch=8 \
@@ -57,13 +57,13 @@ class CLIConfig:
     """Command-line configuration for multi-turn harbor distillation."""
 
     # Student model
-    model_name: str = "moonshotai/Kimi-K2-Thinking"
+    model_name: str = "moonshotai/Kimi-K2.6"
     lora_rank: int = 32
     renderer_name: str | None = None
     load_checkpoint_path: str | None = None
 
     # Teacher model
-    teacher_model: str = "moonshotai/Kimi-K2-Thinking"
+    teacher_model: str = "moonshotai/Kimi-K2.6"
     teacher_checkpoint: str | None = None
 
     # Harbor environment

--- a/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
@@ -3,13 +3,13 @@ Multi-teacher on-policy distillation example.
 
 This script demonstrates on-policy distillation with multiple datasets and
 different teacher models for each dataset. It uses:
-- DeepMath dataset with Qwen3-32B as teacher
-- Tulu3 dataset with Qwen3-235B-A22B-Instruct-2507 as teacher
-- Qwen3-8B as student model
-- qwen3_instruct renderer
+- DeepMath dataset with Qwen3.6-27B as teacher
+- Tulu3 dataset with Qwen3.5-397B-A17B as teacher
+- Qwen3.5-9B as student model
 
 Example usage:
     python -m tinker_cookbook.recipes.distillation.on_policy_multi_teacher \
+        model_name=Qwen/Qwen3.5-9B \
         learning_rate=1e-4 \
         deepmath_groups_per_batch=256 \
         tulu3_groups_per_batch=256 \
@@ -42,15 +42,15 @@ class CLIConfig:
     """Command-line configuration for multi-teacher on-policy distillation."""
 
     # Model configuration
-    model_name: str = "Qwen/Qwen3-8B"  # Student model
+    model_name: str = "Qwen/Qwen3.5-9B"  # Student model
     lora_rank: int = 128
     renderer_name: str | None = None
     load_checkpoint_path: str | None = None  # Student checkpoint
 
     # Teacher configurations
-    deepmath_teacher_model: str = "Qwen/Qwen3-32B"
+    deepmath_teacher_model: str = "Qwen/Qwen3.6-27B"
     deepmath_teacher_checkpoint: str | None = None
-    tulu3_teacher_model: str = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+    tulu3_teacher_model: str = "Qwen/Qwen3.5-397B-A17B"
     tulu3_teacher_checkpoint: str | None = None
 
     # Dataset configuration
@@ -163,10 +163,10 @@ async def cli_main(cli_config: CLIConfig):
 
     # Create full config with both datasets
     config = train_on_policy.Config(
+        recipe_name="recipe_distillation_on_policy_multi_teacher",
         learning_rate=cli_config.learning_rate,
         dataset_configs=[deepmath_dataset_config, tulu3_dataset_config],
         model_name=cli_config.model_name,
-        recipe_name="recipe_distillation_on_policy_multi_teacher",
         renderer_name=renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,


### PR DESCRIPTION
## Summary
- update the distillation recipe commands and defaults for the Qwen3.5 rerun setup
- record the refreshed rank-128 SFT and on-policy distillation checkpoints/results
- keep the distillation changes separate from the broader model update branch