### PR TITLE
Write rollout traces to summaries

### DIFF
--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -129,22 +129,27 @@ class ProblemEnv(Env):
         correct_answer = float(self.check_answer(content))
         total_reward = self.format_coef * (correct_format - 1) + correct_answer
 
+        trace = {}
+
         # Log the attempt in a fixed structure that scales to longer content.
         with logtree.scope_header("Prompt"):
-            logtree.log_formatter(ConversationFormatter(messages=convo))
+            prompt_formatter = ConversationFormatter(messages=convo)
+            logtree.log_formatter(prompt_formatter)
+            trace["prompt"] = prompt_formatter.to_data()
         with logtree.scope_header("Policy Response"):
-            logtree.log_formatter(ConversationFormatter(messages=[message]))
+            response_formatter = ConversationFormatter(messages=[message])
+            logtree.log_formatter(response_formatter)
+            trace["policy_response"] = response_formatter.to_data()
         with logtree.scope_header("Reward"):
-            logtree.table_from_dict(
-                {
-                    "reference_answer": self.get_reference_answer(),
-                    "format_valid": bool(correct_format),
-                    "correct": bool(correct_answer),
-                    "format_coef": self.format_coef,
-                    "reward": f"{total_reward:.3f}",
-                },
-                caption="Reward components",
-            )
+            reward_table = {
+                "reference_answer": self.get_reference_answer(),
+                "format_valid": bool(correct_format),
+                "correct": bool(correct_answer),
+                "format_coef": self.format_coef,
+                "reward": f"{total_reward:.3f}",
+            }
+            logtree.table_from_dict(reward_table, caption="Reward components")
+            trace["reward"] = reward_table
 
         return StepResult(
             reward=total_reward,
@@ -155,6 +160,7 @@ class ProblemEnv(Env):
                 "format": correct_format,
                 "correct": correct_answer,
             },
+            trace=trace,
         )
 
 

--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -129,27 +129,22 @@ class ProblemEnv(Env):
         correct_answer = float(self.check_answer(content))
         total_reward = self.format_coef * (correct_format - 1) + correct_answer
 
-        trace = {}
-
         # Log the attempt in a fixed structure that scales to longer content.
         with logtree.scope_header("Prompt"):
-            prompt_formatter = ConversationFormatter(messages=convo)
-            logtree.log_formatter(prompt_formatter)
-            trace["prompt"] = prompt_formatter.to_data()
+            logtree.log_formatter(ConversationFormatter(messages=convo))
         with logtree.scope_header("Policy Response"):
-            response_formatter = ConversationFormatter(messages=[message])
-            logtree.log_formatter(response_formatter)
-            trace["policy_response"] = response_formatter.to_data()
+            logtree.log_formatter(ConversationFormatter(messages=[message]))
         with logtree.scope_header("Reward"):
-            reward_table = {
-                "reference_answer": self.get_reference_answer(),
-                "format_valid": bool(correct_format),
-                "correct": bool(correct_answer),
-                "format_coef": self.format_coef,
-                "reward": f"{total_reward:.3f}",
-            }
-            logtree.table_from_dict(reward_table, caption="Reward components")
-            trace["reward"] = reward_table
+            logtree.table_from_dict(
+                {
+                    "reference_answer": self.get_reference_answer(),
+                    "format_valid": bool(correct_format),
+                    "correct": bool(correct_answer),
+                    "format_coef": self.format_coef,
+                    "reward": f"{total_reward:.3f}",
+                },
+                caption="Reward components",
+            )
 
         return StepResult(
             reward=total_reward,
@@ -160,7 +155,6 @@ class ProblemEnv(Env):
                 "format": correct_format,
                 "correct": correct_answer,
             },
-            trace=trace,
         )
 
 

--- a/tinker_cookbook/rl/rollout_logging.py
+++ b/tinker_cookbook/rl/rollout_logging.py
@@ -90,7 +90,13 @@ def serialize_rollout_summaries(
             "tags": list[str], "sampling_client_step": int | None,
             "total_reward": float, "final_reward": float,
             "trajectory_metrics": dict, "final_ob_len": int,
-            "steps": [{"step_idx", "ob_len", "ac_len", "reward", "episode_done", "metrics", "logs"}, ...]
+            "steps": [
+                {
+                    "step_idx", "ob_len", "ac_len", "reward", "episode_done",
+                    "stop_reason", "metrics", "logs", "trace" (optional)
+                },
+                ...
+            ]
         }
 
     Args:
@@ -113,17 +119,19 @@ def serialize_rollout_summaries(
         for traj_idx, trajectory in enumerate(trajectory_group.trajectories_G):
             steps = []
             for step_idx, transition in enumerate(trajectory.transitions):
-                steps.append(
-                    {
-                        "step_idx": step_idx,
-                        "ob_len": transition.ob.length,
-                        "ac_len": len(transition.ac.tokens),
-                        "reward": transition.reward,
-                        "episode_done": transition.episode_done,
-                        "metrics": transition.metrics,
-                        "logs": transition.logs,
-                    }
-                )
+                step = {
+                    "step_idx": step_idx,
+                    "ob_len": transition.ob.length,
+                    "ac_len": len(transition.ac.tokens),
+                    "reward": transition.reward,
+                    "episode_done": transition.episode_done,
+                    "stop_reason": transition.ac.stop_reason,
+                    "metrics": transition.metrics,
+                    "logs": transition.logs,
+                }
+                if transition.trace is not None:
+                    step["trace"] = transition.trace
+                steps.append(step)
 
             records.append(
                 _json_safe(

--- a/tinker_cookbook/rl/rollout_logging.py
+++ b/tinker_cookbook/rl/rollout_logging.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -57,13 +57,16 @@ def _json_safe(value: Any) -> Any:
     """Convert values to JSON-serializable form."""
     if value is None or isinstance(value, (str, bool, int, float)):
         return value
+    if is_dataclass(value) and not isinstance(value, type):
+        return _json_safe(asdict(value))
     if isinstance(value, dict):
         return {str(k): _json_safe(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_json_safe(v) for v in value]
-    if hasattr(value, "item"):
+    item = getattr(value, "item", None)
+    if item is not None:
         try:
-            return value.item()
+            return item()
         except Exception:
             logger.debug("Failed to convert %r via .item(), falling back to str()", type(value))
     return str(value)

--- a/tinker_cookbook/rl/rollout_logging.py
+++ b/tinker_cookbook/rl/rollout_logging.py
@@ -58,7 +58,7 @@ def _json_safe(value: Any) -> Any:
     if value is None or isinstance(value, (str, bool, int, float)):
         return value
     if is_dataclass(value) and not isinstance(value, type):
-        return _json_safe(asdict(value))
+        return _json_safe({k: v for k, v in asdict(value).items() if v is not None})
     if isinstance(value, dict):
         return {str(k): _json_safe(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):

--- a/tinker_cookbook/rl/rollout_logging_test.py
+++ b/tinker_cookbook/rl/rollout_logging_test.py
@@ -6,7 +6,14 @@ import tinker
 
 from tinker_cookbook.completers import TokensWithLogprobs
 from tinker_cookbook.rl.rollout_logging import serialize_rollout_summaries
-from tinker_cookbook.rl.types import Logs, Metrics, Trajectory, TrajectoryGroup, Transition
+from tinker_cookbook.rl.types import (
+    Logs,
+    Metrics,
+    RolloutTrace,
+    Trajectory,
+    TrajectoryGroup,
+    Transition,
+)
 
 
 def test_serialize_rollout_summaries_handles_numpy_scalars_and_trace():
@@ -17,7 +24,7 @@ def test_serialize_rollout_summaries_handles_numpy_scalars_and_trace():
         episode_done=True,
         metrics=cast(Metrics, {"score": np.float32(1.5)}),
         logs=cast(Logs, {"rank": np.int64(2)}),
-        trace={"prompt": {"messages": [{"role": "user", "content": "2+2?"}]}},
+        trace=RolloutTrace(prompt={"messages": [{"role": "user", "content": "2+2?"}]}),
     )
     trajectory = Trajectory(transitions=[transition], final_ob=tinker.ModelInput.from_ints([1] * 8))
     trajectory_group = TrajectoryGroup(

--- a/tinker_cookbook/rl/rollout_logging_test.py
+++ b/tinker_cookbook/rl/rollout_logging_test.py
@@ -1,16 +1,15 @@
 import json
-from pathlib import Path
 from typing import cast
 
 import numpy as np
 import tinker
 
 from tinker_cookbook.completers import TokensWithLogprobs
-from tinker_cookbook.rl.rollout_logging import write_rollout_summaries_jsonl
+from tinker_cookbook.rl.rollout_logging import serialize_rollout_summaries
 from tinker_cookbook.rl.types import Logs, Metrics, Trajectory, TrajectoryGroup, Transition
 
 
-def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
+def test_serialize_rollout_summaries_handles_numpy_scalars_and_trace():
     transition = Transition(
         ob=tinker.ModelInput.from_ints([101, 102, 103, 104, 105]),
         ac=TokensWithLogprobs(tokens=[1, 2, 3], maybe_logprobs=[-0.1, -0.2, -0.3]),
@@ -18,6 +17,7 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         episode_done=True,
         metrics=cast(Metrics, {"score": np.float32(1.5)}),
         logs=cast(Logs, {"rank": np.int64(2)}),
+        trace={"prompt": {"messages": [{"role": "user", "content": "2+2?"}]}},
     )
     trajectory = Trajectory(transitions=[transition], final_ob=tinker.ModelInput.from_ints([1] * 8))
     trajectory_group = TrajectoryGroup(
@@ -25,10 +25,7 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         final_rewards_G=[cast(float, np.float32(0.75))],
         metrics_G=[cast(Metrics, {"traj_metric": np.float32(3.0)})],
     )
-    output_path = tmp_path / "rollouts.jsonl"
-
-    write_rollout_summaries_jsonl(
-        output_path,
+    records = serialize_rollout_summaries(
         split="train",
         iteration=1,
         trajectory_groups_P=[trajectory_group],
@@ -36,11 +33,13 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         sampling_client_steps_P=[7],
     )
 
-    record = json.loads(output_path.read_text().strip())
+    record = json.loads(json.dumps(records[0]))
     assert record["iteration"] == 1
     assert record["sampling_client_step"] == 7
     assert record["total_reward"] == 1.0
     assert record["final_reward"] == 0.75
     assert record["steps"][0]["reward"] == 0.25
+    assert record["steps"][0]["stop_reason"] == "stop"
     assert record["steps"][0]["metrics"]["score"] == 1.5
     assert record["steps"][0]["logs"]["rank"] == 2
+    assert record["steps"][0]["trace"]["prompt"]["messages"][0]["content"] == "2+2?"

--- a/tinker_cookbook/rl/rollouts.py
+++ b/tinker_cookbook/rl/rollouts.py
@@ -191,6 +191,7 @@ async def do_single_rollout(policy: TokenCompleter, env: Env) -> Trajectory:
             episode_done=step_result.episode_done,
             metrics=step_result.metrics,
             logs=step_result.logs,
+            trace=step_result.trace,
         )
         transitions.append(transition)
         ob = step_result.next_observation

--- a/tinker_cookbook/rl/types.py
+++ b/tinker_cookbook/rl/types.py
@@ -15,7 +15,7 @@ Type aliases
 - ``Logprobs`` – ``list[float]`` of per-token log-probabilities.
 - ``Metrics`` – ``dict[str, float | int]`` of numeric values aggregated in logs.
 - ``Logs`` – ``dict[str, str | int | float]`` of diagnostic info for display.
-- ``TracePayload`` – JSON-like structured data for rollout transcript summaries.
+- ``RolloutTrace`` – structured transcript data for rollout summaries.
 """
 
 from abc import ABC, abstractmethod
@@ -35,7 +35,29 @@ Observation: TypeAlias = tinker.ModelInput
 Logprobs: TypeAlias = list[float]
 Metrics: TypeAlias = dict[str, float | int]
 Logs: TypeAlias = dict[str, str | int | float]
-TracePayload: TypeAlias = dict[str, object]
+
+
+@dataclass
+class RolloutTrace:
+    """Structured transcript data attached to one environment step in a rollout.
+
+    Attributes:
+        prompt: Structured prompt/input data, usually
+            ``ConversationFormatter(...).to_data()``.
+        policy_response: Structured policy response data, usually
+            ``ConversationFormatter(...).to_data()``.
+        reward_data: Optional reward breakdown or reward-specific diagnostics.
+        env_state: Optional environment state metadata, such as turn number or
+            game-over status.
+        extra: Optional environment-specific structured data that does not fit
+            the common fields.
+    """
+
+    prompt: dict[str, object] | None = None
+    policy_response: dict[str, object] | None = None
+    reward_data: dict[str, object] | None = None
+    env_state: dict[str, object] | None = None
+    extra: dict[str, object] | None = None
 
 
 @dataclass
@@ -53,7 +75,7 @@ class StepResult:
             logs (e.g., timing, counts).
         logs (Logs): Diagnostic info for display/debugging tools (not
             aggregated like metrics).
-        trace (TracePayload | None): Optional structured transcript data for
+        trace (RolloutTrace | None): Optional structured transcript data for
             durable rollout summaries. This is not aggregated into metrics.
     """
 
@@ -69,7 +91,7 @@ class StepResult:
     """Numeric values aggregated and reported in training logs (e.g., timing, counts)."""
     logs: Logs = field(default_factory=dict)
     """Diagnostic info for display/debugging tools (not aggregated like metrics)."""
-    trace: TracePayload | None = None
+    trace: RolloutTrace | None = None
     """Optional structured transcript data for durable rollout summaries."""
 
 
@@ -87,7 +109,7 @@ class Transition:
             logs.
         logs (Logs): Diagnostic info for display/debugging tools (not
             aggregated like metrics).
-        trace (TracePayload | None): Optional structured transcript data for
+        trace (RolloutTrace | None): Optional structured transcript data for
             durable rollout summaries.
     """
 
@@ -103,7 +125,7 @@ class Transition:
     """Numeric values aggregated and reported in training logs."""
     logs: Logs = field(default_factory=dict)
     """Diagnostic info for display/debugging tools (not aggregated like metrics)."""
-    trace: TracePayload | None = None
+    trace: RolloutTrace | None = None
     """Optional structured transcript data for durable rollout summaries."""
 
 

--- a/tinker_cookbook/rl/types.py
+++ b/tinker_cookbook/rl/types.py
@@ -15,6 +15,7 @@ Type aliases
 - ``Logprobs`` – ``list[float]`` of per-token log-probabilities.
 - ``Metrics`` – ``dict[str, float | int]`` of numeric values aggregated in logs.
 - ``Logs`` – ``dict[str, str | int | float]`` of diagnostic info for display.
+- ``TracePayload`` – JSON-like structured data for rollout transcript summaries.
 """
 
 from abc import ABC, abstractmethod
@@ -34,6 +35,7 @@ Observation: TypeAlias = tinker.ModelInput
 Logprobs: TypeAlias = list[float]
 Metrics: TypeAlias = dict[str, float | int]
 Logs: TypeAlias = dict[str, str | int | float]
+TracePayload: TypeAlias = dict[str, object]
 
 
 @dataclass
@@ -51,6 +53,8 @@ class StepResult:
             logs (e.g., timing, counts).
         logs (Logs): Diagnostic info for display/debugging tools (not
             aggregated like metrics).
+        trace (TracePayload | None): Optional structured transcript data for
+            durable rollout summaries. This is not aggregated into metrics.
     """
 
     reward: float
@@ -65,6 +69,8 @@ class StepResult:
     """Numeric values aggregated and reported in training logs (e.g., timing, counts)."""
     logs: Logs = field(default_factory=dict)
     """Diagnostic info for display/debugging tools (not aggregated like metrics)."""
+    trace: TracePayload | None = None
+    """Optional structured transcript data for durable rollout summaries."""
 
 
 @dataclass
@@ -81,6 +87,8 @@ class Transition:
             logs.
         logs (Logs): Diagnostic info for display/debugging tools (not
             aggregated like metrics).
+        trace (TracePayload | None): Optional structured transcript data for
+            durable rollout summaries.
     """
 
     ob: Observation
@@ -95,6 +103,8 @@ class Transition:
     """Numeric values aggregated and reported in training logs."""
     logs: Logs = field(default_factory=dict)
     """Diagnostic info for display/debugging tools (not aggregated like metrics)."""
+    trace: TracePayload | None = None
+    """Optional structured transcript data for durable rollout summaries."""
 
 
 class ActionExtra(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- Adds a `RolloutTrace` dataclass for structured per-step transcript data.
- Carries `StepResult.trace` into `Transition.trace`.
- Writes `steps[].trace` and `steps[].stop_reason` into rollout summary JSONL records.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #749
* __->__ #748

Co-authored-by: Cursor <cursoragent@cursor.com>