### PR TITLE
[codex] Load Kimi tokenizers directly

### DIFF
--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -144,22 +144,20 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
         kwargs["trust_remote_code"] = True
         kwargs["revision"] = "b5aabbfb20227ed42becbf5541dbffd213942c58"
 
-    tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
-
     # Kimi models require the custom TikTokenTokenizer which overrides apply_chat_template
     # to format tool declarations as TypeScript. On some platforms (x86_64 + transformers
-    # >=5.5), AutoTokenizer resolves to TokenizersBackend instead. Bypass AutoTokenizer
-    # and directly load the custom class in that case.
-    if (
-        model_name.startswith("moonshotai/Kimi-K2")
-        and "apply_chat_template" not in type(tokenizer).__dict__
-    ):
-        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+    # 5.4.0-5.5.3), AutoTokenizer resolves to TokenizersBackend instead or raises
+    # during backend construction. Bypass AutoTokenizer and directly load the class.
+    if model_name.startswith("moonshotai/Kimi-K2"):
+        return _get_kimi_tokenizer(model_name, revision=kwargs.get("revision"))
 
-        revision = kwargs.get("revision")
-        cls = get_class_from_dynamic_module(
-            "tokenization_kimi.TikTokenTokenizer", model_name, revision=revision
-        )
-        tokenizer = cls.from_pretrained(model_name, revision=revision)
+    return AutoTokenizer.from_pretrained(model_name, **kwargs)
 
-    return tokenizer
+
+def _get_kimi_tokenizer(model_name: str, revision: str | None) -> Tokenizer:
+    from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+    cls = get_class_from_dynamic_module(
+        "tokenization_kimi.TikTokenTokenizer", model_name, revision=revision
+    )
+    return cls.from_pretrained(model_name, revision=revision)

--- a/tinker_cookbook/tokenizer_utils_test.py
+++ b/tinker_cookbook/tokenizer_utils_test.py
@@ -11,32 +11,37 @@ def _clear_cache() -> None:
     _get_hf_tokenizer.cache_clear()
 
 
+@pytest.mark.parametrize(
+    ("model_name", "revision"),
+    [
+        ("moonshotai/Kimi-K2-Thinking", "a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55"),
+        ("moonshotai/Kimi-K2.5", "2426b45b6af0da48d0dcce71bbce6225e5c73adc"),
+        ("moonshotai/Kimi-K2.6", "b5aabbfb20227ed42becbf5541dbffd213942c58"),
+    ],
+)
+@patch("transformers.dynamic_module_utils.get_class_from_dynamic_module")
 @patch("transformers.models.auto.tokenization_auto.AutoTokenizer")
-def test_kimi_k2_thinking_trusts_remote_code_without_env(
-    mock_auto: MagicMock, monkeypatch: pytest.MonkeyPatch
+def test_kimi_tokenizers_bypass_auto_tokenizer(
+    mock_auto: MagicMock,
+    mock_get_class: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    model_name: str,
+    revision: str,
 ) -> None:
-    """Hardcoded Kimi models should pass trust_remote_code=True without the env var."""
+    """Hardcoded Kimi models should load TikTokenTokenizer directly."""
     monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
-    _get_hf_tokenizer("moonshotai/Kimi-K2-Thinking")
-    mock_auto.from_pretrained.assert_called_once_with(
-        "moonshotai/Kimi-K2-Thinking",
-        trust_remote_code=True,
-        revision="a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55",
-    )
+    mock_tokenizer = object()
+    mock_tokenizer_cls = MagicMock()
+    mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+    mock_get_class.return_value = mock_tokenizer_cls
 
+    assert _get_hf_tokenizer(model_name) is mock_tokenizer
 
-@patch("transformers.models.auto.tokenization_auto.AutoTokenizer")
-def test_kimi_k25_trusts_remote_code_without_env(
-    mock_auto: MagicMock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Hardcoded Kimi K2.5 should pass trust_remote_code=True without the env var."""
-    monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
-    _get_hf_tokenizer("moonshotai/Kimi-K2.5")
-    mock_auto.from_pretrained.assert_called_once_with(
-        "moonshotai/Kimi-K2.5",
-        trust_remote_code=True,
-        revision="2426b45b6af0da48d0dcce71bbce6225e5c73adc",
+    mock_auto.from_pretrained.assert_not_called()
+    mock_get_class.assert_called_once_with(
+        "tokenization_kimi.TikTokenTokenizer", model_name, revision=revision
     )
+    mock_tokenizer_cls.from_pretrained.assert_called_once_with(model_name, revision=revision)
 
 
 @patch("transformers.models.auto.tokenization_auto.AutoTokenizer")


### PR DESCRIPTION
## Summary

Make cookbook Kimi tokenizer loading bypass `AutoTokenizer` directly and load `tokenization_kimi.TikTokenTokenizer` via `get_class_from_dynamic_module()`.

## Details

Kimi K2/K2.5/K2.6 require Moonshot's custom `TikTokenTokenizer` for correct chat formatting and special-token IDs. We have observed two bad `AutoTokenizer` paths for Kimi K2.5/K2.6:

- returning `TokenizersBackend`, which corrupts tokens such as `<think>` and `</think>`
- raising during backend construction before the existing fallback can run

This PR makes `_get_hf_tokenizer()` route Kimi repos directly to the custom tokenizer class and updates the tokenizer utility tests to assert that Kimi bypasses `AutoTokenizer`.

## Validation

- `PYTHONPATH=/tmp/tinker-cookbook-kimi-tokenizer-bypass /home/derek/tinker-cookbook/.venv/bin/python -m pytest tinker_cookbook/tokenizer_utils_test.py`
- `PYTHONPATH=/tmp/tinker-cookbook-kimi-tokenizer-bypass /home/derek/tinker-cookbook/.venv/bin/python - <<PY ...` live-loaded Kimi K2.5/K2.6 and confirmed `TikTokenTokenizer`, `<think> -> [163606]`, `</think> -> [163607]`, and `decode([163607]) == "</think>"`
- `git diff --check`