### PR TITLE
Tidy section comments in downstream compat tests

### DIFF
--- a/tests/downstream_compat/test_recipes.py
+++ b/tests/downstream_compat/test_recipes.py
@@ -156,7 +156,7 @@ class TestEvaluators:
 
 
 # ---------------------------------------------------------------------------
-# distillation.datasets (used by tibo)
+# distillation.datasets (used by downstream training code)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/downstream_compat/test_rl_train.py
+++ b/tests/downstream_compat/test_rl_train.py
@@ -56,7 +56,7 @@ class TestRLDataProcessing:
 
 
 # ---------------------------------------------------------------------------
-# rl.metrics (used by tibo training code)
+# rl.metrics (used by downstream training code)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/downstream_compat/test_utils.py
+++ b/tests/downstream_compat/test_utils.py
@@ -96,7 +96,7 @@ class TestMiscUtils:
 
 
 # ---------------------------------------------------------------------------
-# trace (import-only check — used by tibo training code)
+# trace (import-only check — used by downstream training code)
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Small comment-only cleanup in `tests/downstream_compat/` — rewords a few section-header comments for clarity. No test logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145m7h9XhD8Zpy1TxpvPD4z