### PR TITLE
recipes: route run-artifact I/O through Storage

### DIFF
--- a/tinker_cookbook/recipes/chat_sl/sweep/results.py
+++ b/tinker_cookbook/recipes/chat_sl/sweep/results.py
@@ -1,46 +1,28 @@
 """Result collection for completed sweep runs."""
 
-import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
+from tinker_cookbook.stores import TrainingRunStore, storage_from_uri
+
 logger = logging.getLogger(__name__)
 
 
-def _read_final_metrics(run_dir: Path) -> dict[str, Any]:
-    """Read the last line of metrics.jsonl to get final training metrics."""
-    metrics_file = run_dir / "metrics.jsonl"
-    if not metrics_file.exists():
-        return {}
-    last_line = None
-    with open(metrics_file) as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                last_line = line
-    if last_line is None:
-        return {}
-    try:
-        return json.loads(last_line)
-    except json.JSONDecodeError:
-        logger.warning(f"Failed to parse last line of {metrics_file}")
-        return {}
+def _read_final_metrics(run_dir: str | Path) -> dict[str, Any]:
+    """Read the last metrics.jsonl record (final training metrics) for a run."""
+    store = TrainingRunStore(storage_from_uri(str(run_dir), mkdir=False))
+    records = store.read_metrics()
+    return records[-1] if records else {}
 
 
-def _read_config(run_dir: Path) -> dict[str, Any]:
+def _read_config(run_dir: str | Path) -> dict[str, Any]:
     """Read config.json from a run directory."""
-    config_file = run_dir / "config.json"
-    if not config_file.exists():
-        return {}
-    try:
-        with open(config_file) as f:
-            return json.load(f)
-    except json.JSONDecodeError:
-        logger.warning(f"Failed to parse {config_file}")
-        return {}
+    store = TrainingRunStore(storage_from_uri(str(run_dir), mkdir=False))
+    return store.read_config() or {}
 
 
 def _extract_config_value(config: dict[str, Any], key: str) -> Any:
@@ -79,29 +61,33 @@ def collect(
     Returns:
         pandas DataFrame with config columns, metric columns, and ``log_path``.
     """
-    sweep_path = Path(sweep_dir)
-    if not sweep_path.is_dir():
+    sweep_uri = str(sweep_dir)
+    sweep_storage = storage_from_uri(sweep_uri, mkdir=False)
+    if not sweep_storage.exists(""):
         raise FileNotFoundError(f"Sweep directory does not exist: {sweep_dir}")
 
     rows: list[dict[str, Any]] = []
-    for run_dir in sorted(sweep_path.iterdir()):
-        if not run_dir.is_dir():
+    for run_name in sweep_storage.list_dir(""):
+        # Join directly (not via url(), which percent-encodes run names like "lr=1e-4").
+        run_path = os.path.join(sweep_uri, run_name)
+        # Skip non-run children (e.g. stray files): a run must have metrics.jsonl.
+        if not storage_from_uri(run_path, mkdir=False).exists("metrics.jsonl"):
             continue
 
-        metrics = _read_final_metrics(run_dir)
+        metrics = _read_final_metrics(run_path)
         if not metrics:
-            logger.warning(f"Skipping {run_dir.name}: no metrics.jsonl or empty")
+            logger.warning(f"Skipping {run_name}: no metrics.jsonl or empty")
             continue
 
         if require_complete:
             progress = metrics.get("progress", 0)
             if isinstance(progress, (int, float)) and progress < 0.98:
-                logger.warning(f"Skipping {run_dir.name}: incomplete (progress={progress:.2f})")
+                logger.warning(f"Skipping {run_name}: incomplete (progress={progress:.2f})")
                 continue
 
-        config = _read_config(run_dir)
+        config = _read_config(run_path)
 
-        row: dict[str, Any] = {"log_path": str(run_dir)}
+        row: dict[str, Any] = {"log_path": run_path}
 
         # Extract config values
         if config_keys is not None:

--- a/tinker_cookbook/recipes/chat_sl/sweep/runner.py
+++ b/tinker_cookbook/recipes/chat_sl/sweep/runner.py
@@ -14,6 +14,7 @@ import pandas as pd
 from tinker_cookbook.recipes.chat_sl.sweep.grid import default_run_name
 from tinker_cookbook.recipes.chat_sl.sweep.grid import grid as make_grid
 from tinker_cookbook.recipes.chat_sl.sweep.results import collect
+from tinker_cookbook.stores.storage import storage_from_uri
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +180,7 @@ def _run_sequential(
         run_name = namer(overrides)
         log_path = os.path.join(sweep_dir, run_name)
 
-        if skip_existing and os.path.exists(os.path.join(log_path, "metrics.jsonl")):
+        if skip_existing and storage_from_uri(log_path, mkdir=False).exists("metrics.jsonl"):
             print(f"  [{i + 1}/{len(points)}] Skipping {run_name} (already exists)")
             continue
 
@@ -206,7 +207,7 @@ def _run_parallel(
         run_name = namer(overrides)
         log_path = os.path.join(sweep_dir, run_name)
 
-        if skip_existing and os.path.exists(os.path.join(log_path, "metrics.jsonl")):
+        if skip_existing and storage_from_uri(log_path, mkdir=False).exists("metrics.jsonl"):
             print(f"  Skipping {run_name} (already exists)")
             continue
 

--- a/tinker_cookbook/recipes/sdft/benchmark.py
+++ b/tinker_cookbook/recipes/sdft/benchmark.py
@@ -45,6 +45,7 @@ import chz
 import tinker
 
 from tinker_cookbook import checkpoint_utils, cli_utils, renderers
+from tinker_cookbook.stores.storage import storage_from_uri
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 
@@ -340,22 +341,17 @@ def _save_results(
     config: BenchmarkConfig,
     model_path: str | None,
 ) -> None:
-    Path(log_path).mkdir(parents=True, exist_ok=True)
-    output_path = Path(log_path) / "eval_results.json"
-    with open(output_path, "w") as f:
-        json.dump(
-            {
-                "metrics": metrics,
-                "config": {
-                    "model_name": config.model_name,
-                    "model_path": model_path,
-                    "dataset": config.dataset,
-                },
-            },
-            f,
-            indent=2,
-        )
-    logger.info(f"Saved results to {output_path}")
+    storage = storage_from_uri(log_path)
+    payload = {
+        "metrics": metrics,
+        "config": {
+            "model_name": config.model_name,
+            "model_path": model_path,
+            "dataset": config.dataset,
+        },
+    }
+    storage.write("eval_results.json", json.dumps(payload, indent=2).encode("utf-8"))
+    logger.info("Saved results to %s", storage.url("eval_results.json"))
 
 
 async def cli_main(config: BenchmarkConfig) -> None:
@@ -400,11 +396,10 @@ async def cli_main(config: BenchmarkConfig) -> None:
 
     # Save summary
     log_root = config.log_root or "/tmp/tinker-examples/sdft-benchmark"
-    summary_path = Path(log_root) / f"benchmark_summary_{config.dataset}.json"
-    summary_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(summary_path, "w") as f:
-        json.dump(results, f, indent=2)
-    logger.info(f"Saved summary to {summary_path}")
+    storage = storage_from_uri(log_root)
+    summary_name = f"benchmark_summary_{config.dataset}.json"
+    storage.write(summary_name, json.dumps(results, indent=2).encode("utf-8"))
+    logger.info("Saved summary to %s", storage.url(summary_name))
 
 
 if __name__ == "__main__":

--- a/tinker_cookbook/recipes/sdft/run_continual_learning.py
+++ b/tinker_cookbook/recipes/sdft/run_continual_learning.py
@@ -37,6 +37,7 @@ from tinker_cookbook.recipes.sdft.datasets import (
     load_science_from_arrow,
     load_tooluse_from_arrow,
 )
+from tinker_cookbook.stores.storage import storage_from_uri
 from tinker_cookbook.supervised import train as sl_train
 from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
 from tinker_cookbook.tokenizer_utils import get_tokenizer
@@ -313,9 +314,9 @@ async def run_single(
     }
 
     # Save result
-    Path(log_path).mkdir(parents=True, exist_ok=True)
-    with open(f"{log_path}/run_result.json", "w") as f:
-        json.dump(result, f, indent=2)
+    storage_from_uri(log_path).write(
+        "run_result.json", json.dumps(result, indent=2).encode("utf-8")
+    )
 
     return result
 
@@ -362,20 +363,23 @@ async def cli_main(config: ExperimentConfig) -> None:
                 stage1_checkpoints[key] = result.get("checkpoint_path")
 
         # Save stage 1 checkpoint map
-        Path(config.log_root).mkdir(parents=True, exist_ok=True)
-        with open(f"{config.log_root}/stage1_checkpoints.json", "w") as f:
-            json.dump(stage1_checkpoints, f, indent=2)
+        storage_from_uri(config.log_root).write(
+            "stage1_checkpoints.json", json.dumps(stage1_checkpoints, indent=2).encode("utf-8")
+        )
         logger.info(f"Stage 1 checkpoints: {json.dumps(stage1_checkpoints, indent=2)}")
 
     # Load stage 1 checkpoints if we're only running stage 2
     if 1 not in stages and 2 in stages:
-        ckpt_file = f"{config.log_root}/stage1_checkpoints.json"
-        if Path(ckpt_file).exists():
-            with open(ckpt_file) as f:
-                stage1_checkpoints = json.load(f)
-            logger.info(f"Loaded stage 1 checkpoints from {ckpt_file}")
+        log_root_storage = storage_from_uri(config.log_root, mkdir=False)
+        if log_root_storage.exists("stage1_checkpoints.json"):
+            stage1_checkpoints = json.loads(log_root_storage.read("stage1_checkpoints.json"))
+            logger.info(
+                f"Loaded stage 1 checkpoints from {log_root_storage.url('stage1_checkpoints.json')}"
+            )
         else:
-            logger.error(f"No stage 1 checkpoints found at {ckpt_file}")
+            logger.error(
+                f"No stage 1 checkpoints found at {log_root_storage.url('stage1_checkpoints.json')}"
+            )
             return
 
     # Run stage 2

--- a/tinker_cookbook/recipes/true_thinking_score/analyze.py
+++ b/tinker_cookbook/recipes/true_thinking_score/analyze.py
@@ -29,7 +29,6 @@ import logging
 import random
 import sys
 from datetime import datetime
-from pathlib import Path
 from typing import Literal, cast
 
 import chz
@@ -41,6 +40,7 @@ from tinker_cookbook.recipes.math_rl.math_grading import extract_boxed
 from tinker_cookbook.recipes.true_thinking_score.tts import (
     generate_cot_and_compute_tts,
 )
+from tinker_cookbook.stores.storage import storage_from_uri
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
@@ -145,7 +145,7 @@ async def analyze_one_problem(
 async def cli_main(config: CLIConfig) -> None:
     # Build log path
     if config.log_path is not None:
-        log_dir = Path(config.log_path)
+        log_uri = config.log_path
     else:
         model_slug = config.model_name.replace("/", "-")
         run_name = (
@@ -153,15 +153,15 @@ async def cli_main(config: CLIConfig) -> None:
             f"{config.n_problems}problems-"
             f"{datetime.now().strftime('%Y-%m-%d-%H-%M')}"
         )
-        log_dir = Path(f"/tmp/tinker-examples/tts/{run_name}")
-    log_dir.mkdir(parents=True, exist_ok=True)
+        log_uri = f"/tmp/tinker-examples/tts/{run_name}"
+    storage = storage_from_uri(log_uri)
 
     logger.info("=== TTS Analysis ===")
     logger.info(f"Model: {config.model_name}")
     logger.info(f"Dataset: {config.dataset}")
     logger.info(f"Problems: {config.n_problems}")
     logger.info(f"Concurrency: {config.concurrency}")
-    logger.info(f"Log dir: {log_dir}")
+    logger.info(f"Log dir: {storage.url()}")
 
     # Load problems
     problems = _load_problems(config.dataset, config.n_problems, config.seed)
@@ -195,11 +195,9 @@ async def cli_main(config: CLIConfig) -> None:
     error_results = [r for r in results if r is not None and "error" in r]
 
     # Save per-problem JSONL
-    jsonl_path = log_dir / "tts_per_problem.jsonl"
-    with open(jsonl_path, "w") as f:
-        for r in results:
-            if r is not None:
-                f.write(json.dumps(r) + "\n")
+    jsonl_data = "".join(json.dumps(r) + "\n" for r in results if r is not None)
+    storage.write("tts_per_problem.jsonl", jsonl_data.encode("utf-8"))
+    jsonl_uri = storage.url("tts_per_problem.jsonl")
 
     # Compute aggregate stats
     all_tts: list[float] = []
@@ -235,9 +233,8 @@ async def cli_main(config: CLIConfig) -> None:
     }
 
     # Save aggregate summary
-    summary_path = log_dir / "tts_summary.json"
-    with open(summary_path, "w") as f:
-        json.dump(aggregate, f, indent=2)
+    storage.write("tts_summary.json", json.dumps(aggregate, indent=2).encode("utf-8"))
+    summary_uri = storage.url("tts_summary.json")
 
     # Print results
     logger.info(f"\n{'=' * 60}")
@@ -262,8 +259,8 @@ async def cli_main(config: CLIConfig) -> None:
     logger.info(f"  Paper SV decorative:  12-21%   | Ours: {aggregate['frac_sv_decorative']:.1%}")
 
     logger.info("\nResults saved to:")
-    logger.info(f"  Per-problem: {jsonl_path}")
-    logger.info(f"  Summary:     {summary_path}")
+    logger.info(f"  Per-problem: {jsonl_uri}")
+    logger.info(f"  Summary:     {summary_uri}")
 
 
 if __name__ == "__main__":

--- a/tinker_cookbook/recipes/true_thinking_score/run_small_experiment.py
+++ b/tinker_cookbook/recipes/true_thinking_score/run_small_experiment.py
@@ -17,11 +17,11 @@ Expected behavior:
 import asyncio
 import json
 import logging
-from pathlib import Path
 
 import tinker
 
 from tinker_cookbook.recipes.true_thinking_score.tts import generate_cot_and_compute_tts
+from tinker_cookbook.stores.storage import storage_from_uri
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
@@ -56,13 +56,12 @@ MODEL_NAME = "Qwen/Qwen3.5-4B"
 
 
 async def main():
-    log_dir = Path("/tmp/tinker-tts-experiment")
-    log_dir.mkdir(parents=True, exist_ok=True)
+    storage = storage_from_uri("/tmp/tinker-tts-experiment")
 
     logger.info("=== TTS Small-Scale Experiment ===")
     logger.info(f"Model: {MODEL_NAME}")
     logger.info(f"Problems: {len(PROBLEMS)}")
-    logger.info(f"Log dir: {log_dir}")
+    logger.info(f"Log dir: {storage.url()}")
 
     service_client = tinker.ServiceClient(
         user_metadata=recipe_user_metadata("experiment_true_thinking_score"),
@@ -118,32 +117,27 @@ async def main():
         logger.info(f"  Paper high TTS: ~2.3%  |  Ours: {high_tts * 100:.1f}%")
 
     # Save results
-    results_path = log_dir / "tts_results.json"
-    with open(results_path, "w") as f:
-        json.dump(
-            {
-                "model": MODEL_NAME,
-                "problems": results,
-                "aggregate": {
-                    "n_problems": len(results),
-                    "n_steps": len(all_tts_scores),
-                    "mean_tts": sum(all_tts_scores) / len(all_tts_scores) if all_tts_scores else 0,
-                    "frac_high_tts": (
-                        sum(1 for t in all_tts_scores if t >= 0.7) / len(all_tts_scores)
-                        if all_tts_scores
-                        else 0
-                    ),
-                    "frac_decorative": (
-                        sum(1 for t in all_tts_scores if t <= 0.005) / len(all_tts_scores)
-                        if all_tts_scores
-                        else 0
-                    ),
-                },
-            },
-            f,
-            indent=2,
-        )
-    logger.info(f"\nResults saved to {results_path}")
+    payload = {
+        "model": MODEL_NAME,
+        "problems": results,
+        "aggregate": {
+            "n_problems": len(results),
+            "n_steps": len(all_tts_scores),
+            "mean_tts": sum(all_tts_scores) / len(all_tts_scores) if all_tts_scores else 0,
+            "frac_high_tts": (
+                sum(1 for t in all_tts_scores if t >= 0.7) / len(all_tts_scores)
+                if all_tts_scores
+                else 0
+            ),
+            "frac_decorative": (
+                sum(1 for t in all_tts_scores if t <= 0.005) / len(all_tts_scores)
+                if all_tts_scores
+                else 0
+            ),
+        },
+    }
+    storage.write("tts_results.json", json.dumps(payload, indent=2).encode("utf-8"))
+    logger.info("\nResults saved to %s", storage.url("tts_results.json"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #762
* __->__ #761
* #760
* #759
* #758
* #757
* #756

Migrate sweep result collection, the SDFT benchmark and continual-learning
scripts, and the true-thinking-score scripts off pathlib/open() to
storage_from_uri/TrainingRunStore so their outputs land on cloud roots
too. Also fixes a percent-encoding bug when discovering sweep runs whose
names contain '=' (e.g. lr=1e-4).

Co-authored-by: Cursor <cursoragent@cursor.com>