### PR TITLE
Add rollout traces to built-in envs

### DIFF
--- a/tinker_cookbook/distillation/datasets.py
+++ b/tinker_cookbook/distillation/datasets.py
@@ -27,6 +27,7 @@ from tinker_cookbook.rl.types import (
     StepResult,
 )
 from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.utils.logtree_formatters import ConversationFormatter
 
 
 @chz.chz
@@ -112,12 +113,18 @@ class PromptOnlyEnv(ProblemEnv):
 
     async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         """Return zero reward always."""
+        convo = self.convo_prefix + [{"role": "user", "content": self.get_question()}]
+        message, _termination = self.renderer.parse_response(action)
         return StepResult(
             reward=0.0,
             episode_done=True,
             next_observation=tinker.ModelInput.empty(),
             next_stop_condition=self.stop_condition,
             metrics={},
+            trace={
+                "prompt": ConversationFormatter(messages=convo).to_data(),
+                "policy_response": ConversationFormatter(messages=[message]).to_data(),
+            },
         )
 
 

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
@@ -20,6 +20,7 @@ from tinker_cookbook.rl.types import (
     StepResult,
 )
 from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.utils.logtree_formatters import ConversationFormatter
 
 _UPPER_BOUND = 1024
 SYSTEM_PROMPT = f"""
@@ -70,6 +71,7 @@ class GuessNumberEnv(Env):
             return RETURN_ON_FAIL
 
     async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
+        convo_for_player = [self.system_prompt] + self.turns
         # step 1: parse the action tokens into a message
         # this step is specific to our library, but usually templated, so you can just copy it.
         (action_message, _termination) = self.renderer.parse_response(action)
@@ -94,6 +96,10 @@ class GuessNumberEnv(Env):
                 "guess": action_content,
                 "feedback": ensure_text(user_turn["content"]),
                 "target": self.gold_answer,
+            },
+            trace={
+                "prompt": ConversationFormatter(messages=convo_for_player).to_data(),
+                "policy_response": ConversationFormatter(messages=[action_message]).to_data(),
             },
         )
 

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/env.py
@@ -34,6 +34,7 @@ from tinker_cookbook.rl.types import (
     StepResult,
 )
 from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.utils.logtree_formatters import ConversationFormatter
 
 STOP_CONDITION = ["]\n"]
 ILLEGAL_MOVE_REWARD = -2.0
@@ -149,6 +150,8 @@ class TwoPlayerEnv(Env):
         assert self.coordinator.current_player_id == self.player_id, "Not the current player's turn"
 
         # make a move ...
+        _current_player_id, observation_str = self.coordinator.shared_env.get_observation()
+        prompt_messages: list[Message] = [{"role": "user", "content": observation_str}]
         action_message: Message = self.renderer.parse_response(action)[0]
         action_content = get_text_content(action_message)
         await self.coordinator.make_move(self.player_id, action_content)
@@ -163,6 +166,11 @@ class TwoPlayerEnv(Env):
             next_observation=self.get_observation(),
             next_stop_condition=self.stop_condition,
             metrics={},
+            trace={
+                "prompt": ConversationFormatter(messages=prompt_messages).to_data(),
+                "policy_response": ConversationFormatter(messages=[action_message]).to_data(),
+                "game_done": self.coordinator.game_done,
+            },
         )
 
     def get_done_step(self) -> StepResult:

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
@@ -28,6 +28,7 @@ from tinker_cookbook.rl.types import (
 )
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 from tinker_cookbook.utils import logtree
+from tinker_cookbook.utils.logtree_formatters import ConversationFormatter
 
 ANSWERER_SYSTEM_PROMPT = """
 You are the answerer in a game of 20 questions. You should only ever respond with 'yes' or 'no'. Your secret word is {answer}. If the other player guesses it with Guess: <answer>, respond with 'yes' only if the answer is precisely your secret word.
@@ -106,6 +107,7 @@ class TwentyQuestionsEnv(Env):
         """
 
         # step 1: accepts the action from the player (policy)
+        player_prompt = self._convo_for_player()
         (action_message, _termination) = self.renderer.parse_response(action)
         self.turns.append({"role": "player", "content": action_message["content"]})
 
@@ -134,6 +136,13 @@ class TwentyQuestionsEnv(Env):
             next_stop_condition=self.stop_condition,
             episode_done=episode_done,
             reward=reward,
+            trace={
+                "prompt": ConversationFormatter(messages=player_prompt).to_data(),
+                "policy_response": ConversationFormatter(messages=[action_message]).to_data(),
+                "answerer_response": ConversationFormatter(messages=[answer_message]).to_data(),
+                "turn": turn_num,
+                "game_over": episode_done,
+            },
         )
 
         return step_result

--- a/tinker_cookbook/recipes/rubric/env.py
+++ b/tinker_cookbook/recipes/rubric/env.py
@@ -90,7 +90,8 @@ class RubricGradedEnv(Env):
 
     async def step(self, action: Action, *, extra: ActionExtra | None = None) -> StepResult:
         with logtree.scope_header("Prompt"):
-            logtree.log_formatter(ConversationFormatter(messages=self.convo))
+            prompt_formatter = ConversationFormatter(messages=self.convo)
+            logtree.log_formatter(prompt_formatter)
 
         # obtain the policy action message
         (policy_action_message, termination) = self.renderer.parse_response(action)
@@ -114,7 +115,8 @@ class RubricGradedEnv(Env):
             print(colored(f"Termination: {termination}", "green") + "\n")
 
         with logtree.scope_header("Policy Response"):
-            logtree.log_formatter(ConversationFormatter(messages=[policy_action_message]))
+            response_formatter = ConversationFormatter(messages=[policy_action_message])
+            logtree.log_formatter(response_formatter)
             logtree.log_text(f"Termination: {termination}")
 
         convo = self.convo + [policy_action_message]
@@ -126,6 +128,7 @@ class RubricGradedEnv(Env):
 
         with logtree.scope_header("Rubric Grades"):
             rows = []
+            rubric_grades = []
             for idx, (rubric_item, (score, grader_response)) in enumerate(
                 zip(self.rubric_items, results, strict=True),
                 start=1,
@@ -138,6 +141,13 @@ class RubricGradedEnv(Env):
                         + ("..." if len(rubric_item.rubric_str) > 120 else ""),
                     }
                 )
+                rubric_grades.append(
+                    {
+                        "score": score,
+                        "criterion": rubric_item.rubric_str,
+                        "grader_response": grader_response,
+                    }
+                )
                 with logtree.scope_header(f"Rubric {idx}: score={score:.3f}"):
                     logtree.log_text(f"Criterion: {rubric_item.rubric_str}")
                     logtree.details(grader_response, summary="Model output", pre=True)
@@ -148,15 +158,13 @@ class RubricGradedEnv(Env):
         total_reward = format_penalty + avg_score
 
         with logtree.scope_header("Reward Terms"):
-            logtree.table_from_dict(
-                {
-                    "rubric_score_mean": f"{avg_score:.3f}",
-                    "format_valid": format_valid,
-                    "format_penalty": f"{format_penalty:.3f}",
-                    "total_reward": f"{total_reward:.3f}",
-                },
-                caption="Per-step reward breakdown",
-            )
+            reward_terms = {
+                "rubric_score_mean": f"{avg_score:.3f}",
+                "format_valid": format_valid,
+                "format_penalty": f"{format_penalty:.3f}",
+                "total_reward": f"{total_reward:.3f}",
+            }
+            logtree.table_from_dict(reward_terms, caption="Per-step reward breakdown")
 
         return StepResult(
             reward=total_reward,
@@ -171,6 +179,12 @@ class RubricGradedEnv(Env):
                 "format_valid": int(format_valid),
                 "termination": str(termination),
                 "num_rubrics": len(self.rubric_items),
+            },
+            trace={
+                "prompt": prompt_formatter.to_data(),
+                "policy_response": response_formatter.to_data(),
+                "rubric_grades": rubric_grades,
+                "reward_terms": reward_terms,
             },
         )
 

--- a/tinker_cookbook/rl/message_env.py
+++ b/tinker_cookbook/rl/message_env.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass, field
 
 import tinker
@@ -146,7 +147,9 @@ class EnvFromMessageEnv(types.Env):
                 metrics={"max_tokens_reached": 1.0},
             )
 
-        prompt_messages = self._last_messages or await self.message_env.initial_observation()
+        if self._last_messages is None:
+            self._last_messages = await self.message_env.initial_observation()
+        prompt_messages = deepcopy(self._last_messages)
         assistant_message, termination = self.renderer.parse_response(action)
 
         if not termination.is_clean:

--- a/tinker_cookbook/rl/message_env.py
+++ b/tinker_cookbook/rl/message_env.py
@@ -18,6 +18,7 @@ from tinker_cookbook.completers import StopCondition
 from tinker_cookbook.renderers import Renderer
 from tinker_cookbook.renderers.base import Message
 from tinker_cookbook.rl import types
+from tinker_cookbook.utils.logtree_formatters import ConversationFormatter
 
 
 @dataclass
@@ -71,6 +72,7 @@ class EnvFromMessageEnv(types.Env):
         self.max_generation_tokens = max_generation_tokens
         self.context_overflow_reward = context_overflow_reward
         self._base_stop_condition = renderer.get_stop_sequences()
+        self._last_messages: list[Message] | None = None
 
         # Forward example_id from the inner MessageEnv for trajectory storage.
         # This ensures truncated examples (where MessageEnv.step() never runs)
@@ -93,8 +95,23 @@ class EnvFromMessageEnv(types.Env):
         generation_reserve = self.max_generation_tokens or 0
         return observation_length + generation_reserve > self.max_trajectory_tokens
 
+    def _trace_payload(
+        self,
+        prompt_messages: list[Message],
+        assistant_message: Message,
+        result: MessageStepResult | None = None,
+    ) -> types.TracePayload:
+        trace: types.TracePayload = {
+            "prompt": ConversationFormatter(messages=prompt_messages).to_data(),
+            "policy_response": ConversationFormatter(messages=[assistant_message]).to_data(),
+        }
+        if result is not None and result.next_messages:
+            trace["next_messages"] = ConversationFormatter(messages=result.next_messages).to_data()
+        return trace
+
     async def initial_observation(self) -> tuple[tinker.ModelInput, StopCondition]:
         messages = await self.message_env.initial_observation()
+        self._last_messages = messages
         model_input = await self._render_in_thread(messages)
 
         if self._exceeds_context_limit(model_input.length):
@@ -125,6 +142,7 @@ class EnvFromMessageEnv(types.Env):
                 metrics={"max_tokens_reached": 1.0},
             )
 
+        prompt_messages = self._last_messages or await self.message_env.initial_observation()
         assistant_message, termination = self.renderer.parse_response(action)
 
         if not termination.is_clean:
@@ -134,9 +152,11 @@ class EnvFromMessageEnv(types.Env):
                 next_observation=tinker.ModelInput.empty(),
                 next_stop_condition=self._base_stop_condition,
                 metrics={"parse_error": 1.0},
+                trace=self._trace_payload(prompt_messages, assistant_message),
             )
 
         msg_step = await self.message_env.step(assistant_message)
+        self._last_messages = msg_step.next_messages
         next_observation = await self._render_in_thread(msg_step.next_messages)
         next_stop_condition = msg_step.next_stop_condition or self._base_stop_condition
 
@@ -152,6 +172,7 @@ class EnvFromMessageEnv(types.Env):
                 next_stop_condition=self._base_stop_condition,
                 metrics={**msg_step.metrics, "context_overflow": 1.0},
                 logs=msg_step.logs,
+                trace=self._trace_payload(prompt_messages, assistant_message, msg_step),
             )
 
         return types.StepResult(
@@ -161,4 +182,5 @@ class EnvFromMessageEnv(types.Env):
             next_stop_condition=next_stop_condition,
             metrics=msg_step.metrics,
             logs=msg_step.logs,
+            trace=self._trace_payload(prompt_messages, assistant_message, msg_step),
         )

--- a/tinker_cookbook/rl/message_env_test.py
+++ b/tinker_cookbook/rl/message_env_test.py
@@ -46,6 +46,25 @@ class StubMessageEnv(MessageEnv):
         return self._step_result
 
 
+class MutatingMessageEnv(MessageEnv):
+    """MessageEnv that mutates history in place, like tool-use envs do."""
+
+    def __init__(self, initial_messages: list[Message]):
+        self.history = initial_messages
+
+    async def initial_observation(self) -> list[Message]:
+        return self.history
+
+    async def step(self, message: Message) -> MessageStepResult:
+        self.history.append(message)
+        self.history.append({"role": "tool", "content": "tool result"})
+        return MessageStepResult(
+            reward=1.0,
+            episode_done=True,
+            next_messages=self.history,
+        )
+
+
 def _make_renderer(
     gen_prompt_tokens: list[int] | None = None,
     stop_sequences: list[str] | None = None,
@@ -250,6 +269,22 @@ class TestStepSuccess:
         assert result.next_observation.to_ints() == [10, 20, 30, 40]
         assert result.metrics == {"custom": 1.0}
         assert result.next_stop_condition == ["<stop>"]
+
+    def test_trace_prompt_snapshots_messages_before_step_mutation(self):
+        """Trace prompt should not include messages appended by MessageEnv.step."""
+        assistant_msg: Message = {"role": "assistant", "content": "answer"}
+        initial_msgs: list[Message] = [{"role": "user", "content": "hi"}]
+        renderer = _make_renderer(parse_message=assistant_msg)
+        msg_env = MutatingMessageEnv(initial_msgs)
+        env = EnvFromMessageEnv(renderer=renderer, message_env=msg_env)
+
+        asyncio.run(env.initial_observation())
+        result = asyncio.run(env.step([5, 6, 7]))
+
+        assert result.trace is not None
+        assert result.trace.prompt is not None
+        assert result.trace.prompt["messages"] == [{"role": "user", "content": "hi"}]
+        assert len(msg_env.history) == 3
 
     def test_custom_stop_condition_from_message_env(self):
         """When MessageEnv returns a next_stop_condition, it overrides the base one."""

--- a/tinker_cookbook/rl/preference_envs.py
+++ b/tinker_cookbook/rl/preference_envs.py
@@ -287,7 +287,8 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
 
         # Log prompt
         with logtree.scope_header("Prompt"):
-            logtree.log_formatter(ConversationFormatter(messages=self.convo_prefix))
+            prompt_formatter = ConversationFormatter(messages=self.convo_prefix)
+            logtree.log_formatter(prompt_formatter)
 
         # Log trajectories
         for idx, (messages, is_valid) in enumerate(
@@ -333,12 +334,39 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
 
         win_minus_loss_list = [0.0 for _ in range(len(response_messages))]
         matchup_count = [0 for _ in range(len(response_messages))]
+        pairwise_by_response: list[list[dict[str, object]]] = [
+            [] for _ in range(len(response_messages))
+        ]
         for (i, j), j_reward in safezip(comparison_indices_pairs, j_rewards):
             win_minus_loss_list[j] += j_reward
             win_minus_loss_list[i] -= j_reward
             matchup_count[j] += 1
             matchup_count[i] += 1
+            pairwise_by_response[i].append(
+                {"opponent_idx": j, "preference_reward": -float(j_reward)}
+            )
+            pairwise_by_response[j].append(
+                {"opponent_idx": i, "preference_reward": float(j_reward)}
+            )
         format_coef = 1.0
+
+        prompt_trace = prompt_formatter.to_data()
+        for idx, (trajectory, messages, is_valid, win_minus_loss, mc) in enumerate(
+            safezip(trajectory_group, response_messages, is_valid_list, win_minus_loss_list, matchup_count)
+        ):
+            avg_win_minus_loss = win_minus_loss / mc if mc > 0 else 0.0
+            format_penalty = format_coef * (float(is_valid) - 1.0)
+            trajectory.transitions[0].trace = {
+                "prompt": prompt_trace,
+                "policy_response": ConversationFormatter(messages=messages).to_data(),
+                "valid_format": bool(is_valid),
+                "pairwise_comparisons": pairwise_by_response[idx],
+                "reward_terms": {
+                    "win_minus_loss": avg_win_minus_loss,
+                    "format_penalty": format_penalty,
+                    "total_reward": avg_win_minus_loss + format_penalty,
+                },
+            }
 
         return [
             (

--- a/tinker_cookbook/rl/preference_envs.py
+++ b/tinker_cookbook/rl/preference_envs.py
@@ -334,38 +334,23 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
 
         win_minus_loss_list = [0.0 for _ in range(len(response_messages))]
         matchup_count = [0 for _ in range(len(response_messages))]
-        pairwise_by_response: list[list[dict[str, object]]] = [
-            [] for _ in range(len(response_messages))
-        ]
         for (i, j), j_reward in safezip(comparison_indices_pairs, j_rewards):
             win_minus_loss_list[j] += j_reward
             win_minus_loss_list[i] -= j_reward
             matchup_count[j] += 1
             matchup_count[i] += 1
-            pairwise_by_response[i].append(
-                {"opponent_idx": j, "preference_reward": -float(j_reward)}
-            )
-            pairwise_by_response[j].append(
-                {"opponent_idx": i, "preference_reward": float(j_reward)}
-            )
         format_coef = 1.0
 
         prompt_trace = prompt_formatter.to_data()
-        for idx, (trajectory, messages, is_valid, win_minus_loss, mc) in enumerate(
-            safezip(trajectory_group, response_messages, is_valid_list, win_minus_loss_list, matchup_count)
+        for trajectory, messages, is_valid in safezip(
+            trajectory_group,
+            response_messages,
+            is_valid_list,
         ):
-            avg_win_minus_loss = win_minus_loss / mc if mc > 0 else 0.0
-            format_penalty = format_coef * (float(is_valid) - 1.0)
             trajectory.transitions[0].trace = {
                 "prompt": prompt_trace,
                 "policy_response": ConversationFormatter(messages=messages).to_data(),
                 "valid_format": bool(is_valid),
-                "pairwise_comparisons": pairwise_by_response[idx],
-                "reward_terms": {
-                    "win_minus_loss": avg_win_minus_loss,
-                    "format_penalty": format_penalty,
-                    "total_reward": avg_win_minus_loss + format_penalty,
-                },
             }
 
         return [

--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -129,17 +129,13 @@ class ProblemEnv(Env):
         correct_answer = float(self.check_answer(content))
         total_reward = self.format_coef * (correct_format - 1) + correct_answer
 
-        trace = {}
-
         # Log the attempt in a fixed structure that scales to longer content.
         with logtree.scope_header("Prompt"):
             prompt_formatter = ConversationFormatter(messages=convo)
             logtree.log_formatter(prompt_formatter)
-            trace["prompt"] = prompt_formatter.to_data()
         with logtree.scope_header("Policy Response"):
             response_formatter = ConversationFormatter(messages=[message])
             logtree.log_formatter(response_formatter)
-            trace["policy_response"] = response_formatter.to_data()
         with logtree.scope_header("Reward"):
             reward_table = {
                 "reference_answer": self.get_reference_answer(),
@@ -149,7 +145,6 @@ class ProblemEnv(Env):
                 "reward": f"{total_reward:.3f}",
             }
             logtree.table_from_dict(reward_table, caption="Reward components")
-            trace["reward"] = reward_table
 
         return StepResult(
             reward=total_reward,
@@ -160,7 +155,11 @@ class ProblemEnv(Env):
                 "format": correct_format,
                 "correct": correct_answer,
             },
-            trace=trace,
+            trace={
+                "prompt": prompt_formatter.to_data(),
+                "policy_response": response_formatter.to_data(),
+                "reward": reward_table,
+            },
         )
 
 


### PR DESCRIPTION
## Summary
- Adds `RolloutTrace` payloads to built-in rollout envs that can decode prompt/response text.
- Covers problem, prompt-only distillation, rubric, preference, message-env, and multiplayer rollout paths.
- Keeps reward and state details in structured fields where useful.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #749
* #748

Co-authored-by: Cursor <cursoragent@cursor.com>