### PR TITLE
logtree: add Trace.to_html()

### DIFF
--- a/tinker_cookbook/utils/logtree.py
+++ b/tinker_cookbook/utils/logtree.py
@@ -255,6 +255,18 @@ class Trace:
 
         return "\n".join(parts)
 
+    def to_html(self, theme: "Theme | None" = None) -> str:
+        """Render the full standalone HTML document as a string."""
+        return (
+            "<!doctype html>\n"
+            '<html lang="en">\n'
+            "<head>\n"
+            f"{self.head_html(theme=theme)}"
+            "</head>\n"
+            f"{self.body_html(wrap_body=True)}"
+            "</html>\n"
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """Convert the trace to a JSON-serializable dictionary.
 
@@ -498,13 +510,7 @@ def _write_trace(trace: Trace, theme: Theme | None = None) -> None:
     trace.path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(trace.path, "w") as f:
-        f.write("<!doctype html>\n")
-        f.write('<html lang="en">\n')
-        f.write("<head>\n")
-        f.write(trace.head_html(theme=theme))
-        f.write("</head>\n")
-        f.write(trace.body_html(wrap_body=True))
-        f.write("</html>\n")
+        f.write(trace.to_html(theme=theme))
 
 
 # Public API: Trace lifecycle

--- a/tinker_cookbook/utils/logtree_test.py
+++ b/tinker_cookbook/utils/logtree_test.py
@@ -32,6 +32,18 @@ def test_basic_trace():
         assert "Content in section 1" in content
 
 
+def test_trace_to_html_returns_full_document():
+    """Trace.to_html renders a standalone document without writing a file."""
+    with logtree.init_trace("My Report", path=None) as trace:
+        logtree.log_text("hello world")
+
+    html = trace.to_html()
+    assert html.startswith("<!doctype html>")
+    assert "<title>My Report</title>" in html
+    assert "hello world" in html
+    assert html.rstrip().endswith("</html>")
+
+
 def test_log_text_renders_inline_text_node():
     """Text-only paragraphs should render inline, without leading newline whitespace."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #762
* #761
* #760
* #759
* #758
* __->__ #757
* #756

Render a logtree as a standalone HTML document string (factored out of
_write_trace) so callers can persist it through a Storage backend rather
than writing directly to a local path.

Co-authored-by: Cursor <cursoragent@cursor.com>