### PR TITLE
Fix broken docs-site links in tutorials

### DIFF
--- a/tutorials/101_hello_tinker.py
+++ b/tutorials/101_hello_tinker.py
@@ -207,8 +207,8 @@ def _(mo):
     ## Next steps
 
     - **[Tutorial 102: First SFT](./102_first_sft.py)** -- Train a model with supervised fine-tuning
-    - **[Getting Started Guide](https://docs.thinkingmachines.ai/training-sampling)** -- Full walkthrough of training and sampling
-    - **[Available Models](https://docs.thinkingmachines.ai/model-lineup)** -- All supported models and their characteristics
+    - **[Getting Started Guide](https://tinker-docs.thinkingmachines.ai/tinker/quickstart/)** -- Full walkthrough of training and sampling
+    - **[Available Models](https://tinker-docs.thinkingmachines.ai/tinker/models/)** -- All supported models and their characteristics
     """)
     return
 

--- a/tutorials/102_first_sft.py
+++ b/tutorials/102_first_sft.py
@@ -496,7 +496,7 @@ def _(mo):
 
     - **Efficient sampling** shows how to run many inference requests concurrently for maximum throughput. See `tutorials/103_async_patterns.py`.
     - **Real training loops** iterate over a full dataset with proper batching and evaluation. See `tinker_cookbook/recipes/sl_loop.py`.
-    - **Renderers** handle chat templates, vision inputs, and per-token weight assignment. See the [Rendering docs](https://tinker-docs.thinkingmachines.ai/rendering).
+    - **Renderers** handle chat templates, vision inputs, and per-token weight assignment. See the [Rendering docs](https://tinker-docs.thinkingmachines.ai/tutorials/core-concepts/rendering/).
     """)
     return
 

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -369,8 +369,8 @@ def _(mo):
 
     - **Tutorial 301** (`301_cookbook_abstractions.py`): Adapt this pattern to your own task with a custom reward function
     - **Production recipes**: See `tinker_cookbook/recipes/rl_loop.py` for a minimal script and `tinker_cookbook/recipes/math_rl/` for a full-featured GSM8K/MATH training setup
-    - **Scaling up**: The [RL Hyperparameters](https://tinker-docs.thinkingmachines.ai/rl/rl-hyperparams) guide covers batch size, group size, learning rates, and async training for larger runs
-    - **Custom environments**: The [RL Environments](https://tinker-docs.thinkingmachines.ai/rl/rl-envs) guide shows how to define multi-step environments using the `Env` / `EnvGroupBuilder` / `RLDataset` abstractions
+    - **Scaling up**: The [RL Hyperparameters](https://tinker-docs.thinkingmachines.ai/tutorials/advanced/rl-hyperparams/) guide covers batch size, group size, learning rates, and async training for larger runs
+    - **Custom environments**: The [RL Environments](https://tinker-docs.thinkingmachines.ai/cookbook/rl/) guide shows how to define multi-step environments using the `Env` / `EnvGroupBuilder` / `RLDataset` abstractions
     """)
     return
 

--- a/tutorials/302_custom_environment.py
+++ b/tutorials/302_custom_environment.py
@@ -544,7 +544,7 @@ def _(mo):
     - **Multi-step environments**: Implement `Env` directly for tasks where the agent takes multiple actions (tool use, search, games). See `tinker_cookbook/recipes/code_rl/` for an example with sandbox execution.
     - **Production recipes**: `tinker_cookbook/recipes/math_rl/` and `tinker_cookbook/recipes/code_rl/` show full-featured training setups with dataset loading, grading, and configuration.
     - **Custom group rewards**: Override `EnvGroupBuilder.compute_group_rewards()` for pairwise or multi-agent reward functions.
-    - **Full docs**: [RL Environments](../docs/rl/rl-envs.mdx) covers the complete Env lifecycle, builder patterns, and advanced features.
+    - **Full docs**: [RL Environments](https://tinker-docs.thinkingmachines.ai/cookbook/rl/) covers the complete Env lifecycle, builder patterns, and advanced features.
     """)
     return
 


### PR DESCRIPTION
All six verified against the live sitemap:
- 101: wrong domain (docs. -> tinker-docs.thinkingmachines.ai) for Getting Started (-> /tinker/quickstart/) and Available Models (-> /tinker/models/).
- 102: /rendering -> /tutorials/core-concepts/rendering/
- 104: /rl/rl-hyperparams -> /tutorials/advanced/rl-hyperparams/ and /rl/rl-envs -> /cookbook/rl/
- 302: relative ../docs/rl/rl-envs.mdx (no docs/ dir in repo) -> /cookbook/rl/, matching the link 301 already uses.