### PR TITLE
Flush training store writes on logger close

### DIFF
--- a/tinker_cookbook/stores/training_store.py
+++ b/tinker_cookbook/stores/training_store.py
@@ -321,6 +321,10 @@ class TrainingRunStore:
         """Write code.diff (overwrites)."""
         self.storage.write(self._path("code.diff"), diff.encode("utf-8"))
 
+    def flush(self) -> None:
+        """Flush buffered writes in the underlying storage backend."""
+        self.storage.flush()
+
     # ── Async variants ────────────────────────────────────────────────
 
     async def aread_config(self) -> dict[str, Any] | None:
@@ -362,3 +366,7 @@ class TrainingRunStore:
     async def awrite_checkpoint(self, record: dict[str, Any]) -> None:
         """Async version of :meth:`write_checkpoint`."""
         await asyncio.to_thread(self.write_checkpoint, record)
+
+    async def aflush(self) -> None:
+        """Async version of :meth:`flush`."""
+        await asyncio.to_thread(self.flush)

--- a/tinker_cookbook/stores/training_store_test.py
+++ b/tinker_cookbook/stores/training_store_test.py
@@ -306,6 +306,20 @@ class TestTrainingRunStoreWrites:
         data = store.storage.read("code.diff")
         assert b"file.py" in data
 
+    def test_flush_delegates_to_storage(self, tmp_path: Path) -> None:
+        class FlushCountingStorage(LocalStorage):
+            def __init__(self, root: Path):
+                super().__init__(root)
+                self.flush_count = 0
+
+            def flush(self) -> None:
+                self.flush_count += 1
+
+        storage = FlushCountingStorage(tmp_path)
+        store = TrainingRunStore(storage)
+        store.flush()
+        assert storage.flush_count == 1
+
     def test_roundtrip_write_read(self, tmp_path: Path) -> None:
         """Full roundtrip: write all data types, then read them back."""
         store = TrainingRunStore(LocalStorage(tmp_path))

--- a/tinker_cookbook/utils/ml_log.py
+++ b/tinker_cookbook/utils/ml_log.py
@@ -205,6 +205,14 @@ class JsonLogger(Logger):
         self._store.write_metrics(metrics, step)
         logger.info("Wrote metrics to %s/metrics.jsonl", self.log_dir)
 
+    def sync(self) -> None:
+        """Flush buffered JSON logger writes to the backing store."""
+        self._store.flush()
+
+    def close(self) -> None:
+        """Flush buffered JSON logger writes before shutdown."""
+        self.sync()
+
 
 class PrettyPrintLogger(Logger):
     """Logger that displays metrics as a Rich-formatted table in the console.

--- a/tinker_cookbook/utils/ml_log_test.py
+++ b/tinker_cookbook/utils/ml_log_test.py
@@ -3,7 +3,10 @@ import shlex
 import sys
 from unittest.mock import patch
 
-from .ml_log import configure_logging_module
+from tinker_cookbook.stores.storage import LocalStorage
+from tinker_cookbook.stores.training_store import TrainingRunStore
+
+from .ml_log import JsonLogger, configure_logging_module
 
 
 def _flush_root_handlers() -> None:
@@ -40,3 +43,22 @@ def test_configure_logging_module_logs_invocation_and_appends(tmp_path):
     assert final_contents.count("Command line invocation:") == 2
     assert final_contents.index("first message") < final_contents.index(second_invocation)
     assert final_contents.index(second_invocation) < final_contents.index("second message")
+
+
+def test_json_logger_close_flushes_store(tmp_path):
+    class FlushCountingStorage(LocalStorage):
+        def __init__(self, root):
+            super().__init__(root)
+            self.flush_count = 0
+
+        def flush(self) -> None:
+            self.flush_count += 1
+
+    storage = FlushCountingStorage(tmp_path)
+    logger = JsonLogger(tmp_path, store=TrainingRunStore(storage))
+
+    logger.log_metrics({"loss": 1.0}, step=0)
+    logger.sync()
+    logger.close()
+
+    assert storage.flush_count == 2


### PR DESCRIPTION
## Summary
- Adds `TrainingRunStore.flush()`/`aflush()` as a thin wrapper over the configured storage backend.
- Flushes the JSON logger store on `sync()` and `close()` so cloud-backed staged appends are persisted before shutdown.
- Covers the flush behavior with focused unit tests.

## Test plan
- `uv run --extra dev ruff check tinker_cookbook/stores/training_store.py tinker_cookbook/stores/training_store_test.py tinker_cookbook/utils/ml_log.py tinker_cookbook/utils/ml_log_test.py`
- `uv run --extra dev pytest tinker_cookbook/stores/training_store_test.py tinker_cookbook/utils/ml_log_test.py`
- `uv run --extra dev --extra wandb --extra neptune-scale --extra trackio pyright tinker_cookbook/stores/training_store.py tinker_cookbook/stores/training_store_test.py tinker_cookbook/utils/ml_log.py tinker_cookbook/utils/ml_log_test.py`


Made with [Cursor](https://cursor.com)