### PR TITLE
Add training run artifact summary

### DIFF
--- a/tinker_cookbook/recipes/README.md
+++ b/tinker_cookbook/recipes/README.md
@@ -45,3 +45,15 @@ Our examples support the following CLI arguments to log the results.
     - `{log_path}/metrics.jsonl` saves training metrics.
     - `{log_path}/checkpoints.jsonl` records all the checkpoints saved during training. You can share these checkpoints for model release, offline evaluation, etc.
   - Resuming: When using an existing `log_path`, you can either overwrite the previous run or resume training. This is particularly useful for recovering from runtime interruptions.
+
+To quickly inspect which machine-readable artifacts are available for a run,
+use `TrainingRunStore.summarize()`:
+
+```python
+from tinker_cookbook.stores.storage import LocalStorage
+from tinker_cookbook.stores.training_store import TrainingRunStore
+
+store = TrainingRunStore(LocalStorage("/path/to/log_path"))
+summary = store.summarize()
+print(summary.to_dict())
+```

--- a/tinker_cookbook/stores/training_store.py
+++ b/tinker_cookbook/stores/training_store.py
@@ -23,6 +23,14 @@ logger = logging.getLogger(__name__)
 _ITERATION_RE = re.compile(r"^iteration_(\d+)$")
 
 
+def _latest_int_value(records: list[dict[str, Any]], key: str) -> int | None:
+    for record in reversed(records):
+        value = record.get(key)
+        if isinstance(value, int):
+            return value
+    return None
+
+
 class _Unset:
     """Sentinel that survives pickle (unlike bare object())."""
 
@@ -45,6 +53,39 @@ class IterationInfo:
     has_train_rollouts: bool = False
     has_train_logtree: bool = False
     eval_labels: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RunArtifactSummary:
+    """Compact inventory of machine-readable artifacts for a training run."""
+
+    has_config: bool
+    metric_count: int
+    metric_keys: list[str]
+    latest_metric_step: int | None
+    checkpoint_count: int
+    latest_checkpoint_name: str | None
+    iterations: list[IterationInfo] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the summary to a JSON-friendly dictionary."""
+        return {
+            "has_config": self.has_config,
+            "metric_count": self.metric_count,
+            "metric_keys": self.metric_keys,
+            "latest_metric_step": self.latest_metric_step,
+            "checkpoint_count": self.checkpoint_count,
+            "latest_checkpoint_name": self.latest_checkpoint_name,
+            "iterations": [
+                {
+                    "iteration": iteration.iteration,
+                    "has_train_rollouts": iteration.has_train_rollouts,
+                    "has_train_logtree": iteration.has_train_logtree,
+                    "eval_labels": iteration.eval_labels,
+                }
+                for iteration in self.iterations
+            ],
+        }
 
 
 class TrainingRunStore:
@@ -152,6 +193,30 @@ class TrainingRunStore:
     def metric_keys(self) -> set[str]:
         """All metric keys seen so far (excluding 'step')."""
         return self._get_metrics().known_keys
+
+    def summarize(self) -> RunArtifactSummary:
+        """Return a compact inventory of artifacts available for this run.
+
+        The summary is intended for scripts, dashboards, and debugging tools
+        that need to quickly inspect a ``log_path`` without loading large
+        rollout/logtree payloads.
+        """
+        config = self.read_config()
+        metrics = self.read_metrics()
+        checkpoints = self.read_checkpoints()
+        latest_metric_step = _latest_int_value(metrics, "step")
+        latest_checkpoint_name = (
+            str(checkpoints[-1]["name"]) if checkpoints and "name" in checkpoints[-1] else None
+        )
+        return RunArtifactSummary(
+            has_config=config is not None,
+            metric_count=len(metrics),
+            metric_keys=sorted(self.metric_keys()),
+            latest_metric_step=latest_metric_step,
+            checkpoint_count=len(checkpoints),
+            latest_checkpoint_name=latest_checkpoint_name,
+            iterations=self.list_iterations(),
+        )
 
     # ── Rollouts (typed, cached) ──────────────────────────────────────
 

--- a/tinker_cookbook/stores/training_store_test.py
+++ b/tinker_cookbook/stores/training_store_test.py
@@ -179,6 +179,18 @@ class TestTrainingRunStore:
             "eval_labels": [],
         }
 
+    def test_summarize_empty_run(self, tmp_path: Path) -> None:
+        store = TrainingRunStore(LocalStorage(tmp_path))
+        summary = store.summarize()
+
+        assert not summary.has_config
+        assert summary.metric_count == 0
+        assert summary.metric_keys == []
+        assert summary.latest_metric_step is None
+        assert summary.checkpoint_count == 0
+        assert summary.latest_checkpoint_name is None
+        assert summary.iterations == []
+
     def test_read_rollouts(self, run_dir: Path) -> None:
         store = TrainingRunStore(LocalStorage(run_dir))
         rollouts = store.read_rollouts(0)

--- a/tinker_cookbook/stores/training_store_test.py
+++ b/tinker_cookbook/stores/training_store_test.py
@@ -151,6 +151,34 @@ class TestTrainingRunStore:
         assert "env/all/reward/total" in keys
         assert "step" not in keys
 
+    def test_summarize_run_artifacts(self, run_dir: Path) -> None:
+        store = TrainingRunStore(LocalStorage(run_dir))
+        summary = store.summarize()
+
+        assert summary.has_config
+        assert summary.metric_count == 5
+        assert summary.metric_keys == ["env/all/reward/total", "train_mean_nll"]
+        assert summary.latest_metric_step == 4
+        assert summary.checkpoint_count == 1
+        assert summary.latest_checkpoint_name == "000004"
+        assert [iteration.iteration for iteration in summary.iterations] == [0, 2]
+        assert summary.iterations[0].has_train_rollouts
+        assert summary.iterations[0].has_train_logtree
+
+    def test_summarize_to_dict(self, run_dir: Path) -> None:
+        store = TrainingRunStore(LocalStorage(run_dir))
+        summary_dict = store.summarize().to_dict()
+
+        assert summary_dict["has_config"]
+        assert summary_dict["metric_count"] == 5
+        assert summary_dict["latest_metric_step"] == 4
+        assert summary_dict["iterations"][0] == {
+            "iteration": 0,
+            "has_train_rollouts": True,
+            "has_train_logtree": True,
+            "eval_labels": [],
+        }
+
     def test_read_rollouts(self, run_dir: Path) -> None:
         store = TrainingRunStore(LocalStorage(run_dir))
         rollouts = store.read_rollouts(0)


### PR DESCRIPTION
## Summary

Adds a compact `TrainingRunStore.summarize()` helper for inspecting the machine-readable artifacts available in a training run log directory without loading large rollout/logtree payloads.

The summary includes:

- whether `config.json` is present
- metric count, metric keys, and latest metric step
- checkpoint count and latest checkpoint name
- iteration-level rollout/logtree availability
- `RunArtifactSummary.to_dict()` for JSON-friendly scripts and dashboards

This is useful for debugging scripts, dashboards, and external tools that need a quick inventory of a `log_path` before deeper analysis.

## Tests

- `.venv/bin/python -m pytest tinker_cookbook/stores/training_store_test.py`
- `.venv/bin/ruff check tinker_cookbook/stores/training_store.py tinker_cookbook/stores/training_store_test.py`