### PR TITLE
Skip blank lines when reading JSONL

### DIFF
--- a/tinker_cookbook/utils/file_utils.py
+++ b/tinker_cookbook/utils/file_utils.py
@@ -21,4 +21,4 @@ def read_jsonl(path: str) -> list[dict]:
             print(record["step"], record["loss"])
     """
     with open(path) as f:
-        return [json.loads(line) for line in f]
+        return [json.loads(line) for line in f if line.strip()]

--- a/tinker_cookbook/utils/file_utils_test.py
+++ b/tinker_cookbook/utils/file_utils_test.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+from tinker_cookbook.utils.file_utils import read_jsonl
+
+
+def test_read_jsonl_skips_blank_lines(tmp_path: Path) -> None:
+    path = tmp_path / "records.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"step": 0, "loss": 1.0}),
+                "",
+                "   ",
+                json.dumps({"step": 1, "loss": 0.5}),
+                "",
+            ]
+        )
+    )
+
+    assert read_jsonl(str(path)) == [
+        {"step": 0, "loss": 1.0},
+        {"step": 1, "loss": 0.5},
+    ]


### PR DESCRIPTION
## Summary

Makes `read_jsonl` tolerate blank or whitespace-only lines. This keeps small debugging/reporting scripts from failing on JSONL files that have been concatenated or hand-edited with spacer lines.

Adds a focused unit test for the blank-line behavior.

## Tests

- `.venv/bin/python -m pytest tinker_cookbook/utils/file_utils_test.py`
- `.venv/bin/ruff check tinker_cookbook/utils/file_utils.py tinker_cookbook/utils/file_utils_test.py`
- `.venv/bin/ruff format --check tinker_cookbook/utils/file_utils.py tinker_cookbook/utils/file_utils_test.py`