### PR TITLE
ci: add /land workflow for ghstack PRs

### DIFF
--- a/.github/workflows/ghstack_land.yaml
+++ b/.github/workflows/ghstack_land.yaml
@@ -12,8 +12,8 @@ name: ghstack land
 # normal push CI, so the default `GITHUB_TOKEN` is not enough. Configure a
 # GitHub App with `contents: write` + `pull_requests: write` that is allowed to
 # bypass branch protection, and store its credentials as repo secrets:
-#   GHSTACK_APP_ID           the App's id
-#   GHSTACK_APP_PRIVATE_KEY  the App's private key (PEM)
+#   BOT_APP_ID           the App's id
+#   BOT_APP_PRIVATE_KEY  the App's private key (PEM)
 
 on:
   issue_comment:
@@ -27,8 +27,8 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ secrets.GHSTACK_APP_ID }}
-          private-key: ${{ secrets.GHSTACK_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Acknowledge the comment
         run: |

--- a/.github/workflows/ghstack_land.yaml
+++ b/.github/workflows/ghstack_land.yaml
@@ -21,7 +21,15 @@ on:
 
 jobs:
   ghstack_land:
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/land') }}
+    # `issue_comment` runs in the base repo with access to secrets no matter who
+    # commented, so on a public repo the trigger must be gated to trusted users.
+    # `OWNER`/`MEMBER` means a member of the org that owns this repo
+    # (thinking-machines-lab); `COLLABORATOR` is intentionally excluded so that
+    # outside collaborators cannot land.
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/land') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/ghstack_land.yaml
+++ b/.github/workflows/ghstack_land.yaml
@@ -1,0 +1,174 @@
+name: ghstack land
+
+# Land a PR by commenting `/land` on it.
+#
+#   /land                  Land a ghstack stack bottom-up once every PR is
+#                          approved and CI is green (waits for in-flight CI).
+#   /land --force <reason> Skip CI. For a ghstack PR this lands the stack
+#                          anyway; for a regular PR it does an admin squash
+#                          merge. A reason is mandatory.
+#
+# Landing pushes to `main` (a protected branch) and must be able to trigger the
+# normal push CI, so the default `GITHUB_TOKEN` is not enough. Configure a
+# GitHub App with `contents: write` + `pull_requests: write` that is allowed to
+# bypass branch protection, and store its credentials as repo secrets:
+#   GHSTACK_APP_ID           the App's id
+#   GHSTACK_APP_PRIVATE_KEY  the App's private key (PEM)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ghstack_land:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/land') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.GHSTACK_APP_ID }}
+          private-key: ${{ secrets.GHSTACK_APP_PRIVATE_KEY }}
+
+      - name: Acknowledge the comment
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -d '{"content":"rocket"}'
+
+      - name: Parse --force flag
+        id: parse
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT: ${{ github.event.comment.body }}
+        run: |
+          if [[ "$COMMENT" == *"--force"* ]]; then
+            # Everything after `/land --force` is the (mandatory) reason.
+            REASON=$(echo "$COMMENT" \
+              | sed -E 's/(^|[[:space:]])--force([[:space:]]|$)/ /g' \
+              | sed -E 's/^[[:space:]]*\/land[[:space:]]*//' \
+              | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+            if [[ -z "$REASON" ]]; then
+              echo "::error::--force requires a reason"
+              gh pr comment "${{ github.event.issue.html_url }}" \
+                --body "⚠️ Force landing failed: provide a reason, e.g. \`/land --force <reason>\`"
+              exit 1
+            fi
+            echo "force=true" >> "$GITHUB_OUTPUT"
+            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          else
+            echo "force=false" >> "$GITHUB_OUTPUT"
+            echo "reason=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get PR details
+        id: get-pr
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          PR_DATA=$(curl -s \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/pulls/$PR_NUMBER")
+
+          PR_HEAD_REF=$(echo "$PR_DATA" | jq -r .head.ref)
+          PR_URL="${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER"
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_branch=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+          # ghstack PRs use the gh/<user>/<n>/head branch convention.
+          if [[ "$PR_HEAD_REF" =~ ^gh/[^/]+/[0-9]+/head$ ]]; then
+            echo "is_ghstack=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_ghstack=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # --- Regular (non-ghstack) PRs ---------------------------------------
+
+      - name: Reject /land on a regular PR without --force
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'false' && steps.parse.outputs.force == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr comment "${{ steps.get-pr.outputs.pr_url }}" \
+            --body "ℹ️ \`/land\` is only for ghstack PRs. For a regular PR, use the merge button or \`/land --force <reason>\` to admin-merge."
+          exit 1
+
+      - uses: actions/checkout@v4
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'false' && steps.parse.outputs.force == 'true' }}
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Force admin-merge regular PR
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'false' && steps.parse.outputs.force == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          FORCE_REASON: ${{ steps.parse.outputs.reason }}
+        run: |
+          gh pr comment "${{ steps.get-pr.outputs.pr_url }}" \
+            --body "⚠️ **Force landing** (admin merge) by @${{ github.event.comment.user.login }}: $FORCE_REASON"
+          if ! gh pr merge "${{ steps.get-pr.outputs.pr_number }}" --admin --squash; then
+            gh pr comment "${{ steps.get-pr.outputs.pr_url }}" \
+              --body "❌ Admin merge failed. See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            exit 1
+          fi
+
+      # --- ghstack PRs ------------------------------------------------------
+
+      - uses: actions/checkout@v4
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'true' }}
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'true' }}
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'true' }}
+        uses: astral-sh/setup-uv@v6
+
+      - name: Require approvals and green CI
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'true' && steps.parse.outputs.force == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          uvx --with requests python .github/workflows/scripts/ghstack-perm-check.py \
+            ${{ github.event.issue.number }} \
+            ${{ steps.get-pr.outputs.pr_branch }} \
+            ${{ github.repository }}
+
+      - name: Log force landing
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'true' && steps.parse.outputs.force == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          FORCE_REASON: ${{ steps.parse.outputs.reason }}
+        run: |
+          gh pr comment "${{ steps.get-pr.outputs.pr_url }}" \
+            --body "⚠️ **Force landing** by @${{ github.event.comment.user.login }}: $FORCE_REASON"
+
+      - name: Land it
+        if: ${{ steps.get-pr.outputs.is_ghstack == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global user.email "bot@users.noreply.github.com"
+          git config --global user.name "ghstack bot"
+          cat <<EOF > ~/.ghstackrc
+          [ghstack]
+          github_url = github.com
+          github_oauth = $GITHUB_TOKEN
+          github_username = ghstack-bot
+          remote_name = origin
+          EOF
+          if ! uvx --with ghstack==0.11.0 ghstack land "${{ steps.get-pr.outputs.pr_url }}"; then
+            gh pr comment "${{ steps.get-pr.outputs.pr_url }}" \
+              --body "Failed to land via ghstack (likely a merge conflict). See: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            exit 1
+          fi

--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Gate a ghstack `/land` on approvals and green CI.
+
+Given the top PR of a ghstack stack, this:
+  1. Reconstructs the stack by reading the `Pull-Request-resolved` trailers from
+     the commits on the PR's `orig` branch.
+  2. Requires every not-yet-merged PR in the stack to have at least one approval.
+  3. Waits for the top PR's checks to settle and only succeeds when GitHub
+     reports the PR as mergeable (clean). Fails fast on conflicts or failing
+     required checks.
+
+Relies only on GitHub-native status/check-runs, so it works for any CI setup.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import time
+from typing import Any, Dict, List, Literal, Tuple
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def classify_checks(
+    statuses: List[Dict[str, Any]],
+    check_runs: List[Dict[str, Any]],
+) -> Tuple[Literal["pending", "failed", "success"], List[str]]:
+    """Classify the head commit's combined checks without hardcoding context names."""
+    failed: List[str] = []
+    pending: List[str] = []
+
+    # Legacy commit statuses (e.g. third-party integrations).
+    for status in statuses:
+        state = status.get("state")
+        if state in ("failure", "error"):
+            failed.append(status.get("context", "status"))
+        elif state == "pending":
+            pending.append(status.get("context", "status"))
+
+    # GitHub Actions / check-runs.
+    for run in check_runs:
+        if run.get("status") != "completed":
+            pending.append(run.get("name", "check"))
+        elif run.get("conclusion") not in ("success", "neutral", "skipped"):
+            failed.append(run.get("name", "check"))
+
+    if failed:
+        return "failed", failed
+    if pending:
+        return "pending", pending
+    return "success", []
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check ghstack PR approvals and CI status")
+    parser.add_argument("pr_number", type=int, help="PR number to check")
+    parser.add_argument("head_ref", help="Head reference of the PR")
+    parser.add_argument("repo", help="Repository in owner/repo format")
+    parser.add_argument(
+        "--max-wait-time",
+        type=int,
+        default=1800,
+        help="Maximum wait time in seconds for checks to settle",
+    )
+
+    args = parser.parse_args()
+
+    gh = requests.Session()
+    gh.headers.update(
+        {
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+    )
+    # Retry transient GitHub-side 5xx / rate-limit responses. urllib3's Retry
+    # ships with `requests`, so this needs no extra dependency.
+    retry = Retry(
+        total=5,
+        backoff_factor=2.0,  # 0s, 2s, 4s, 8s, 16s
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset(["GET", "POST"]),
+        raise_on_status=False,
+        respect_retry_after_header=True,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    gh.mount("https://", adapter)
+    gh.mount("http://", adapter)
+
+    NUMBER, head_ref, REPO = args.pr_number, args.head_ref, args.repo
+    MAX_WAIT_TIME = args.max_wait_time
+
+    def must(cond: Any, msg: str):
+        if not cond:
+            print(msg)
+            gh.post(
+                f"https://api.github.com/repos/{REPO}/issues/{NUMBER}/comments",
+                json={"body": f"ghstack land check failed: {msg}"},
+            )
+            exit(1)
+
+    print(head_ref)
+    must(
+        head_ref and re.match(r"^gh/[\w-]+/\d+/head$", head_ref),
+        "Not a ghstack PR",
+    )
+    orig_ref = head_ref.replace("/head", "/orig")
+
+    def git_fetch_with_retry(ref: str, *, attempts: int = 5, initial_backoff: float = 2.0) -> bool:
+        backoff = initial_backoff
+        for attempt in range(1, attempts + 1):
+            rc = os.system(f"git fetch origin {ref}")
+            if rc == 0:
+                return True
+            print(f"git fetch origin {ref} failed (attempt {attempt}/{attempts}, exit={rc})")
+            if attempt < attempts:
+                print(f"   retrying in {backoff:.0f}s...")
+                time.sleep(backoff)
+                backoff *= 2
+        return False
+
+    print(":: Fetching newest main...")
+    must(git_fetch_with_retry("main"), "Can't fetch main")
+    print(":: Fetching orig branch...")
+    must(git_fetch_with_retry(orig_ref), "Can't fetch orig branch")
+
+    proc = subprocess.Popen(
+        "git log FETCH_HEAD...$(git merge-base FETCH_HEAD origin/main)",
+        stdout=subprocess.PIPE,
+        shell=True,
+    )
+    out, _ = proc.communicate()
+    must(proc.wait() == 0, "`git log` command failed!")
+
+    pr_numbers = re.findall(
+        r"Pull[- ]Request(?:[- ]resolved)?: https://github.com/.*?/pull/([0-9]+)",
+        out.decode("utf-8"),
+    )
+    pr_numbers = list(map(int, pr_numbers))
+    print(pr_numbers)
+    must(pr_numbers and pr_numbers[0] == NUMBER, "Extracted PR numbers don't seem right!")
+
+    # Every not-yet-merged PR in the stack needs an approval.
+    print(":: Checking approvals for all PRs...")
+    for n in pr_numbers:
+        resp = gh.get(f"https://api.github.com/repos/{REPO}/pulls/{n}")
+        must(resp.ok, f"Error checking merge status for PR #{n}!")
+        if resp.json()["merged"]:
+            continue
+        print(f"Checking approvals for PR #{n}... ", end="")
+        resp = gh.get(f"https://api.github.com/repos/{REPO}/pulls/{n}/reviews")
+        must(resp.ok, f"Error getting reviews for PR #{n}!")
+        has_approval = any(review["state"] == "APPROVED" for review in resp.json())
+        must(has_approval, f"PR #{n} has no approvals!")
+        print("APPROVED!")
+
+    def check_pr_status(pr_number: int):
+        waiting_comment_posted = False
+        start_time = time.time()
+
+        def post_success_comment():
+            gh.post(
+                f"https://api.github.com/repos/{REPO}/issues/{pr_number}/comments",
+                json={"body": f"PR #{pr_number} checks have completed successfully!"},
+            )
+
+        while True:
+            resp = gh.get(
+                f"https://api.github.com/repos/{REPO}/pulls/{pr_number}",
+                headers={"Accept": "application/vnd.github.v3+json"},
+            )
+            must(resp.ok, f"Error getting PR #{pr_number}!")
+            pr_obj = resp.json()
+
+            mergeable_state = pr_obj.get("mergeable_state", "unknown")
+            if mergeable_state == "unknown":
+                # GitHub is still computing mergeability; give it a moment.
+                time.sleep(2)
+                resp = gh.get(
+                    f"https://api.github.com/repos/{REPO}/pulls/{pr_number}",
+                    headers={"Accept": "application/vnd.github.v3+json"},
+                )
+                must(resp.ok, f"Error getting PR #{pr_number} on retry!")
+                pr_obj = resp.json()
+                mergeable_state = pr_obj.get("mergeable_state", "unknown")
+
+            if mergeable_state == "unstable":
+                # Non-required checks are still running (or a required one is
+                # pending). Inspect the checks and wait until they settle.
+                if time.time() - start_time > MAX_WAIT_TIME:
+                    must(
+                        False,
+                        f"PR #{pr_number} stayed unstable for over "
+                        f"{MAX_WAIT_TIME // 60} minutes!",
+                    )
+
+                sha = pr_obj["head"]["sha"]
+                status_resp = gh.get(f"https://api.github.com/repos/{REPO}/commits/{sha}/status")
+                must(status_resp.ok, f"Error getting statuses for PR #{pr_number}!")
+                check_resp = gh.get(
+                    f"https://api.github.com/repos/{REPO}/commits/{sha}/check-runs",
+                    params={"per_page": 100},
+                )
+                must(check_resp.ok, f"Error getting check runs for PR #{pr_number}!")
+
+                result, relevant = classify_checks(
+                    status_resp.json().get("statuses", []),
+                    check_resp.json().get("check_runs", []),
+                )
+                if result == "failed":
+                    must(False, f"PR #{pr_number} has failing checks: {', '.join(relevant)}")
+                elif result == "success":
+                    post_success_comment()
+                    return pr_obj
+
+                message = f"PR #{pr_number} has pending checks: {', '.join(relevant)}"
+                if not waiting_comment_posted:
+                    print(f"\n{message}. Waiting for checks to settle...")
+                    gh.post(
+                        f"https://api.github.com/repos/{REPO}/issues/{pr_number}/comments",
+                        json={"body": message},
+                    )
+                    waiting_comment_posted = True
+                time.sleep(30)
+                print(".", end="", flush=True)
+                continue
+
+            if mergeable_state == "blocked":
+                must(
+                    False,
+                    f"PR #{pr_number} is blocked from merging (failing or missing "
+                    f"required checks)! Use `/land --force <reason>` to bypass CI.",
+                )
+            elif mergeable_state == "dirty":
+                must(False, f"PR #{pr_number} has merge conflicts that need to be resolved!")
+            elif mergeable_state == "clean":
+                if waiting_comment_posted:
+                    post_success_comment()
+                return pr_obj
+            else:
+                must(False, f"PR #{pr_number} is not ready to merge (state: {mergeable_state})!")
+
+    if pr_numbers:
+        print(f":: Checking status for primary PR #{pr_numbers[0]}... ", end="")
+        check_pr_status(pr_numbers[0])
+        print("SUCCESS!")
+
+    print(":: All PRs are ready to be landed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -24,6 +24,10 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+# Only count approvals from people with write access to the repo, so two
+# outside accounts can't approve each other's PRs to clear the gate.
+TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
 
 def classify_checks(
     statuses: List[Dict[str, Any]],
@@ -154,8 +158,12 @@ def main():
         print(f"Checking approvals for PR #{n}... ", end="")
         resp = gh.get(f"https://api.github.com/repos/{REPO}/pulls/{n}/reviews")
         must(resp.ok, f"Error getting reviews for PR #{n}!")
-        has_approval = any(review["state"] == "APPROVED" for review in resp.json())
-        must(has_approval, f"PR #{n} has no approvals!")
+        has_approval = any(
+            review["state"] == "APPROVED"
+            and review.get("author_association") in TRUSTED_ASSOCIATIONS
+            for review in resp.json()
+        )
+        must(has_approval, f"PR #{n} has no approval from a user with write access!")
         print("APPROVED!")
 
     def check_pr_status(pr_number: int):

--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Gate a ghstack `/land` on approvals and green CI.
 
 Given the top PR of a ghstack stack, this:
@@ -18,7 +17,7 @@ import os
 import re
 import subprocess
 import time
-from typing import Any, Dict, List, Literal, Tuple
+from typing import Any, Literal
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -30,12 +29,12 @@ TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 
 
 def classify_checks(
-    statuses: List[Dict[str, Any]],
-    check_runs: List[Dict[str, Any]],
-) -> Tuple[Literal["pending", "failed", "success"], List[str]]:
+    statuses: list[dict[str, Any]],
+    check_runs: list[dict[str, Any]],
+) -> tuple[Literal["pending", "failed", "success"], list[str]]:
     """Classify the head commit's combined checks without hardcoding context names."""
-    failed: List[str] = []
-    pending: List[str] = []
+    failed: list[str] = []
+    pending: list[str] = []
 
     # Legacy commit statuses (e.g. third-party integrations).
     for status in statuses:
@@ -202,8 +201,7 @@ def main():
                 if time.time() - start_time > MAX_WAIT_TIME:
                     must(
                         False,
-                        f"PR #{pr_number} stayed unstable for over "
-                        f"{MAX_WAIT_TIME // 60} minutes!",
+                        f"PR #{pr_number} stayed unstable for over {MAX_WAIT_TIME // 60} minutes!",
                     )
 
                 sha = pr_obj["head"]["sha"]


### PR DESCRIPTION
Adds a `/land` GitHub Actions workflow so a PR can be landed by commenting on it, with a small helper script that gates landing on review and CI state.

## Behavior

- **`/land`** on a ghstack PR (`gh/<user>/<n>/head` branch) lands the whole stack bottom-up via `ghstack land`, but only once **every PR in the stack is approved and CI is green**. If CI is still running it waits for it to settle, then lands or aborts on failure.
- **`/land --force <reason>`** skips the CI/approval gate. On a ghstack PR it lands the stack anyway; on a regular PR it does an admin squash merge. A reason is mandatory.
- Plain `/land` on a non-ghstack PR is rejected with a hint to use the merge button.

The comment gets a 🚀 reaction on receipt, and progress/failure is reported back as PR comments.

## How the gate works

`.github/workflows/scripts/ghstack-perm-check.py` reconstructs the stack from the `Pull-Request-resolved` trailers, requires an approval on every unmerged PR, then waits on the top PR's `mergeable_state` and classifies its check-runs/statuses. It relies only on GitHub-native review and check state, so it isn't tied to any particular CI provider.

## Setup required before this works

Landing pushes to `main` (protected) and needs to trigger the normal push CI, so the default `GITHUB_TOKEN` isn't sufficient. Configure a GitHub App with `contents: write` + `pull_requests: write` that can bypass branch protection, and add its credentials as repo secrets:

- `GHSTACK_APP_ID`
- `GHSTACK_APP_PRIVATE_KEY`