### PR TITLE
Account for renderer mismatches in distillation recipe

### DIFF
--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -19,7 +19,7 @@ import tinker
 import torch
 from tinker.types import LossFnType
 
-from tinker_cookbook import checkpoint_utils, model_info
+from tinker_cookbook import checkpoint_utils, model_info, renderers
 from tinker_cookbook.display import colorize_example
 from tinker_cookbook.distillation.datasets import (
     CompositeDataset,
@@ -57,6 +57,8 @@ async def incorporate_kl_penalty(
     dataset_indices_D: list[int],
     kl_penalty_coef: float,
     kl_discount_factor: float,
+    teacher_renderer: renderers.Renderer | None = None,
+    tokenizer: Tokenizer | None = None,
 ) -> dict[str, float]:
     """
     Compute reverse KL between the student (log p) and the teacher model (log q), computed as
@@ -68,13 +70,59 @@ async def incorporate_kl_penalty(
         dataset_indices_D: List of dataset indices, one per datum
         kl_penalty_coef: Coefficient for KL penalty
         kl_discount_factor: Discount factor for future KL
+        teacher_renderer: Optional renderer for the teacher model. If provided, the prompt
+            will be reformatted using this renderer before computing teacher logprobs.
+        tokenizer: Optional tokenizer, required if teacher_renderer is provided.
     """
-    # Note: if your teacher has a different renderer than the student, you may want to modify
-    #       the full_sequence_inputs_D to match the teacher's renderer.
-    full_sequence_inputs_D = [
-        datum.model_input.append_int(cast(int, datum.loss_fn_inputs["target_tokens"].data[-1]))
-        for datum in data_D
-    ]
+    # Build full sequence inputs for teacher logprob computation
+    # If teacher_renderer is provided, reformat the prompt using the teacher's native renderer
+    # to avoid biased logprobs from format mismatch
+    full_sequence_inputs_D: list[tinker.ModelInput] = []
+    teacher_prompt_lengths_D: list[int] = []  # Track prompt length for each datum
+    for datum in data_D:
+        if teacher_renderer is not None and tokenizer is not None:
+            # Decode the student's prompt to text (only EncodedTextChunk tokens)
+            prompt_tokens: list[int] = []
+            for chunk in datum.model_input.chunks:
+                if isinstance(chunk, tinker.EncodedTextChunk):
+                    prompt_tokens.extend(chunk.tokens)
+            prompt_text = str(tokenizer.decode(prompt_tokens))
+            # Build a new prompt using the teacher's renderer
+            # Extract the user message from the prompt text (simple heuristic)
+            # The prompt text is in student's format, e.g., "User: ...\n\nAssistant:"
+            # We need to extract just the user content
+            if "User:" in prompt_text and "Assistant:" in prompt_text:
+                user_content = prompt_text.split("User:")[1].split("Assistant:")[0].strip()
+            else:
+                user_content = prompt_text
+            # Build teacher-formatted prompt
+            teacher_messages: list[renderers.Message] = [{"role": "user", "content": user_content}]
+            teacher_prompt = teacher_renderer.build_generation_prompt(teacher_messages)
+            # Count tokens in teacher prompt
+            teacher_prompt_len = sum(
+                len(chunk.tokens)
+                for chunk in teacher_prompt.chunks
+                if isinstance(chunk, tinker.EncodedTextChunk)
+            )
+            teacher_prompt_lengths_D.append(teacher_prompt_len)
+            # Append the response tokens
+            target_tokens = datum.loss_fn_inputs["target_tokens"].data
+            full_sequence = teacher_prompt.append_int(cast(int, target_tokens[-1]))
+            full_sequence_inputs_D.append(full_sequence)
+        else:
+            # Original behavior: use student's format
+            # Count tokens in student prompt
+            student_prompt_len = sum(
+                len(chunk.tokens)
+                for chunk in datum.model_input.chunks
+                if isinstance(chunk, tinker.EncodedTextChunk)
+            )
+            teacher_prompt_lengths_D.append(student_prompt_len)
+            full_sequence_inputs_D.append(
+                datum.model_input.append_int(
+                    cast(int, datum.loss_fn_inputs["target_tokens"].data[-1])
+                )
+            )
     # Compute the teacher's logprobs for each element of the batch
     # Each datum uses its corresponding teacher sampling client
     teacher_logprobs_D = await asyncio.gather(
@@ -88,12 +136,20 @@ async def incorporate_kl_penalty(
     #   - q: teacher_logprobs
     sampled_logprobs_D = [datum.loss_fn_inputs["logprobs"].to_torch() for datum in data_D]
     float_masks = [datum.loss_fn_inputs["mask"].to_torch().float() for datum in data_D]
-    reverse_kl = [
-        (sampled_logprobs - torch.tensor(teacher_logprobs[1:])) * mask
-        for teacher_logprobs, sampled_logprobs, mask in safezip(
-            teacher_logprobs_D, sampled_logprobs_D, float_masks
-        )
-    ]
+    reverse_kl = []
+    for teacher_logprobs, sampled_logprobs, mask, teacher_prompt_len in safezip(
+        teacher_logprobs_D, sampled_logprobs_D, float_masks, teacher_prompt_lengths_D
+    ):
+        # Slice teacher logprobs to align with student's response tokens
+        # Teacher logprobs: [prompt_token_0, prompt_token_1, ..., response_token_0, ...]
+        # We want logprobs for response tokens, starting at index teacher_prompt_len
+        teacher_response_logprobs = torch.tensor(teacher_logprobs[teacher_prompt_len:])
+        # Ensure lengths match (in case of off-by-one)
+        min_len = min(len(sampled_logprobs), len(teacher_response_logprobs))
+        sampled_logprobs_aligned = sampled_logprobs[:min_len]
+        teacher_logprobs_aligned = teacher_response_logprobs[:min_len]
+        mask_aligned = mask[:min_len]
+        reverse_kl.append((sampled_logprobs_aligned - teacher_logprobs_aligned) * mask_aligned)
     # Track per-dataset KL for logging
     # dataset_idx -> (sum of KL, sum of mask)
     per_dataset_kl: dict[int, tuple[float, float]] = {}
@@ -137,6 +193,7 @@ class Config:
     model_name: str
     recipe_name: str
     renderer_name: str | None = None
+    teacher_renderer_name: str | None = None
     max_tokens: int
     temperature: float = 1.0
     compute_post_kl: bool = False
@@ -180,6 +237,7 @@ async def prepare_minibatch(
     teacher_clients: list[tinker.SamplingClient],
     kl_penalty_coef: float,
     kl_discount_factor: float,
+    teacher_renderer: renderers.Renderer | None = None,
 ) -> tuple[list[tinker.Datum], dict[str, Any]]:
     """Converts the trajectories into a minibatch, and provides metrics about the minibatch"""
 
@@ -220,6 +278,8 @@ async def prepare_minibatch(
                 dataset_indices_D,
                 kl_penalty_coef,
                 kl_discount_factor,
+                teacher_renderer,
+                tokenizer,
             )
         metrics.update(kl_penalty_metrics)
 
@@ -238,6 +298,7 @@ async def do_train_step_and_get_sampling_client(
     trajectory_groups_P: list[TrajectoryGroup],
     dataset_indices_P: list[int],
     teacher_clients: list[tinker.SamplingClient],
+    teacher_renderer: renderers.Renderer | None = None,
     store: TrainingRunStore | None = None,
 ) -> tuple[tinker.SamplingClient, dict[str, Any]]:
     trace.update_scope_context({"step": i_batch})
@@ -251,6 +312,7 @@ async def do_train_step_and_get_sampling_client(
         teacher_clients,
         kl_penalty_coef=config.kl_penalty_coef,
         kl_discount_factor=config.kl_discount_factor,
+        teacher_renderer=teacher_renderer,
     )
     metrics.update(prepare_minibatch_metrics)
 
@@ -293,6 +355,7 @@ async def do_sync_training(
     teacher_clients: list[tinker.SamplingClient],
     ml_logger: ml_log.Logger,
     tokenizer: Tokenizer,
+    teacher_renderer: renderers.Renderer | None = None,
 ):
     """Implements fully synchronous on-policy training"""
 
@@ -354,6 +417,7 @@ async def do_sync_training(
                 trajectory_groups_P,
                 dataset_indices_P,
                 teacher_clients,
+                teacher_renderer,
             )
 
             metrics.update(train_step_metrics)
@@ -440,6 +504,12 @@ async def main(
     # Get tokenizer from training client
     tokenizer = training_client.get_tokenizer()
 
+    # Create teacher renderer if specified
+    teacher_renderer = None
+    if config.teacher_renderer_name is not None:
+        teacher_renderer = renderers.get_renderer(config.teacher_renderer_name, tokenizer=tokenizer)
+        logger.info(f"Using teacher renderer: {config.teacher_renderer_name}")
+
     # Create datasets and teacher sampling clients from configs
     datasets = []
     teacher_clients = []
@@ -499,6 +569,7 @@ async def main(
         evaluators=evaluators,
         dataset=composite_dataset,
         teacher_clients=teacher_clients,
+        teacher_renderer=teacher_renderer,
         ml_logger=ml_logger,
         tokenizer=tokenizer,
     )

--- a/tinker_cookbook/recipes/distillation/README.md
+++ b/tinker_cookbook/recipes/distillation/README.md
@@ -33,6 +33,7 @@ We observe an AIME'24 score of ~76.7% using a rank-128 LoRA after 200 steps with
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
     model_name=Qwen/Qwen3.5-9B-Base \
     teacher_model=Qwen/Qwen3.5-9B \
+    teacher_renderer_name=qwen3_5 \
     load_checkpoint_path=tinker://b89f6676-49c4-53ed-9788-2e0c81a9eabf:train:0/weights/final \
     dataset=deepmath \
     learning_rate=1e-4 \
@@ -41,6 +42,8 @@ python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
     max_tokens=16384 \
     wandb_project=cookbook_distillation
 ```
+
+**Important:** When the teacher model uses a different renderer than the student (e.g., `qwen3_5` for the instruct teacher vs `role_colon` for the base student), you should specify `teacher_renderer_name` to ensure the teacher computes logprobs on properly formatted input. Without this, the teacher's logprobs are biased, which can cause training instability (see [Renderer mismatch](#renderer-mismatch) below).
 
 This script can also be used to replicate the experiments in our Discussion section, after you have run RL to obtain an appropriate checkpoint for the teacher model.
 
@@ -71,6 +74,7 @@ In our experiment, we saw [IF-eval](https://huggingface.co/datasets/google/IFEva
 python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
     model_name=Qwen/Qwen3.5-9B-Base \
     teacher_model=Qwen/Qwen3.5-9B \
+    teacher_renderer_name=qwen3_5 \
     load_checkpoint_path=tinker://YOUR_SFT_INITIALIZATION \
     dataset=tulu3 \
     learning_rate=1e-4 \
@@ -128,6 +132,41 @@ python -m tinker_cookbook.recipes.distillation.on_policy_distillation_harbor_mul
 ```
 
 ## Additional details
+
+### Renderer mismatch
+
+When the student and teacher models use different renderers (e.g., `role_colon` for the base student vs `qwen3_5` for the instruct teacher), the teacher computes logprobs on input formatted for the student, not its native format. This creates a biased KL target:
+
+**Student format (role_colon):**
+```
+User: What is 2+2?
+
+Assistant: The answer is 4.
+```
+
+**Teacher format (qwen3_5):**
+```
+<|im_start|>user
+What is 2+2?<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+
+The answer is 4.<|im_end|>
+```
+
+The teacher was trained on the `qwen3_5` format, so its logprobs on `role_colon`-formatted input are biased. This can cause training instability, especially with large batch sizes where the model confidently converges to the biased target then overshoots.
+
+**Fix:** Specify `teacher_renderer_name` to make the teacher compute logprobs using its native renderer:
+
+```bash
+python -m tinker_cookbook.recipes.distillation.on_policy_distillation \
+    model_name=Qwen/Qwen3.5-9B-Base \
+    teacher_model=Qwen/Qwen3.5-9B \
+    teacher_renderer_name=qwen3_5 \
+    ...
+```
 
 ### Reward calculation
 

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -36,7 +36,7 @@ from typing import Any
 import chz
 from tinker.types import LossFnType
 
-from tinker_cookbook import checkpoint_utils, cli_utils
+from tinker_cookbook import checkpoint_utils, cli_utils, model_info
 from tinker_cookbook.distillation import train_on_policy
 from tinker_cookbook.distillation.datasets import (
     DistillationDatasetConfig,
@@ -60,6 +60,7 @@ class CLIConfig:
     # Teacher configuration
     teacher_model: str = "Qwen/Qwen3.5-9B"
     teacher_checkpoint: str | None = None
+    teacher_renderer_name: str | None = None
 
     # Dataset configuration
     dataset: str = "deepmath"  # Options: deepmath, tulu3
@@ -110,6 +111,12 @@ async def cli_main(cli_config: CLIConfig):
         base_url=cli_config.base_url,
     )
 
+    # Get teacher renderer name (defaults to teacher model's recommended renderer)
+    if cli_config.teacher_renderer_name is not None:
+        teacher_renderer_name = cli_config.teacher_renderer_name
+    else:
+        teacher_renderer_name = model_info.get_recommended_renderer_name(cli_config.teacher_model)
+
     # Create log path if not specified
     if cli_config.log_path is not None:
         log_path = cli_config.log_path
@@ -157,6 +164,7 @@ async def cli_main(cli_config: CLIConfig):
         dataset_configs=[dataset_config],
         model_name=cli_config.model_name,
         renderer_name=renderer_name,
+        teacher_renderer_name=teacher_renderer_name,
         lora_rank=cli_config.lora_rank,
         max_tokens=cli_config.max_tokens,
         kl_penalty_coef=cli_config.kl_penalty_coef,


### PR DESCRIPTION
Fix for issue https://github.com/thinking-machines-lab/tinker-cookbook/issues/796

## Changes
#### 1. on_policy_distillation.py

- Added teacher_renderer_name: str | None = None parameter to CLIConfig
- Defaults to the teacher model's recommended renderer (e.g., qwen3_5 for Qwen3.5-9B)
- Passed through to the training config

#### 2. train_on_policy.py

- Added teacher_renderer and tokenizer parameters to incorporate_kl_penalty
- When teacher_renderer is provided, the prompt is reformatted using the teacher's native renderer before computing teacher logprobs
- Tracks teacher prompt length to correctly slice teacher logprobs for alignment with student's response tokens

#### 3. README.md

- Updated example commands to include teacher_renderer_name=qwen3_5
- Added "Renderer mismatch" section explaining the issue and fix



## How it works

Before (biased):
```
Student generates: "User: ...\n\nAssistant: 4.\n\nUser:"
Teacher sees:      "User: ...\n\nAssistant: 4.\n\nUser:"  ← wrong format!
Teacher logprobs:  biased (+0.287 nats/token)
```

After (fixed):
```
Student generates: "User: ...\n\nAssistant: 4.\n\nUser:"
Teacher sees:      "<|im_start|>user\n...<|im_end|>
```