### PR TITLE
Add optional Weave rollout tracing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ cloud = [
 ]
 wandb = [
     "wandb>=0.16.0",
+    "weave>=0.52.0",
     "plotly>=5.0.0",
 ]
 neptune-scale = [

--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -32,6 +32,10 @@ from tinker_cookbook.rl.data_processing import (
 )
 from tinker_cookbook.rl.metric_util import RLTestSetEvaluator, compute_trajectory_metrics
 from tinker_cookbook.rl.metrics import discounted_future_sum_vectorized
+from tinker_cookbook.rl.rollout_logging import (
+    RolloutSummaryGroup,
+    serialize_rollout_summaries_from_groups,
+)
 from tinker_cookbook.rl.train import (
     compute_full_batch_metrics_and_get_sampling_client,
     do_group_rollout_and_filter_constant_reward,
@@ -157,6 +161,7 @@ class Config:
 
     wandb_project: str | None = None
     wandb_name: str | None = None
+    rollout_trace_logging: bool = False
 
     log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
     base_url: str | None = None
@@ -321,7 +326,7 @@ async def do_sync_training(
             # Get batch and sample trajectories
             env_group_builders_P, dataset_indices_P = dataset.get_batch(i_batch)
             async with trace.scope_span("sample"):
-                trajectory_groups_P = await asyncio.gather(
+                rollout_results_P = await asyncio.gather(
                     *[
                         asyncio.create_task(
                             do_group_rollout_and_filter_constant_reward(
@@ -336,11 +341,39 @@ async def do_sync_training(
                         for i, builder in enumerate(env_group_builders_P)
                     ],
                 )
-            trajectory_groups_P = [
-                trajectory_group
-                for trajectory_group in trajectory_groups_P
+            successful_rollouts = [
+                (env_group_builder, dataset_idx, trajectory_group)
+                for env_group_builder, dataset_idx, trajectory_group in safezip(
+                    env_group_builders_P,
+                    dataset_indices_P,
+                    rollout_results_P,
+                )
                 if trajectory_group is not None
             ]
+            env_group_builders_P = [
+                env_group_builder for env_group_builder, _dataset_idx, _tg in successful_rollouts
+            ]
+            dataset_indices_P = [dataset_idx for _builder, dataset_idx, _tg in successful_rollouts]
+            trajectory_groups_P = [
+                trajectory_group for _builder, _dataset_idx, trajectory_group in successful_rollouts
+            ]
+            if config.rollout_trace_logging:
+                rollout_records = serialize_rollout_summaries_from_groups(
+                    split="train",
+                    iteration=i_batch,
+                    groups_P=[
+                        RolloutSummaryGroup(
+                            trajectory_group=trajectory_group,
+                            tags=env_group_builder.logging_tags(),
+                            sampling_client_step=i_batch,
+                        )
+                        for env_group_builder, trajectory_group in safezip(
+                            env_group_builders_P, trajectory_groups_P
+                        )
+                    ],
+                    tokenizer=tokenizer,
+                )
+                ml_logger.log_rollouts(rollout_records, step=i_batch)
 
             # Train step
             sampling_client, train_step_metrics = await do_train_step_and_get_sampling_client(

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -83,6 +83,7 @@ class CLIConfig:
     log_path: str | None = None
     wandb_project: str | None = None
     wandb_name: str | None = None
+    rollout_trace_logging: bool = False
     compute_post_kl: bool = False
 
     # Evaluation and checkpointing
@@ -164,6 +165,7 @@ async def cli_main(cli_config: CLIConfig):
         loss_fn_config=cli_config.loss_fn_config,
         wandb_project=cli_config.wandb_project,
         wandb_name=wandb_name,
+        rollout_trace_logging=cli_config.rollout_trace_logging,
         log_path=log_path,
         base_url=cli_config.base_url,
         load_checkpoint_path=cli_config.load_checkpoint_path,

--- a/tinker_cookbook/rl/rollout_logging.py
+++ b/tinker_cookbook/rl/rollout_logging.py
@@ -1,15 +1,20 @@
-"""Utilities for exporting per-rollout records to JSONL."""
+"""Utilities for exporting per-rollout records."""
+
+from __future__ import annotations
 
 import json
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from tinker_cookbook.rl.types import TrajectoryGroup
 from tinker_cookbook.utils.deprecation import deprecated
 from tinker_cookbook.utils.misc_utils import safezip
+
+if TYPE_CHECKING:
+    from tinker_cookbook.tokenizer_utils import Tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +74,20 @@ def _json_safe(value: Any) -> Any:
     return str(value)
 
 
+def _decode_tokens(tokenizer: Tokenizer, tokens: Sequence[int]) -> str:
+    if not tokens:
+        return ""
+    return tokenizer.decode(list(tokens))
+
+
+def _decode_model_input(tokenizer: Tokenizer, model_input: Any) -> str | None:
+    try:
+        return _decode_tokens(tokenizer, model_input.to_ints())
+    except Exception:
+        logger.debug("Failed to decode rollout model input", exc_info=True)
+        return None
+
+
 def serialize_rollout_summaries(
     *,
     split: str,
@@ -76,6 +95,7 @@ def serialize_rollout_summaries(
     trajectory_groups_P: Sequence[TrajectoryGroup],
     taglist_P: Sequence[list[str]],
     sampling_client_steps_P: Sequence[int | None] | None = None,
+    tokenizer: Tokenizer | None = None,
 ) -> list[dict[str, Any]]:
     """Serialize trajectory groups into JSON-safe rollout summary records.
 
@@ -99,6 +119,8 @@ def serialize_rollout_summaries(
         trajectory_groups_P: One trajectory group per problem (subscript ``_P``).
         taglist_P: Tags for each trajectory group, aligned with *trajectory_groups_P*.
         sampling_client_steps_P: Per-group sampling-client step counters, or ``None``.
+        tokenizer: Optional tokenizer used to add best-effort decoded observation
+            and action text to each step.
 
     Returns:
         List of JSON-serializable rollout summary records, one per trajectory.
@@ -113,17 +135,22 @@ def serialize_rollout_summaries(
         for traj_idx, trajectory in enumerate(trajectory_group.trajectories_G):
             steps = []
             for step_idx, transition in enumerate(trajectory.transitions):
-                steps.append(
-                    {
-                        "step_idx": step_idx,
-                        "ob_len": transition.ob.length,
-                        "ac_len": len(transition.ac.tokens),
-                        "reward": transition.reward,
-                        "episode_done": transition.episode_done,
-                        "metrics": transition.metrics,
-                        "logs": transition.logs,
-                    }
-                )
+                step = {
+                    "step_idx": step_idx,
+                    "ob_len": transition.ob.length,
+                    "ac_len": len(transition.ac.tokens),
+                    "reward": transition.reward,
+                    "episode_done": transition.episode_done,
+                    "metrics": transition.metrics,
+                    "logs": transition.logs,
+                }
+                if tokenizer is not None:
+                    ob_text = _decode_model_input(tokenizer, transition.ob)
+                    if ob_text is not None:
+                        step["ob_text"] = ob_text
+                    step["ac_text"] = _decode_tokens(tokenizer, transition.ac.tokens)
+                    step["stop_reason"] = str(transition.ac.stop_reason)
+                steps.append(step)
 
             records.append(
                 _json_safe(
@@ -158,6 +185,7 @@ def write_rollout_summaries_jsonl(
     trajectory_groups_P: Sequence[TrajectoryGroup],
     taglist_P: Sequence[list[str]],
     sampling_client_steps_P: Sequence[int | None] | None = None,
+    tokenizer: Tokenizer | None = None,
 ) -> None:
     """Write one JSON record per rollout trajectory to a JSONL file.
 
@@ -171,6 +199,7 @@ def write_rollout_summaries_jsonl(
         trajectory_groups_P (Sequence[TrajectoryGroup]): One trajectory group per problem.
         taglist_P (Sequence[list[str]]): Tags for each trajectory group.
         sampling_client_steps_P (Sequence[int | None] | None): Per-group step counters.
+        tokenizer: Optional tokenizer used to add decoded observation/action text.
     """
     records = serialize_rollout_summaries(
         split=split,
@@ -178,6 +207,7 @@ def write_rollout_summaries_jsonl(
         trajectory_groups_P=trajectory_groups_P,
         taglist_P=taglist_P,
         sampling_client_steps_P=sampling_client_steps_P,
+        tokenizer=tokenizer,
     )
     path_obj = Path(path)
     path_obj.parent.mkdir(parents=True, exist_ok=True)
@@ -206,6 +236,7 @@ def serialize_rollout_summaries_from_groups(
     split: str,
     iteration: int,
     groups_P: Sequence[RolloutSummaryGroup],
+    tokenizer: Tokenizer | None = None,
 ) -> list[dict[str, Any]]:
     """Serialize pre-grouped rollout summaries into JSON-safe dicts.
 
@@ -218,6 +249,7 @@ def serialize_rollout_summaries_from_groups(
         trajectory_groups_P=[group.trajectory_group for group in groups_P],
         taglist_P=[group.tags for group in groups_P],
         sampling_client_steps_P=[group.sampling_client_step for group in groups_P],
+        tokenizer=tokenizer,
     )
 
 
@@ -227,6 +259,7 @@ def write_rollout_summaries_jsonl_from_groups(
     split: str,
     iteration: int,
     groups_P: Sequence[RolloutSummaryGroup],
+    tokenizer: Tokenizer | None = None,
 ) -> None:
     """Serialize rollout summaries from pre-grouped records to a JSONL file.
 
@@ -241,6 +274,7 @@ def write_rollout_summaries_jsonl_from_groups(
         groups_P (Sequence[RolloutSummaryGroup]): One summary group per
             problem, each containing a trajectory group, tags, and an optional
             sampling-client step.
+        tokenizer: Optional tokenizer used to add decoded observation/action text.
     """
     write_rollout_summaries_jsonl(
         path,
@@ -249,4 +283,5 @@ def write_rollout_summaries_jsonl_from_groups(
         trajectory_groups_P=[group.trajectory_group for group in groups_P],
         taglist_P=[group.tags for group in groups_P],
         sampling_client_steps_P=[group.sampling_client_step for group in groups_P],
+        tokenizer=tokenizer,
     )

--- a/tinker_cookbook/rl/rollout_logging_test.py
+++ b/tinker_cookbook/rl/rollout_logging_test.py
@@ -1,16 +1,15 @@
 import json
-from pathlib import Path
 from typing import cast
 
 import numpy as np
 import tinker
 
 from tinker_cookbook.completers import TokensWithLogprobs
-from tinker_cookbook.rl.rollout_logging import write_rollout_summaries_jsonl
+from tinker_cookbook.rl.rollout_logging import serialize_rollout_summaries
 from tinker_cookbook.rl.types import Logs, Metrics, Trajectory, TrajectoryGroup, Transition
 
 
-def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
+def test_serialize_rollout_summaries_handles_numpy_scalars():
     transition = Transition(
         ob=tinker.ModelInput.from_ints([101, 102, 103, 104, 105]),
         ac=TokensWithLogprobs(tokens=[1, 2, 3], maybe_logprobs=[-0.1, -0.2, -0.3]),
@@ -25,10 +24,7 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         final_rewards_G=[cast(float, np.float32(0.75))],
         metrics_G=[cast(Metrics, {"traj_metric": np.float32(3.0)})],
     )
-    output_path = tmp_path / "rollouts.jsonl"
-
-    write_rollout_summaries_jsonl(
-        output_path,
+    records = serialize_rollout_summaries(
         split="train",
         iteration=1,
         trajectory_groups_P=[trajectory_group],
@@ -36,7 +32,7 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         sampling_client_steps_P=[7],
     )
 
-    record = json.loads(output_path.read_text().strip())
+    record = json.loads(json.dumps(records[0]))
     assert record["iteration"] == 1
     assert record["sampling_client_step"] == 7
     assert record["total_reward"] == 1.0
@@ -44,3 +40,36 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
     assert record["steps"][0]["reward"] == 0.25
     assert record["steps"][0]["metrics"]["score"] == 1.5
     assert record["steps"][0]["logs"]["rank"] == 2
+
+
+class _FakeTokenizer:
+    def decode(self, tokens: list[int]) -> str:
+        return " ".join(str(token) for token in tokens)
+
+
+def test_serialize_rollout_summaries_can_include_decoded_text():
+    transition = Transition(
+        ob=tinker.ModelInput.from_ints([10, 20]),
+        ac=TokensWithLogprobs(tokens=[30, 40], maybe_logprobs=[-0.1, -0.2]),
+        reward=1.0,
+        episode_done=True,
+    )
+    trajectory_group = TrajectoryGroup(
+        trajectories_G=[
+            Trajectory(transitions=[transition], final_ob=tinker.ModelInput.from_ints([]))
+        ],
+        final_rewards_G=[0.0],
+        metrics_G=[{}],
+    )
+
+    records = serialize_rollout_summaries(
+        split="train",
+        iteration=3,
+        trajectory_groups_P=[trajectory_group],
+        taglist_P=[["unit-test"]],
+        tokenizer=_FakeTokenizer(),
+    )
+
+    assert records[0]["steps"][0]["ob_text"] == "10 20"
+    assert records[0]["steps"][0]["ac_text"] == "30 40"
+    assert records[0]["steps"][0]["stop_reason"] == "stop"

--- a/tinker_cookbook/utils/ml_log.py
+++ b/tinker_cookbook/utils/ml_log.py
@@ -33,6 +33,12 @@ try:
 except ImportError:
     wandb = None
 
+# Weave is imported lazily because it is relatively heavy, and regular W&B
+# metrics should not pay that cost unless rollout tracing is actually used.
+_weave_available: bool | None = None
+weave: Any | None = None
+_weave_log_rollout: Any | None = None
+
 # Check Neptune availability
 _neptune_available = False
 try:
@@ -50,6 +56,44 @@ try:
     _trackio_available = True
 except ImportError:
     trackio = None
+
+
+def _rollout_for_weave(record: dict[str, Any]) -> dict[str, Any]:
+    """Return one rollout in a scan-friendly shape for Weave."""
+    return {
+        "schema_version": record.get("schema_version"),
+        "split": record.get("split"),
+        "iteration": record.get("iteration"),
+        "group_idx": record.get("group_idx"),
+        "traj_idx": record.get("traj_idx"),
+        "tags": record.get("tags", []),
+        "sampling_client_step": record.get("sampling_client_step"),
+        "total_reward": record.get("total_reward"),
+        "final_reward": record.get("final_reward"),
+        "trajectory_metrics": record.get("trajectory_metrics", {}),
+        "final_ob_len": record.get("final_ob_len"),
+        "turns": record.get("steps", []),
+    }
+
+
+def _load_weave() -> bool:
+    global _weave_available, _weave_log_rollout, weave
+    if _weave_available is not None:
+        return _weave_available
+
+    try:
+        import weave as weave_module
+    except ImportError:
+        _weave_available = False
+        weave = None
+        return False
+
+    weave = weave_module
+    _weave_available = True
+    _weave_log_rollout = weave_module.op(name="tinker_rollout", enable_code_capture=False)(
+        _rollout_for_weave
+    )
+    return True
 
 
 def dump_config(config: Any) -> Any:
@@ -124,6 +168,15 @@ class Logger(ABC):
         Args:
             key (str): Identifier for the text entry.
             text (str): The text content to log.
+        """
+        pass
+
+    def log_rollouts(self, records: list[dict[str, Any]], step: int | None = None) -> None:
+        """Log per-rollout records to a trace backend, when available.
+
+        Args:
+            records: JSON-serializable rollout records.
+            step: Training step associated with the records.
         """
         pass
 
@@ -320,6 +373,35 @@ class WandbLogger(Logger):
             dir=str(log_dir) if log_dir else None,
             name=wandb_name,
         )
+        self._weave_client = None
+        self._weave_project_name = self._get_weave_project_name(project)
+        self._warned_weave_unavailable = False
+
+    def _get_weave_project_name(self, project: str | None) -> str | None:
+        project_name = project or getattr(self.run, "project", None)
+        entity = getattr(self.run, "entity", None)
+        if project_name and entity and "/" not in project_name:
+            return f"{entity}/{project_name}"
+        return project_name
+
+    def _ensure_weave_client(self) -> bool:
+        if self._weave_client is not None:
+            return True
+        if not _load_weave() or weave is None:
+            if not self._warned_weave_unavailable:
+                logger.warning("weave is not installed; skipping Weave rollout logging")
+                self._warned_weave_unavailable = True
+            return False
+        if not self._weave_project_name:
+            logger.warning("Could not initialize Weave rollout tracing: missing W&B project")
+            return False
+        try:
+            self._weave_client = weave.init(self._weave_project_name)
+            logger.info("Weave rollout tracing enabled for project: %s", self._weave_project_name)
+            return True
+        except Exception as e:
+            logger.warning("Could not initialize Weave rollout tracing: %s", e)
+            return False
 
     def log_hparams(self, config: Any) -> None:
         """Log hyperparameters to wandb."""
@@ -332,8 +414,39 @@ class WandbLogger(Logger):
             wandb.log(metrics, step=step)
             logger.info("Logging to: %s", self.run.url)
 
+    def log_rollouts(self, records: list[dict[str, Any]], step: int | None = None) -> None:
+        """Log rollout records as Weave traces linked to this W&B run."""
+        if not records or not self.run:
+            return
+        if not self._ensure_weave_client() or _weave_log_rollout is None:
+            return
+
+        did_set_run_context = False
+        try:
+            if step is not None:
+                self._weave_client.set_wandb_run_context(run_id=self.run.id, step=step)
+                did_set_run_context = True
+            for record in records:
+                attrs = {
+                    "split": record.get("split"),
+                    "iteration": record.get("iteration"),
+                    "group_idx": record.get("group_idx"),
+                    "traj_idx": record.get("traj_idx"),
+                    "tags": record.get("tags", []),
+                }
+                with weave.attributes(attrs):
+                    _weave_log_rollout(record)
+            logger.info("Logged %d rollout traces to Weave", len(records))
+        except Exception as e:
+            logger.warning("Failed to log rollout traces to Weave: %s", e)
+        finally:
+            if did_set_run_context:
+                self._weave_client.clear_wandb_run_context()
+
     def close(self) -> None:
         """Close wandb run."""
+        if self._weave_client is not None and weave is not None:
+            weave.finish()
         if self.run and wandb is not None:
             wandb.finish()
 
@@ -492,6 +605,11 @@ class MultiplexLogger(Logger):
         for logger in self.loggers:
             if hasattr(logger, "log_long_text"):
                 logger.log_long_text(key, text)
+
+    def log_rollouts(self, records: list[dict[str, Any]], step: int | None = None) -> None:
+        """Forward rollout records to trace-capable child loggers."""
+        for logger in self.loggers:
+            logger.log_rollouts(records, step)
 
     def close(self) -> None:
         """Close all child loggers."""

--- a/tinker_cookbook/utils/ml_log_test.py
+++ b/tinker_cookbook/utils/ml_log_test.py
@@ -1,8 +1,10 @@
 import logging
 import shlex
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from . import ml_log
 from .ml_log import configure_logging_module
 
 
@@ -40,3 +42,134 @@ def test_configure_logging_module_logs_invocation_and_appends(tmp_path):
     assert final_contents.count("Command line invocation:") == 2
     assert final_contents.index("first message") < final_contents.index(second_invocation)
     assert final_contents.index(second_invocation) < final_contents.index("second message")
+
+
+def test_wandb_logger_log_rollouts_uses_weave_lazily(monkeypatch):
+    init_projects = []
+    contexts = []
+    attrs_seen = []
+    records_seen = []
+
+    class FakeClient:
+        def set_wandb_run_context(self, *, run_id, step):
+            contexts.append((run_id, step))
+
+        def clear_wandb_run_context(self):
+            contexts.append("cleared")
+
+    class FakeAttributes:
+        def __init__(self, attrs):
+            self.attrs = attrs
+
+        def __enter__(self):
+            attrs_seen.append(self.attrs)
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeWeave:
+        @staticmethod
+        def init(project_name):
+            init_projects.append(project_name)
+            return FakeClient()
+
+        @staticmethod
+        def attributes(attrs):
+            return FakeAttributes(attrs)
+
+    def fake_log_rollout(record):
+        records_seen.append(record)
+
+    logger = object.__new__(ml_log.WandbLogger)
+    logger.run = SimpleNamespace(id="abc123")
+    logger._weave_client = None
+    logger._weave_project_name = "entity/project"
+    logger._warned_weave_unavailable = False
+
+    monkeypatch.setattr(ml_log, "_weave_available", True)
+    monkeypatch.setattr(ml_log, "weave", FakeWeave)
+    monkeypatch.setattr(ml_log, "_weave_log_rollout", fake_log_rollout)
+
+    record = {
+        "split": "train",
+        "iteration": 2,
+        "group_idx": 3,
+        "traj_idx": 4,
+        "tags": ["unit-test"],
+        "steps": [{"ac_len": 2, "ac_text": "hello"}],
+    }
+    logger.log_rollouts([record], step=2)
+
+    assert init_projects == ["entity/project"]
+    assert contexts == [("abc123", 2), "cleared"]
+    assert attrs_seen == [
+        {
+            "split": "train",
+            "iteration": 2,
+            "group_idx": 3,
+            "traj_idx": 4,
+            "tags": ["unit-test"],
+        }
+    ]
+    assert records_seen == [record]
+
+
+def test_rollout_for_weave_preserves_full_trajectory():
+    record = {
+        "schema_version": 1,
+        "split": "train",
+        "iteration": 0,
+        "group_idx": 1,
+        "traj_idx": 2,
+        "tags": ["unit-test"],
+        "sampling_client_step": 0,
+        "total_reward": 2.0,
+        "final_reward": 0.5,
+        "trajectory_metrics": {"success": 1},
+        "steps": [
+            {
+                "step_idx": 0,
+                "ob_len": 3,
+                "ac_len": 2,
+                "reward": 0.5,
+                "episode_done": False,
+                "metrics": {"score": 0.5},
+                "logs": {"tool": "none"},
+                "ob_text": "User: first question",
+                "ac_text": "Assistant: first answer",
+                "stop_reason": "stop",
+            },
+            {
+                "step_idx": 1,
+                "ob_len": 7,
+                "ac_len": 4,
+                "reward": 1.0,
+                "episode_done": True,
+                "metrics": {"score": 1.0},
+                "logs": {"tool": "calculator"},
+                "ob_text": "User: follow-up",
+                "ac_text": "Assistant: final answer",
+                "stop_reason": "length",
+            },
+        ],
+        "final_ob_len": 11,
+    }
+
+    view = ml_log._rollout_for_weave(record)
+
+    assert view["total_reward"] == 2.0
+    assert view["turns"] == record["steps"]
+    assert sorted(view) == [
+        "final_ob_len",
+        "final_reward",
+        "group_idx",
+        "iteration",
+        "sampling_client_step",
+        "schema_version",
+        "split",
+        "tags",
+        "total_reward",
+        "traj_idx",
+        "trajectory_metrics",
+        "turns",
+    ]


### PR DESCRIPTION
## Summary
- add a generic logger hook for rollout trace records, implemented by W&B via Weave
- add optional decoded rollout text to rollout summary serialization
- wire opt-in rollout trace logging into on-policy distillation with a backend-neutral flag

## Verification
- .venv/bin/ruff check pyproject.toml tinker_cookbook/utils/ml_log.py tinker_cookbook/utils/ml_log_test.py tinker_cookbook/rl/rollout_logging.py tinker_cookbook/distillation/train_on_policy.py tinker_cookbook/recipes/distillation/on_policy_distillation.py tinker_cookbook/rl/rollout_logging_test.py
- .venv/bin/pytest -q tinker_cookbook/rl/rollout_logging_test.py tinker_cookbook/utils/ml_log_test.py
- .venv/bin/pytest -q tests/downstream_compat/test_utils.py

## Notes
- rollout tracing is opt-in via rollout_trace_logging=True
- Weave is imported lazily and only used by WandbLogger when rollout traces are logged