### PR TITLE
Remove transformers versions with Kimi tokenizer regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "tinker>=0.22.3",
     "torch>=2.0",
     "tqdm>=4.60.0",
-    "transformers>=4.57.6,<=5.5.3",
+    "transformers>=4.57.6,!=5.4.*,!=5.5.0,!=5.5.1,!=5.5.2,!=5.5.3,<=5.5.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Exclude Transformers releases that force Kimi K2.5/K2.6 through `TokenizersBackend`, while allowing `5.5.4` where the upstream forced-backend entry for `kimi_k25` is removed.

## Details

A version audit over the relevant released range found:

- `4.57.6`, `5.0.0`, `5.1.0`, `5.2.0`: no `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` forced-backend table
- `5.3.0`: forced-backend table exists, but does not include `kimi_k25`
- `5.4.0`, `5.5.0`, `5.5.1`, `5.5.2`, `5.5.3`: table includes `kimi_k25`, causing `AutoTokenizer` to ignore Kimi `tokenization_kimi.TikTokenTokenizer` auto-map
- `5.5.4`: released on PyPI and no longer includes `kimi_k25` in the forced-backend table

This changes the dependency bound to `transformers>=4.57.6,!=5.4.*,!=5.5.0,!=5.5.1,!=5.5.2,!=5.5.3,<=5.5.4`.

## Validation

- `git diff --check`
- parsed `pyproject.toml` with `tomllib` and confirmed the dependency spec