### PR TITLE
Load Kimi K2 tokenizers directly instead of relying on AutoTokenizer

### DIFF
--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -116,6 +116,15 @@ def get_tokenizer(model_name: str) -> Tokenizer:
     return _get_hf_tokenizer(model_name)
 
 
+# Pinned revisions for Kimi K2 tokenizers, loaded directly via the custom
+# TikTokenTokenizer class (see _get_hf_tokenizer).
+_KIMI_TOKENIZER_REVISIONS: dict[str, str] = {
+    "moonshotai/Kimi-K2-Thinking": "a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55",
+    "moonshotai/Kimi-K2.5": "2426b45b6af0da48d0dcce71bbce6225e5c73adc",
+    "moonshotai/Kimi-K2.6": "b5aabbfb20227ed42becbf5541dbffd213942c58",
+}
+
+
 @cache
 def _get_hf_tokenizer(model_name: str) -> Tokenizer:
     from transformers.models.auto.tokenization_auto import AutoTokenizer
@@ -134,32 +143,21 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
     if os.environ.get("HF_TRUST_REMOTE_CODE", "").lower() in ("1", "true", "yes"):
         kwargs["trust_remote_code"] = True
 
-    if model_name == "moonshotai/Kimi-K2-Thinking":
-        kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55"
-    elif model_name == "moonshotai/Kimi-K2.5":
-        kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "2426b45b6af0da48d0dcce71bbce6225e5c73adc"
-    elif model_name == "moonshotai/Kimi-K2.6":
-        kwargs["trust_remote_code"] = True
-        kwargs["revision"] = "b5aabbfb20227ed42becbf5541dbffd213942c58"
-
-    tokenizer = AutoTokenizer.from_pretrained(model_name, **kwargs)
-
-    # Kimi models require the custom TikTokenTokenizer which overrides apply_chat_template
-    # to format tool declarations as TypeScript. On some platforms (x86_64 + transformers
-    # >=5.5), AutoTokenizer resolves to TokenizersBackend instead. Bypass AutoTokenizer
-    # and directly load the custom class in that case.
-    if (
-        model_name.startswith("moonshotai/Kimi-K2")
-        and "apply_chat_template" not in type(tokenizer).__dict__
-    ):
+    # Kimi K2 models require the custom TikTokenTokenizer, which overrides
+    # apply_chat_template to format tool declarations as TypeScript. AutoTokenizer
+    # cannot be relied on to resolve it: on some platforms (x86_64 + certain
+    # transformers releases) the model is forced through TokenizersBackend, and on
+    # K2.5/K2.6 AutoTokenizer.from_pretrained raises outright ("Couldn't instantiate
+    # the backend tokenizer ...") instead of using Kimi's tokenization_kimi auto-map.
+    # Load the custom class directly so the result is correct regardless of the
+    # installed transformers version.
+    if model_name.startswith("moonshotai/Kimi-K2"):
         from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
-        revision = kwargs.get("revision")
+        revision = _KIMI_TOKENIZER_REVISIONS.get(model_name)
         cls = get_class_from_dynamic_module(
             "tokenization_kimi.TikTokenTokenizer", model_name, revision=revision
         )
-        tokenizer = cls.from_pretrained(model_name, revision=revision)
+        return cls.from_pretrained(model_name, revision=revision)
 
-    return tokenizer
+    return AutoTokenizer.from_pretrained(model_name, **kwargs)

--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -151,14 +151,6 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
     # the backend tokenizer ...") instead of using Kimi's tokenization_kimi auto-map.
     # Load the custom class directly so the result is correct regardless of the
     # installed transformers version.
-    #
-    # A previous version called AutoTokenizer first and only fell back to the custom
-    # class when `apply_chat_template` was missing from the result's type (the signal
-    # that AutoTokenizer had returned a TokenizersBackend rather than the custom
-    # class). That guard is dropped here: when AutoTokenizer.from_pretrained raises
-    # (the K2.5/K2.6 case) the fallback was never reached. Loading the custom class
-    # unconditionally removes the dependency on AutoTokenizer resolving Kimi at all,
-    # so there is no post-hoc result to inspect.
     if model_name.startswith("moonshotai/Kimi-K2"):
         from transformers.dynamic_module_utils import get_class_from_dynamic_module
 

--- a/tinker_cookbook/tokenizer_utils.py
+++ b/tinker_cookbook/tokenizer_utils.py
@@ -151,6 +151,14 @@ def _get_hf_tokenizer(model_name: str) -> Tokenizer:
     # the backend tokenizer ...") instead of using Kimi's tokenization_kimi auto-map.
     # Load the custom class directly so the result is correct regardless of the
     # installed transformers version.
+    #
+    # A previous version called AutoTokenizer first and only fell back to the custom
+    # class when `apply_chat_template` was missing from the result's type (the signal
+    # that AutoTokenizer had returned a TokenizersBackend rather than the custom
+    # class). That guard is dropped here: when AutoTokenizer.from_pretrained raises
+    # (the K2.5/K2.6 case) the fallback was never reached. Loading the custom class
+    # unconditionally removes the dependency on AutoTokenizer resolving Kimi at all,
+    # so there is no post-hoc result to inspect.
     if model_name.startswith("moonshotai/Kimi-K2"):
         from transformers.dynamic_module_utils import get_class_from_dynamic_module
 

--- a/tinker_cookbook/tokenizer_utils_test.py
+++ b/tinker_cookbook/tokenizer_utils_test.py
@@ -11,32 +11,34 @@ def _clear_cache() -> None:
     _get_hf_tokenizer.cache_clear()
 
 
+@pytest.mark.parametrize(
+    "model_name,revision",
+    [
+        ("moonshotai/Kimi-K2-Thinking", "a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55"),
+        ("moonshotai/Kimi-K2.5", "2426b45b6af0da48d0dcce71bbce6225e5c73adc"),
+        ("moonshotai/Kimi-K2.6", "b5aabbfb20227ed42becbf5541dbffd213942c58"),
+    ],
+)
+@patch("transformers.dynamic_module_utils.get_class_from_dynamic_module")
 @patch("transformers.models.auto.tokenization_auto.AutoTokenizer")
-def test_kimi_k2_thinking_trusts_remote_code_without_env(
-    mock_auto: MagicMock, monkeypatch: pytest.MonkeyPatch
+def test_kimi_loads_custom_class_directly(
+    mock_auto: MagicMock,
+    mock_get_class: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    model_name: str,
+    revision: str,
 ) -> None:
-    """Hardcoded Kimi models should pass trust_remote_code=True without the env var."""
+    """Kimi K2 models load the custom TikTokenTokenizer directly at the pinned
+    revision, bypassing AutoTokenizer (which fails on some transformers releases)."""
     monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
-    _get_hf_tokenizer("moonshotai/Kimi-K2-Thinking")
-    mock_auto.from_pretrained.assert_called_once_with(
-        "moonshotai/Kimi-K2-Thinking",
-        trust_remote_code=True,
-        revision="a51ccc050d73dab088bf7b0e2dd9b30ae85a4e55",
+    _get_hf_tokenizer(model_name)
+    mock_get_class.assert_called_once_with(
+        "tokenization_kimi.TikTokenTokenizer", model_name, revision=revision
     )
-
-
-@patch("transformers.models.auto.tokenization_auto.AutoTokenizer")
-def test_kimi_k25_trusts_remote_code_without_env(
-    mock_auto: MagicMock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Hardcoded Kimi K2.5 should pass trust_remote_code=True without the env var."""
-    monkeypatch.delenv("HF_TRUST_REMOTE_CODE", raising=False)
-    _get_hf_tokenizer("moonshotai/Kimi-K2.5")
-    mock_auto.from_pretrained.assert_called_once_with(
-        "moonshotai/Kimi-K2.5",
-        trust_remote_code=True,
-        revision="2426b45b6af0da48d0dcce71bbce6225e5c73adc",
+    mock_get_class.return_value.from_pretrained.assert_called_once_with(
+        model_name, revision=revision
     )
+    mock_auto.from_pretrained.assert_not_called()
 
 
 @patch("transformers.models.auto.tokenization_auto.AutoTokenizer")


### PR DESCRIPTION
## Summary

`get_tokenizer("moonshotai/Kimi-K2.5")` and `"moonshotai/Kimi-K2.6"` fail on some environments with:

```
Couldn't instantiate the backend tokenizer from one of:
(1) a `tokenizers` library serialization file,
(2) a slow tokenizer instance to convert or
(3) an equivalent slow tokenizer class to instantiate and convert.
You need to have sentencepiece or tiktoken installed to convert a slow tokenizer to a fast one.
```

## Root cause

Kimi K2 models need the custom `TikTokenTokenizer`, which overrides `apply_chat_template` to format tool declarations as TypeScript. On certain transformers releases, `AutoTokenizer` forces these models through `TokenizersBackend` instead of using Kimi's `tokenization_kimi` auto-map. For K2.5/K2.6 that path raises outright (the error above) rather than returning a `TokenizersBackend`.

The previous code called `AutoTokenizer.from_pretrained` first and only fell back to loading the custom class when the result lacked `apply_chat_template`. Because `from_pretrained` itself raises on K2.5/K2.6, the fallback was never reached. K2-Thinking was unaffected because it resolves the custom class successfully on the same versions.

## Fix

For any `moonshotai/Kimi-K2*` model, load `tokenization_kimi.TikTokenTokenizer` directly via `get_class_from_dynamic_module` at the pinned revision, rather than calling `AutoTokenizer` first and bypassing on failure. This removes the dependency on `AutoTokenizer` resolving Kimi correctly, so it works regardless of the installed transformers version (no version pin required).

## Testing

`pytest tinker_cookbook/tokenizer_utils_test.py` (13 passed). The Kimi tests now assert the direct-load path for all three K2 models and that `AutoTokenizer` is not called.