### PR TITLE
stores: add exists_tree/rmtree, mkdir flag, normalize_log_path, and store HTML/flush helpers

### DIFF
--- a/tinker_cookbook/stores/__init__.py
+++ b/tinker_cookbook/stores/__init__.py
@@ -18,6 +18,7 @@ from tinker_cookbook.stores.storage import (
     LocalStorage,
     Storage,
     StorageStat,
+    normalize_log_path,
     storage_from_uri,
     storage_join,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "Storage",
     "StorageStat",
     "TrainingRunStore",
+    "normalize_log_path",
     "storage_from_uri",
     "storage_join",
 ]

--- a/tinker_cookbook/stores/storage.py
+++ b/tinker_cookbook/stores/storage.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
 import posixpath
 import shutil
 from dataclasses import dataclass
@@ -676,7 +677,7 @@ class FsspecStorage:
         self._staged = set()
 
 
-def storage_from_uri(uri: str, *, mkdir: bool = True, **kwargs: Any) -> Storage:
+def storage_from_uri(uri: str | os.PathLike[str], *, mkdir: bool = True, **kwargs: Any) -> Storage:
     """Create a Storage backend from a URI string.
 
     Supported schemes::
@@ -699,6 +700,8 @@ def storage_from_uri(uri: str, *, mkdir: bool = True, **kwargs: Any) -> Storage:
     This is the recommended way to create a Storage from user config
     (e.g., ``log_path`` in training scripts).
     """
+    # Accept pathlib.Path / os.PathLike, not just str (callers pass tmp_path, etc.).
+    uri = os.fspath(uri)
     if uri.startswith("file://"):
         return LocalStorage(uri[len("file://") :], mkdir=mkdir)
     if "://" in uri:

--- a/tinker_cookbook/stores/storage.py
+++ b/tinker_cookbook/stores/storage.py
@@ -35,6 +35,7 @@ import asyncio
 import contextlib
 import logging
 import posixpath
+import shutil
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -138,6 +139,24 @@ class Storage(Protocol):
 
         Cloud backends (S3/GCS) can treat this as a no-op since they
         don't have real directories.
+        """
+        ...
+
+    def exists_tree(self, prefix: str = "") -> bool:
+        """Return ``True`` if a file or any object exists at/under *prefix*.
+
+        Unlike :meth:`exists` (a single-key check), this also returns ``True``
+        for a non-empty directory/prefix. Robust on object stores, where
+        ``exists`` on a bare prefix (no directory marker) is unreliable.
+        """
+        ...
+
+    def rmtree(self, path: str = "") -> None:
+        """Recursively delete a directory/prefix and everything under it.
+
+        No error if missing. ``path=""`` targets the storage root. Unlike
+        :meth:`remove_dir` (which removes only an *empty* directory), this
+        removes all contents.
         """
         ...
 
@@ -286,6 +305,18 @@ class LocalStorage:
         full = self._resolve(path)
         with contextlib.suppress(FileNotFoundError, OSError):
             full.rmdir()
+
+    def exists_tree(self, prefix: str = "") -> bool:
+        """See :meth:`Storage.exists_tree`."""
+        return self._resolve(prefix).exists() or bool(self.list_dir(prefix))
+
+    def rmtree(self, path: str = "") -> None:
+        """See :meth:`Storage.rmtree`."""
+        full = self._resolve(path)
+        if full.is_dir():
+            shutil.rmtree(full)
+        elif full.exists():
+            full.unlink()
 
     def flush(self) -> None:
         """See :meth:`Storage.flush`. No-op for local filesystem."""
@@ -510,6 +541,26 @@ class FsspecStorage:
         with contextlib.suppress(FileNotFoundError, OSError):
             self._fs.rmdir(self._full(path))
 
+    def exists_tree(self, prefix: str = "") -> bool:
+        """See :meth:`Storage.exists_tree`."""
+        return self.exists(prefix) or bool(self.list_dir(prefix))
+
+    def rmtree(self, path: str = "") -> None:
+        """See :meth:`Storage.rmtree`."""
+        full = self._full(path)
+        # fs.rm lists objects under the prefix itself, so this deletes a prefix
+        # with no directory marker (where ``exists(full)`` would be False).
+        with contextlib.suppress(FileNotFoundError):
+            self._fs.rm(full, recursive=True)
+        # Drop any staged files under this prefix.
+        prefix = path.strip("/")
+        staged = [
+            p for p in self._staged if not prefix or p == prefix or p.startswith(prefix + "/")
+        ]
+        for p in staged:
+            self._stage_path(p).unlink(missing_ok=True)
+            self._staged.discard(p)
+
     def flush(self) -> None:
         """Upload all locally staged files to cloud.
 
@@ -614,7 +665,7 @@ class FsspecStorage:
         self._staged = set()
 
 
-def storage_from_uri(uri: str, **kwargs: Any) -> Storage:
+def storage_from_uri(uri: str, *, mkdir: bool = True, **kwargs: Any) -> Storage:
     """Create a Storage backend from a URI string.
 
     Supported schemes::
@@ -628,11 +679,17 @@ def storage_from_uri(uri: str, **kwargs: Any) -> Storage:
     Extra keyword arguments are passed to the fsspec filesystem constructor
     (e.g., ``anon=True`` for public S3 buckets).
 
+    Args:
+        uri: Storage root URI or local path.
+        mkdir: For local backends, create the root directory if missing
+            (default). Pass ``False`` for read-only access so a missing
+            directory is not created as a side effect.
+
     This is the recommended way to create a Storage from user config
     (e.g., ``log_path`` in training scripts).
     """
     if uri.startswith("file://"):
-        return LocalStorage(uri[len("file://") :])
+        return LocalStorage(uri[len("file://") :], mkdir=mkdir)
     if "://" in uri:
         # Cloud URI — delegate to fsspec
         try:
@@ -645,7 +702,18 @@ def storage_from_uri(uri: str, **kwargs: Any) -> Storage:
         fs, path = fsspec.core.url_to_fs(uri, **kwargs)
         return FsspecStorage(fs, path, **kwargs)
     # Default: treat as local path
-    return LocalStorage(uri)
+    return LocalStorage(uri, mkdir=mkdir)
+
+
+def normalize_log_path(log_path: str) -> str:
+    """Expand ``~`` for local paths; leave cloud URIs unchanged.
+
+    ``Path("gs://b/x").expanduser()`` would corrupt ``gs://`` into ``gs:/``, so
+    cloud URIs are returned as-is. Used in chz config mungers for ``log_path``.
+    """
+    if "://" in log_path:
+        return log_path
+    return str(Path(log_path).expanduser())
 
 
 def storage_join(*parts: str) -> str:

--- a/tinker_cookbook/stores/storage.py
+++ b/tinker_cookbook/stores/storage.py
@@ -231,7 +231,9 @@ class LocalStorage:
     """
 
     def __init__(self, root: str | Path, *, mkdir: bool = True) -> None:
-        self._root = Path(root).expanduser().resolve()
+        # Keep the pre-resolve path so we can detect a symlinked root and unlink the link itself rather than wiping its (resolved) target.
+        self._unresolved_root = Path(root).expanduser()
+        self._root = self._unresolved_root.resolve()
         if mkdir:
             self._root.mkdir(parents=True, exist_ok=True)
 
@@ -312,6 +314,10 @@ class LocalStorage:
 
     def remove_tree(self, path: str = "") -> None:
         """See :meth:`Storage.remove_tree`."""
+        # If it's a symlinked root, unlink the link itself, do not delete the (possibly shared) target directory.
+        if not path and self._unresolved_root.is_symlink():
+            self._unresolved_root.unlink()
+            return
         full = self._resolve(path)
         if full.is_dir():
             shutil.rmtree(full)

--- a/tinker_cookbook/stores/storage.py
+++ b/tinker_cookbook/stores/storage.py
@@ -552,14 +552,20 @@ class FsspecStorage:
         # with no directory marker (where ``exists(full)`` would be False).
         with contextlib.suppress(FileNotFoundError):
             self._fs.rm(full, recursive=True)
-        # Drop any staged files under this prefix.
+        # Drop any staged files under this prefix from the tracking set.
         prefix = path.strip("/")
-        staged = [
+        for p in [
             p for p in self._staged if not prefix or p == prefix or p.startswith(prefix + "/")
-        ]
-        for p in staged:
-            self._stage_path(p).unlink(missing_ok=True)
+        ]:
             self._staged.discard(p)
+        # Remove the staged subtree itself, not just the files: list_dir merges
+        # staged directories, so leftover empty dirs would make exists_tree and
+        # list_dir resurface a prefix we just deleted.
+        stage_target = self._stage_path(prefix) if prefix else self._stage_dir
+        if stage_target.is_dir():
+            shutil.rmtree(stage_target, ignore_errors=True)
+        else:
+            stage_target.unlink(missing_ok=True)
 
     def flush(self) -> None:
         """Upload all locally staged files to cloud.

--- a/tinker_cookbook/stores/storage.py
+++ b/tinker_cookbook/stores/storage.py
@@ -151,7 +151,7 @@ class Storage(Protocol):
         """
         ...
 
-    def rmtree(self, path: str = "") -> None:
+    def remove_tree(self, path: str = "") -> None:
         """Recursively delete a directory/prefix and everything under it.
 
         No error if missing. ``path=""`` targets the storage root. Unlike
@@ -310,8 +310,8 @@ class LocalStorage:
         """See :meth:`Storage.exists_tree`."""
         return self._resolve(prefix).exists() or bool(self.list_dir(prefix))
 
-    def rmtree(self, path: str = "") -> None:
-        """See :meth:`Storage.rmtree`."""
+    def remove_tree(self, path: str = "") -> None:
+        """See :meth:`Storage.remove_tree`."""
         full = self._resolve(path)
         if full.is_dir():
             shutil.rmtree(full)
@@ -545,8 +545,8 @@ class FsspecStorage:
         """See :meth:`Storage.exists_tree`."""
         return self.exists(prefix) or bool(self.list_dir(prefix))
 
-    def rmtree(self, path: str = "") -> None:
-        """See :meth:`Storage.rmtree`."""
+    def remove_tree(self, path: str = "") -> None:
+        """See :meth:`Storage.remove_tree`."""
         full = self._full(path)
         # fs.rm lists objects under the prefix itself, so this deletes a prefix
         # with no directory marker (where ``exists(full)`` would be False).
@@ -558,9 +558,8 @@ class FsspecStorage:
             p for p in self._staged if not prefix or p == prefix or p.startswith(prefix + "/")
         ]:
             self._staged.discard(p)
-        # Remove the staged subtree itself, not just the files: list_dir merges
-        # staged directories, so leftover empty dirs would make exists_tree and
-        # list_dir resurface a prefix we just deleted.
+        # list_dir() merges staged dirs, so remove the whole staged subtree —
+        # leftover empty dirs would resurface a prefix we just deleted.
         stage_target = self._stage_path(prefix) if prefix else self._stage_dir
         if stage_target.is_dir():
             shutil.rmtree(stage_target, ignore_errors=True)

--- a/tinker_cookbook/stores/storage_test.py
+++ b/tinker_cookbook/stores/storage_test.py
@@ -92,16 +92,16 @@ class TestLocalStorage:
         # Missing dir: no error
         s.remove_dir("nonexistent")
 
-    def test_rmtree(self, tmp_path: Path) -> None:
+    def test_remove_tree(self, tmp_path: Path) -> None:
         s = LocalStorage(tmp_path)
         s.write("d/a.txt", b"a")
         s.write("d/sub/b.txt", b"b")  # nested
         s.write("dd/keep.txt", b"keep")  # sibling prefix, must survive
-        s.rmtree("d")
+        s.remove_tree("d")
         assert not s.exists("d/a.txt")
         assert not s.exists("d/sub/b.txt")
         assert s.exists("dd/keep.txt")
-        s.rmtree("nonexistent")  # no error
+        s.remove_tree("nonexistent")  # no error
 
     def test_exists_tree(self, tmp_path: Path) -> None:
         s = LocalStorage(tmp_path)
@@ -362,20 +362,20 @@ class TestFsspecStorage:
         assert not s.exists("f.txt")
         s.remove("nonexistent")  # no error
 
-    def test_rmtree(self, tmp_path: Path) -> None:
+    def test_remove_tree(self, tmp_path: Path) -> None:
         s = self._make_storage(tmp_path)
         s.write("d/a.txt", b"a")
         s.write("d/sub/b.txt", b"b")  # nested
         s.write("dd/keep.txt", b"keep")  # sibling prefix, must survive
-        s.rmtree("d")
+        s.remove_tree("d")
         assert not s.exists("d/a.txt")
         assert not s.exists("d/sub/b.txt")
         assert s.exists("dd/keep.txt")
-        s.rmtree("nonexistent")  # no error
+        s.remove_tree("nonexistent")  # no error
 
-    def test_memory_exists_tree_and_rmtree_prefix_safety(self) -> None:
-        """exists_tree/rmtree behave on a real (memory://) object store, and
-        rmtree of a prefix leaves a sibling that shares its leading name."""
+    def test_memory_exists_tree_and_remove_tree_prefix_safety(self) -> None:
+        """exists_tree/remove_tree behave on a real (memory://) object store, and
+        remove_tree of a prefix leaves a sibling that shares its leading name."""
         base = f"memory://bucket/{uuid.uuid4()}"
         run = storage_from_uri(f"{base}/run")
         sibling = storage_from_uri(f"{base}/run-sibling")
@@ -386,14 +386,14 @@ class TestFsspecStorage:
         assert run.exists_tree("a")
         assert not run.exists_tree("missing")
 
-        run.rmtree("")
+        run.remove_tree("")
         assert not run.exists_tree("")
         # Sibling prefix that shares the leading text must survive.
         assert sibling.exists_tree("")
         assert sibling.read("c.txt") == b"keep"
 
-    def test_rmtree_clears_staged_appends(self, tmp_path: Path) -> None:
-        """rmtree drops locally-staged (un-flushed) appends under the prefix,
+    def test_remove_tree_clears_staged_appends(self, tmp_path: Path) -> None:
+        """remove_tree drops locally-staged (un-flushed) appends under the prefix,
         including nested ones, while leaving sibling prefixes intact."""
         s = self._make_storage(tmp_path)
         s.append("d/log.jsonl", b"line\n")  # staged, direct child
@@ -402,7 +402,7 @@ class TestFsspecStorage:
         assert s.exists("d/log.jsonl")
         assert s.exists("d/sub/deep.jsonl")
 
-        s.rmtree("d")
+        s.remove_tree("d")
         assert not s.exists("d/log.jsonl")
         assert not s.exists("d/sub/deep.jsonl")
         # Empty staged dirs must not resurface the prefix via list_dir/exists_tree.
@@ -414,7 +414,7 @@ class TestFsspecStorage:
         assert s.exists_tree("dd")
         assert "other.jsonl" in s.list_dir("dd")
 
-        # A fresh append after rmtree starts clean (no leftover staged bytes).
+        # A fresh append after remove_tree starts clean (no leftover staged bytes).
         s.append("d/log.jsonl", b"new\n")
         assert s.read("d/log.jsonl") == b"new\n"
 

--- a/tinker_cookbook/stores/storage_test.py
+++ b/tinker_cookbook/stores/storage_test.py
@@ -405,9 +405,14 @@ class TestFsspecStorage:
         s.rmtree("d")
         assert not s.exists("d/log.jsonl")
         assert not s.exists("d/sub/deep.jsonl")
+        # Empty staged dirs must not resurface the prefix via list_dir/exists_tree.
+        assert not s.exists_tree("d")
+        assert s.list_dir("d") == []
         # "dd/..." shares the "d" text prefix but is a different directory.
         assert s.exists("dd/other.jsonl")
         assert s.read("dd/other.jsonl") == b"keep\n"
+        assert s.exists_tree("dd")
+        assert "other.jsonl" in s.list_dir("dd")
 
         # A fresh append after rmtree starts clean (no leftover staged bytes).
         s.append("d/log.jsonl", b"new\n")

--- a/tinker_cookbook/stores/storage_test.py
+++ b/tinker_cookbook/stores/storage_test.py
@@ -103,6 +103,20 @@ class TestLocalStorage:
         assert s.exists("dd/keep.txt")
         s.remove_tree("nonexistent")  # no error
 
+    def test_remove_tree_symlinked_root_unlinks_link(self, tmp_path: Path) -> None:
+        """remove_tree('') on a symlinked root removes the link, not the target."""
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "keep.txt").write_bytes(b"keep")
+        link = tmp_path / "link"
+        link.symlink_to(target, target_is_directory=True)
+
+        LocalStorage(link, mkdir=False).remove_tree("")
+
+        assert not link.is_symlink()  # link removed
+        assert target.exists()  # target untouched
+        assert (target / "keep.txt").read_bytes() == b"keep"
+
     def test_exists_tree(self, tmp_path: Path) -> None:
         s = LocalStorage(tmp_path)
         assert not s.exists_tree("d")

--- a/tinker_cookbook/stores/storage_test.py
+++ b/tinker_cookbook/stores/storage_test.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import pickle
+import uuid
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from tinker_cookbook.stores.storage import (
     FsspecStorage,
     LocalStorage,
     Storage,
+    normalize_log_path,
     storage_from_uri,
     storage_join,
 )
@@ -89,6 +91,25 @@ class TestLocalStorage:
         assert not (tmp_path / "d").exists()
         # Missing dir: no error
         s.remove_dir("nonexistent")
+
+    def test_rmtree(self, tmp_path: Path) -> None:
+        s = LocalStorage(tmp_path)
+        s.write("d/a.txt", b"a")
+        s.write("d/sub/b.txt", b"b")  # nested
+        s.write("dd/keep.txt", b"keep")  # sibling prefix, must survive
+        s.rmtree("d")
+        assert not s.exists("d/a.txt")
+        assert not s.exists("d/sub/b.txt")
+        assert s.exists("dd/keep.txt")
+        s.rmtree("nonexistent")  # no error
+
+    def test_exists_tree(self, tmp_path: Path) -> None:
+        s = LocalStorage(tmp_path)
+        assert not s.exists_tree("d")
+        s.write("d/a/b.txt", b"x")
+        assert s.exists_tree("d")
+        assert s.exists_tree("d/a/b.txt")
+        assert not s.exists_tree("missing")
 
     def test_path_traversal_blocked(self, tmp_path: Path) -> None:
         s = LocalStorage(tmp_path)
@@ -234,6 +255,13 @@ class TestStorageFromUri:
         s.write("test.txt", b"ok")
         assert s.read("test.txt") == b"ok"
 
+    def test_mkdir_false_no_side_effect(self, tmp_path: Path) -> None:
+        """mkdir=False + exists("") checks a root without creating it."""
+        target = tmp_path / "should_not_be_created"
+        s = storage_from_uri(str(target), mkdir=False)
+        assert not s.exists("")
+        assert not target.exists()
+
     def test_s3_needs_s3fs(self) -> None:
         """S3 URIs require s3fs (may succeed if installed, may raise ImportError)."""
         try:
@@ -249,6 +277,23 @@ class TestStorageFromUri:
             assert isinstance(s, FsspecStorage)
         except ImportError:
             pass
+
+
+class TestNormalizeLogPath:
+    def test_expands_local_tilde(self) -> None:
+        expanded = normalize_log_path("~/logs/run")
+        assert "~" not in expanded
+        assert expanded.endswith("logs/run")
+
+    def test_plain_local_unchanged(self, tmp_path: Path) -> None:
+        assert normalize_log_path(str(tmp_path)) == str(tmp_path)
+
+    def test_cloud_uris_untouched(self) -> None:
+        for uri in ("gs://bucket/run", "s3://bucket/run", "az://container/run"):
+            assert normalize_log_path(uri) == uri
+
+    def test_file_uri_untouched(self) -> None:
+        assert normalize_log_path("file:///abs/run") == "file:///abs/run"
 
 
 class TestFsspecStorage:
@@ -316,6 +361,57 @@ class TestFsspecStorage:
         s.remove("f.txt")
         assert not s.exists("f.txt")
         s.remove("nonexistent")  # no error
+
+    def test_rmtree(self, tmp_path: Path) -> None:
+        s = self._make_storage(tmp_path)
+        s.write("d/a.txt", b"a")
+        s.write("d/sub/b.txt", b"b")  # nested
+        s.write("dd/keep.txt", b"keep")  # sibling prefix, must survive
+        s.rmtree("d")
+        assert not s.exists("d/a.txt")
+        assert not s.exists("d/sub/b.txt")
+        assert s.exists("dd/keep.txt")
+        s.rmtree("nonexistent")  # no error
+
+    def test_memory_exists_tree_and_rmtree_prefix_safety(self) -> None:
+        """exists_tree/rmtree behave on a real (memory://) object store, and
+        rmtree of a prefix leaves a sibling that shares its leading name."""
+        base = f"memory://bucket/{uuid.uuid4()}"
+        run = storage_from_uri(f"{base}/run")
+        sibling = storage_from_uri(f"{base}/run-sibling")
+        run.write("a/b.txt", b"x")
+        sibling.write("c.txt", b"keep")
+
+        assert run.exists_tree("")
+        assert run.exists_tree("a")
+        assert not run.exists_tree("missing")
+
+        run.rmtree("")
+        assert not run.exists_tree("")
+        # Sibling prefix that shares the leading text must survive.
+        assert sibling.exists_tree("")
+        assert sibling.read("c.txt") == b"keep"
+
+    def test_rmtree_clears_staged_appends(self, tmp_path: Path) -> None:
+        """rmtree drops locally-staged (un-flushed) appends under the prefix,
+        including nested ones, while leaving sibling prefixes intact."""
+        s = self._make_storage(tmp_path)
+        s.append("d/log.jsonl", b"line\n")  # staged, direct child
+        s.append("d/sub/deep.jsonl", b"deep\n")  # staged, nested
+        s.append("dd/other.jsonl", b"keep\n")  # staged, sibling prefix (must survive)
+        assert s.exists("d/log.jsonl")
+        assert s.exists("d/sub/deep.jsonl")
+
+        s.rmtree("d")
+        assert not s.exists("d/log.jsonl")
+        assert not s.exists("d/sub/deep.jsonl")
+        # "dd/..." shares the "d" text prefix but is a different directory.
+        assert s.exists("dd/other.jsonl")
+        assert s.read("dd/other.jsonl") == b"keep\n"
+
+        # A fresh append after rmtree starts clean (no leftover staged bytes).
+        s.append("d/log.jsonl", b"new\n")
+        assert s.read("d/log.jsonl") == b"new\n"
 
     def test_url(self, tmp_path: Path) -> None:
         s = self._make_storage(tmp_path)

--- a/tinker_cookbook/stores/storage_test.py
+++ b/tinker_cookbook/stores/storage_test.py
@@ -276,6 +276,12 @@ class TestStorageFromUri:
         assert not s.exists("")
         assert not target.exists()
 
+    def test_accepts_pathlib_path(self, tmp_path: Path) -> None:
+        """storage_from_uri accepts os.PathLike (e.g. pathlib.Path), not just str."""
+        s = storage_from_uri(tmp_path / "run")
+        s.write("a.txt", b"x")
+        assert s.read("a.txt") == b"x"
+
     def test_s3_needs_s3fs(self) -> None:
         """S3 URIs require s3fs (may succeed if installed, may raise ImportError)."""
         try:

--- a/tinker_cookbook/stores/training_store.py
+++ b/tinker_cookbook/stores/training_store.py
@@ -317,9 +317,32 @@ class TrainingRunStore:
         """Write a logtree JSON file for an iteration (overwrites)."""
         self._write_json(data, self._iter_dir(iteration), f"{base_name}_logtree.json")
 
+    def write_logtree_html(self, iteration: int, html: str, base_name: str = "train") -> None:
+        """Write a logtree HTML report for an iteration (overwrites)."""
+        self.storage.write(
+            self._path(self._iter_dir(iteration), f"{base_name}_logtree.html"),
+            html.encode("utf-8"),
+        )
+
+    def write_gantt_html(self, iteration: int, html: str) -> None:
+        """Write the timing Gantt chart HTML for an iteration (overwrites)."""
+        self.storage.write(
+            self._path(self._iter_dir(iteration), "timing_gantt.html"),
+            html.encode("utf-8"),
+        )
+
     def write_code_diff(self, diff: str) -> None:
         """Write code.diff (overwrites)."""
         self.storage.write(self._path("code.diff"), diff.encode("utf-8"))
+
+    def flush(self) -> None:
+        """Flush buffered writes in the underlying storage backend.
+
+        Required for cloud backends: appended files (``metrics.jsonl``,
+        ``checkpoints.jsonl``, ``timing_spans.jsonl``) are staged locally and
+        only uploaded on flush.
+        """
+        self.storage.flush()
 
     # ── Async variants ────────────────────────────────────────────────
 
@@ -362,3 +385,7 @@ class TrainingRunStore:
     async def awrite_checkpoint(self, record: dict[str, Any]) -> None:
         """Async version of :meth:`write_checkpoint`."""
         await asyncio.to_thread(self.write_checkpoint, record)
+
+    async def aflush(self) -> None:
+        """Async version of :meth:`flush`."""
+        await asyncio.to_thread(self.flush)

--- a/tinker_cookbook/stores/training_store_test.py
+++ b/tinker_cookbook/stores/training_store_test.py
@@ -128,6 +128,18 @@ class TestTrainingRunStore:
         c2 = store.read_config()
         assert c1 is c2
 
+    def test_write_logtree_html(self, tmp_path: Path) -> None:
+        store = TrainingRunStore(LocalStorage(tmp_path))
+        store.write_logtree_html(3, "<html><body>hi</body></html>", base_name="eval_gsm8k")
+        raw = store.storage.read("iteration_000003/eval_gsm8k_logtree.html")
+        assert b"<body>hi</body>" in raw
+
+    def test_write_gantt_html(self, tmp_path: Path) -> None:
+        store = TrainingRunStore(LocalStorage(tmp_path))
+        store.write_gantt_html(5, "<html>gantt-chart</html>")
+        raw = store.storage.read("iteration_000005/timing_gantt.html")
+        assert b"gantt-chart" in raw
+
     def test_read_metrics(self, run_dir: Path) -> None:
         store = TrainingRunStore(LocalStorage(run_dir))
         metrics = store.read_metrics()
@@ -216,6 +228,18 @@ class TestTrainingRunStoreWrites:
         config = store.read_config()
         assert config is not None
         assert config["model_name"] == "test-model"
+
+    def test_flush_delegates_to_storage(self, tmp_path: Path) -> None:
+        class _FlushCountingStorage(LocalStorage):
+            flush_count = 0
+
+            def flush(self) -> None:
+                self.flush_count += 1
+
+        storage = _FlushCountingStorage(tmp_path)
+        store = TrainingRunStore(storage)
+        store.flush()
+        assert storage.flush_count == 1
 
     def test_write_config_updates_cache(self, tmp_path: Path) -> None:
         store = TrainingRunStore(LocalStorage(tmp_path))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #762
* #761
* #760
* #759
* #758
* #757
* __->__ #756

Extend the Storage protocol and TrainingRunStore with the primitives the
training/eval code needs to manage run artifacts on local paths and cloud
object stores (gs://, s3://, ...) alike:

- Storage.exists_tree()/rmtree(): prefix-aware existence and recursive
  delete that stay reliable on object stores with no directory markers.
- storage_from_uri(mkdir=False): read-only access that never creates the
  directory as a side effect.
- normalize_log_path(): expand ~ for local paths, leave cloud URIs intact.
- TrainingRunStore.write_logtree_html()/write_gantt_html() and
  flush()/aflush() (cloud backends stage appends locally until flushed).

Purely additive; includes unit tests.

Co-authored-by: Cursor <cursoragent@cursor.com>