### PR TITLE
Fix installation error for Tinker skill for Claude Code

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,6 +9,5 @@
   "homepage": "https://thinkingmachines.ai/tinker/",
   "repository": "https://github.com/thinking-machines-lab/tinker-cookbook",
   "license": "MIT",
-  "keywords": ["tinker", "fine-tuning", "rl", "sft", "dpo", "llm"],
-  "skills": "skills/"
+  "keywords": ["tinker", "fine-tuning", "rl", "sft", "dpo", "llm"]
 }

--- a/tests/downstream_compat/test_install_skills.py
+++ b/tests/downstream_compat/test_install_skills.py
@@ -61,10 +61,7 @@ class TestPluginManifest:
         """plugin.json must be valid JSON with required fields."""
         data = json.loads(PLUGIN_JSON.read_text())
         assert "name" in data, "plugin.json missing 'name'"
-        assert "skills" in data, "plugin.json missing 'skills'"
-        assert data["skills"] == "skills/", (
-            f"plugin.json 'skills' should be 'skills/', got '{data['skills']}'"
-        )
+        assert "description" in data, "plugin.json missing 'description'"
 
     def test_plugin_name_is_tinker(self):
         """Plugin name must be 'tinker' for /tinker:* namespace."""


### PR DESCRIPTION
fix for [tinker-cookbook issue #764]( https://github.com/thinking-machines-lab/tinker-cookbook/issues/764)

in the tinker-cookbook repo, this file:
```bash
.claude-plugin/plugin.json
```
had this field value
```javascript
"skills": "skills/"
```
which was rejected by Claude Code's manifest validator with error
```javascript
skills: Invalid input
```
The field specified a relative path without the required `./` prefix.

The fix was simply removing the `"skills": "skills/"` field.
Claude Code already scans `skills/` by default, so the explicit path was both redundant and malformed.
 