### PR TITLE
trace + trainers: route tracing, Gantt, logtree, and log_path through Storage

### DIFF
--- a/skills/research/references/ops.md
+++ b/skills/research/references/ops.md
@@ -306,7 +306,7 @@ for i_batch in range(n_batches):
         await gather_rollouts(...)
         await train_step(...)
     metrics.update(window.get_timing_metrics())
-    window.write_spans_jsonl(log_path / "timing_spans.jsonl", step=i_batch)
+    window.save_timing(i_batch, store=store)
 ```
 
 #### Instrumenting code

--- a/tinker_cookbook/distillation/sdft.py
+++ b/tinker_cookbook/distillation/sdft.py
@@ -43,7 +43,6 @@ loss functions used, see the `Tinker loss docs <https://tinker-docs.thinkingmach
 import asyncio
 import logging
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any, Protocol, cast, runtime_checkable
 
 import chz
@@ -69,6 +68,7 @@ from tinker_cookbook.rl.types import (
     RLDataset,
     TrajectoryGroup,
 )
+from tinker_cookbook.stores.storage import normalize_log_path
 from tinker_cookbook.utils import ml_log, trace
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 from tinker_cookbook.utils.misc_utils import split_list
@@ -779,7 +779,7 @@ class Config:
 
     # Standard infra
     num_substeps: int = 1
-    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
+    log_path: str = chz.field(munger=lambda _, s: normalize_log_path(s))
     wandb_project: str | None = None
     wandb_name: str | None = None
     load_checkpoint_path: str | None = None
@@ -830,9 +830,10 @@ async def main(
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.set_name("main")
-        trace_events_path = str(Path(cfg.log_path) / "trace_events.jsonl")
-        logger.info(f"Tracing enabled. Events saved to {trace_events_path}")
-        trace.trace_init(output_file=trace_events_path)
+        assert store is not None, "Tracing requires a TrainingRunStore (provided by setup_logging)"
+        trace_events_uri = store.url(trace.TRACE_EVENTS_FILENAME)
+        logger.info(f"Tracing enabled. Events saved to {trace_events_uri}")
+        trace.trace_init(cfg.log_path)
 
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("pylatexenc").setLevel(logging.WARNING)
@@ -905,8 +906,6 @@ async def main(
     sampling_client, _ = await save_checkpoint_and_get_sampling_client(
         training_client, checkpoint_mgr, start_batch, start_batch
     )
-
-    log_path = Path(cfg.log_path)
 
     for i_batch in range(start_batch, num_batches):
         metrics: dict[str, Any] = {
@@ -1067,10 +1066,7 @@ async def main(
         # Log timing
         metrics.update(window.get_timing_metrics())
         window.save_timing(i_batch, store=store)
-        if cfg.span_chart_every > 0 and i_batch % cfg.span_chart_every == 0:
-            trace.save_gantt_chart_html(
-                window, i_batch, log_path / f"timing_gantt_{i_batch:06d}.html"
-            )
+        trace.maybe_write_gantt_html(window, i_batch, store, every=cfg.span_chart_every)
         ml_logger.log_metrics(metrics, step=i_batch)
 
     # Final checkpoint

--- a/tinker_cookbook/distillation/train_off_policy.py
+++ b/tinker_cookbook/distillation/train_off_policy.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from pathlib import Path
 from typing import Any
 
 import chz
@@ -53,6 +52,7 @@ from tinker_cookbook import checkpoint_utils, model_info
 from tinker_cookbook.distillation.datasets import TeacherConfig
 from tinker_cookbook.eval.evaluators import SamplingClientEvaluatorBuilder
 from tinker_cookbook.exceptions import ConfigurationError
+from tinker_cookbook.stores.storage import normalize_log_path
 from tinker_cookbook.supervised.types import SupervisedDataset, SupervisedDatasetBuilder
 from tinker_cookbook.utils import ml_log, trace
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
@@ -119,7 +119,7 @@ class Config:
     eval_every: int = 20
     max_steps: int | None = None
     load_checkpoint_path: str | None = None
-    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
+    log_path: str = chz.field(munger=lambda _, s: normalize_log_path(s))
     wandb_project: str | None = None
     wandb_name: str | None = None
     base_url: str | None = None
@@ -347,9 +347,10 @@ async def main(config: Config) -> None:
     )
     store = ml_logger.store
     if config.enable_trace:
-        trace_events_path = str(Path(config.log_path) / "trace_events.jsonl")
-        logger.info(f"Tracing enabled. Events saved to {trace_events_path}")
-        trace.trace_init(output_file=trace_events_path)
+        assert store is not None, "Tracing requires a TrainingRunStore (provided by setup_logging)"
+        trace_events_uri = store.url(trace.TRACE_EVENTS_FILENAME)
+        logger.info(f"Tracing enabled. Events saved to {trace_events_uri}")
+        trace.trace_init(config.log_path)
 
     resume_info = checkpoint_utils.get_last_checkpoint(config.log_path)
     start_batch = resume_info.batch if resume_info else 0

--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Sequence
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -42,10 +41,11 @@ from tinker_cookbook.rl.types import (
     EnvGroupBuilder,
     TrajectoryGroup,
 )
+from tinker_cookbook.stores.storage import normalize_log_path
 from tinker_cookbook.tokenizer_utils import Tokenizer
 from tinker_cookbook.utils import ml_log, trace
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
-from tinker_cookbook.utils.misc_utils import iteration_dir, safezip
+from tinker_cookbook.utils.misc_utils import safezip
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +158,7 @@ class Config:
     wandb_project: str | None = None
     wandb_name: str | None = None
 
-    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
+    log_path: str = chz.field(munger=lambda _, s: normalize_log_path(s))
     base_url: str | None = None
     enable_trace: bool = False
     span_chart_every: int = 0
@@ -301,8 +301,6 @@ async def do_sync_training(
         training_client, checkpoint_mgr, start_batch, start_batch
     )
 
-    log_path = Path(config.log_path)
-
     for i_batch in range(start_batch, end_batch):
         metrics = {
             "progress/batch": i_batch,
@@ -361,11 +359,9 @@ async def do_sync_training(
         # Log timing metrics from trace_iteration window
         metrics.update(window.get_timing_metrics())
         window.save_timing(i_batch, store=ml_logger.store)
-        if config.span_chart_every > 0 and i_batch % config.span_chart_every == 0:
-            iter_dir = iteration_dir(log_path, i_batch)
-            if iter_dir is not None:
-                iter_dir.mkdir(parents=True, exist_ok=True)
-                trace.save_gantt_chart_html(window, i_batch, iter_dir / "timing_gantt.html")
+        trace.maybe_write_gantt_html(
+            window, i_batch, ml_logger.store, every=config.span_chart_every
+        )
         ml_logger.log_metrics(metrics, step=i_batch)
 
 
@@ -381,17 +377,19 @@ async def main(
         config=config,
         wandb_name=config.wandb_name,
     )
+    store = ml_logger.store
     if config.enable_trace:
         # Get and rename the current (main) task
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.set_name("main")
-        trace_events_path = str(Path(config.log_path) / "trace_events.jsonl")
-        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_path}")
+        assert store is not None, "Tracing requires a TrainingRunStore (provided by setup_logging)"
+        trace_events_uri = store.url(trace.TRACE_EVENTS_FILENAME)
+        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_uri}")
         logger.info(
-            f"Run `python tinker_cookbook/utils/trace.py {trace_events_path} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
+            f"Run `python tinker_cookbook/utils/trace.py {trace_events_uri} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
         )
-        trace.trace_init(output_file=trace_events_path)
+        trace.trace_init(config.log_path)
 
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("pylatexenc").setLevel(logging.WARNING)

--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -4,7 +4,6 @@ Direct Preference Optimization (DPO) training
 
 import asyncio
 import logging
-from pathlib import Path
 from typing import cast
 
 import chz
@@ -14,6 +13,7 @@ import torch.nn.functional as F
 
 from tinker_cookbook import checkpoint_utils, model_info
 from tinker_cookbook.eval.evaluators import Evaluator, EvaluatorBuilder
+from tinker_cookbook.stores.storage import normalize_log_path
 from tinker_cookbook.supervised.train import run_evals
 from tinker_cookbook.supervised.types import ChatDatasetBuilder, SupervisedDataset
 from tinker_cookbook.tokenizer_utils import Tokenizer, get_tokenizer
@@ -21,7 +21,6 @@ from tinker_cookbook.utils import ml_log, trace
 from tinker_cookbook.utils.format_colorized import format_colorized
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 from tinker_cookbook.utils.lr_scheduling import LRSchedule, compute_schedule_lr_multiplier
-from tinker_cookbook.utils.misc_utils import iteration_dir
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +86,7 @@ class Config:
     """
 
     # Required parameters
-    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
+    log_path: str = chz.field(munger=lambda _, s: normalize_log_path(s))
     model_name: str
     recipe_name: str
     dataset_builder: ChatDatasetBuilder
@@ -269,7 +268,6 @@ def do_update(
     infrequent_evaluators: list[Evaluator],
     dataset: SupervisedDataset,
     ml_logger: ml_log.Logger,
-    log_path: str,
     tokenizer: Tokenizer,
     checkpoint_mgr: checkpoint_utils.CheckpointManager | None = None,
 ):
@@ -294,7 +292,6 @@ def do_update(
         dataset (SupervisedDataset): Training dataset providing batches of
             interleaved chosen/rejected ``Datum`` pairs.
         ml_logger (ml_log.Logger): Logger for metrics and W&B integration.
-        log_path (str): Directory for checkpoint and log output.
         tokenizer (Tokenizer): Tokenizer used for printing debug examples.
     """
     step = epoch_idx * n_batches + batch_idx
@@ -451,11 +448,7 @@ def do_update(
     # Log timing metrics from trace_iteration window
     metrics.update(window.get_timing_metrics())
     window.save_timing(step, store=ml_logger.store)
-    if config.span_chart_every > 0 and step % config.span_chart_every == 0:
-        iter_dir = iteration_dir(log_path, step)
-        if iter_dir is not None:
-            iter_dir.mkdir(parents=True, exist_ok=True)
-            trace.save_gantt_chart_html(window, step, iter_dir / "timing_gantt.html")
+    trace.maybe_write_gantt_html(window, step, ml_logger.store, every=config.span_chart_every)
     ml_logger.log_metrics(metrics=metrics, step=step)
 
 
@@ -488,12 +481,13 @@ def main(config: Config):
     )
     store = ml_logger.store
     if config.enable_trace:
-        trace_events_path = str(Path(config.log_path) / "trace_events.jsonl")
-        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_path}")
+        assert store is not None, "Tracing requires a TrainingRunStore (provided by setup_logging)"
+        trace_events_uri = store.url(trace.TRACE_EVENTS_FILENAME)
+        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_uri}")
         logger.info(
-            f"Run `python tinker_cookbook/utils/trace.py {trace_events_path} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
+            f"Run `python tinker_cookbook/utils/trace.py {trace_events_uri} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
         )
-        trace.trace_init(output_file=trace_events_path)
+        trace.trace_init(config.log_path)
 
     service_client = tinker.ServiceClient(
         base_url=config.base_url,
@@ -556,7 +550,6 @@ def main(config: Config):
                 infrequent_evaluators=infrequent_evaluators,
                 dataset=dataset,
                 ml_logger=ml_logger,
-                log_path=config.log_path,
                 tokenizer=tokenizer,
                 checkpoint_mgr=checkpoint_mgr,
             )

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -13,7 +13,6 @@ from collections.abc import Callable, Coroutine, Iterable, Iterator, Sequence
 from concurrent.futures import Executor
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
@@ -62,10 +61,11 @@ from tinker_cookbook.rl.types import (
     RLDatasetBuilder,
     TrajectoryGroup,
 )
+from tinker_cookbook.stores.storage import normalize_log_path
 from tinker_cookbook.tokenizer_utils import Tokenizer
 from tinker_cookbook.utils import logtree, ml_log, trace
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
-from tinker_cookbook.utils.misc_utils import iteration_dir, safezip, split_list
+from tinker_cookbook.utils.misc_utils import safezip, split_list
 
 logger = logging.getLogger(__name__)
 
@@ -165,32 +165,30 @@ _LOGTREE_EXPLANATION = (
 
 @contextmanager
 def _get_logtree_scope(
-    output_dir: Path | None,
     num_groups_to_log: int,
     f_name: str,
     scope_name: str,
     iteration: int,
     store: TrainingRunStore | None,
 ) -> Iterator[None]:
-    """Context manager that logs rollout data to HTML and JSON via logtree.
+    """Context manager that logs rollout data to HTML and JSON via the store.
 
-    Creates ``output_dir/f_name.html`` (direct I/O — visualization artifact)
-    and writes the logtree JSON via ``store.write_logtree()`` when store is available.
+    Writes ``iteration_NNNNNN/{f_name}_logtree.json`` and ``..._logtree.html``
+    through the store (cloud-safe) when one is available.
     """
-    if output_dir is None or num_groups_to_log <= 0:
+    if store is None or num_groups_to_log <= 0:
         yield
         return
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-    logtree_path = str(output_dir / f"{f_name}.html")
     logtree_trace = None
     try:
-        with logtree.init_trace(scope_name, path=logtree_path) as logtree_trace:
+        with logtree.init_trace(scope_name, path=None) as logtree_trace:
             logtree.log_text(_LOGTREE_EXPLANATION)
             yield
     finally:
-        if logtree_trace is not None and store is not None:
+        if logtree_trace is not None:
             store.write_logtree(iteration, logtree_trace.to_dict(), base_name=f_name)
+            store.write_logtree_html(iteration, logtree_trace.to_html(), base_name=f_name)
 
 
 def _select_representative_inds(scores: list[float], num_inds: int) -> list[int]:
@@ -437,7 +435,7 @@ class Config:
     # Maximum number of generated tokens per rollout trajectory.
     max_tokens: int
     # Directory for checkpoints, logs, and traces.
-    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
+    log_path: str = chz.field(munger=lambda _, s: normalize_log_path(s))
     # Evaluation cadence in training iterations (0 = disabled).
     eval_every: int = 20
     # Checkpoint cadence in training iterations (0 = disabled).
@@ -553,9 +551,7 @@ async def run_single_evaluation(
     """
     ev_name = _get_evaluator_name(evaluator)
     eval_base_name = f"eval_{evaluator_label}"
-    iter_dir = iteration_dir(config.log_path, i_batch)
     with _get_logtree_scope(
-        output_dir=iter_dir,
         num_groups_to_log=config.num_groups_to_log,
         f_name=eval_base_name,
         scope_name=f"Running evaluation {ev_name} {i_batch}",
@@ -570,7 +566,7 @@ async def run_single_evaluation(
                     base_name=eval_base_name,
                     sampling_client_step=i_batch,
                 )
-                if config.rollout_json_export and iter_dir is not None
+                if config.rollout_json_export and store is not None
                 else None
             )
             eval_metrics = await evaluator(
@@ -699,9 +695,7 @@ async def do_sync_training_with_stream_minibatch(
                     )
                     metrics.update(eval_metrics)
 
-            iter_dir = iteration_dir(config.log_path, i_batch)
             with _get_logtree_scope(
-                iter_dir,
                 config.num_groups_to_log,
                 "train",
                 f"RL Iteration {i_batch}",
@@ -805,13 +799,9 @@ async def do_sync_training_with_stream_minibatch(
             metrics.update(error_counter.get_metrics())
         metrics.update(window.get_timing_metrics())
         window.save_timing(i_batch, store=ml_logger.store)
-        if (
-            config.span_chart_every > 0
-            and i_batch % config.span_chart_every == 0
-            and iter_dir is not None
-        ):
-            iter_dir.mkdir(parents=True, exist_ok=True)
-            trace.save_gantt_chart_html(window, i_batch, iter_dir / "timing_gantt.html")
+        trace.maybe_write_gantt_html(
+            window, i_batch, ml_logger.store, every=config.span_chart_every
+        )
         ml_logger.log_metrics(metrics, step=i_batch)
 
 
@@ -1108,7 +1098,6 @@ async def do_async_training(
                     train_step_metrics,
                     full_batch_wrapped_trajectory_groups,
                 ) = streaming_result
-                iter_dir = iteration_dir(config.log_path, i_batch)
                 _maybe_export_rollout_summary_jsonl(
                     config=config,
                     base_name="train",
@@ -1165,7 +1154,6 @@ async def do_async_training(
                         [g.env_group_builder for g in wrapped_trajectory_groups],
                         [g.trajectory_group for g in wrapped_trajectory_groups],
                     )
-                iter_dir = iteration_dir(config.log_path, i_batch)
                 _maybe_export_rollout_summary_jsonl(
                     config=config,
                     base_name="train",
@@ -1196,11 +1184,9 @@ async def do_async_training(
                 metrics.update(error_counter.get_metrics())
             metrics.update(window.get_timing_metrics())
             window.save_timing(i_batch, store=ml_logger.store)
-            if config.span_chart_every > 0 and i_batch % config.span_chart_every == 0:
-                iter_dir = iteration_dir(config.log_path, i_batch)
-                if iter_dir is not None:
-                    iter_dir.mkdir(parents=True, exist_ok=True)
-                    trace.save_gantt_chart_html(window, i_batch, iter_dir / "timing_gantt.html")
+            trace.maybe_write_gantt_html(
+                window, i_batch, ml_logger.store, every=config.span_chart_every
+            )
             ml_logger.log_metrics(metrics, step=i_batch)
             i_batch += 1
             wrapped_trajectory_groups = []
@@ -1705,10 +1691,8 @@ async def do_sync_training(
             env_group_builders_P = dataset.get_batch(i_batch)
 
             # Initialize logtree trace for this iteration if logging is enabled
-            iter_dir = iteration_dir(config.log_path, i_batch)
             async with trace.scope_span("sampling"):
                 with _get_logtree_scope(
-                    output_dir=iter_dir,
                     num_groups_to_log=config.num_groups_to_log,
                     f_name="train",
                     scope_name=f"RL Iteration {i_batch}",
@@ -1796,13 +1780,9 @@ async def do_sync_training(
         if error_counter is not None:
             metrics.update(error_counter.get_metrics())
         window.save_timing(i_batch, store=ml_logger.store)
-        if (
-            config.span_chart_every > 0
-            and i_batch % config.span_chart_every == 0
-            and iter_dir is not None
-        ):
-            iter_dir.mkdir(parents=True, exist_ok=True)
-            trace.save_gantt_chart_html(window, i_batch, iter_dir / "timing_gantt.html")
+        trace.maybe_write_gantt_html(
+            window, i_batch, ml_logger.store, every=config.span_chart_every
+        )
         ml_logger.log_metrics(metrics, step=i_batch)
 
 
@@ -1861,12 +1841,13 @@ async def main(
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.set_name("main")
-        trace_events_path = str(Path(config.log_path) / "trace_events.jsonl")
-        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_path}")
+        assert store is not None, "Tracing requires a TrainingRunStore (provided by setup_logging)"
+        trace_events_uri = store.url(trace.TRACE_EVENTS_FILENAME)
+        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_uri}")
         logger.info(
-            f"Run `python tinker_cookbook/utils/trace.py {trace_events_path} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
+            f"Run `python tinker_cookbook/utils/trace.py {trace_events_uri} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
         )
-        trace.trace_init(output_file=trace_events_path)
+        trace.trace_init(config.log_path)
 
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("pylatexenc").setLevel(logging.WARNING)

--- a/tinker_cookbook/rl/train_test.py
+++ b/tinker_cookbook/rl/train_test.py
@@ -1,0 +1,75 @@
+"""Unit tests for rl.train helpers that do not require the Tinker API."""
+
+from pathlib import Path
+
+from tinker_cookbook.rl.train import _get_logtree_scope
+from tinker_cookbook.stores.storage import LocalStorage
+from tinker_cookbook.stores.training_store import TrainingRunStore
+from tinker_cookbook.utils import logtree
+
+
+def test_get_logtree_scope_writes_json_and_html(tmp_path: Path) -> None:
+    """The scope routes both the logtree JSON and HTML through the store."""
+    store = TrainingRunStore(LocalStorage(tmp_path))
+    with _get_logtree_scope(
+        num_groups_to_log=2,
+        f_name="train",
+        scope_name="RL Iteration 0",
+        iteration=0,
+        store=store,
+    ):
+        logtree.log_text("hello-from-rollout")
+
+    # JSON logtree round-trips through the store.
+    data = store.read_logtree(0, base_name="train")
+    assert data is not None
+    assert data["title"] == "RL Iteration 0"
+
+    # HTML logtree is a full document containing the logged content.
+    html = store.storage.read("iteration_000000/train_logtree.html").decode("utf-8")
+    assert html.startswith("<!doctype html>")
+    assert "hello-from-rollout" in html
+
+
+def test_get_logtree_scope_uses_base_name(tmp_path: Path) -> None:
+    """f_name controls the artifact base name (e.g. per-evaluator logtrees)."""
+    store = TrainingRunStore(LocalStorage(tmp_path))
+    with _get_logtree_scope(
+        num_groups_to_log=1,
+        f_name="eval_gsm8k",
+        scope_name="Eval gsm8k",
+        iteration=3,
+        store=store,
+    ):
+        logtree.log_text("eval-rollout")
+
+    assert store.read_logtree(3, base_name="eval_gsm8k") is not None
+    assert store.storage.exists("iteration_000003/eval_gsm8k_logtree.html")
+
+
+def test_get_logtree_scope_skips_when_num_groups_zero(tmp_path: Path) -> None:
+    """num_groups_to_log <= 0 disables logtree capture and writes nothing."""
+    store = TrainingRunStore(LocalStorage(tmp_path))
+    with _get_logtree_scope(
+        num_groups_to_log=0,
+        f_name="train",
+        scope_name="RL Iteration 0",
+        iteration=0,
+        store=store,
+    ):
+        logtree.log_text("should-not-be-written")
+
+    assert store.read_logtree(0, base_name="train") is None
+    assert not store.storage.exists("iteration_000000/train_logtree.html")
+
+
+def test_get_logtree_scope_no_store_is_noop() -> None:
+    """With no store the scope is a safe no-op (logging gracefully disabled)."""
+    with _get_logtree_scope(
+        num_groups_to_log=2,
+        f_name="train",
+        scope_name="RL Iteration 0",
+        iteration=0,
+        store=None,
+    ):
+        logtree.log_text("no-store")  # no active trace -> graceful no-op

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -12,7 +12,6 @@ import logging
 import time
 from collections import deque
 from dataclasses import dataclass
-from pathlib import Path
 
 import chz
 import tinker
@@ -27,6 +26,7 @@ from tinker_cookbook.eval.evaluators import (
     TrainingClientEvaluator,
 )
 from tinker_cookbook.exceptions import ConfigurationError
+from tinker_cookbook.stores.storage import normalize_log_path
 from tinker_cookbook.supervised.common import compute_mean_nll
 from tinker_cookbook.supervised.nll_evaluator import NLLEvaluator
 from tinker_cookbook.supervised.types import SupervisedDatasetBuilder
@@ -34,7 +34,6 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
 from tinker_cookbook.utils import ml_log, trace
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 from tinker_cookbook.utils.lr_scheduling import LRSchedule, compute_schedule_lr_multiplier
-from tinker_cookbook.utils.misc_utils import iteration_dir
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +108,7 @@ class Config:
     """
 
     # Required parameters
-    log_path: str = chz.field(munger=lambda _, s: str(Path(s).expanduser()))
+    log_path: str = chz.field(munger=lambda _, s: normalize_log_path(s))
     model_name: str
     recipe_name: str
     load_checkpoint_path: str | None = None
@@ -311,12 +310,13 @@ async def main(config: Config):
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.set_name("main")
-        trace_events_path = str(Path(config.log_path) / "trace_events.jsonl")
-        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_path}")
+        assert store is not None, "Tracing requires a TrainingRunStore (provided by setup_logging)"
+        trace_events_uri = store.url(trace.TRACE_EVENTS_FILENAME)
+        logger.info(f"Tracing is enabled. Trace events will be saved to {trace_events_uri}")
         logger.info(
-            f"Run `python tinker_cookbook/utils/trace.py {trace_events_path} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
+            f"Run `python tinker_cookbook/utils/trace.py {trace_events_uri} trace.json` and visualize in chrome://tracing or https://ui.perfetto.dev/"
         )
-        trace.trace_init(output_file=trace_events_path)
+        trace.trace_init(config.log_path)
 
     service_client = tinker.ServiceClient(
         base_url=config.base_url,
@@ -494,18 +494,12 @@ async def main(config: Config):
         if submitted.infrequent_eval_metrics is not None:
             metrics.update(submitted.infrequent_eval_metrics)
 
-    log_path = Path(config.log_path)
-
     async def finish_and_log(submitted: SubmittedBatch, window: trace.IterationWindow) -> None:
         """Finish a batch, merge timing metrics, and log."""
         await finish_batch(submitted)
         submitted.metrics.update(window.get_timing_metrics())
         window.save_timing(submitted.step, store=store)
-        if config.span_chart_every > 0 and submitted.step % config.span_chart_every == 0:
-            iter_dir = iteration_dir(log_path, submitted.step)
-            if iter_dir is not None:
-                iter_dir.mkdir(parents=True, exist_ok=True)
-                trace.save_gantt_chart_html(window, submitted.step, iter_dir / "timing_gantt.html")
+        trace.maybe_write_gantt_html(window, submitted.step, store, every=config.span_chart_every)
         ml_logger.log_metrics(metrics=submitted.metrics, step=submitted.step)
 
     assert config.submit_ahead >= 0, f"submit_ahead must be >= 0, got {config.submit_ahead}"

--- a/tinker_cookbook/utils/misc_utils.py
+++ b/tinker_cookbook/utils/misc_utils.py
@@ -7,7 +7,6 @@ import logging
 import time
 from collections.abc import Sequence
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Any, TypeVar, cast
 
 import numpy as np
@@ -174,24 +173,3 @@ def not_none(x: T | None) -> T:
     """
     assert x is not None, f"{x=} must not be None"
     return x
-
-
-def iteration_dir(log_path: str | Path | None, step: int) -> Path | None:
-    """Return the per-iteration subdirectory path for one training step.
-
-    Output files for each training step are grouped under
-    ``log_path/iteration_NNNNNN/`` to keep the top-level directory manageable.
-
-    Args:
-        log_path (str | Path | None): Root log directory, or ``None`` to
-            disable iteration directories.
-        step (int): Training step number (zero-padded to 6 digits in the
-            directory name).
-
-    Returns:
-        Path | None: The iteration subdirectory path, or ``None`` when
-            *log_path* is ``None`` or empty.
-    """
-    if not log_path:
-        return None
-    return Path(log_path) / f"iteration_{step:06d}"

--- a/tinker_cookbook/utils/trace.py
+++ b/tinker_cookbook/utils/trace.py
@@ -15,14 +15,17 @@ from collections.abc import Callable, Generator
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum
-from io import TextIOWrapper
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from tinker_cookbook.stores.training_store import TrainingRunStore
+import tinker
+
+from tinker_cookbook.stores.storage import Storage, storage_from_uri
+from tinker_cookbook.stores.training_store import TrainingRunStore
 
 logger = logging.getLogger(__name__)
+
+# Filename of the per-run Perfetto/Chrome trace stream, written under log_dir.
+TRACE_EVENTS_FILENAME = "trace_events.jsonl"
 
 
 class EventType(StrEnum):
@@ -125,12 +128,11 @@ class IterationWindow:
             # Aggregated metrics: time/total, time/run_evals, time/sample_async:total, ...
             metrics.update(window.get_timing_metrics())
 
-            # Persist per-span data for post-hoc analysis
-            window.write_spans_jsonl(log_path / "timing_spans.jsonl", step=i_batch)
+            # Persist per-span data for post-hoc analysis (cloud-safe via the store)
+            window.save_timing(i_batch, store=store)
 
-            # Optional: save a Gantt chart every K steps
-            if i_batch % 10 == 0:
-                save_gantt_chart_html(window, i_batch, log_path / f"gantt_{i_batch}.html")
+            # Optional: save a Gantt chart on a cadence (no-op on other steps)
+            maybe_write_gantt_html(window, i_batch, store, every=10)
 
             ml_logger.log_metrics(metrics, step=i_batch)
     """
@@ -276,27 +278,7 @@ class IterationWindow:
             for s in spans
         ]
 
-    def write_spans_jsonl(self, path: Path | str, step: int) -> None:
-        """Append span records for this iteration as one JSON line to the given file.
-
-        Format: ``{"step": N, "spans": [{"name": ..., "duration": ..., "wall_start": ..., "wall_end": ...}, ...]}``
-
-        .. deprecated::
-            Prefer ``store.write_timing_spans(step, window.get_span_dicts())``
-            which goes through the Storage protocol.
-
-        Args:
-            path (Path | str): File path to append to (created if missing).
-            step (int): Training step number to include in the record.
-        """
-        span_dicts = self.get_span_dicts()
-        if not span_dicts:
-            return
-        line = json.dumps({"step": step, "spans": span_dicts})
-        with open(path, "a") as f:
-            f.write(line + "\n")
-
-    def save_timing(self, step: int, *, store: "TrainingRunStore | None") -> None:
+    def save_timing(self, step: int, *, store: TrainingRunStore | None) -> None:
         """Write timing spans to ``timing_spans.jsonl`` via the store.
 
         Args:
@@ -321,14 +303,18 @@ class TraceCollector:
     flush remaining events and join the thread.
 
     Args:
-        flush_interval_sec (float): Maximum seconds between disk flushes.
-        output_file (str): Path for the JSONL output file.
+        storage (Storage): Backend that ``trace_events.jsonl`` is appended to.
+        flush_interval_sec (float): Maximum seconds between flushes.
     """
 
-    def __init__(self, flush_interval_sec: float = 1.0, output_file: str = "trace_events.jsonl"):
+    def __init__(
+        self,
+        storage: Storage,
+        flush_interval_sec: float = 1.0,
+    ):
         self.event_queue: queue.Queue[TraceEvent] = queue.Queue()
         self.flush_interval_sec = flush_interval_sec
-        self.output_file = output_file
+        self.storage = storage
         self.shutdown_event = threading.Event()
         self.flusher_thread = threading.Thread(target=self._flush_worker, daemon=True)
         self.flusher_thread.start()
@@ -368,7 +354,8 @@ class TraceCollector:
                 break
         return events
 
-    def _write_events(self, events: list[TraceEvent], f: TextIOWrapper) -> None:
+    def _serialize_events(self, events: list[TraceEvent]) -> bytes:
+        lines: list[str] = []
         for event in events:
             # Map the event pids (thread ids) to fake pids. If pid numbers are large,
             # Perfetto has issues rendering these as different groups of tracks
@@ -383,31 +370,37 @@ class TraceCollector:
                     continue
                 self.metadata_events[(event.pid, event.tid)] = event
 
-            json.dump(event.to_dict(), f)
-            f.write("\n")
-        f.flush()
+            lines.append(json.dumps(event.to_dict()))
+        if not lines:
+            return b""
+        return ("\n".join(lines) + "\n").encode("utf-8")
+
+    def _flush_events(self, events: list[TraceEvent]) -> None:
+        """Serialize a batch of events and append it via Storage (no-op if empty)."""
+        data = self._serialize_events(events)
+        if data:
+            self.storage.append(TRACE_EVENTS_FILENAME, data)
 
     def _flush_worker(self):
-        """Background thread worker that periodically flushes events to file."""
-        # Use append mode to avoid overwriting previous events when resuming
-        # from a checkpoint
-        with open(self.output_file, "a") as f:
-            while not self.shutdown_event.is_set():
-                events_to_write = self.get_all_events_immediately_available()
+        """Background thread: batch trace events and append them via Storage.
 
-                # Collect events with a timeout to check shutdown periodically
-                try:
-                    # Get first event with timeout and any additional events that are immediately available
-                    event = self.event_queue.get(timeout=self.flush_interval_sec)
-                    events_to_write.append(event)
-                    events_to_write.extend(self.get_all_events_immediately_available())
-                except queue.Empty:
-                    # No events to flush, continue checking for shutdown
-                    continue
-                self._write_events(events_to_write, f)
+        All Storage access is on this one thread, so no locking is needed.
+        ``append`` grows the file (cloud backends stage locally); the final
+        ``flush`` uploads any staged data on shutdown.
+        """
+        while not self.shutdown_event.is_set():
+            events = self.get_all_events_immediately_available()
+            # Wait briefly for the next event so appends stay batched.
+            try:
+                events.append(self.event_queue.get(timeout=self.flush_interval_sec))
+                events.extend(self.get_all_events_immediately_available())
+            except queue.Empty:
+                pass
+            self._flush_events(events)
 
-            # Flush remaining events on shutdown
-            self._write_events(self.get_all_events_immediately_available(), f)
+        # Drain remaining events, then upload staged data (cloud) on shutdown.
+        self._flush_events(self.get_all_events_immediately_available())
+        self.storage.flush()
 
     def shutdown(self) -> None:
         """Shutdown the background flusher thread and flush remaining events."""
@@ -431,8 +424,6 @@ atexit.register(_atexit_trace_shutdown)
 
 def _instrument_sdk_clients() -> None:
     """Patch Tinker SDK client classes with @scope for automatic tracing."""
-    import tinker
-
     _methods_to_patch = {
         tinker.TrainingClient: [
             "forward_async",
@@ -465,18 +456,18 @@ def _instrument_sdk_clients() -> None:
                     setattr(cls, method_name, wrapped)
 
 
-def trace_init(
-    flush_interval_sec: float = 1.0,
-    output_file: str = "trace_events.jsonl",
-) -> None:
+def trace_init(log_dir: str = ".", flush_interval_sec: float = 1.0) -> None:
     """Initialize the trace collector.
 
     Args:
-        flush_interval_sec: How often to flush trace events to disk.
-        output_file: Path for Perfetto trace output (JSONL format).
+        log_dir: Run log directory or URI to write ``trace_events.jsonl`` into.
+        flush_interval_sec: Maximum seconds between flushes.
     """
     global _trace_collector
-    _trace_collector = TraceCollector(flush_interval_sec, output_file)
+    _trace_collector = TraceCollector(
+        storage=storage_from_uri(log_dir),
+        flush_interval_sec=flush_interval_sec,
+    )
     _instrument_sdk_clients()
 
 
@@ -914,20 +905,40 @@ def _build_gantt_chart(span_records: list[dict[str, Any]], step: int) -> Any:
     return fig
 
 
-def save_gantt_chart_html(window: IterationWindow, step: int, path: Path | str) -> None:
-    """Build a Plotly Gantt chart from the window's spans and save as standalone HTML.
+def gantt_chart_html(window: IterationWindow, step: int) -> str | None:
+    """Return a standalone Plotly Gantt chart as an HTML string, or ``None``.
 
-    No-op if plotly is not installed or the window has no spans.
+    ``None`` when plotly is not installed or the window has no spans. Use this
+    to write the chart through a ``Storage`` backend (cloud-safe).
 
     Args:
         window (IterationWindow): The iteration window containing span data.
         step (int): Training step number, used in the chart title.
-        path (Path | str): Output file path for the HTML chart.
     """
     span_records = window.get_span_records()
     fig = _build_gantt_chart(span_records, step)
-    if fig is not None:
-        fig.write_html(str(path))
+    if fig is None:
+        return None
+    return fig.to_html()
+
+
+def maybe_write_gantt_html(
+    window: IterationWindow,
+    step: int,
+    store: TrainingRunStore | None,
+    *,
+    every: int,
+) -> None:
+    """Render and write the per-iteration Gantt chart via the store when due.
+
+    No-op when *every* <= 0, *step* is not a multiple of *every*, there is no
+    store, or plotly is unavailable.
+    """
+    if every <= 0 or step % every != 0 or store is None:
+        return
+    html = gantt_chart_html(window, step)
+    if html is not None:
+        store.write_gantt_html(step, html)
 
 
 @contextlib.contextmanager
@@ -960,7 +971,7 @@ def trace_iteration(step: int) -> Generator[IterationWindow, None, None]:
                 await gather_rollouts(...)
                 await train_step(...)
             metrics.update(window.get_timing_metrics())
-            window.write_spans_jsonl(log_path / "timing_spans.jsonl", step=i_batch)
+            window.save_timing(i_batch, store=store)
             ml_logger.log_metrics(metrics, step=i_batch)
     """
     window = IterationWindow()

--- a/tinker_cookbook/utils/trace_test.py
+++ b/tinker_cookbook/utils/trace_test.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import tinker
 
 from tinker_cookbook.utils.trace import (
@@ -15,7 +16,7 @@ from tinker_cookbook.utils.trace import (
     SpanRecord,
     _build_gantt_chart,
     get_scope_context,
-    save_gantt_chart_html,
+    maybe_write_gantt_html,
     scope,
     scope_span,
     scope_span_sync,
@@ -30,11 +31,11 @@ from tinker_cookbook.utils.trace import (
 
 @contextlib.contextmanager
 def trace_session():
-    """Start a trace session backed by a temporary JSONL file."""
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=True) as f:
-        trace_init(output_file=f.name)
+    """Start a trace session backed by a temporary trace_events.jsonl file."""
+    with tempfile.TemporaryDirectory() as d:
+        trace_init(d)
         try:
-            yield f.name
+            yield str(Path(d) / "trace_events.jsonl")
         finally:
             trace_shutdown()
 
@@ -117,12 +118,12 @@ async def example_program():
 
 
 def test_trace():
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=True) as temp_file:
-        trace_init(output_file=temp_file.name)
+    with tempfile.TemporaryDirectory() as d:
+        trace_init(d)
         asyncio.run(example_program())
         trace_shutdown()
 
-        with open(temp_file.name) as f:
+        with open(Path(d) / "trace_events.jsonl") as f:
             events = [json.loads(line) for line in f]
 
         # There should be 2 process metadata events
@@ -271,45 +272,105 @@ def test_get_timing_metrics_without_total():
     assert "time/total" not in metrics
 
 
-# --- write_spans_jsonl ---
+# --- save_timing ---
 
 
-def test_write_spans_jsonl():
-    """write_spans_jsonl appends one JSON line per call."""
+def test_save_timing_writes_via_store(tmp_path):
+    """save_timing appends one timing_spans.jsonl record per call via the store."""
+    from tinker_cookbook.stores import TrainingRunStore, storage_from_uri
+
+    store = TrainingRunStore(storage_from_uri(str(tmp_path)))
     window = IterationWindow()
     window.record_span("a", 100.0, 101.5)
     window.record_span("b", 100.2, 102.0)
 
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=True, mode="w") as f:
-        path = f.name
+    window.save_timing(0, store=store)
+    window.save_timing(1, store=store)
 
-    window.write_spans_jsonl(path, step=0)
-    window.write_spans_jsonl(path, step=1)
-
-    with open(path) as f:
-        lines = [json.loads(line) for line in f]
-
-    assert len(lines) == 2
-    assert lines[0]["step"] == 0
-    assert lines[1]["step"] == 1
-    assert len(lines[0]["spans"]) == 2
-    assert lines[0]["spans"][0]["name"] == "a"
-    assert lines[0]["spans"][1]["name"] == "b"
-    assert abs(lines[0]["spans"][0]["duration"] - 1.5) < 1e-9
+    records = store.read_timing()
+    assert len(records) == 2
+    assert records[0]["step"] == 0
+    assert records[1]["step"] == 1
+    assert len(records[0]["spans"]) == 2
+    assert records[0]["spans"][0]["name"] == "a"
+    assert records[0]["spans"][1]["name"] == "b"
+    assert abs(records[0]["spans"][0]["duration"] - 1.5) < 1e-9
     # wall_start of first span should be ~0 (relative)
-    assert lines[0]["spans"][0]["wall_start"] < 0.1
-
-    Path(path).unlink(missing_ok=True)
+    assert records[0]["spans"][0]["wall_start"] < 0.1
 
 
-def test_write_spans_jsonl_empty_window():
-    """write_spans_jsonl is a no-op for empty windows."""
+def test_save_timing_empty_window_noop(tmp_path):
+    """save_timing is a no-op for empty windows."""
+    from tinker_cookbook.stores import TrainingRunStore, storage_from_uri
+
+    store = TrainingRunStore(storage_from_uri(str(tmp_path)))
     window = IterationWindow()
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=True, mode="w") as f:
-        path = f.name
+    window.save_timing(0, store=store)
+    assert store.read_timing() == []
 
-    window.write_spans_jsonl(path, step=0)
-    assert not Path(path).exists()
+
+# --- trace_init ---
+
+
+def test_trace_init_writes_trace_events(tmp_path):
+    """trace_init(log_dir) appends trace_events.jsonl under the log dir (cloud-safe)."""
+    trace_init(str(tmp_path))
+    try:
+        with scope_span_sync("unit_span"):
+            pass
+    finally:
+        trace_shutdown()
+
+    trace_file = tmp_path / "trace_events.jsonl"
+    assert trace_file.exists()
+    assert trace_file.read_bytes()
+
+
+def test_trace_init_appends_across_sessions(tmp_path):
+    """A second trace_init appends to trace_events.jsonl (resume-safe)."""
+    trace_file = tmp_path / "trace_events.jsonl"
+
+    trace_init(str(tmp_path))
+    try:
+        with scope_span_sync("first"):
+            pass
+    finally:
+        trace_shutdown()
+    size_after_first = len(trace_file.read_bytes())
+    assert size_after_first > 0
+
+    trace_init(str(tmp_path))
+    try:
+        with scope_span_sync("second"):
+            pass
+    finally:
+        trace_shutdown()
+    size_after_second = len(trace_file.read_bytes())
+    assert size_after_second > size_after_first
+
+
+# --- maybe_write_gantt_html ---
+
+
+def test_maybe_write_gantt_html_writes_via_store(tmp_path):
+    pytest.importorskip("plotly")
+    from tinker_cookbook.stores import TrainingRunStore, storage_from_uri
+
+    store = TrainingRunStore(storage_from_uri(str(tmp_path)))
+    window = IterationWindow()
+    window.record_span("a", 100.0, 101.0)
+    maybe_write_gantt_html(window, 2, store, every=1)
+    assert store.storage.exists("iteration_000002/timing_gantt.html")
+
+
+def test_maybe_write_gantt_html_skips_when_not_due(tmp_path):
+    from tinker_cookbook.stores import TrainingRunStore, storage_from_uri
+
+    store = TrainingRunStore(storage_from_uri(str(tmp_path)))
+    window = IterationWindow()
+    window.record_span("a", 100.0, 101.0)
+    maybe_write_gantt_html(window, 3, store, every=2)  # 3 % 2 != 0 -> skip
+    assert not store.storage.exists("iteration_000003/timing_gantt.html")
 
 
 # --- trace_iteration ---
@@ -503,13 +564,11 @@ def test_scope_span_async():
 def test_scope_span_with_perfetto():
     """scope_span records to both Perfetto and iteration window."""
 
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as tmp:
-        trace_file = tmp.name
-
-    try:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trace_file = Path(tmpdir) / "trace_events.jsonl"
 
         async def run():
-            trace_init(output_file=trace_file)
+            trace_init(tmpdir)
             try:
                 with trace_iteration(step=0) as window:
                     async with scope_span("traced_span"):
@@ -529,8 +588,6 @@ def test_scope_span_with_perfetto():
             events = [json.loads(line) for line in f]
         span_events = [e for e in events if e.get("name") == "traced_span"]
         assert len(span_events) >= 2  # BEGIN + END
-    finally:
-        Path(trace_file).unlink(missing_ok=True)
 
 
 def test_scope_span_noop():
@@ -642,30 +699,6 @@ def test_build_gantt_chart_no_plotly():
     with patch.dict("sys.modules", {"plotly": None, "plotly.express": None}):
         fig = _build_gantt_chart(span_records, step=0)
     assert fig is None
-
-
-def test_save_gantt_chart_html():
-    """save_gantt_chart_html writes an HTML file when plotly is available."""
-    window = IterationWindow()
-    window.record_span("a", 100.0, 101.0)
-    window.record_span("b", 100.5, 102.0)
-
-    with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
-        path = Path(f.name)
-
-    save_gantt_chart_html(window, step=0, path=path)
-
-    try:
-        import plotly  # noqa: F401
-
-        assert path.exists()
-        content = path.read_text()
-        assert "plotly" in content.lower() or "Plotly" in content
-    except ImportError:
-        # plotly not installed — file should not be created
-        pass
-    finally:
-        path.unlink(missing_ok=True)
 
 
 # --- SDK client instrumentation ---
@@ -861,20 +894,6 @@ def test_gantt_chart_sync_rl_layout():
     # Phase-level spans are single calls
     assert "time/sampling" in metrics
     assert "time/train_step" in metrics
-
-    # Gantt chart renders without error
-    with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as f:
-        path = Path(f.name)
-    try:
-        save_gantt_chart_html(window, step=0, path=path)
-        try:
-            import plotly  # noqa: F401
-
-            assert path.exists()
-        except ImportError:
-            pass
-    finally:
-        path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/tinker_cookbook/utils/trace_test.py
+++ b/tinker_cookbook/utils/trace_test.py
@@ -917,7 +917,9 @@ def test_convert_jsonl_to_json_main_cloud(monkeypatch):
 
     base = f"memory://bucket/{uuid.uuid4()}"
     storage_from_uri(base).write("trace_events.jsonl", b'{"name": "a"}\n{"name": "b"}\n')
-    monkeypatch.setattr("sys.argv", ["trace.py", f"{base}/trace_events.jsonl", f"{base}/trace.json"])
+    monkeypatch.setattr(
+        "sys.argv", ["trace.py", f"{base}/trace_events.jsonl", f"{base}/trace.json"]
+    )
 
     convert_jsonl_to_json_main()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #762
* #761
* #760
* #759
* #758
* #757
* #756

Make the training loops fully cloud-safe and drop local-only assumptions:

- trace.py: TraceCollector / trace_init(log_dir) append trace_events.jsonl
  through Storage; add gantt_chart_html() and maybe_write_gantt_html();
  add a TRACE_EVENTS_FILENAME constant; remove the dead write_spans_jsonl
  and save_gantt_chart_html helpers; fix an event-loss edge in the flush
  loop.
- 6 trainers (rl, supervised, dpo, on/off-policy distillation, sdft): use
  normalize_log_path mungers, trace_init(log_path), and
  maybe_write_gantt_html; rl routes logtree HTML/JSON through the store.
- Remove the now-unused misc_utils.iteration_dir.

Updates ops.md and adds rl/train_test.py.

Co-authored-by: Cursor <cursoragent@cursor.com>