### PR TITLE
cli_utils: make check_log_dir cloud-safe

### DIFF
--- a/tinker_cookbook/cli_utils.py
+++ b/tinker_cookbook/cli_utils.py
@@ -1,9 +1,8 @@
 import logging
-import shutil
-from pathlib import Path
 from typing import Literal
 
 from tinker_cookbook.exceptions import ConfigurationError
+from tinker_cookbook.stores.storage import storage_from_uri
 
 logger = logging.getLogger(__name__)
 
@@ -28,19 +27,23 @@ def check_log_dir(log_dir: str, behavior_if_exists: LogdirBehavior):
     Returns:
         None
     """
-    if Path(log_dir).exists():
+    # mkdir=False so the existence check itself never creates the directory.
+    storage = storage_from_uri(log_dir, mkdir=False)
+    # exists_tree (not exists) so a cloud prefix with objects but no directory
+    # marker is correctly detected.
+    if storage.exists_tree(""):
         if behavior_if_exists == "delete":
             logger.info(
                 f"Log directory {log_dir} already exists. Will delete it and start logging there."
             )
-            shutil.rmtree(log_dir)
+            storage.rmtree("")
         elif behavior_if_exists == "ask":
             while True:
                 user_input = input(
                     f"Log directory {log_dir} already exists. What do you want to do? [delete, resume, exit]: "
                 )
                 if user_input == "delete":
-                    shutil.rmtree(log_dir)
+                    storage.rmtree("")
                     return
                 elif user_input == "resume":
                     return

--- a/tinker_cookbook/cli_utils_test.py
+++ b/tinker_cookbook/cli_utils_test.py
@@ -1,11 +1,13 @@
 """Tests for cli_utils path handling."""
 
 import tempfile
+import uuid
 from pathlib import Path
 
 import pytest
 
 from tinker_cookbook.cli_utils import check_log_dir
+from tinker_cookbook.stores.storage import storage_from_uri
 
 
 def test_check_log_dir_nonexistent_is_noop():
@@ -37,3 +39,31 @@ def test_check_log_dir_raise_raises():
     with tempfile.TemporaryDirectory() as tmpdir:
         with pytest.raises(ValueError, match="already exists"):
             check_log_dir(tmpdir, "raise")
+
+
+def test_check_log_dir_cloud_nonexistent_is_noop():
+    """A cloud prefix with no objects is treated as nonexistent (no raise)."""
+    base = f"memory://bucket/{uuid.uuid4()}"
+    check_log_dir(f"{base}/run", "raise")
+
+
+def test_check_log_dir_cloud_raise_when_objects_exist():
+    """A cloud prefix with objects (no directory marker) is detected via exists_tree."""
+    base = f"memory://bucket/{uuid.uuid4()}"
+    storage_from_uri(f"{base}/run").write("metrics.jsonl", b"{}\n")
+    with pytest.raises(ValueError, match="already exists"):
+        check_log_dir(f"{base}/run", "raise")
+
+
+def test_check_log_dir_cloud_delete_prefix_safety():
+    """'delete' clears the run prefix but leaves a sibling that shares its name."""
+    base = f"memory://bucket/{uuid.uuid4()}"
+    run = storage_from_uri(f"{base}/run")
+    sibling = storage_from_uri(f"{base}/run-sibling")
+    run.write("subdir/file.txt", b"x")
+    sibling.write("g.txt", b"keep")
+
+    check_log_dir(f"{base}/run", "delete")
+
+    assert not run.exists_tree("")
+    assert sibling.read("g.txt") == b"keep"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #762
* #761
* __->__ #760
* #759
* #758
* #757
* #756

Use storage_from_uri(mkdir=False).exists_tree("")/rmtree("") so the
resume/delete prompt works on cloud prefixes (which lack directory
markers) and never creates the directory just by checking it.

Co-authored-by: Cursor <cursoragent@cursor.com>