### PR TITLE
docs: remove duplicated 'the' in tool_use README

### DIFF
--- a/tinker_cookbook/tool_use/README.md
+++ b/tinker_cookbook/tool_use/README.md
@@ -93,7 +93,7 @@ async def make_envs(self) -> Sequence[Env]:
 
 ## Examples
 
-For examples of using the tool-use library, see the the following:
+For examples of using the tool-use library, see the following:
 
 - [code_rl recipe](../recipes/code_rl/) - Code generation with python execution tool
 - [search_tool recipe](../recipes/search_tool/) - Multi-hop QA with search tool


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #769

