### PR TITLE
Update Basics tutorials (1xx) for model deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ modal = [
 multiplayer-rl = [
     "textarena>=0.7.4",
 ]
+tutorials = [
+    "marimo>=0.23.8",
+    "matplotlib>=3.7.0",
+]
 vector-search = [
     "chromadb>=1.0.0",
     "google-genai>=1.0.0",

--- a/tutorials/101_hello_tinker.py
+++ b/tutorials/101_hello_tinker.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -94,7 +94,7 @@ def _(mo):
     mo.md(r"""
     ## Sampling from a model
 
-    Let's create a **SamplingClient** to generate text. We will use `Qwen/Qwen3-4B-Instruct-2507`, a compact model that keeps costs low.
+    Let's create a **SamplingClient** to generate text. We will use `Qwen/Qwen3.5-9B-Base`, a base (non-chat-tuned) model, so we can feed it raw tokens and get a plain text completion -- no chat template required.
 
     The sampling workflow is:
     1. Create a `SamplingClient` with a base model name
@@ -107,7 +107,7 @@ def _(mo):
 
 @app.cell
 async def _(service_client):
-    MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+    MODEL_NAME = "Qwen/Qwen3.5-9B-Base"
 
     # Create a sampling client -- this connects to a remote GPU worker
     sampling_client = await service_client.create_sampling_client_async(base_model=MODEL_NAME)
@@ -125,7 +125,7 @@ async def _(sampling_client, tokenizer, types):
     prompt = types.ModelInput.from_ints(tokenizer.encode(prompt_text))
 
     # Sample a completion
-    params = types.SamplingParams(max_tokens=50, temperature=0.7, stop=["\n"])
+    params = types.SamplingParams(max_tokens=50, temperature=0.5)
     result = await sampling_client.sample_async(
         prompt=prompt, sampling_params=params, num_samples=1
     )
@@ -134,7 +134,7 @@ async def _(sampling_client, tokenizer, types):
     completion_tokens = result.sequences[0].tokens
     print("Completion tokens:", completion_tokens)
     print(prompt_text + tokenizer.decode(completion_tokens))
-    return prompt, result
+    return prompt, prompt_text, result
 
 
 @app.cell(hide_code=True)
@@ -169,15 +169,15 @@ def _(mo):
 
 
 @app.cell
-async def _(prompt, sampling_client, tokenizer, types):
+async def _(prompt, prompt_text, sampling_client, tokenizer, types):
     result_1 = await sampling_client.sample_async(
         prompt=prompt,
-        sampling_params=types.SamplingParams(max_tokens=50, temperature=0.9, stop=["\n"]),
+        sampling_params=types.SamplingParams(max_tokens=50, temperature=0.7),
         num_samples=3,
     )
     for i, _seq in enumerate(result_1.sequences):
         text = tokenizer.decode(_seq.tokens)
-        print(f"Sample {i}: {text}")
+        print(f"Sample {i}: {prompt_text}{text}")
     return
 
 

--- a/tutorials/101_hello_tinker.py
+++ b/tutorials/101_hello_tinker.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 01: Hello Tinker
+    # Tutorial 101: Hello Tinker
 
     Tinker is a remote GPU service for LLM training and inference. You write training loops in Python on your local machine; Tinker executes the heavy GPU operations (forward passes, backpropagation, sampling) on remote workers.
 
@@ -206,7 +206,7 @@ def _(mo):
     mo.md(r"""
     ## Next steps
 
-    - **[Tutorial 02: First SFT](./102_first_sft.py)** -- Train a model with supervised fine-tuning
+    - **[Tutorial 102: First SFT](./102_first_sft.py)** -- Train a model with supervised fine-tuning
     - **[Getting Started Guide](https://docs.thinkingmachines.ai/training-sampling)** -- Full walkthrough of training and sampling
     - **[Available Models](https://docs.thinkingmachines.ai/model-lineup)** -- All supported models and their characteristics
     """)

--- a/tutorials/102_first_sft.py
+++ b/tutorials/102_first_sft.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 02: Your First Supervised Fine-Tuning Run
+    # Tutorial 102: Your First Supervised Fine-Tuning Run
 
     In this tutorial, you will fine-tune a language model using supervised learning (SFT). By the end, you will have:
 

--- a/tutorials/102_first_sft.py
+++ b/tutorials/102_first_sft.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -212,8 +212,8 @@ def _(TrainOnWhat, conversation_to_datum, get_renderer, tokenizer):
             {
                 "role": "assistant",
                 "content": (
-                    "Tinker supports a range of open models including Qwen3, Qwen3.5, Llama 3.1, "
-                    "Llama 3.3, DeepSeek V3, and more. Most training uses LoRA (Low-Rank Adaptation) "
+                    "Tinker supports a range of open models including Qwen3.5, Qwen3.6, "
+                    "Kimi K2.6, NVIDIA Nemotron 3, and DeepSeek V3.1. Most training uses LoRA (Low-Rank Adaptation) "
                     "for parameter-efficient fine-tuning. You create a LoRA training client by calling "
                     "service_client.create_lora_training_client(base_model=model_name, rank=32). "
                     "Check service_client.get_server_capabilities() for the full list of available models."
@@ -243,7 +243,7 @@ def _(TrainOnWhat, conversation_to_datum, get_renderer, tokenizer):
     ]
 
     print(f"Built {len(training_data)} training examples")
-    return SYSTEM_PROMPT, renderer, training_data
+    return SYSTEM_PROMPT, conversations, renderer, training_data
 
 
 @app.cell(hide_code=True)
@@ -316,11 +316,15 @@ def _(mo):
 
 
 @app.cell
-async def _(SYSTEM_PROMPT, get_text_content, renderer, tinker, training_client):
+async def _(
+    SYSTEM_PROMPT,
+    get_text_content,
+    renderer,
+    tinker,
+    training_client,
+):
     # Save weights and create a sampling client in one step
-    sampling_client = await training_client.save_weights_and_get_sampling_client_async(
-        name="tinker-tinker-sft"
-    )
+    sampling_client = await training_client.save_weights_and_get_sampling_client_async()
     stop_sequences = renderer.get_stop_sequences()
     params = tinker.SamplingParams(max_tokens=200, temperature=0.7, stop=stop_sequences)
     _test_questions = [
@@ -349,28 +353,34 @@ async def _(SYSTEM_PROMPT, get_text_content, renderer, tinker, training_client):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## Scaling up: fine-tuning Kimi K2.5 with the same code
+    ## Scaling up: fine-tuning Kimi K2.6 with the same code
 
-    Everything we just did on Qwen3.5-4B (4 billion parameters) works identically on much larger models. Let's fine-tune **Kimi K2.5** -- a frontier-class model -- using the exact same training data and loop. With Tinker, you don't need to own the GPUs; you just change the model name.
+    Everything we just did on Qwen3.5-4B (4 billion parameters) works identically on much larger models. Let's fine-tune **Kimi K2.6** -- a frontier-class model -- using the exact same training data and loop. With Tinker, you don't need to own the GPUs; you just change the model name.
     """)
     return
 
 
 @app.cell
-async def _(conversations, conversation_to_datum, get_renderer, service_client, TrainOnWhat):
+async def _(
+    TrainOnWhat,
+    conversation_to_datum,
+    conversations,
+    get_renderer,
+    service_client,
+):
     import contextlib
     import io
 
-    BIG_MODEL = "moonshotai/Kimi-K2.5"
+    BIG_MODEL = "moonshotai/Kimi-K2.6"
 
-    # Create a LoRA training client for Kimi K2.5 -- same API, bigger model
+    # Create a LoRA training client for Kimi K2.6 -- same API, bigger model
     big_training_client = await service_client.create_lora_training_client_async(
         base_model=BIG_MODEL, rank=16
     )
     big_tokenizer = big_training_client.get_tokenizer()
 
-    # Use the disable-thinking renderer so Kimi K2.5 responds directly without <think> blocks
-    big_renderer = get_renderer("kimi_k25_disable_thinking", big_tokenizer)
+    # Use the disable-thinking renderer so Kimi K2.6 responds directly without <think> blocks
+    big_renderer = get_renderer("kimi_k26_disable_thinking", big_tokenizer)
 
     # Build the same training data with the new renderer (suppress noisy tokenizer debug output)
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
@@ -380,11 +390,26 @@ async def _(conversations, conversation_to_datum, get_renderer, service_client, 
             )
             for conv in conversations
         ]
-    return BIG_MODEL, big_training_client, big_training_data, big_renderer
+    return BIG_MODEL, big_renderer, big_training_client, big_training_data
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Note that individual steps will now take longer since this model is significantly larger.
+    """)
+    return
 
 
 @app.cell
-async def _(BIG_MODEL, big_training_client, big_training_data, np, time, tinker):
+async def _(
+    BIG_MODEL,
+    big_training_client,
+    big_training_data,
+    np,
+    time,
+    tinker,
+):
     print(f"Model: {BIG_MODEL}")
     print(f"Training data: {len(big_training_data)} examples (same Tinker Tinker conversations)\n")
     big_losses = []
@@ -421,7 +446,7 @@ def _(big_losses, losses, plt):
         marker="s",
         linewidth=2,
         color="#dc2626",
-        label="Kimi K2.5",
+        label="Kimi K2.6",
     )
     _ax.set_xlabel("Training step")
     _ax.set_ylabel("Loss (cross-entropy)")
@@ -441,10 +466,8 @@ async def _(
     get_text_content,
     tinker,
 ):
-    # Sample from the fine-tuned Kimi K2.5
-    big_sampling_client = await big_training_client.save_weights_and_get_sampling_client_async(
-        name="tinker-tinker-kimi"
-    )
+    # Sample from the fine-tuned Kimi K2.6
+    big_sampling_client = await big_training_client.save_weights_and_get_sampling_client_async()
     big_stop = big_renderer.get_stop_sequences()
     big_params = tinker.SamplingParams(max_tokens=200, temperature=0.7, stop=big_stop)
     _test_questions = ["Who are you?", "What is Tinker?"]

--- a/tutorials/103_async_patterns.py
+++ b/tutorials/103_async_patterns.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 03: Efficient Sampling with Tinker
+    # Tutorial 103: Efficient Sampling with Tinker
 
     Tinker runs on remote GPUs. Every API call involves network latency plus GPU compute time. If you send sampling requests one at a time -- send, wait, send, wait -- you spend most of your time idle while Tinker works.
 
@@ -281,7 +281,7 @@ def _(mo):
 
     This tutorial showed the two key techniques for efficient sampling: **concurrent requests** with `asyncio.gather` (submit all requests before collecting results) and **num_samples** (generate multiple completions per call). Together, they give you high throughput with minimal code changes.
 
-    - **Tutorial 04** (`104_first_rl.py`): Uses this exact pattern -- sample many completions, grade them with a reward function, and train with GRPO.
+    - **Tutorial 104** (`104_first_rl.py`): Uses this exact pattern -- sample many completions, grade them with a reward function, and train with GRPO.
     - **Async docs** (`docs/async.mdx`): Full reference for sync/async APIs, the double-await pattern, and overlapping training requests.
     """)
     return

--- a/tutorials/103_async_patterns.py
+++ b/tutorials/103_async_patterns.py
@@ -25,6 +25,8 @@ def _(mo):
 
 @app.cell
 def _():
+    import asyncio
+    import os
     import time
     import warnings
 
@@ -34,7 +36,7 @@ def _():
 
     from tinker_cookbook.renderers import get_renderer, get_text_content
 
-    return get_renderer, get_text_content, time, tinker
+    return asyncio, get_renderer, get_text_content, os, time, tinker
 
 
 @app.cell(hide_code=True)
@@ -55,9 +57,7 @@ def _(mo):
 
 
 @app.cell
-async def _(api_key, get_renderer, mo, tinker):
-    import os
-
+async def _(api_key, get_renderer, mo, os, tinker):
     mo.stop(
         "TINKER_API_KEY" not in os.environ and not api_key.value,
         "Paste your API key above",
@@ -236,6 +236,7 @@ def _(mo):
 
 @app.cell
 async def _(
+    asyncio,
     get_text_content,
     params,
     prompts,
@@ -243,8 +244,6 @@ async def _(
     sampling_client,
     time,
 ):
-    import asyncio
-
     _GROUP_SIZE = 4
     _start = time.time()
 
@@ -271,7 +270,7 @@ async def _(
     batch_time = time.time() - _start
     print(f"Total: {total_completions} completions in {batch_time:.1f}s")
     print(f"Throughput: {total_completions / batch_time:.1f} completions/second")
-    return (asyncio,)
+    return
 
 
 @app.cell(hide_code=True)

--- a/tutorials/103_async_patterns.py
+++ b/tutorials/103_async_patterns.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.0"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -18,7 +18,7 @@ def _(mo):
 
     Tinker runs on remote GPUs. Every API call involves network latency plus GPU compute time. If you send sampling requests one at a time -- send, wait, send, wait -- you spend most of your time idle while Tinker works.
 
-    The solution: send requests **concurrently** as futures. Tinker can batch and pipeline concurrent requests on the GPU, so N requests take far less than N times the cost of one request. This matters most for sampling, where RL training may require hundreds of completions per step.
+    The solution: send requests **concurrently** with `asyncio.gather`. Tinker can batch and pipeline concurrent requests on the GPU, so N requests take far less than N times the cost of one request. This matters most for sampling, where RL training may require hundreds of completions per step.
     """)
     return
 
@@ -98,7 +98,7 @@ def _(mo):
     mo.md(r"""
     ## Sequential sampling (the slow way)
 
-    The simplest approach: for each prompt, build the generation input, call `sample()`, immediately call `.result()` to block until it finishes, then move on to the next. Each request waits for the previous one to complete before starting.
+    The simplest approach: for each prompt, build the generation input, `await sample_async()` to block until it finishes, then move on to the next. Each request waits for the previous one to complete before starting.
     """)
     return
 
@@ -137,9 +137,9 @@ async def _(
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## Concurrent sampling with futures
+    ## Concurrent sampling with `asyncio.gather`
 
-    `sample()` returns a future immediately -- the request is already in flight before you call `.result()`. The key insight: submit **all** requests first, then collect results. Tinker batches concurrent requests on the GPU for higher throughput.
+    `asyncio.gather` schedules every `sample_async()` coroutine onto the event loop at once, so all the requests go out before any of them finishes -- then it waits for the whole batch. The key insight: submit **all** requests first, then collect results. Tinker batches concurrent requests on the GPU for higher throughput.
     """)
     return
 
@@ -201,6 +201,7 @@ async def _(get_text_content, params, renderer, sampling_client, time):
     _result = await sampling_client.sample_async(
         prompt=_model_input, num_samples=_GROUP_SIZE, sampling_params=params
     )
+
     # Single call with num_samples=4 -- generates 4 independent completions
     multi_time = time.time() - _start
     print(f"Prompt: {test_prompt}\n")
@@ -208,12 +209,14 @@ async def _(get_text_content, params, renderer, sampling_client, time):
         _response_msg, _ = renderer.parse_response(_seq.tokens)
         text = get_text_content(_response_msg)
         print(f"Completion {i + 1}: {text[:150]}\n")
+
     _start = time.time()
     for _ in range(_GROUP_SIZE):
         await sampling_client.sample_async(
             prompt=_model_input, num_samples=1, sampling_params=params
         )
     sequential_multi_time = time.time() - _start
+
     print(f"num_samples={_GROUP_SIZE} in one call: {multi_time:.1f}s")
     print(f"{_GROUP_SIZE} sequential calls:        {sequential_multi_time:.1f}s")
     # Compare: 4 sequential single calls
@@ -226,7 +229,7 @@ def _(mo):
     mo.md(r"""
     ## Putting it together: batch evaluation
 
-    Combine both techniques -- concurrent futures across prompts and `num_samples` per prompt -- for maximum throughput. This is exactly the pattern used in RL training: submit many sampling requests in parallel, each generating a group of completions, then collect and grade them all.
+    Combine both techniques -- concurrent requests across prompts and `num_samples` per prompt -- for maximum throughput. This is exactly the pattern used in RL training: submit many sampling requests in parallel, each generating a group of completions, then collect and grade them all.
     """)
     return
 
@@ -276,7 +279,7 @@ def _(mo):
     mo.md(r"""
     ## Next steps
 
-    This tutorial showed the two key techniques for efficient sampling: **concurrent futures** (submit all requests before collecting results) and **num_samples** (generate multiple completions per call). Together, they give you high throughput with minimal code changes.
+    This tutorial showed the two key techniques for efficient sampling: **concurrent requests** with `asyncio.gather` (submit all requests before collecting results) and **num_samples** (generate multiple completions per call). Together, they give you high throughput with minimal code changes.
 
     - **Tutorial 04** (`104_first_rl.py`): Uses this exact pattern -- sample many completions, grade them with a reward function, and train with GRPO.
     - **Async docs** (`docs/async.mdx`): Full reference for sync/async APIs, the double-await pattern, and overlapping training requests.

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 04: Reinforcement Learning with Verifiable Rewards
+    # Tutorial 104: Reinforcement Learning with Verifiable Rewards
 
     Supervised fine-tuning teaches a model from example outputs. Reinforcement learning (RL) teaches from *rewards* -- the model generates its own outputs, and a reward function scores them. The model learns to produce outputs that score higher.
 
@@ -367,7 +367,7 @@ def _(mo):
     mo.md(r"""
     ## Next steps
 
-    - **Tutorial 05** (`301_cookbook_abstractions.py`): Adapt this pattern to your own task with a custom reward function
+    - **Tutorial 301** (`301_cookbook_abstractions.py`): Adapt this pattern to your own task with a custom reward function
     - **Production recipes**: See `tinker_cookbook/recipes/rl_loop.py` for a minimal script and `tinker_cookbook/recipes/math_rl/` for a full-featured GSM8K/MATH training setup
     - **Scaling up**: The [RL Hyperparameters](https://tinker-docs.thinkingmachines.ai/rl/rl-hyperparams) guide covers batch size, group size, learning rates, and async training for larger runs
     - **Custom environments**: The [RL Environments](https://tinker-docs.thinkingmachines.ai/rl/rl-envs) guide shows how to define multi-step environments using the `Env` / `EnvGroupBuilder` / `RLDataset` abstractions

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -66,7 +66,7 @@ def _(mo):
     mo.md(r"""
     ## Setup
 
-    Create a LoRA training client and a renderer. We use Llama-3.1-8B (a base/pretrained model) since RL works well from a base model that has broad knowledge but hasn't been instruction-tuned.
+    Create a LoRA training client and a renderer. We use Qwen3.5-9B-Base (a base/pretrained model) since RL works well from a base model that has broad knowledge but hasn't been instruction-tuned.
     """)
     return
 
@@ -90,14 +90,14 @@ async def _(api_key, get_renderer, mo, tinker):
     if api_key.value:
         os.environ["TINKER_API_KEY"] = api_key.value
 
-    base_model = "meta-llama/Llama-3.1-8B"
+    base_model = "Qwen/Qwen3.5-9B-Base"
 
     service_client = tinker.ServiceClient()
     training_client = await service_client.create_lora_training_client_async(
         base_model=base_model, rank=32
     )
     tokenizer = training_client.get_tokenizer()
-    renderer = get_renderer("llama3", tokenizer)
+    renderer = get_renderer("role_colon", tokenizer)
 
     sampling_params = tinker.SamplingParams(
         max_tokens=256,

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -12,9 +12,11 @@ These tutorials are [marimo](https://marimo.io/) notebooks — reactive Python n
 ## Setup
 
 ```bash
-uv pip install tinker tinker-cookbook marimo
+uv pip install tinker "tinker-cookbook[tutorials]"
 export TINKER_API_KEY="your-api-key-here"
 ```
+
+The `[tutorials]` extra installs `marimo` (to open the notebooks) and `matplotlib` (for the loss-curve plots in some tutorials).
 
 ## Running a tutorial
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -6,7 +6,7 @@ These tutorials are [marimo](https://marimo.io/) notebooks — reactive Python n
 
 ## Prerequisites
 
-- Python 3.10+
+- Python 3.11+
 - A Tinker API key ([get one here](https://tinker-console.thinkingmachines.ai))
 
 ## Setup
@@ -38,7 +38,7 @@ Alternatively, you can try notebooks online in [molab](https://molab.marimo.io/n
 |---|----------|-------------------|--------------|
 | 101 | [Hello Tinker](101_hello_tinker.py) | Architecture overview, client hierarchy, sampling from a model | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/101_hello_tinker.py) |
 | 102 | [Your First SFT](102_first_sft.py) | Renderers, datum construction, training loop | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/102_first_sft.py) |
-| 103 | [Async Patterns](103_async_patterns.py) | Concurrent futures, `num_samples`, batch evaluation throughput | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/103_async_patterns.py) |
+| 103 | [Async Patterns](103_async_patterns.py) | Concurrent sampling with `asyncio.gather`, `num_samples`, batch evaluation throughput | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/103_async_patterns.py) |
 | 104 | [First RL](104_first_rl.py) | GRPO on GSM8K: reward functions, group-relative advantages | [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/thinking-machines-lab/tinker-cookbook/blob/main/tutorials/104_first_rl.py) |
 
 ### Core Concepts (2xx)


### PR DESCRIPTION
Note: branched from https://github.com/thinking-machines-lab/tinker-cookbook/pull/732 to split up into smaller PRs.

Refreshes the Basics tutorials (101–104) off models slated for retirement on 2026-06-12, plus a few fixes found while running each notebook. First in a stack of five PRs splitting the tutorial refresh by section (Basics → Core Concepts → Cookbook Abstractions → Advanced → Deployment); this one is based on `main`.

## Tutorials
- **101 Hello Tinker** — switch to `Qwen/Qwen3.5-9B-Base`. A base model is the right fit for the raw `tokenizer.encode → sample` demo (a chat-tuned model drops into thinking mode on raw prompts). Tidy the sampling params.
- **102 First SFT** — `Qwen3-4B-Instruct-2507 → Qwen3.5-4B`; `Kimi-K2.5 → Kimi-K2.6` (with the `kimi_k26_disable_thinking` renderer); drop the deprecated `name=` arg from `save_weights_and_get_sampling_client`.
- **103 Async Patterns** — align the narration with the `asyncio.gather` API the code actually uses (it previously described the synchronous `sample()`/`.result()` futures API).
- **104 First RL** — `meta-llama/Llama-3.1-8B → Qwen/Qwen3.5-9B-Base` with the `role_colon` renderer (the recommended renderer for this base model).

## Tooling
- Add a `[tutorials]` optional-dependencies extra (`marimo`, `matplotlib`) so a plain `pip install tinker-cookbook` stays lean; update `tutorials/README.md` to install via `tinker-cookbook[tutorials]`.

## Testing
Ran the notebooks end-to-end in marimo against the live Tinker service.

_Note: diffs include some marimo serialization churn (the `__generated_with` version bump and trimmed cell-return tuples) from running the notebooks._

🤖 Generated with [Claude Code](https://claude.com/claude-code)