### PR TITLE
Add Nemotron Ultra renderer

### DIFF
--- a/tests/downstream_compat/test_cli_and_hyperparam.py
+++ b/tests/downstream_compat/test_cli_and_hyperparam.py
@@ -333,6 +333,15 @@ _REFERENCE_PARAMS_PER_RANK: dict[str, dict[tuple[bool, bool, bool], int]] = {
         (False, True, False): 1_675_264,
         (False, False, True): 135_168,
     },
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": {
+        (True, True, True): 258_803_712,
+        (True, True, False): 258_664_448,
+        (True, False, True): 254_668_800,
+        (True, False, False): 254_529_536,
+        (False, True, True): 4_274_176,
+        (False, True, False): 4_134_912,
+        (False, False, True): 139_264,
+    },
     "openai/gpt-oss-120b": {
         (True, True, True): 41_074_624,
         (True, True, False): 40_870_656,

--- a/tests/downstream_compat/test_renderers.py
+++ b/tests/downstream_compat/test_renderers.py
@@ -185,6 +185,9 @@ EXPECTED_RENDERER_NAMES = [
     "nemotron3",
     "nemotron3_low_thinking",
     "nemotron3_disable_thinking",
+    "nemotron3_ultra",
+    "nemotron3_ultra_disable_thinking",
+    "nemotron3_ultra_medium_thinking",
 ]
 
 

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -125,6 +125,7 @@ def _get_hidden_size(model_name: str) -> int:
         "openai/gpt-oss-120b": 2880,
         "openai/gpt-oss-20b": 2880,
         # NVIDIA Nemotron
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": 8192,
         "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16": 4096,
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": 2688,
     }
@@ -202,6 +203,11 @@ _LORA_PARAMS_PER_RANK_BY_COMPONENT: dict[str, dict[str, int]] = {
         "attn": 1_675_264,
         "unembed": 135_168,
     },
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": {
+        "mlp": 254_529_536,
+        "attn": 4_134_912,
+        "unembed": 139_264,
+    },
     "openai/gpt-oss-120b": {"mlp": 40_124_160, "attn": 746_496, "unembed": 203_968},
     "openai/gpt-oss-20b": {"mlp": 6_842_880, "attn": 497_664, "unembed": 203_968},
 }
@@ -275,6 +281,7 @@ def get_lr(model_name: str, is_lora: bool = True) -> float:
         "moonshotai/Kimi-K2.6",
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
         "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
     ):
         raise NotImplementedError(
             f"Learning rate formula for {model_name} is not yet calibrated. "

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -29,6 +29,11 @@ _KIMI_K25 = ("kimi_k25", "kimi_k25_disable_thinking")
 _KIMI_K26 = ("kimi_k26", "kimi_k26_disable_thinking", "kimi_k26_preserve_thinking")
 _NEMOTRON3 = ("nemotron3", "nemotron3_disable_thinking")
 _NEMOTRON3_SUPER = _NEMOTRON3 + ("nemotron3_low_thinking",)
+_NEMOTRON3_ULTRA = (
+    "nemotron3_ultra",
+    "nemotron3_ultra_disable_thinking",
+    "nemotron3_ultra_medium_thinking",
+)
 
 
 @dataclass
@@ -178,6 +183,9 @@ def get_nvidia_info() -> dict[str, ModelAttributes]:
         ),
         "NVIDIA-Nemotron-3-Super-120B-A12B-BF16": ModelAttributes(
             org, "3", "120B-A12B", True, _NEMOTRON3_SUPER
+        ),
+        "NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": ModelAttributes(
+            org, "3", "550B-A55B", True, _NEMOTRON3_ULTRA
         ),
     }
 

--- a/tinker_cookbook/model_info_test.py
+++ b/tinker_cookbook/model_info_test.py
@@ -5,6 +5,7 @@ import pytest
 from tinker_cookbook.model_info import (
     get_model_attributes,
     get_recommended_renderer_name,
+    get_recommended_renderer_names,
     warn_if_renderer_not_recommended,
 )
 
@@ -26,6 +27,35 @@ class TestQwen3_6:
         assert attrs.size_str == size_str
         assert attrs.is_chat is True
         assert attrs.is_vl is True
+
+
+class TestNemotron3:
+    def test_ultra_uses_nemotron3_ultra_renderer(self):
+        assert (
+            get_recommended_renderer_name("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16")
+            == "nemotron3_ultra"
+        )
+
+    def test_ultra_peft_suffix_uses_nemotron3_ultra_renderer(self):
+        assert (
+            get_recommended_renderer_name(
+                "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16:peft:262144"
+            )
+            == "nemotron3_ultra"
+        )
+
+    def test_ultra_attributes(self):
+        attrs = get_model_attributes("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16")
+        assert attrs.organization == "nvidia"
+        assert attrs.version_str == "3"
+        assert attrs.size_str == "550B-A55B"
+        assert attrs.is_chat is True
+        assert attrs.is_vl is False
+        assert get_recommended_renderer_names("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16") == [
+            "nemotron3_ultra",
+            "nemotron3_ultra_disable_thinking",
+            "nemotron3_ultra_medium_thinking",
+        ]
 
 
 class TestWarnIfRendererNotRecommended:

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -140,9 +140,12 @@ def get_renderer(
             - ``"kimi_k26"``: Kimi K2.6 with thinking enabled (HF default — same token output as ``kimi_k25``)
             - ``"kimi_k26_disable_thinking"``: Kimi K2.6 with thinking disabled
             - ``"kimi_k26_preserve_thinking"``: Kimi K2.6 with thinking enabled and historical ``<think>...</think>`` blocks preserved (HF ``preserve_thinking=true``); use for long-horizon agents / multi-turn RL
-            - ``"nemotron3"``: Nemotron-3 with full reasoning (Nano & Super)
+            - ``"nemotron3"``: Nemotron-3 with full reasoning
             - ``"nemotron3_low_thinking"``: Nemotron-3 with low-effort reasoning (Super only)
-            - ``"nemotron3_disable_thinking"``: Nemotron-3 with reasoning off (Nano & Super)
+            - ``"nemotron3_disable_thinking"``: Nemotron-3 with reasoning off
+            - ``"nemotron3_ultra"``: Nemotron-3 Ultra with full reasoning
+            - ``"nemotron3_ultra_disable_thinking"``: Nemotron-3 Ultra with reasoning off
+            - ``"nemotron3_ultra_medium_thinking"``: Nemotron-3 Ultra with medium-effort reasoning
             - ``"gpt_oss_no_sysprompt"``: GPT-OSS without system prompt
             - ``"gpt_oss_low_reasoning"``: GPT-OSS with low reasoning
             - ``"gpt_oss_medium_reasoning"``: GPT-OSS with medium reasoning
@@ -199,6 +202,9 @@ def get_renderer(
         Nemotron3DisableThinkingRenderer,
         Nemotron3LowThinkingRenderer,
         Nemotron3Renderer,
+        Nemotron3UltraDisableThinkingRenderer,
+        Nemotron3UltraMediumThinkingRenderer,
+        Nemotron3UltraRenderer,
     )
     from tinker_cookbook.renderers.qwen3 import (
         Qwen3DisableThinkingRenderer,
@@ -255,6 +261,12 @@ def get_renderer(
         renderer = Nemotron3LowThinkingRenderer(tokenizer)
     elif name == "nemotron3_disable_thinking":
         renderer = Nemotron3DisableThinkingRenderer(tokenizer)
+    elif name == "nemotron3_ultra":
+        renderer = Nemotron3UltraRenderer(tokenizer)
+    elif name == "nemotron3_ultra_disable_thinking":
+        renderer = Nemotron3UltraDisableThinkingRenderer(tokenizer)
+    elif name == "nemotron3_ultra_medium_thinking":
+        renderer = Nemotron3UltraMediumThinkingRenderer(tokenizer)
     elif name == "gpt_oss_no_sysprompt":
         renderer = GptOssRenderer(tokenizer, use_system_prompt=False)
     elif name == "gpt_oss_low_reasoning":

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -1,10 +1,9 @@
 """
 Nemotron-3 family renderer.
 
-Nemotron-3 models (NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 and
-NVIDIA-Nemotron-3-Super-120B-A12B-BF16) use a chat format similar to Qwen3.5
-(im_start/im_end tokens, thinking blocks, XML-style tool calls) but differ in
-the following ways:
+Nemotron-3 models (Nano, Super, and Ultra) use a chat format similar to
+Qwen3.5 (im_start/im_end tokens, thinking blocks, XML-style tool calls) but
+differ in the following ways:
 
 1. Tool declarations: Nemotron-3 uses structured XML inside <tools>...</tools>
    (Qwen3.5 uses JSON per line).
@@ -16,8 +15,8 @@ the following ways:
    to ALL assistant messages that lack thinking, including historical ones
    (Qwen3.5 only does this for messages after the last user query).
 
-4. Think block separator: one newline between </think> and text content
-   (Qwen3.5 uses two newlines).
+4. Think block separator: Nano/Super use one newline between </think> and
+   text content (Qwen3.5 uses two newlines). Ultra uses no separator newline.
 
 5. Disable-thinking generation suffix: <think></think> with no trailing
    newlines (Qwen3.5 uses <think>\\n\\n</think>\\n\\n).
@@ -30,8 +29,9 @@ the following ways:
 
 Thinking modes
 --------------
-Both Nano and Super support reasoning ON/OFF. The Super model additionally
-supports a low-effort reasoning mode that produces shorter thinking traces.
+Nemotron-3 models support reasoning ON/OFF. Super additionally supports a
+low-effort reasoning mode that produces shorter thinking traces; Ultra
+additionally supports a medium-effort reasoning mode.
 
 +---------------------+-------------------------------+---------------------+
 | Mode                | HF template params            | Renderer name       |
@@ -41,6 +41,10 @@ supports a low-effort reasoning mode that produces shorter thinking traces.
 | Low-effort thinking | enable_thinking=True,         | nemotron3_low       |
 | (Super only)        | low_effort=True               | _thinking           |
 +---------------------+-------------------------------+---------------------+
+| Medium-effort       | enable_thinking=True,         | nemotron3_ultra     |
+| thinking            | medium_effort=True            | _medium_thinking    |
+| (Ultra only)        |                               |                     |
++---------------------+-------------------------------+---------------------+
 | Reasoning OFF       | enable_thinking=False         | nemotron3_disable   |
 |                     |                               | _thinking           |
 +---------------------+-------------------------------+---------------------+
@@ -48,6 +52,9 @@ supports a low-effort reasoning mode that produces shorter thinking traces.
 The low-effort mode appends ``{reasoning effort: low}`` to the last user
 message, signaling the model to use shorter reasoning traces. The generation
 suffix remains ``<think>\\n`` (thinking is still enabled).
+
+The Ultra medium-effort mode appends ``{reasoning effort: efficient}`` to the
+last user message, matching Ultra's ``medium_effort=True`` HF template path.
 
 Reference: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
 """
@@ -358,10 +365,10 @@ class Nemotron3Renderer(Qwen3_5Renderer):
 
 
 class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
-    """Renderer for Nemotron-3 Super with low-effort reasoning.
+    """Renderer for Nemotron-3 models with low-effort reasoning.
 
-    Matches the Nemotron-3 Super HF template with ``enable_thinking=True``
-    and ``low_effort=True``. The model still produces a ``<think>`` block but
+    Matches the Nemotron-3 HF template with ``enable_thinking=True`` and
+    ``low_effort=True``. The model still produces a ``<think>`` block but
     uses significantly fewer reasoning tokens than full thinking mode.
 
     Mechanically, ``{reasoning effort: low}`` is appended to the last user
@@ -369,8 +376,8 @@ class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
     the full-thinking ``Nemotron3Renderer``).
 
     This mode is only available on the Nemotron-3 Super model
-    (NVIDIA-Nemotron-3-Super-120B-A12B-BF16); the Nano model's HF template
-    does not support ``low_effort``.
+    (NVIDIA-Nemotron-3-Super-120B-A12B-BF16); the Nano and Ultra HF templates
+    do not support ``low_effort``.
 
     Reference: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
     """
@@ -380,10 +387,71 @@ class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
         if message["role"] == "user" and ctx.idx == ctx.last_user_index:
             content = message.get("content", "")
             assert isinstance(content, str), (
-                "Nemotron-3 Super is text-only; list content not supported"
+                "Nemotron-3 low-thinking mode is text-only; list content not supported"
             )
             message = message.copy()
             message["content"] = content + "\n\n{reasoning effort: low}"
+        return super().render_message(message, ctx)
+
+
+class Nemotron3UltraRenderer(Nemotron3Renderer):
+    """Renderer for Nemotron-3 Ultra.
+
+    Ultra mostly shares Nemotron-3's XML tool format and empty system-message
+    behavior, but its HF template differs from Nano/Super in the formatting of
+    historical and explicit thinking blocks:
+
+    - ``<think>`` content is rendered as ``<think>\n...</think>`` with no
+      newline before ``</think>`` and no separator after ``</think>``.
+    - Historical thinking truncation prepends ``<think></think>`` directly to
+      the post-thinking text.
+    """
+
+    def _assistant_header_suffix(self, message: Message, ctx: RenderContext) -> str:
+        """Prepend <think></think> when Ultra's template omits thinking content."""
+        is_historical = ctx.idx < ctx.last_user_index
+        content = message.get("content", "")
+        has_think = False
+        if isinstance(content, list):
+            has_think = any(p["type"] == "thinking" for p in content)
+        elif isinstance(content, str):
+            has_think = "<think>" in content
+        if has_think and not is_historical:
+            return ""
+        return "<think></think>"
+
+    def _format_thinking_text(self, thinking: str) -> str:
+        """Ultra does not add separator newlines around ``</think>``."""
+        return f"<think>\n{thinking}</think>"
+
+    def _format_tool_calls_chunks(self, message: Message) -> list[ImagePart | TextPart]:
+        """Ultra appends one newline after assistant content before tool calls."""
+        assert "tool_calls" in message
+        calls = "".join(self._format_tool_call_xml(tc) + "\n" for tc in message["tool_calls"])
+        return [TextPart(type="text", text="\n" + calls)]
+
+    def _postprocess_parsed_message(self, message: Message) -> None:
+        """Ultra has no separator newline after ``</think>`` to strip."""
+        Qwen3_5Renderer._postprocess_parsed_message(self, message)
+
+
+class Nemotron3UltraMediumThinkingRenderer(Nemotron3UltraRenderer):
+    """Renderer for Nemotron-3 Ultra with medium-effort reasoning.
+
+    Matches Ultra's HF template with ``enable_thinking=True`` and
+    ``medium_effort=True`` by appending ``{reasoning effort: efficient}`` to
+    the last user message.
+    """
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        """Render message, appending medium-effort suffix to the last user message."""
+        if message["role"] == "user" and ctx.idx == ctx.last_user_index:
+            content = message.get("content", "")
+            assert isinstance(content, str), (
+                "Nemotron-3 Ultra medium-thinking mode is text-only; list content not supported"
+            )
+            message = message.copy()
+            message["content"] = content + "\n\n{reasoning effort: efficient}"
         return super().render_message(message, ctx)
 
 
@@ -408,3 +476,9 @@ class Nemotron3DisableThinkingRenderer(Nemotron3Renderer):
         maybe_newline = "\n" if ctx.idx > 0 else ""
         header_str = f"{maybe_newline}<|im_start|>{role}\n<think></think>"
         return self.tokenizer.encode(header_str, add_special_tokens=False)
+
+
+class Nemotron3UltraDisableThinkingRenderer(
+    Nemotron3UltraRenderer, Nemotron3DisableThinkingRenderer
+):
+    """Renderer for Nemotron-3 Ultra with thinking disabled."""

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -20,12 +20,16 @@ from tinker_cookbook.renderers.nemotron3 import (
     Nemotron3DisableThinkingRenderer,
     Nemotron3LowThinkingRenderer,
     Nemotron3Renderer,
+    Nemotron3UltraDisableThinkingRenderer,
+    Nemotron3UltraMediumThinkingRenderer,
+    Nemotron3UltraRenderer,
     _format_nemotron3_tool_declaration,
 )
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
 NEMOTRON3_NANO_MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
 NEMOTRON3_SUPER_MODEL = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
+NEMOTRON3_ULTRA_MODEL = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
 NEMOTRON3_TOKENIZER_PATH = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
 
 
@@ -50,7 +54,12 @@ def nemotron_renderer_disable_thinking(nemotron_tokenizer):
 
 
 def _hf_generation_tokens(
-    tokenizer, hf_messages, tools=None, enable_thinking: bool = True, low_effort: bool = False
+    tokenizer,
+    hf_messages,
+    tools=None,
+    enable_thinking: bool = True,
+    low_effort: bool = False,
+    medium_effort: bool = False,
 ):
     """Run HF apply_chat_template with generation prompt and return token list."""
     kwargs = {"add_generation_prompt": True, "tokenize": True, "enable_thinking": enable_thinking}
@@ -58,6 +67,8 @@ def _hf_generation_tokens(
         kwargs["tools"] = tools
     if low_effort:
         kwargs["low_effort"] = True
+    if medium_effort:
+        kwargs["medium_effort"] = True
     result = tokenizer.apply_chat_template(hf_messages, **kwargs)
     # apply_chat_template may return BatchEncoding (dict-like) when tools are provided.
     if hasattr(result, "input_ids"):
@@ -66,7 +77,12 @@ def _hf_generation_tokens(
 
 
 def _hf_supervised_tokens(
-    tokenizer, hf_messages, tools=None, enable_thinking: bool = True, low_effort: bool = False
+    tokenizer,
+    hf_messages,
+    tools=None,
+    enable_thinking: bool = True,
+    low_effort: bool = False,
+    medium_effort: bool = False,
 ):
     """Run HF apply_chat_template without generation prompt, strip trailing newline, re-encode."""
     kwargs = {"add_generation_prompt": False, "tokenize": False, "enable_thinking": enable_thinking}
@@ -74,6 +90,8 @@ def _hf_supervised_tokens(
         kwargs["tools"] = tools
     if low_effort:
         kwargs["low_effort"] = True
+    if medium_effort:
+        kwargs["medium_effort"] = True
     result = tokenizer.apply_chat_template(hf_messages, **kwargs)
     # apply_chat_template with tokenize=False may return BatchEncoding when tools are provided.
     hf_str = result.input_ids if hasattr(result, "input_ids") else result
@@ -890,4 +908,200 @@ def test_low_thinking_multiturn_supervised_matches_hf(
     assert cookbook == hf, (
         f"Cookbook: {nemotron_super_tokenizer.decode(cookbook)}\n"
         f"HF: {nemotron_super_tokenizer.decode(hf)}"
+    )
+
+
+# =============================================================================
+# Ultra Renderer Tests
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def nemotron_ultra_tokenizer():
+    return get_tokenizer(NEMOTRON3_ULTRA_MODEL)
+
+
+@pytest.fixture(scope="module")
+def nemotron_ultra_renderer(nemotron_ultra_tokenizer):
+    return get_renderer("nemotron3_ultra", nemotron_ultra_tokenizer)
+
+
+@pytest.fixture(scope="module")
+def nemotron_ultra_disable_thinking_renderer(nemotron_ultra_tokenizer):
+    return get_renderer("nemotron3_ultra_disable_thinking", nemotron_ultra_tokenizer)
+
+
+@pytest.fixture(scope="module")
+def nemotron_ultra_medium_thinking_renderer(nemotron_ultra_tokenizer):
+    return get_renderer("nemotron3_ultra_medium_thinking", nemotron_ultra_tokenizer)
+
+
+def test_ultra_renderer_types(
+    nemotron_ultra_renderer,
+    nemotron_ultra_disable_thinking_renderer,
+    nemotron_ultra_medium_thinking_renderer,
+):
+    assert isinstance(nemotron_ultra_renderer, Nemotron3UltraRenderer)
+    assert isinstance(
+        nemotron_ultra_disable_thinking_renderer, Nemotron3UltraDisableThinkingRenderer
+    )
+    assert isinstance(nemotron_ultra_medium_thinking_renderer, Nemotron3UltraMediumThinkingRenderer)
+
+
+def test_ultra_generation_matches_hf(nemotron_ultra_tokenizer, nemotron_ultra_renderer):
+    """Ultra full-thinking generation prompt matches HF template."""
+    messages = get_basic_conversation_for_generation()
+    cookbook = nemotron_ultra_renderer.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_ultra_tokenizer,
+        [nemotron_ultra_renderer.to_openai_message(m) for m in messages],
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_thinking_supervised_matches_hf(nemotron_ultra_tokenizer, nemotron_ultra_renderer):
+    """Ultra uses no separator newlines around explicit thinking blocks."""
+    messages = get_thinking_conversation_for_supervised()
+    cookbook = nemotron_ultra_renderer.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_ultra_tokenizer,
+        [nemotron_ultra_renderer.to_openai_message(m) for m in messages],
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_multiturn_thinking_supervised_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_renderer
+):
+    """Ultra historical thinking truncation has no post-</think> separator."""
+    messages = get_multiturn_thinking_conversation()
+    cookbook = nemotron_ultra_renderer.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_ultra_tokenizer,
+        [nemotron_ultra_renderer.to_openai_message(m) for m in messages],
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_tool_call_conversation_supervised_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_renderer
+):
+    """Ultra tool calls match HF after thinking-block formatting differences."""
+    messages, tools = get_tool_call_conversation_for_supervised()
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+
+    prefix = nemotron_ultra_renderer.create_conversation_prefix_with_tools(
+        tools, system_prompt=system_prompt
+    )
+    cookbook = nemotron_ultra_renderer.build_supervised_example(prefix + messages)[0].to_ints()
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        *[nemotron_ultra_renderer.to_openai_message(m) for m in messages],
+    ]
+    hf = _hf_supervised_tokens(nemotron_ultra_tokenizer, hf_messages, tools=openai_tools)
+
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_disable_thinking_generation_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_disable_thinking_renderer
+):
+    """Ultra disable-thinking generation matches HF with enable_thinking=False."""
+    messages = get_basic_conversation_for_generation()
+    r = nemotron_ultra_disable_thinking_renderer
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_ultra_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        enable_thinking=False,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_medium_thinking_generation_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_medium_thinking_renderer
+):
+    """Ultra medium-thinking generation matches HF template with medium_effort=True."""
+    messages = get_basic_conversation_for_generation()
+    r = nemotron_ultra_medium_thinking_renderer
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_ultra_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        medium_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_medium_thinking_supervised_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_medium_thinking_renderer
+):
+    """Ultra medium-thinking supervised example matches HF template."""
+    messages = get_basic_conversation_for_supervised()
+    r = nemotron_ultra_medium_thinking_renderer
+    cookbook = r.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_ultra_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        medium_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_medium_thinking_multiturn_generation_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_medium_thinking_renderer
+):
+    """Multi-turn Ultra medium-thinking generation matches HF template."""
+    messages = get_multiturn_thinking_conversation()[:4]
+    r = nemotron_ultra_medium_thinking_renderer
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_ultra_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        medium_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_medium_thinking_multiturn_supervised_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_medium_thinking_renderer
+):
+    """Multi-turn Ultra medium-thinking supervised example matches HF template."""
+    messages = get_multiturn_thinking_conversation()
+    r = nemotron_ultra_medium_thinking_renderer
+    cookbook = r.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_ultra_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        medium_effort=True,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
     )


### PR DESCRIPTION
## Summary

Adds cookbook metadata for `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16` so renderer auto-selection recognizes the model and maps it to the existing Nemotron-3 renderer family.

## Details

- Registers Ultra in `model_info` with `nemotron3` and `nemotron3_disable_thinking` recommendations.
- Keeps `nemotron3_low_thinking` scoped to Super, matching the public HF chat templates where Super includes `low_effort` and Ultra does not.
- Adds Ultra hidden size and derived LoRA parameter-count metadata.
- Adds regression coverage for the Ultra model id and `:peft:` suffix handling.

## Validation

- `.venv/bin/python -m pytest tinker_cookbook/model_info_test.py tests/downstream_compat/test_model_info.py tests/downstream_compat/test_cli_and_hyperparam.py`
- `.venv/bin/python -m ruff check tinker_cookbook/model_info.py tinker_cookbook/model_info_test.py tinker_cookbook/hyperparam_utils.py tests/downstream_compat/test_cli_and_hyperparam.py tinker_cookbook/renderers/__init__.py tinker_cookbook/renderers/nemotron3.py`