### PR TITLE
Remove redundant skills field from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,6 +9,5 @@
   "homepage": "https://thinkingmachines.ai/tinker/",
   "repository": "https://github.com/thinking-machines-lab/tinker-cookbook",
   "license": "MIT",
-  "keywords": ["tinker", "fine-tuning", "rl", "sft", "dpo", "llm"],
-  "skills": "skills/"
+  "keywords": ["tinker", "fine-tuning", "rl", "sft", "dpo", "llm"]
 }

--- a/tests/downstream_compat/test_install_skills.py
+++ b/tests/downstream_compat/test_install_skills.py
@@ -61,10 +61,27 @@ class TestPluginManifest:
         """plugin.json must be valid JSON with required fields."""
         data = json.loads(PLUGIN_JSON.read_text())
         assert "name" in data, "plugin.json missing 'name'"
-        assert "skills" in data, "plugin.json missing 'skills'"
-        assert data["skills"] == "skills/", (
-            f"plugin.json 'skills' should be 'skills/', got '{data['skills']}'"
-        )
+
+    def test_plugin_json_no_redundant_skills_field(self):
+        """The 'skills' field must not point at the default skills/ directory.
+
+        Claude Code auto-discovers skills from the default skills/ directory; the
+        manifest 'skills' field is only for *additional* directories and, when
+        present, must be a './'-prefixed relative path. Pointing it at the default
+        location is redundant and the bare 'skills/' value fails manifest
+        validation ("skills: Invalid input"), blocking /plugin install.
+        """
+        data = json.loads(PLUGIN_JSON.read_text())
+        if "skills" in data:
+            values = data["skills"] if isinstance(data["skills"], list) else [data["skills"]]
+            for value in values:
+                assert value not in ("skills/", "./skills/"), (
+                    f"plugin.json 'skills' redundantly points at the default skills/ "
+                    f"directory ({value!r}); remove the field and rely on auto-discovery"
+                )
+                assert value.startswith("./"), (
+                    f"plugin.json 'skills' path must be './'-prefixed, got {value!r}"
+                )
 
     def test_plugin_name_is_tinker(self):
         """Plugin name must be 'tinker' for /tinker:* namespace."""


### PR DESCRIPTION
## Problem

`/plugin install tinker@...` fails with:

```
Failed to install: ... has an invalid manifest file
Validation errors: skills: Invalid input
```

`.claude-plugin/plugin.json` sets `"skills": "skills/"`. Per the [Claude Code plugin spec](https://code.claude.com/docs/en/plugins-reference), the `skills` field is for **additional** skill directories *beyond* the auto-discovered default `skills/`, and when present it must be a `./`-prefixed relative path (e.g. `"./custom/skills/"`).

This repo's skills already live in the default `skills/` directory, so the field is:
- **redundant** — Claude Code auto-discovers `skills/` without it, and
- **malformed** — the bare `"skills/"` value fails manifest validation, blocking install entirely.

## Fix

Remove the `skills` field and rely on default auto-discovery. Verified that the plugin installs and both `/tinker:research` and `/tinker:debug` load once the field is gone.

## Test change

`tests/downstream_compat/test_install_skills.py` previously asserted `data["skills"] == "skills/"` — i.e. it pinned the exact value that breaks real installation. Updated to stop requiring the redundant field and instead guard against it being reintroduced with an invalid (non-`./`-prefixed, or default-pointing) value.

## Verification

- `plugin.json` parses as valid JSON.
- `pytest tests/downstream_compat/test_install_skills.py` → 8 passed.
