### PR TITLE
Update Core Concepts tutorials (2xx) for model deprecations and SDK API drift

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ modal = [
 multiplayer-rl = [
     "textarena>=0.7.4",
 ]
+tutorials = [
+    "marimo>=0.23.8",
+    "matplotlib>=3.7.0",
+]
 vector-search = [
     "chromadb>=1.0.0",
     "google-genai>=1.0.0",

--- a/tutorials/101_hello_tinker.py
+++ b/tutorials/101_hello_tinker.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -94,7 +94,7 @@ def _(mo):
     mo.md(r"""
     ## Sampling from a model
 
-    Let's create a **SamplingClient** to generate text. We will use `Qwen/Qwen3-4B-Instruct-2507`, a compact model that keeps costs low.
+    Let's create a **SamplingClient** to generate text. We will use `Qwen/Qwen3.5-9B-Base`, a base (non-chat-tuned) model, so we can feed it raw tokens and get a plain text completion -- no chat template required.
 
     The sampling workflow is:
     1. Create a `SamplingClient` with a base model name
@@ -107,7 +107,7 @@ def _(mo):
 
 @app.cell
 async def _(service_client):
-    MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+    MODEL_NAME = "Qwen/Qwen3.5-9B-Base"
 
     # Create a sampling client -- this connects to a remote GPU worker
     sampling_client = await service_client.create_sampling_client_async(base_model=MODEL_NAME)
@@ -125,7 +125,7 @@ async def _(sampling_client, tokenizer, types):
     prompt = types.ModelInput.from_ints(tokenizer.encode(prompt_text))
 
     # Sample a completion
-    params = types.SamplingParams(max_tokens=50, temperature=0.7, stop=["\n"])
+    params = types.SamplingParams(max_tokens=50, temperature=0.5)
     result = await sampling_client.sample_async(
         prompt=prompt, sampling_params=params, num_samples=1
     )
@@ -134,7 +134,7 @@ async def _(sampling_client, tokenizer, types):
     completion_tokens = result.sequences[0].tokens
     print("Completion tokens:", completion_tokens)
     print(prompt_text + tokenizer.decode(completion_tokens))
-    return prompt, result
+    return prompt, prompt_text, result
 
 
 @app.cell(hide_code=True)
@@ -169,15 +169,15 @@ def _(mo):
 
 
 @app.cell
-async def _(prompt, sampling_client, tokenizer, types):
+async def _(prompt, prompt_text, sampling_client, tokenizer, types):
     result_1 = await sampling_client.sample_async(
         prompt=prompt,
-        sampling_params=types.SamplingParams(max_tokens=50, temperature=0.9, stop=["\n"]),
+        sampling_params=types.SamplingParams(max_tokens=50, temperature=0.7),
         num_samples=3,
     )
     for i, _seq in enumerate(result_1.sequences):
         text = tokenizer.decode(_seq.tokens)
-        print(f"Sample {i}: {text}")
+        print(f"Sample {i}: {prompt_text}{text}")
     return
 
 

--- a/tutorials/101_hello_tinker.py
+++ b/tutorials/101_hello_tinker.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 01: Hello Tinker
+    # Tutorial 101: Hello Tinker
 
     Tinker is a remote GPU service for LLM training and inference. You write training loops in Python on your local machine; Tinker executes the heavy GPU operations (forward passes, backpropagation, sampling) on remote workers.
 
@@ -206,7 +206,7 @@ def _(mo):
     mo.md(r"""
     ## Next steps
 
-    - **[Tutorial 02: First SFT](./102_first_sft.py)** -- Train a model with supervised fine-tuning
+    - **[Tutorial 102: First SFT](./102_first_sft.py)** -- Train a model with supervised fine-tuning
     - **[Getting Started Guide](https://docs.thinkingmachines.ai/training-sampling)** -- Full walkthrough of training and sampling
     - **[Available Models](https://docs.thinkingmachines.ai/model-lineup)** -- All supported models and their characteristics
     """)

--- a/tutorials/102_first_sft.py
+++ b/tutorials/102_first_sft.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 02: Your First Supervised Fine-Tuning Run
+    # Tutorial 102: Your First Supervised Fine-Tuning Run
 
     In this tutorial, you will fine-tune a language model using supervised learning (SFT). By the end, you will have:
 

--- a/tutorials/102_first_sft.py
+++ b/tutorials/102_first_sft.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -212,8 +212,8 @@ def _(TrainOnWhat, conversation_to_datum, get_renderer, tokenizer):
             {
                 "role": "assistant",
                 "content": (
-                    "Tinker supports a range of open models including Qwen3, Qwen3.5, Llama 3.1, "
-                    "Llama 3.3, DeepSeek V3, and more. Most training uses LoRA (Low-Rank Adaptation) "
+                    "Tinker supports a range of open models including Qwen3.5, Qwen3.6, "
+                    "Kimi K2.6, NVIDIA Nemotron 3, and DeepSeek V3.1. Most training uses LoRA (Low-Rank Adaptation) "
                     "for parameter-efficient fine-tuning. You create a LoRA training client by calling "
                     "service_client.create_lora_training_client(base_model=model_name, rank=32). "
                     "Check service_client.get_server_capabilities() for the full list of available models."
@@ -243,7 +243,7 @@ def _(TrainOnWhat, conversation_to_datum, get_renderer, tokenizer):
     ]
 
     print(f"Built {len(training_data)} training examples")
-    return SYSTEM_PROMPT, renderer, training_data
+    return SYSTEM_PROMPT, conversations, renderer, training_data
 
 
 @app.cell(hide_code=True)
@@ -316,11 +316,15 @@ def _(mo):
 
 
 @app.cell
-async def _(SYSTEM_PROMPT, get_text_content, renderer, tinker, training_client):
+async def _(
+    SYSTEM_PROMPT,
+    get_text_content,
+    renderer,
+    tinker,
+    training_client,
+):
     # Save weights and create a sampling client in one step
-    sampling_client = await training_client.save_weights_and_get_sampling_client_async(
-        name="tinker-tinker-sft"
-    )
+    sampling_client = await training_client.save_weights_and_get_sampling_client_async()
     stop_sequences = renderer.get_stop_sequences()
     params = tinker.SamplingParams(max_tokens=200, temperature=0.7, stop=stop_sequences)
     _test_questions = [
@@ -349,28 +353,34 @@ async def _(SYSTEM_PROMPT, get_text_content, renderer, tinker, training_client):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## Scaling up: fine-tuning Kimi K2.5 with the same code
+    ## Scaling up: fine-tuning Kimi K2.6 with the same code
 
-    Everything we just did on Qwen3.5-4B (4 billion parameters) works identically on much larger models. Let's fine-tune **Kimi K2.5** -- a frontier-class model -- using the exact same training data and loop. With Tinker, you don't need to own the GPUs; you just change the model name.
+    Everything we just did on Qwen3.5-4B (4 billion parameters) works identically on much larger models. Let's fine-tune **Kimi K2.6** -- a frontier-class model -- using the exact same training data and loop. With Tinker, you don't need to own the GPUs; you just change the model name.
     """)
     return
 
 
 @app.cell
-async def _(conversations, conversation_to_datum, get_renderer, service_client, TrainOnWhat):
+async def _(
+    TrainOnWhat,
+    conversation_to_datum,
+    conversations,
+    get_renderer,
+    service_client,
+):
     import contextlib
     import io
 
-    BIG_MODEL = "moonshotai/Kimi-K2.5"
+    BIG_MODEL = "moonshotai/Kimi-K2.6"
 
-    # Create a LoRA training client for Kimi K2.5 -- same API, bigger model
+    # Create a LoRA training client for Kimi K2.6 -- same API, bigger model
     big_training_client = await service_client.create_lora_training_client_async(
         base_model=BIG_MODEL, rank=16
     )
     big_tokenizer = big_training_client.get_tokenizer()
 
-    # Use the disable-thinking renderer so Kimi K2.5 responds directly without <think> blocks
-    big_renderer = get_renderer("kimi_k25_disable_thinking", big_tokenizer)
+    # Use the disable-thinking renderer so Kimi K2.6 responds directly without <think> blocks
+    big_renderer = get_renderer("kimi_k26_disable_thinking", big_tokenizer)
 
     # Build the same training data with the new renderer (suppress noisy tokenizer debug output)
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
@@ -380,11 +390,26 @@ async def _(conversations, conversation_to_datum, get_renderer, service_client, 
             )
             for conv in conversations
         ]
-    return BIG_MODEL, big_training_client, big_training_data, big_renderer
+    return BIG_MODEL, big_renderer, big_training_client, big_training_data
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    Note that individual steps will now take longer since this model is significantly larger.
+    """)
+    return
 
 
 @app.cell
-async def _(BIG_MODEL, big_training_client, big_training_data, np, time, tinker):
+async def _(
+    BIG_MODEL,
+    big_training_client,
+    big_training_data,
+    np,
+    time,
+    tinker,
+):
     print(f"Model: {BIG_MODEL}")
     print(f"Training data: {len(big_training_data)} examples (same Tinker Tinker conversations)\n")
     big_losses = []
@@ -421,7 +446,7 @@ def _(big_losses, losses, plt):
         marker="s",
         linewidth=2,
         color="#dc2626",
-        label="Kimi K2.5",
+        label="Kimi K2.6",
     )
     _ax.set_xlabel("Training step")
     _ax.set_ylabel("Loss (cross-entropy)")
@@ -441,10 +466,8 @@ async def _(
     get_text_content,
     tinker,
 ):
-    # Sample from the fine-tuned Kimi K2.5
-    big_sampling_client = await big_training_client.save_weights_and_get_sampling_client_async(
-        name="tinker-tinker-kimi"
-    )
+    # Sample from the fine-tuned Kimi K2.6
+    big_sampling_client = await big_training_client.save_weights_and_get_sampling_client_async()
     big_stop = big_renderer.get_stop_sequences()
     big_params = tinker.SamplingParams(max_tokens=200, temperature=0.7, stop=big_stop)
     _test_questions = ["Who are you?", "What is Tinker?"]

--- a/tutorials/103_async_patterns.py
+++ b/tutorials/103_async_patterns.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 03: Efficient Sampling with Tinker
+    # Tutorial 103: Efficient Sampling with Tinker
 
     Tinker runs on remote GPUs. Every API call involves network latency plus GPU compute time. If you send sampling requests one at a time -- send, wait, send, wait -- you spend most of your time idle while Tinker works.
 
@@ -281,7 +281,7 @@ def _(mo):
 
     This tutorial showed the two key techniques for efficient sampling: **concurrent requests** with `asyncio.gather` (submit all requests before collecting results) and **num_samples** (generate multiple completions per call). Together, they give you high throughput with minimal code changes.
 
-    - **Tutorial 04** (`104_first_rl.py`): Uses this exact pattern -- sample many completions, grade them with a reward function, and train with GRPO.
+    - **Tutorial 104** (`104_first_rl.py`): Uses this exact pattern -- sample many completions, grade them with a reward function, and train with GRPO.
     - **Async docs** (`docs/async.mdx`): Full reference for sync/async APIs, the double-await pattern, and overlapping training requests.
     """)
     return

--- a/tutorials/103_async_patterns.py
+++ b/tutorials/103_async_patterns.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.0"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -18,7 +18,7 @@ def _(mo):
 
     Tinker runs on remote GPUs. Every API call involves network latency plus GPU compute time. If you send sampling requests one at a time -- send, wait, send, wait -- you spend most of your time idle while Tinker works.
 
-    The solution: send requests **concurrently** as futures. Tinker can batch and pipeline concurrent requests on the GPU, so N requests take far less than N times the cost of one request. This matters most for sampling, where RL training may require hundreds of completions per step.
+    The solution: send requests **concurrently** with `asyncio.gather`. Tinker can batch and pipeline concurrent requests on the GPU, so N requests take far less than N times the cost of one request. This matters most for sampling, where RL training may require hundreds of completions per step.
     """)
     return
 
@@ -98,7 +98,7 @@ def _(mo):
     mo.md(r"""
     ## Sequential sampling (the slow way)
 
-    The simplest approach: for each prompt, build the generation input, call `sample()`, immediately call `.result()` to block until it finishes, then move on to the next. Each request waits for the previous one to complete before starting.
+    The simplest approach: for each prompt, build the generation input, `await sample_async()` to block until it finishes, then move on to the next. Each request waits for the previous one to complete before starting.
     """)
     return
 
@@ -137,9 +137,9 @@ async def _(
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ## Concurrent sampling with futures
+    ## Concurrent sampling with `asyncio.gather`
 
-    `sample()` returns a future immediately -- the request is already in flight before you call `.result()`. The key insight: submit **all** requests first, then collect results. Tinker batches concurrent requests on the GPU for higher throughput.
+    `asyncio.gather` schedules every `sample_async()` coroutine onto the event loop at once, so all the requests go out before any of them finishes -- then it waits for the whole batch. The key insight: submit **all** requests first, then collect results. Tinker batches concurrent requests on the GPU for higher throughput.
     """)
     return
 
@@ -201,6 +201,7 @@ async def _(get_text_content, params, renderer, sampling_client, time):
     _result = await sampling_client.sample_async(
         prompt=_model_input, num_samples=_GROUP_SIZE, sampling_params=params
     )
+
     # Single call with num_samples=4 -- generates 4 independent completions
     multi_time = time.time() - _start
     print(f"Prompt: {test_prompt}\n")
@@ -208,12 +209,14 @@ async def _(get_text_content, params, renderer, sampling_client, time):
         _response_msg, _ = renderer.parse_response(_seq.tokens)
         text = get_text_content(_response_msg)
         print(f"Completion {i + 1}: {text[:150]}\n")
+
     _start = time.time()
     for _ in range(_GROUP_SIZE):
         await sampling_client.sample_async(
             prompt=_model_input, num_samples=1, sampling_params=params
         )
     sequential_multi_time = time.time() - _start
+
     print(f"num_samples={_GROUP_SIZE} in one call: {multi_time:.1f}s")
     print(f"{_GROUP_SIZE} sequential calls:        {sequential_multi_time:.1f}s")
     # Compare: 4 sequential single calls
@@ -226,7 +229,7 @@ def _(mo):
     mo.md(r"""
     ## Putting it together: batch evaluation
 
-    Combine both techniques -- concurrent futures across prompts and `num_samples` per prompt -- for maximum throughput. This is exactly the pattern used in RL training: submit many sampling requests in parallel, each generating a group of completions, then collect and grade them all.
+    Combine both techniques -- concurrent requests across prompts and `num_samples` per prompt -- for maximum throughput. This is exactly the pattern used in RL training: submit many sampling requests in parallel, each generating a group of completions, then collect and grade them all.
     """)
     return
 
@@ -276,7 +279,7 @@ def _(mo):
     mo.md(r"""
     ## Next steps
 
-    This tutorial showed the two key techniques for efficient sampling: **concurrent futures** (submit all requests before collecting results) and **num_samples** (generate multiple completions per call). Together, they give you high throughput with minimal code changes.
+    This tutorial showed the two key techniques for efficient sampling: **concurrent requests** with `asyncio.gather` (submit all requests before collecting results) and **num_samples** (generate multiple completions per call). Together, they give you high throughput with minimal code changes.
 
     - **Tutorial 04** (`104_first_rl.py`): Uses this exact pattern -- sample many completions, grade them with a reward function, and train with GRPO.
     - **Async docs** (`docs/async.mdx`): Full reference for sync/async APIs, the double-await pattern, and overlapping training requests.

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial 04: Reinforcement Learning with Verifiable Rewards
+    # Tutorial 104: Reinforcement Learning with Verifiable Rewards
 
     Supervised fine-tuning teaches a model from example outputs. Reinforcement learning (RL) teaches from *rewards* -- the model generates its own outputs, and a reward function scores them. The model learns to produce outputs that score higher.
 
@@ -367,7 +367,7 @@ def _(mo):
     mo.md(r"""
     ## Next steps
 
-    - **Tutorial 05** (`301_cookbook_abstractions.py`): Adapt this pattern to your own task with a custom reward function
+    - **Tutorial 301** (`301_cookbook_abstractions.py`): Adapt this pattern to your own task with a custom reward function
     - **Production recipes**: See `tinker_cookbook/recipes/rl_loop.py` for a minimal script and `tinker_cookbook/recipes/math_rl/` for a full-featured GSM8K/MATH training setup
     - **Scaling up**: The [RL Hyperparameters](https://tinker-docs.thinkingmachines.ai/rl/rl-hyperparams) guide covers batch size, group size, learning rates, and async training for larger runs
     - **Custom environments**: The [RL Environments](https://tinker-docs.thinkingmachines.ai/rl/rl-envs) guide shows how to define multi-step environments using the `Env` / `EnvGroupBuilder` / `RLDataset` abstractions

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -66,7 +66,7 @@ def _(mo):
     mo.md(r"""
     ## Setup
 
-    Create a LoRA training client and a renderer. We use Llama-3.1-8B (a base/pretrained model) since RL works well from a base model that has broad knowledge but hasn't been instruction-tuned.
+    Create a LoRA training client and a renderer. We use Qwen3.5-9B-Base (a base/pretrained model) since RL works well from a base model that has broad knowledge but hasn't been instruction-tuned.
     """)
     return
 
@@ -90,14 +90,14 @@ async def _(api_key, get_renderer, mo, tinker):
     if api_key.value:
         os.environ["TINKER_API_KEY"] = api_key.value
 
-    base_model = "meta-llama/Llama-3.1-8B"
+    base_model = "Qwen/Qwen3.5-9B-Base"
 
     service_client = tinker.ServiceClient()
     training_client = await service_client.create_lora_training_client_async(
         base_model=base_model, rank=32
     )
     tokenizer = training_client.get_tokenizer()
-    renderer = get_renderer("llama3", tokenizer)
+    renderer = get_renderer("role_colon", tokenizer)
 
     sampling_params = tinker.SamplingParams(
         max_tokens=256,

--- a/tutorials/201_rendering.py
+++ b/tutorials/201_rendering.py
@@ -102,7 +102,7 @@ def _(mo):
     mo.md(r"""
     The output is a `ModelInput` object containing the tokenized chat template. Notice how each message is wrapped in special tokens like `<|im_start|>` and `<|im_end|>`, and the final `<|im_start|>assistant` is left open for the model to fill in.
 
-    Because `qwen3_5` is a thinking renderer, the prompt also ends with an open `<think>` tag that primes the model to reason before answering. If you'd prefer non-thinking mode instead, the `qwen3_5_disable_thinking` variant instead inserts `<think></think>` instead so the model replies directly.
+    Because `qwen3_5` is a thinking renderer, the prompt also ends with an open `<think>` tag that primes the model to reason before answering. If you'd prefer non-thinking mode instead, the `qwen3_5_disable_thinking` variant inserts a closed `<think></think>` so the model replies directly.
     """)
     return
 
@@ -300,7 +300,7 @@ def _(mo):
     mo.md(r"""
     ## Vision inputs with `ImagePart`
 
-    For vision-language models (Qwen3.5 and Qwen3.6 are all vision-capable), message content can include images alongside text. Use `ImagePart` for images and `TextPart` for text within the same message.
+    For vision-language models (Qwen3.5 and Qwen3.6 models are all vision-capable), message content can include images alongside text. Use `ImagePart` for images and `TextPart` for text within the same message.
     """)
     return
 

--- a/tutorials/201_rendering.py
+++ b/tutorials/201_rendering.py
@@ -14,7 +14,7 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # Tutorial: Rendering
+    # Tutorial 201: Rendering
 
     Rendering converts a list of messages into a token sequence that a model can consume. While similar to HuggingFace chat templates, Tinker's rendering system handles the full training lifecycle: supervised learning, reinforcement learning, and deployment.
 

--- a/tutorials/201_rendering.py
+++ b/tutorials/201_rendering.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -34,7 +34,7 @@ def _(mo):
     mo.md(r"""
     ## Setup
 
-    We need a tokenizer (to map between text and token IDs) and a renderer (to apply the model's chat format).
+    We need a tokenizer (to map between text and token IDs) and a renderer (to apply the model's chat format). Note for this example that both Qwen3.5 and Qwen3.6 models use the same `qwen3_5` renderer.
     """)
     return
 
@@ -43,8 +43,8 @@ def _(mo):
 def _():
     from tinker_cookbook import renderers, tokenizer_utils
 
-    tokenizer = tokenizer_utils.get_tokenizer("Qwen/Qwen3-30B-A3B")
-    renderer = renderers.get_renderer("qwen3", tokenizer)
+    tokenizer = tokenizer_utils.get_tokenizer("Qwen/Qwen3.6-35B-A3B")
+    renderer = renderers.get_renderer("qwen3_5", tokenizer)
     renderer  # noqa: B018
     return renderer, renderers, tokenizer, tokenizer_utils
 
@@ -94,13 +94,15 @@ def _(messages, renderer, tokenizer):
     print()
     print("Decoded tokens:")
     print(tokenizer.decode(prompt.to_ints()))
-    return (prompt,)
+    return
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
     The output is a `ModelInput` object containing the tokenized chat template. Notice how each message is wrapped in special tokens like `<|im_start|>` and `<|im_end|>`, and the final `<|im_start|>assistant` is left open for the model to fill in.
+
+    Because `qwen3_5` is a thinking renderer, the prompt also ends with an open `<think>` tag that primes the model to reason before answering. If you'd prefer non-thinking mode instead, the `qwen3_5_disable_thinking` variant instead inserts `<think></think>` instead so the model replies directly.
     """)
     return
 
@@ -120,11 +122,11 @@ def _(renderer, tokenizer):
     stop_sequences = renderer.get_stop_sequences()
     print(f"Stop sequences: {stop_sequences}")
 
-    # For Qwen3, this is the <|im_end|> token
+    # For Qwen3.5/3.6, this is the <|im_end|> token
     for tok in stop_sequences:
         if isinstance(tok, int):
             print(f"  Token {tok} decodes to: {tokenizer.decode([tok])!r}")
-    return (stop_sequences,)
+    return
 
 
 @app.cell(hide_code=True)
@@ -144,14 +146,19 @@ def _(mo):
 
 
 @app.cell
-def _(renderer):
-    # Simulate some sampled tokens (in practice these come from the model)
-    fake_tokens = [45, 7741, 34651, 31410, 614, 4911, 76665, 13, 151645]
-
+def _(renderer, tokenizer):
+    # Simulate what the model emits during sampling: the assistant's reply text
+    # followed by the <|im_end|> stop token. (In practice these come from the
+    # sampler -- here we build them by hand so the example is reproducible.)
+    fake_tokens = tokenizer.encode(
+        "They have efficient DNA repair and cancer-resistant cells.<|im_end|>"
+    )
     parsed_message, termination = renderer.parse_response(fake_tokens)
+
+    print(f"Fake tokens: {fake_tokens}")
     print(f"Parsed message: {parsed_message}")
     print(f"Termination: {termination} (is_clean={termination.is_clean})")
-    return fake_tokens, parsed_message, termination
+    return
 
 
 @app.cell(hide_code=True)
@@ -166,7 +173,7 @@ def _(mo):
     from tinker.types import SamplingParams
 
     service_client = tinker.ServiceClient()
-    sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3-30B-A3B")
+    sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3.6-35B-A3B")
 
     prompt = renderer.build_generation_prompt(messages[:-1])
     stop_sequences = renderer.get_stop_sequences()
@@ -202,7 +209,7 @@ def _(messages, renderer, tokenizer):
     for i, (tok_id, w) in enumerate(zip(token_ids, weights.tolist())):
         label = "COMPLETION" if w > 0 else "prompt"
         print(f"  [{i:3d}] {label:10s}  {tokenizer.decode([tok_id])!r}")
-    return model_input, token_ids, weights
+    return
 
 
 @app.cell(hide_code=True)
@@ -244,7 +251,7 @@ def _(messages, renderer, renderers):
     # Compare with default (last assistant message only)
     _, weights_last = renderer.build_supervised_example(messages)
     print(f"Tokens with weight > 0 (default): {(weights_last > 0).sum().item()}")
-    return weights_all, weights_last
+    return
 
 
 @app.cell(hide_code=True)
@@ -256,13 +263,13 @@ def _(mo):
 
     | Name | Model family | Notes |
     |---|---|---|
-    | `qwen3` | Qwen3 | Thinking enabled (default) |
-    | `qwen3_disable_thinking` | Qwen3 | Thinking disabled |
-    | `llama3` | Llama 3 | Omits the HF preamble |
+    | `qwen3_5` | Qwen3.5 / Qwen3.6 (incl. VL) | Thinking enabled (default) |
+    | `qwen3_5_disable_thinking` | Qwen3.5 / Qwen3.6 (incl. VL) | Thinking disabled |
     | `deepseekv3` | DeepSeek V3 | Non-thinking mode (default) |
     | `deepseekv3_thinking` | DeepSeek V3 | Thinking mode |
     | `nemotron3` | NVIDIA Nemotron 3 | Thinking enabled |
-    | `kimi_k2` | Kimi K2 | Thinking format |
+    | `kimi_k26` | Kimi K2.6 | Thinking enabled (default) |
+    | `kimi_k26_disable_thinking` | Kimi K2.6 | Thinking disabled |
 
     Each renderer produces the correct special tokens for its model family. The default renderers match HuggingFace's `apply_chat_template` output, so models trained with Tinker work with the OpenAI-compatible endpoint.
     """)
@@ -272,15 +279,20 @@ def _(mo):
 @app.cell
 def _(renderers, tokenizer_utils):
     # Example: switching between renderers
-    # Each model family needs its own tokenizer
-    qwen_tokenizer = tokenizer_utils.get_tokenizer("Qwen/Qwen3-30B-A3B")
-    qwen_renderer = renderers.get_renderer("qwen3", qwen_tokenizer)
+    # Each model family needs its own tokenizer + matching renderer
+    _test_messages = [{"role": "user", "content": "Hello!"}]
 
-    test_messages = [{"role": "user", "content": "Hello!"}]
-    prompt_tokens = qwen_renderer.build_generation_prompt(test_messages)
-    print("Qwen3 prompt:")
-    print(qwen_tokenizer.decode(prompt_tokens.to_ints()))
-    return prompt_tokens, qwen_renderer, qwen_tokenizer, test_messages
+    for _model_name, _renderer_name in [
+        ("Qwen/Qwen3.6-35B-A3B", "qwen3_5"),
+        ("moonshotai/Kimi-K2.6", "kimi_k26"),
+    ]:
+        _tokenizer = tokenizer_utils.get_tokenizer(_model_name)
+        _renderer = renderers.get_renderer(_renderer_name, _tokenizer)
+        _prompt_tokens = _renderer.build_generation_prompt(_test_messages)
+        print(f"--- {_model_name} ({_renderer_name}) ---")
+        print(_tokenizer.decode(_prompt_tokens.to_ints()))
+        print()
+    return
 
 
 @app.cell(hide_code=True)
@@ -288,13 +300,13 @@ def _(mo):
     mo.md(r"""
     ## Vision inputs with `ImagePart`
 
-    For vision-language models (like Qwen3-VL), message content can include images alongside text. Use `ImagePart` for images and `TextPart` for text within the same message.
+    For vision-language models (Qwen3.5 and Qwen3.6 are all vision-capable), message content can include images alongside text. Use `ImagePart` for images and `TextPart` for text within the same message.
     """)
     return
 
 
 @app.cell
-def _(renderers):
+def _():
     from tinker_cookbook.renderers import ImagePart, Message, TextPart
 
     # A multimodal message with an image and text
@@ -310,25 +322,22 @@ def _(renderers):
     # Text-only messages still work as plain strings
     text_message = Message(role="user", content="Describe this in one word.")
     print("Text message:", text_message)
-    return ImagePart, Message, TextPart, multimodal_message, text_message
+    return
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    To use vision renderers, you also need an image processor:
+    The Qwen3.5 and Qwen3.6 models are natively vision-capable -- the same `qwen3_5` renderer you set up above also handles images. You just additionally load an image processor and pass it in:
 
     ```python
     from tinker_cookbook.image_processing_utils import get_image_processor
 
-    model_name = "Qwen/Qwen3-VL-235B-A22B-Instruct"
-    tokenizer = tokenizer_utils.get_tokenizer(model_name)
-    image_processor = get_image_processor(model_name)
-
-    renderer = renderers.get_renderer("qwen3_vl_instruct", tokenizer, image_processor=image_processor)
+    image_processor = get_image_processor("Qwen/Qwen3.6-35B-A3B")
+    renderer = renderers.get_renderer("qwen3_5", tokenizer, image_processor=image_processor)
     ```
 
-    The VL renderers handle vision special tokens (`<|vision_start|>`, `<|vision_end|>`) and image preprocessing automatically.
+    With an image processor attached, the renderer handles the vision special tokens (`<|vision_start|>`, `<|vision_end|>`) and image preprocessing automatically.
     """)
     return
 
@@ -345,15 +354,13 @@ def _(mo):
 
 @app.cell
 def _(renderers):
-    from tinker_cookbook.renderers.base import Renderer
-
     # Define a factory function that creates your renderer
     def my_renderer_factory(tokenizer, image_processor=None):
         # In practice, you would return a custom Renderer subclass here.
-        # For demonstration, we just return the Qwen3 renderer.
-        from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
+        # For demonstration, we just return the Qwen3.5 renderer.
+        from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
 
-        return Qwen3Renderer(tokenizer)
+        return Qwen3_5Renderer(tokenizer)
 
     # Register it under a namespaced name
     renderers.register_renderer("MyOrg/custom_format", my_renderer_factory)
@@ -363,7 +370,7 @@ def _(renderers):
 
     # Clean up
     renderers.unregister_renderer("MyOrg/custom_format")
-    return Renderer, my_renderer_factory
+    return
 
 
 @app.cell(hide_code=True)

--- a/tutorials/202_loss_functions.py
+++ b/tutorials/202_loss_functions.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -70,7 +70,7 @@ async def _(api_key, mo, tinker):
     if api_key.value:
         os.environ["TINKER_API_KEY"] = api_key.value
 
-    MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+    MODEL_NAME = "Qwen/Qwen3.5-4B"
 
     service_client = tinker.ServiceClient()
     training_client = await service_client.create_lora_training_client_async(
@@ -79,7 +79,7 @@ async def _(api_key, mo, tinker):
     tokenizer = training_client.get_tokenizer()
 
     print(f"Training client ready for {MODEL_NAME}")
-    return MODEL_NAME, service_client, tokenizer, training_client
+    return tokenizer, training_client
 
 
 @app.cell(hide_code=True)
@@ -130,7 +130,7 @@ def _(TensorData, tinker, tokenizer, torch):
     model_input_rl = tinker.ModelInput.from_ints(all_ids[:-1])
     rl_target_tokens = all_ids[1:]
     # Fake sampling logprobs (as if from a sampler)
-    rl_logprobs = [0.0] * (len(prompt_ids) - 1) + [-1.5] * len(target_ids)
+    rl_logprobs = [0.0] * (len(prompt_ids) - 1) + [-0.7] * len(target_ids)
     # Positive advantage: this completion was good
     rl_advantages = [0.0] * (len(prompt_ids) - 1) + [1.0] * len(target_ids)
 
@@ -145,7 +145,7 @@ def _(TensorData, tinker, tokenizer, torch):
 
     print(f"SFT datum: {len(all_ids) - 1} tokens, {sum(sft_weights):.0f} completion tokens")
     print(f"RL datum:  {len(all_ids) - 1} tokens, advantage=+1.0 on completion")
-    return model_input_rl, model_input_sft, rl_datum, sft_datum
+    return rl_datum, sft_datum
 
 
 @app.cell(hide_code=True)
@@ -163,7 +163,7 @@ async def _(rl_datum, sft_datum, training_client):
     # Cross-entropy (SFT)
     ce_future = await training_client.forward_backward_async([sft_datum], loss_fn="cross_entropy")
     ce_result = await ce_future.result_async()
-    print(f"cross_entropy      loss:sum = {ce_result.metrics['loss:sum']:.4f}")
+    print(f"cross_entropy       loss:sum = {ce_result.metrics['loss:sum']:.4f}")
 
     # Importance sampling (REINFORCE with IS correction)
     is_future = await training_client.forward_backward_async(
@@ -175,13 +175,13 @@ async def _(rl_datum, sft_datum, training_client):
     # PPO (clipped objective)
     ppo_future = await training_client.forward_backward_async([rl_datum], loss_fn="ppo")
     ppo_result = await ppo_future.result_async()
-    print(f"ppo                loss:sum = {ppo_result.metrics['loss:sum']:.4f}")
+    print(f"ppo                 loss:sum = {ppo_result.metrics['loss:sum']:.4f}")
 
     # CISPO (clipped ratio weighting the log-prob)
     cispo_future = await training_client.forward_backward_async([rl_datum], loss_fn="cispo")
     cispo_result = await cispo_future.result_async()
-    print(f"cispo              loss:sum = {cispo_result.metrics['loss:sum']:.4f}")
-    return ce_result, cispo_result, is_result, ppo_result
+    print(f"cispo               loss:sum = {cispo_result.metrics['loss:sum']:.4f}")
+    return ce_result, is_result
 
 
 @app.cell(hide_code=True)
@@ -197,13 +197,13 @@ def _(mo):
 @app.cell
 def _(ce_result, is_result):
     # Cross-entropy returns logprobs of target tokens
-    ce_logprobs = ce_result.loss_fn_outputs[0]["logprobs"]
+    ce_logprobs = ce_result.loss_fn_outputs[0]["logprobs"].tolist()
     print("cross_entropy logprobs (last 3 tokens):", ce_logprobs[-3:])
 
     # Importance sampling also returns logprobs
-    is_logprobs = is_result.loss_fn_outputs[0]["logprobs"]
+    is_logprobs = is_result.loss_fn_outputs[0]["logprobs"].tolist()
     print("importance_sampling logprobs (last 3):", is_logprobs[-3:])
-    return ce_logprobs, is_logprobs
+    return
 
 
 @app.cell(hide_code=True)
@@ -235,7 +235,7 @@ async def _(rl_datum, training_client):
     )
     ppo_wide = await ppo_wide_future.result_async()
     print(f"PPO (wide clip)  loss:sum = {ppo_wide.metrics['loss:sum']:.4f}")
-    return ppo_tight, ppo_wide
+    return
 
 
 @app.cell(hide_code=True)
@@ -274,7 +274,7 @@ async def _(sft_datum, torch, training_client):
     )
     custom_result = await custom_future.result_async()
     print(f"Custom loss metrics: {custom_result.metrics}")
-    return custom_result, logprob_squared_loss
+    return
 
 
 @app.cell(hide_code=True)

--- a/tutorials/203_completers.py
+++ b/tutorials/203_completers.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -38,26 +38,17 @@ def _():
 
     warnings.filterwarnings("ignore", message="IProgress not found")
 
-    import asyncio
-
     import tinker
 
     from tinker_cookbook.completers import (
-        MessageCompleter,
         TinkerMessageCompleter,
         TinkerTokenCompleter,
-        TokenCompleter,
-        TokensWithLogprobs,
     )
     from tinker_cookbook.renderers import get_renderer, get_text_content
 
     return (
-        MessageCompleter,
         TinkerMessageCompleter,
         TinkerTokenCompleter,
-        TokenCompleter,
-        TokensWithLogprobs,
-        asyncio,
         get_renderer,
         get_text_content,
         tinker,
@@ -114,15 +105,15 @@ def _(api_key, get_renderer, mo, tinker):
     if api_key.value:
         os.environ["TINKER_API_KEY"] = api_key.value
 
-    MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+    MODEL_NAME = "Qwen/Qwen3.5-4B"
 
     service_client = tinker.ServiceClient()
     sampling_client = service_client.create_sampling_client(base_model=MODEL_NAME)
     tokenizer = sampling_client.get_tokenizer()
-    renderer = get_renderer("qwen3_instruct", tokenizer)
+    renderer = get_renderer("qwen3_5_disable_thinking", tokenizer)
 
     print(f"Sampling client ready for {MODEL_NAME}")
-    return MODEL_NAME, renderer, sampling_client, tokenizer
+    return renderer, sampling_client, tokenizer
 
 
 @app.cell(hide_code=True)
@@ -159,7 +150,7 @@ def _(mo):
 
 
 @app.cell
-def _(asyncio, renderer, token_completer, tokenizer):
+async def _(renderer, token_completer, tokenizer):
     # Build a prompt from messages
     messages_for_tokens = [
         {"role": "user", "content": "What is 7 * 8?"},
@@ -168,13 +159,13 @@ def _(asyncio, renderer, token_completer, tokenizer):
     stop_sequences = renderer.get_stop_sequences()
 
     # Generate tokens
-    token_result = asyncio.run(token_completer(model_input, stop=stop_sequences))
+    token_result = await token_completer(model_input, stop=stop_sequences)
 
     print(f"Generated {len(token_result.tokens)} tokens")
     print(f"Stop reason: {token_result.stop_reason}")
     print(f"Log-probs (first 5): {token_result.logprobs[:5]}")
     print(f"Decoded: {tokenizer.decode(token_result.tokens)}")
-    return messages_for_tokens, model_input, stop_sequences, token_result
+    return
 
 
 @app.cell(hide_code=True)
@@ -214,16 +205,16 @@ def _(TinkerMessageCompleter, renderer, sampling_client):
 
 
 @app.cell
-def _(asyncio, get_text_content, message_completer):
+async def _(get_text_content, message_completer):
     # Generate a message response
     conversation = [
         {"role": "user", "content": "Explain what a hash table is in one sentence."},
     ]
 
-    response = asyncio.run(message_completer(conversation))
+    response = await message_completer(conversation)
     print(f"Role: {response['role']}")
     print(f"Content: {get_text_content(response)}")
-    return conversation, response
+    return
 
 
 @app.cell(hide_code=True)
@@ -237,16 +228,16 @@ def _(mo):
 
 
 @app.cell
-def _(asyncio, get_text_content, message_completer):
+async def _(get_text_content, message_completer):
     multi_turn = [
         {"role": "user", "content": "What is the largest planet in our solar system?"},
         {"role": "assistant", "content": "Jupiter."},
         {"role": "user", "content": "How many moons does it have?"},
     ]
 
-    followup = asyncio.run(message_completer(multi_turn))
+    followup = await message_completer(multi_turn)
     print(f"Response: {get_text_content(followup)}")
-    return followup, multi_turn
+    return
 
 
 @app.cell(hide_code=True)
@@ -265,12 +256,12 @@ def _(mo):
 
 
 @app.cell
-def _(asyncio, get_text_content, message_completer):
+async def _(get_text_content, message_completer):
     import re
 
     # Step 1: Generate a candidate answer
     question = "Why do leaves change color in autumn?"
-    candidate = asyncio.run(message_completer([{"role": "user", "content": question}]))
+    candidate = await message_completer([{"role": "user", "content": question}])
     candidate_text = get_text_content(candidate)
     print(f"Candidate answer:\n{candidate_text}\n")
 
@@ -282,7 +273,7 @@ Answer: {candidate_text}
 
 Respond with ONLY a number from 1 to 5."""
 
-    judge_response = asyncio.run(message_completer([{"role": "user", "content": judge_prompt}]))
+    judge_response = await message_completer([{"role": "user", "content": judge_prompt}])
     judge_text = get_text_content(judge_response)
 
     # Step 3: Parse the score
@@ -290,17 +281,7 @@ Respond with ONLY a number from 1 to 5."""
     score = int(match.group()) if match else None
     print(f"Judge response: {judge_text}")
     print(f"Parsed score: {score}")
-    return (
-        candidate,
-        candidate_text,
-        judge_prompt,
-        judge_response,
-        judge_text,
-        match,
-        question,
-        re,
-        score,
-    )
+    return
 
 
 @app.cell(hide_code=True)

--- a/tutorials/204_weights.py
+++ b/tutorials/204_weights.py
@@ -328,7 +328,7 @@ async def _(sampler_path):
     adapter_dir = await asyncio.to_thread(
         weights.download,
         tinker_path=sampler_path,
-        output_dir="/tmp/tinker-tutorial-adapter",
+        output_dir="/tmp/tinker-tutorials/weights-adapter",
     )
     print(f"Downloaded adapter to: {adapter_dir}")
     return

--- a/tutorials/204_weights.py
+++ b/tutorials/204_weights.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -74,7 +74,7 @@ async def _(TensorData, api_key, mo, tinker, torch):
     if api_key.value:
         os.environ["TINKER_API_KEY"] = api_key.value
 
-    MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+    MODEL_NAME = "Qwen/Qwen3.5-4B"
 
     service_client = tinker.ServiceClient()
     training_client = await service_client.create_lora_training_client_async(
@@ -102,7 +102,7 @@ async def _(TensorData, api_key, mo, tinker, torch):
     optim_future = await training_client.optim_step_async(tinker.AdamParams(learning_rate=1e-4))
     await optim_future.result_async()
     print("Training step complete")
-    return MODEL_NAME, datum, service_client, tokenizer, training_client
+    return service_client, tokenizer, training_client
 
 
 @app.cell(hide_code=True)
@@ -125,15 +125,15 @@ def _(mo):
 @app.cell
 async def _(training_client):
     # Save weights for inference (sampler checkpoint)
-    sampler_result = await training_client.save_weights_for_sampler_async("tutorial-sampler")
+    sampler_result = await training_client.save_weights_for_sampler("tutorial-sampler")
     sampler_path = sampler_result.path
     print(f"Sampler weights saved to: {sampler_path}")
 
     # Save full state for resuming training
-    state_result = await training_client.save_state_async("tutorial-state")
+    state_result = await training_client.save_state("tutorial-state")
     state_path = state_result.path
     print(f"Training state saved to:  {state_path}")
-    return sampler_path, sampler_result, state_path, state_result
+    return sampler_path, state_path
 
 
 @app.cell(hide_code=True)
@@ -141,7 +141,7 @@ def _(mo):
     mo.md(r"""
     ### TTL on checkpoints
 
-    You can set a time-to-live when saving. Checkpoints expire and are deleted after the TTL. This is useful for intermediate checkpoints during training.
+    You can set a time-to-live when saving. Checkpoints expire and are deleted after the TTL is reached. This is useful for intermediate checkpoints during training.
     """)
     return
 
@@ -149,11 +149,11 @@ def _(mo):
 @app.cell
 async def _(training_client):
     # Save with a 1-hour TTL
-    ephemeral_result = await training_client.save_weights_for_sampler_async(
+    ephemeral_result = await training_client.save_weights_for_sampler(
         "tutorial-ephemeral", ttl_seconds=3600
     )
     print(f"Ephemeral checkpoint (1h TTL): {ephemeral_result.path}")
-    return (ephemeral_result,)
+    return
 
 
 @app.cell(hide_code=True)
@@ -177,7 +177,7 @@ async def _(service_client, state_path):
     # to restore the full optimizer state (Adam momentum, etc).
     info = await resumed_client.get_info_async()
     print(f"Model ID: {info.model_id}")
-    return info, resumed_client
+    return
 
 
 @app.cell(hide_code=True)
@@ -202,11 +202,12 @@ async def _(sampler_path, service_client, tinker, tokenizer):
     result = await fine_tuned_sampler.sample_async(
         prompt=prompt,
         sampling_params=tinker.SamplingParams(max_tokens=50, temperature=0.5, stop=["\n"]),
-        num_samples=1,
+        num_samples=3,
     )
 
-    print(prompt_text + tokenizer.decode(result.sequences[0].tokens))
-    return fine_tuned_sampler, prompt, prompt_ids, prompt_text, result
+    for sequence in result.sequences:
+        print(prompt_text + tokenizer.decode(sequence.tokens))
+    return
 
 
 @app.cell(hide_code=True)
@@ -225,10 +226,10 @@ async def _(service_client, training_client):
 
     # Get the run ID from the training client's model_id
     _info = await training_client.get_info_async()
+    model_id = _info.model_id
     # model_id format: "<run_id>:train:<seq>"
-    run_id = _info.model_id.split(":")[0]
-    print(f"Training run: {run_id}")
-    return rest_client, run_id
+    print(f"Model ID: {model_id}")
+    return model_id, rest_client
 
 
 @app.cell(hide_code=True)
@@ -242,23 +243,23 @@ def _(mo):
 
 
 @app.cell
-def _(rest_client, run_id):
+async def _(model_id, rest_client):
     # List checkpoints for this training run
-    checkpoints_response = rest_client.list_checkpoints(run_id).result()
+    checkpoints_response = await rest_client.list_checkpoints_async(model_id)
     print(f"Found {len(checkpoints_response.checkpoints)} checkpoints:")
     for cp in checkpoints_response.checkpoints:
         print(f"  [{cp.checkpoint_type}] {cp.checkpoint_id}")
-    return checkpoints_response, cp
+    return
 
 
 @app.cell
-def _(rest_client):
+async def _(rest_client):
     # List all your checkpoints across training runs
-    all_checkpoints = rest_client.list_user_checkpoints(limit=5).result()
+    all_checkpoints = await rest_client.list_user_checkpoints_async(limit=5)
     print(f"Recent checkpoints across all runs ({len(all_checkpoints.checkpoints)}):")
     for _cp in all_checkpoints.checkpoints:
         print(f"  {_cp.tinker_path} ({_cp.checkpoint_type})")
-    return (all_checkpoints,)
+    return
 
 
 @app.cell(hide_code=True)
@@ -272,15 +273,15 @@ def _(mo):
 
 
 @app.cell
-def _(rest_client, sampler_path):
+async def _(rest_client, sampler_path):
     # Set a 7-day TTL on the sampler checkpoint
-    rest_client.set_checkpoint_ttl_from_tinker_path(
+    await rest_client.set_checkpoint_ttl_from_tinker_path_async(
         sampler_path, ttl_seconds=7 * 24 * 3600
-    ).result()
+    )
     print(f"Set 7-day TTL on {sampler_path}")
 
     # Remove TTL (keep indefinitely)
-    rest_client.set_checkpoint_ttl_from_tinker_path(sampler_path, ttl_seconds=None).result()
+    await rest_client.set_checkpoint_ttl_from_tinker_path_async(sampler_path, ttl_seconds=None)
     print(f"Removed TTL on {sampler_path}")
     return
 
@@ -296,13 +297,13 @@ def _(mo):
 
 
 @app.cell
-def _(rest_client, sampler_path):
+async def _(rest_client, sampler_path):
     # Publish the checkpoint
-    rest_client.publish_checkpoint_from_tinker_path(sampler_path).result()
+    await rest_client.publish_checkpoint_from_tinker_path_async(sampler_path)
     print(f"Published: {sampler_path}")
 
     # Unpublish it
-    rest_client.unpublish_checkpoint_from_tinker_path(sampler_path).result()
+    await rest_client.unpublish_checkpoint_from_tinker_path_async(sampler_path)
     print(f"Unpublished: {sampler_path}")
     return
 
@@ -318,16 +319,19 @@ def _(mo):
 
 
 @app.cell
-def _(sampler_path):
+async def _(sampler_path):
+    import asyncio
+
     from tinker_cookbook import weights
 
     # Download the sampler checkpoint to a local directory
-    adapter_dir = weights.download(
+    adapter_dir = await asyncio.to_thread(
+        weights.download,
         tinker_path=sampler_path,
         output_dir="/tmp/tinker-tutorial-adapter",
     )
     print(f"Downloaded adapter to: {adapter_dir}")
-    return adapter_dir, weights
+    return
 
 
 @app.cell(hide_code=True)

--- a/tutorials/204_weights.py
+++ b/tutorials/204_weights.py
@@ -125,13 +125,13 @@ def _(mo):
 @app.cell
 async def _(training_client):
     # Save weights for inference (sampler checkpoint)
-    sampler_result = await training_client.save_weights_for_sampler("tutorial-sampler")
-    sampler_path = sampler_result.path
+    sampler_future = training_client.save_weights_for_sampler("tutorial-sampler")
+    sampler_path = (await sampler_future.result_async()).path
     print(f"Sampler weights saved to: {sampler_path}")
 
     # Save full state for resuming training
-    state_result = await training_client.save_state("tutorial-state")
-    state_path = state_result.path
+    state_future = training_client.save_state("tutorial-state")
+    state_path = (await state_future.result_async()).path
     print(f"Training state saved to:  {state_path}")
     return sampler_path, state_path
 
@@ -149,10 +149,11 @@ def _(mo):
 @app.cell
 async def _(training_client):
     # Save with a 1-hour TTL
-    ephemeral_result = await training_client.save_weights_for_sampler(
+    ephemeral_future = training_client.save_weights_for_sampler(
         "tutorial-ephemeral", ttl_seconds=3600
     )
-    print(f"Ephemeral checkpoint (1h TTL): {ephemeral_result.path}")
+    ephemeral_path = (await ephemeral_future.result_async()).path
+    print(f"Ephemeral checkpoint (1h TTL): {ephemeral_path}")
     return
 
 

--- a/tutorials/205_evaluations.py
+++ b/tutorials/205_evaluations.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.21.1"
+__generated_with = "0.23.8"
 app = marimo.App()
 
 
@@ -111,14 +111,14 @@ async def _(TensorData, api_key, get_renderer, mo, tinker, torch):
     if api_key.value:
         os.environ["TINKER_API_KEY"] = api_key.value
 
-    MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+    MODEL_NAME = "Qwen/Qwen3.5-4B"
 
     service_client = tinker.ServiceClient()
     training_client = await service_client.create_lora_training_client_async(
         base_model=MODEL_NAME, rank=16
     )
     tokenizer = training_client.get_tokenizer()
-    renderer = get_renderer("qwen3_instruct", tokenizer)
+    renderer = get_renderer("qwen3_5_disable_thinking", tokenizer)
 
     # Prepare held-out SFT data for the NLL evaluator
     eval_examples = [
@@ -144,15 +144,7 @@ async def _(TensorData, api_key, get_renderer, mo, tinker, torch):
         )
 
     print(f"Prepared {len(eval_datums)} evaluation datums")
-    return (
-        MODEL_NAME,
-        eval_datums,
-        eval_examples,
-        renderer,
-        service_client,
-        tokenizer,
-        training_client,
-    )
+    return eval_datums, renderer, tokenizer, training_client
 
 
 @app.cell(hide_code=True)
@@ -166,7 +158,7 @@ def _(mo):
 
 
 @app.cell
-def _(TrainingClientEvaluator, tinker, torch):
+def _(TrainingClientEvaluator, tinker):
     class NLLEvaluator(TrainingClientEvaluator):
         """Compute mean NLL on held-out data using forward passes."""
 
@@ -183,8 +175,8 @@ def _(TrainingClientEvaluator, tinker, torch):
             total_nll = 0.0
             total_tokens = 0
             for datum, output in zip(self.eval_data, result.loss_fn_outputs):
-                logprobs = torch.tensor(output["logprobs"])
-                weights = torch.tensor(datum.loss_fn_inputs["weights"])
+                logprobs = output["logprobs"].to_torch()
+                weights = datum.loss_fn_inputs["weights"].to_torch()
                 total_nll += -(logprobs * weights).sum().item()
                 total_tokens += weights.sum().item()
 
@@ -200,7 +192,7 @@ async def _(NLLEvaluator, eval_datums, training_client):
     nll_evaluator = NLLEvaluator(eval_datums, name="held_out")
     nll_metrics = await nll_evaluator(training_client)
     print(f"NLL evaluation: {nll_metrics}")
-    return nll_evaluator, nll_metrics
+    return
 
 
 @app.cell(hide_code=True)
@@ -253,7 +245,7 @@ def _(SamplingClientEvaluator, get_text_content, tinker):
 
 
 @app.cell
-async def _(AccuracyEvaluator, renderer, service_client, tokenizer, training_client):
+async def _(AccuracyEvaluator, renderer, tokenizer, training_client):
     # Create a sampling client from current weights
     sampling_client = await training_client.save_weights_and_get_sampling_client_async()
 
@@ -267,7 +259,7 @@ async def _(AccuracyEvaluator, renderer, service_client, tokenizer, training_cli
     accuracy_evaluator = AccuracyEvaluator(test_qa, renderer, tokenizer)
     acc_metrics = await accuracy_evaluator(sampling_client)
     print(f"Accuracy evaluation: {acc_metrics}")
-    return acc_metrics, accuracy_evaluator, sampling_client, test_qa
+    return
 
 
 @app.cell(hide_code=True)
@@ -299,7 +291,7 @@ def _(mo):
 
     config = train.Config(
         log_path="~/logs/sft-with-evals",
-        model_name="Qwen/Qwen3-4B-Instruct-2507",
+        model_name="Qwen/Qwen3.5-4B",
         dataset_builder=my_dataset_builder,
         learning_rate=1e-4,
 
@@ -328,7 +320,7 @@ def _(mo):
 
     config = train.Config(
         log_path="~/logs/rl-with-evals",
-        model_name="meta-llama/Llama-3.1-8B",
+        model_name="Qwen/Qwen3.5-9B-Base",
         dataset_builder=my_rl_dataset_builder,
 
         evaluator_builders=[make_accuracy_evaluator],
@@ -364,7 +356,7 @@ def _(mo):
     mo.md(r"""
     ## Inspect AI integration
 
-    For standardized benchmarks (MMLU, GSM8K, HumanEval, etc.), the cookbook integrates with [Inspect AI](https://inspect.ai). The `InspectEvaluator` wraps any Inspect task as a `SamplingClientEvaluator`:
+    For standardized benchmarks (MMLU, GSM8K, HumanEval, etc.), the cookbook integrates with [Inspect AI](https://inspect.aisi.org.uk/). The `InspectEvaluator` wraps any Inspect task as a `SamplingClientEvaluator`:
 
     ```python
     from tinker_cookbook.eval.run_inspect_evals import Config

--- a/tutorials/205_evaluations.py
+++ b/tutorials/205_evaluations.py
@@ -290,7 +290,7 @@ def _(mo):
         return AccuracyEvaluator(test_qa, renderer, tokenizer)
 
     config = train.Config(
-        log_path="~/logs/sft-with-evals",
+        log_path="/tmp/tinker-tutorials/sft-with-evals",
         model_name="Qwen/Qwen3.5-4B",
         dataset_builder=my_dataset_builder,
         learning_rate=1e-4,
@@ -319,7 +319,7 @@ def _(mo):
     from tinker_cookbook.rl import train
 
     config = train.Config(
-        log_path="~/logs/rl-with-evals",
+        log_path="/tmp/tinker-tutorials/rl-with-evals",
         model_name="Qwen/Qwen3.5-9B-Base",
         dataset_builder=my_rl_dataset_builder,
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -12,9 +12,11 @@ These tutorials are [marimo](https://marimo.io/) notebooks — reactive Python n
 ## Setup
 
 ```bash
-uv pip install tinker tinker-cookbook marimo
+uv pip install tinker "tinker-cookbook[tutorials]"
 export TINKER_API_KEY="your-api-key-here"
 ```
+
+The `[tutorials]` extra installs `marimo` (to open the notebooks) and `matplotlib` (for the loss-curve plots in some tutorials).
 
 ## Running a tutorial
 


### PR DESCRIPTION
Note: branched from https://github.com/thinking-machines-lab/tinker-cookbook/pull/732 to split up into smaller PRs.

Refreshes the Core Concepts tutorials (201–205). Beyond the model swaps, these notebooks had accumulated breakage from SDK changes (results now come back as `TensorData` wrappers, some calls must be `await`ed, etc.) — all found and fixed by running each notebook end-to-end.

Second in the five-PR stack. **Based on #751 (Basics, 1xx) — review/merge that first.** The diff against `main` will be clean once #751 lands.

## Tutorials
- **201 Rendering** — `Qwen3-30B-A3B → Qwen3.6-35B-A3B` and `Qwen3-VL-235B-A22B-Instruct → Qwen3.5-397B-A17B`, using the `qwen3_5` renderers; modernize the vision section (Qwen3.5/3.6 are natively vision-capable — same renderer plus an image processor); rebuild the `parse_response` example (its hardcoded token IDs were tied to the old tokenizer); make the renderer-switching cell actually switch (Qwen + Kimi); note that `qwen3_5` is a thinking renderer.
- **202 Loss Functions** — `Qwen3.5-4B`; unwrap `TensorData` logprobs with `.tolist()` before slicing.
- **203 Completers** — use top-level `await` instead of `asyncio.run` (which can't run inside marimo's event loop); drop now-unused imports.
- **204 Weights** — fix the checkpoint-lifecycle cells: `await` the async RestClient/save APIs (sync `.result()` calls warn and risk deadlock in marimo's loop), pass the full `model_id` to `list_checkpoints` (truncating it caused `404 Model not found`), and run the blocking `weights.download` via `asyncio.to_thread`.
- **205 Evaluations** — unwrap `TensorData` with `.to_torch()` in the NLL evaluator; fix the dead Inspect AI link (`inspect.ai → inspect.aisi.org.uk`).

## Testing
Ran each notebook end-to-end in marimo against the live Tinker service.

**Requires tinker ≥ 0.22.3** — 204's checkpoint download fails on older SDKs due to a server-side bug fixed in 0.22.3.

_Note: diffs include marimo serialization churn (version-string bump, trimmed cell-return tuples)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)