### PR TITLE
Update additional recipe model defaults

### DIFF
--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/train.py
@@ -10,8 +10,8 @@ from tinker_cookbook.rl import train
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     group_size: int = 8
     batch_size: int = 32
     learning_rate: float = 3e-5

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/README.md
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/README.md
@@ -53,7 +53,7 @@ The default of 80 steps avoids the collapse while capturing the performance plat
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `model_name` | `Qwen/Qwen3-4B-Instruct-2507` | Base model to train |
+| `model_name` | `Qwen/Qwen3.5-4B` | Starting checkpoint to fine-tune (uses `qwen3_5_disable_thinking` renderer) |
 | `batch_size` | `512` | Trajectories per training step |
 | `num_train_datapoints` | `40960` | Total training trajectories (~80 steps) |
 | `learning_rate` | `3e-5` | Adam learning rate |

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/play.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/play.py
@@ -124,8 +124,8 @@ async def eval_model(
 @chz.chz
 class PlayConfig:
     checkpoint_path: str
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     game_name: str = "TicTacToe-v0"
     mode: Literal["human_vs_model", "eval"] = "human_vs_model"
     opponent: OpponentType = "random"

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/train.py
@@ -11,8 +11,8 @@ from tinker_cookbook.rl import train
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     game_name: str = "TicTacToe-v0"
     test_opponent: OpponentType = "base_model"
     batch_size: int = 512

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/env.py
@@ -15,7 +15,6 @@ from tinker_cookbook.completers import (
     StopCondition,
     TinkerMessageCompleter,
 )
-from tinker_cookbook.model_info import get_recommended_renderer_name
 from tinker_cookbook.renderers import Message, Renderer, get_renderer, get_text_content
 from tinker_cookbook.rl.types import (
     Action,
@@ -203,7 +202,7 @@ class TwentyQuestionsDatasetBuilder(RLDatasetBuilder):
     base_url: str | None = None
     num_epochs: int = 1
     test_group_size: int = 32
-    answerer_base_model: str = "meta-llama/Llama-3.1-8B-Instruct"
+    answerer_base_model: str = "Qwen/Qwen3.5-9B"
 
     async def __call__(self) -> tuple[RLDataset, RLDataset]:
         service_client = tinker.ServiceClient(base_url=self.base_url)
@@ -230,7 +229,11 @@ class TwentyQuestionsDatasetBuilder(RLDatasetBuilder):
         return training_dataset, test_dataset
 
     def _construct_answer_completer(self, service_client: tinker.ServiceClient) -> MessageCompleter:
-        if self.answerer_base_model.startswith("Qwen/Qwen3"):
+        if self.answerer_base_model.startswith(
+            "Qwen/Qwen3.5"
+        ) or self.answerer_base_model.startswith("Qwen/Qwen3.6"):
+            answerer_renderer_name = "qwen3_5_disable_thinking"
+        elif self.answerer_base_model.startswith("Qwen/Qwen3"):
             answerer_renderer_name = "qwen3_disable_thinking"
         else:
             answerer_renderer_name = model_info.get_recommended_renderer_name(
@@ -256,19 +259,18 @@ class TwentyQuestionsDatasetBuilder(RLDatasetBuilder):
 
 
 def construct_minimal_20q_env(answer: str) -> TwentyQuestionsEnv:
-    answerer_model = "meta-llama/Llama-3.1-8B-Instruct"
+    answerer_model = "Qwen/Qwen3.5-9B"
+    answerer_renderer_name = "qwen3_5_disable_thinking"
 
     service_client = tinker.ServiceClient()
     answerer_sampling_client = service_client.create_sampling_client(base_model=answerer_model)
     answerer = TinkerMessageCompleter(
         sampling_client=answerer_sampling_client,
-        renderer=get_renderer(
-            get_recommended_renderer_name(answerer_model), get_tokenizer(answerer_model)
-        ),
+        renderer=get_renderer(answerer_renderer_name, get_tokenizer(answerer_model)),
         max_tokens=5,
     )
     policy_renderer = get_renderer(
-        get_recommended_renderer_name(answerer_model), get_tokenizer(answerer_model)
+        answerer_renderer_name, get_tokenizer(answerer_model)
     )  # this argument is not actually used and is a placeholder
     env = TwentyQuestionsEnv(answerer, answer, policy_renderer)
     return env

--- a/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/train.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/twenty_questions/train.py
@@ -12,8 +12,8 @@ from tinker_cookbook.rl import train
 
 @chz.chz
 class CLIConfig:
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
-    renderer_name: str | None = None
+    model_name: str = "Qwen/Qwen3.5-4B"
+    renderer_name: str | None = "qwen3_5_disable_thinking"
     group_size: int = 8
     num_epochs: int = 100
     batch_size: int = 64

--- a/tinker_cookbook/recipes/prompt_distillation/README.md
+++ b/tinker_cookbook/recipes/prompt_distillation/README.md
@@ -26,7 +26,7 @@ ar (Arabic), de (German), el (Greek), en (English), es (Spanish), fr (French), h
 
 The recipe in [`create_data.py`](create_data.py) also includes handling strategies for inputs containing code, numerical content, or multiple languages.
 
-In the example below, the same model (`Qwen/Qwen3-30B-A3B`) is used as both teacher and student, though in general they need not be identical.
+In the example below, the same model (`Qwen/Qwen3.6-35B-A3B`) is used as both teacher and student, though in general they need not be identical.
 
 ---
 

--- a/tinker_cookbook/recipes/prompt_distillation/create_data.py
+++ b/tinker_cookbook/recipes/prompt_distillation/create_data.py
@@ -92,9 +92,9 @@ def setup_clients():
         user_metadata=recipe_user_metadata("dataset_prompt_distillation"),
     )
     print("Creating sampling client")
-    sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3-30B-A3B")
-    tokenizer = get_tokenizer("Qwen/Qwen3-30B-A3B")
-    renderer = renderers.get_renderer("qwen3", tokenizer)
+    sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3.6-35B-A3B")
+    tokenizer = get_tokenizer("Qwen/Qwen3.6-35B-A3B")
+    renderer = renderers.get_renderer("qwen3_5", tokenizer)
 
     return sampling_client, tokenizer, renderer
 

--- a/tinker_cookbook/recipes/prompt_distillation/train.py
+++ b/tinker_cookbook/recipes/prompt_distillation/train.py
@@ -21,7 +21,7 @@ class CLIConfig:
     # Required parameters
     file_path: str = "/tmp/tinker-datasets/prompt_distillation_lang.jsonl"
     log_path: str | None = None
-    model_name: str = "Qwen/Qwen3-30B-A3B"
+    model_name: str = "Qwen/Qwen3.6-35B-A3B"
     load_checkpoint_path: str | None = None
 
     # Training parameters

--- a/tinker_cookbook/recipes/search_tool/README.md
+++ b/tinker_cookbook/recipes/search_tool/README.md
@@ -2,7 +2,7 @@
 
 [Search-R1](https://arxiv.org/pdf/2503.09516) is a recent paper that showcases tool-use RL for multi-hop QA on Wikipedia.
 It provides a clean setup for testing tool-use RL and also released their training and evaluation data.
-In this demo, we demonstrate similar experiments using `Qwen3-4B-Instruct-2507`, and we include our replication results using `Qwen/Qwen2.5-7B-Instruct` at the end.
+In this demo, we demonstrate similar experiments using `Qwen3.5-4B` in non-thinking mode, and we include our replication results using `Qwen/Qwen2.5-7B-Instruct` at the end.
 
 ## Running This Demo
 
@@ -25,7 +25,7 @@ If you launch the chroma service locally, you generally need 160+ GB RAM to load
 
 ### Example command
 
-This default command trains a `Qwen3-4B-Instruct-2507` with reasonable hyperparameters.
+This default command trains `Qwen3.5-4B` in non-thinking mode with reasonable hyperparameters.
 
 ```bash
 python -m tinker_cookbook.recipes.search_tool.train
@@ -35,6 +35,8 @@ With the default hyperparameters, you can expect performance like:
 | | Natural Questions | Trivia QA | HotpotQA | 2WikiMultihopQA |
 |---|---|---|---|---|
 | Qwen3-4B-Instruct-2507 | 51.8 | 70.2 | 52.0 | 47.7 |
+
+> **Rerun needed:** these numbers were measured on the now-retired `Qwen3-4B-Instruct-2507`. Rerun with `Qwen/Qwen3.5-4B` + `qwen3_5_disable_thinking` before treating them as current.
 
 A successful run generally learns multi-turn search within 10-25 steps, which can be monitored by checking if `env/all/turns_per_episode` has increased over 2 turns.
 

--- a/tinker_cookbook/recipes/search_tool/offline_eval.py
+++ b/tinker_cookbook/recipes/search_tool/offline_eval.py
@@ -6,7 +6,7 @@ from typing import Literal, TypedDict
 import chz
 import tinker
 
-from tinker_cookbook import checkpoint_utils, model_info, tokenizer_utils
+from tinker_cookbook import checkpoint_utils, tokenizer_utils
 from tinker_cookbook.completers import TinkerTokenCompleter
 from tinker_cookbook.recipes.search_tool.search_env import (
     SEARCH_TASK_INSTRUCTIONS,
@@ -38,7 +38,11 @@ class CLIConfig:
     split: Literal["train", "test"] = chz.field(default="test", doc="Dataset split to use")
 
     # Model parameters
-    base_model: str = chz.field(default="Qwen/Qwen3-4B-Instruct-2507", doc="Base model to use")
+    base_model: str = chz.field(default="Qwen/Qwen3.5-4B", doc="Base model to use")
+    renderer_name: str = chz.field(
+        default="qwen3_5_disable_thinking",
+        doc="Renderer to use if the checkpoint does not record one",
+    )
     tinker_checkpoint_url: str = chz.field(doc="Tinker checkpoint URL (required)")
     max_tokens: int = chz.field(default=1024, doc="Maximum number of tokens to generate")
 
@@ -120,7 +124,7 @@ async def evaluate_one_dataset(data: list[SearchR1Datum], config: CLIConfig):
         service_client, config.tinker_checkpoint_url
     )
     if renderer_name is None:
-        renderer_name = model_info.get_recommended_renderer_name(config.base_model)
+        renderer_name = config.renderer_name
     print(f"Using renderer: {renderer_name}")
     renderer = get_renderer(renderer_name, tokenizer)
 

--- a/tinker_cookbook/recipes/search_tool/train.py
+++ b/tinker_cookbook/recipes/search_tool/train.py
@@ -18,9 +18,9 @@ from tinker_cookbook.rl import train
 @chz.chz
 class CLIConfig:
     # Model parameters
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
+    model_name: str = "Qwen/Qwen3.5-4B"
     lora_rank: int = 32
-    renderer_name: str | None = None
+    renderer_name: str | None = "qwen3_5_disable_thinking"
 
     # Training parameters
     learning_rate: float = 4e-5

--- a/tinker_cookbook/recipes/verifiers_rl/train.py
+++ b/tinker_cookbook/recipes/verifiers_rl/train.py
@@ -27,8 +27,9 @@ logger = logging.getLogger(__name__)
 @chz.chz
 class CLIConfig:
     # model configuration
-    model_name: str = "Qwen/Qwen3-4B-Instruct-2507"
+    model_name: str = "Qwen/Qwen3.5-4B"
     lora_rank: int = 32
+    renderer_name: str | None = "qwen3_5_disable_thinking"
 
     # environment configuration
     vf_env_id: str = "reverse-text"
@@ -84,7 +85,9 @@ async def cli_main(cli_config: CLIConfig, env: Any | None):
         if local_tokenizer is None:
             local_tokenizer = get_tokenizer(cli_config.model_name)
         if shared_renderer is None:
-            renderer_name = model_info.get_recommended_renderer_name(cli_config.model_name)
+            renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
+                cli_config.model_name
+            )
             shared_renderer = renderers.get_renderer(renderer_name, local_tokenizer)
 
         sampling_client = cast(TinkerTokenCompleter, policy).sampling_client
@@ -131,6 +134,7 @@ async def cli_main(cli_config: CLIConfig, env: Any | None):
         dataset_builder=dataset_builder,
         model_name=cli_config.model_name,
         recipe_name="recipe_verifiers_rl",
+        renderer_name=cli_config.renderer_name,
         max_tokens=cli_config.max_tokens,
         temperature=cli_config.temperature,
         lora_rank=cli_config.lora_rank,

--- a/tinker_cookbook/recipes/vlm_classifier/README.md
+++ b/tinker_cookbook/recipes/vlm_classifier/README.md
@@ -9,11 +9,11 @@ python -m tinker_cookbook.recipes.vlm_classifier.train \
     experiment_dir=./vlm_classifier \
     wandb_project=vlm-classifier \
     dataset=caltech101 \
-    renderer_name=qwen3_vl \
-    model_name=Qwen/Qwen3-VL-30B-A3B-Instruct
+    renderer_name=qwen3_5_disable_thinking \
+    model_name=Qwen/Qwen3.6-35B-A3B
 ```
 
-Currently, the qwen series of VLMs are supported. Running the above script after installing tinker-cookbook will fine-tune `Qwen/Qwen3-VL-30B-A3B-Instruct` on the `caltech101` as an example.
+Currently, the qwen series of VLMs are supported. Running the above script after installing tinker-cookbook will fine-tune `Qwen/Qwen3.6-35B-A3B` on the `caltech101` as an example.
 
 ### Evaluation
 
@@ -23,8 +23,8 @@ Once trained, you can evaluate the class predictions from your VLM as follows:
 python -m tinker_cookbook.recipes.vlm_classifier.eval \
     dataset=caltech101 \
     model_path=$YOUR_MODEL_PATH \
-    model_name=Qwen/Qwen3-VL-30B-A3B-Instruct \
-    renderer_name=qwen3_vl
+    model_name=Qwen/Qwen3.6-35B-A3B \
+    renderer_name=qwen3_5_disable_thinking
 ```
 
 This will print the test accuracy of your model.

--- a/tinker_cookbook/recipes/vlm_classifier/eval_sweep.py
+++ b/tinker_cookbook/recipes/vlm_classifier/eval_sweep.py
@@ -72,7 +72,7 @@ def parse_hyperparams_from_experiment_name(experiment_name: str) -> dict[str, An
     Experiment names follow the format from sweep.py:
     {dataset}-{model_name}-{lora_rank}rank-{learning_rate}lr-{batch_size}batch-{examples_per_class}shot-seed{subset_seed}-{date}
 
-    Example: caltech101-Qwen-Qwen3-VL-235B-A22B-Instruct-32rank-0.0005lr-32batch-4shot-seed0-2025-11-26
+    Example: caltech101-Qwen-Qwen3.5-397B-A17B-32rank-0.0005lr-32batch-4shot-seed0-2025-11-26
     """
 
     hyperparams: dict[str, Any] = {}
@@ -116,8 +116,8 @@ class EvalConfig:
     experiment_dir: str
     output_file: str
 
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5_disable_thinking"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     # Infrastructure parameters
     base_url: str | None = None

--- a/tinker_cookbook/recipes/vlm_classifier/sweep.py
+++ b/tinker_cookbook/recipes/vlm_classifier/sweep.py
@@ -5,7 +5,7 @@
 Launcher for training image classifiers based on VLMs.
 
 ```bash
-python -m tinker_cookbook.recipes.vlm_classifier.sweep experiment_dir=./sweep model_name=Qwen/Qwen3-VL-30B-A3B-Instruct
+python -m tinker_cookbook.recipes.vlm_classifier.sweep experiment_dir=./sweep model_name=Qwen/Qwen3.6-35B-A3B
 ```
 
 """
@@ -35,8 +35,8 @@ class ExperimentConfig:
     experiment_dir: str
 
     dataset: str = "caltech101"
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5_disable_thinking"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     # Infrastructure parameters
     base_url: str | None = None
@@ -159,8 +159,8 @@ class SweepConfig:
 
     experiment_dir: str
 
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5_disable_thinking"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     datasets: list[str] = chz.field(default_factory=lambda: ["caltech101"])
     examples_per_class: list[int] = chz.field(default_factory=lambda: [1, 2, 4, 8, 16])

--- a/tinker_cookbook/recipes/vlm_classifier/train.py
+++ b/tinker_cookbook/recipes/vlm_classifier/train.py
@@ -36,8 +36,8 @@ class ExperimentConfig:
 
     dataset: str = "caltech101"
 
-    renderer_name: str = "qwen3_vl"
-    model_name: str = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    renderer_name: str = "qwen3_5_disable_thinking"
+    model_name: str = "Qwen/Qwen3.5-397B-A17B"
 
     # Infrastructure parameters
     base_url: str | None = None


### PR DESCRIPTION
## Summary
- split additional recipe model-default updates out of #718
- update multiplayer RL, prompt distillation, VLM classifier, search tool, and verifiers RL recipe defaults

Stacked on #718 (`derek/tinker-cookbook-model-update-2`).