### PR TITLE
ci: harden /land against branch-name injection and stale approvals

### DIFF
--- a/.github/workflows/ghstack_land.yaml
+++ b/.github/workflows/ghstack_land.yaml
@@ -54,10 +54,13 @@ jobs:
         run: |
           if [[ "$COMMENT" == *"--force"* ]]; then
             # Everything after `/land --force` is the (mandatory) reason.
-            REASON=$(echo "$COMMENT" \
+            # Collapse to a single line first: newlines in the reason would
+            # otherwise inject extra `key=value` pairs into $GITHUB_OUTPUT.
+            REASON=$(printf '%s' "$COMMENT" \
+              | tr '\n\r' '  ' \
               | sed -E 's/(^|[[:space:]])--force([[:space:]]|$)/ /g' \
               | sed -E 's/^[[:space:]]*\/land[[:space:]]*//' \
-              | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+              | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
             if [[ -z "$REASON" ]]; then
               echo "::error::--force requires a reason"
               gh pr comment "${{ github.event.issue.html_url }}" \
@@ -146,11 +149,14 @@ jobs:
         if: ${{ steps.get-pr.outputs.is_ghstack == 'true' && steps.parse.outputs.force == 'false' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The branch name is attacker-influenced, so pass it via env and quote
+          # it below rather than interpolating into the run block directly.
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_BRANCH: ${{ steps.get-pr.outputs.pr_branch }}
+          REPO: ${{ github.repository }}
         run: |
           uvx --with requests python .github/workflows/scripts/ghstack-perm-check.py \
-            ${{ github.event.issue.number }} \
-            ${{ steps.get-pr.outputs.pr_branch }} \
-            ${{ github.repository }}
+            "$PR_NUMBER" "$PR_BRANCH" "$REPO"
 
       - name: Log force landing
         if: ${{ steps.get-pr.outputs.is_ghstack == 'true' && steps.parse.outputs.force == 'true' }}

--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -152,17 +152,28 @@ def main():
     for n in pr_numbers:
         resp = gh.get(f"https://api.github.com/repos/{REPO}/pulls/{n}")
         must(resp.ok, f"Error checking merge status for PR #{n}!")
-        if resp.json()["merged"]:
+        pr_data = resp.json()
+        if pr_data["merged"]:
             continue
+        head_sha = pr_data["head"]["sha"]
         print(f"Checking approvals for PR #{n}... ", end="")
         resp = gh.get(f"https://api.github.com/repos/{REPO}/pulls/{n}/reviews")
         must(resp.ok, f"Error getting reviews for PR #{n}!")
+        # The approval must be from a user with write access AND on the current
+        # head commit. The repo's ruleset does not dismiss stale reviews on push,
+        # so without the commit_id check an approval of a benign commit would
+        # still clear the gate after the PR is updated with different code.
         has_approval = any(
             review["state"] == "APPROVED"
             and review.get("author_association") in TRUSTED_ASSOCIATIONS
+            and review.get("commit_id") == head_sha
             for review in resp.json()
         )
-        must(has_approval, f"PR #{n} has no approval from a user with write access!")
+        must(
+            has_approval,
+            f"PR #{n} has no current approval from a user with write access "
+            f"(an approval on the latest commit {head_sha[:7]} is required).",
+        )
         print("APPROVED!")
 
     def check_pr_status(pr_number: int):


### PR DESCRIPTION
Follow-up hardening for the `/land` workflow (#765). None of these are reachable by a non-member (the `OWNER`/`MEMBER` comment gate sits in front of the whole job), but they're worth closing on a public repo.

### 1. Shell injection via the PR branch name
The perm-check step interpolated the PR head ref straight into the `run:` block. The ghstack detection only requires the ref to match `^gh/[^/]+/[0-9]+/head$`, and that pattern permits shell metacharacters, so the branch name (which a PR author influences) could break out of the command. Now passed via env vars and quoted (`"$PR_BRANCH"`).

### 2. Stale-approval TOCTOU
The `main` ruleset has `dismiss_stale_reviews_on_push: false`, and the perm-check counted any `APPROVED` review. So a member could approve a benign commit, the PR could then be updated with different code, and the old approval would still clear the gate. The perm-check now requires the approving review's `commit_id` to equal the current head SHA.

### 3. `$GITHUB_OUTPUT` injection via the `--force` reason
A multi-line comment body could write extra `key=value` lines into `$GITHUB_OUTPUT`. The reason is now collapsed to a single line before being written.

Verified the branch-quoting and reason-collapse behavior locally.