### PR TITLE
Restore notes on expert layers in docstring for `get_lora_param_count`

### DIFF
--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -234,6 +234,9 @@ def get_lora_param_count(
 
     Returns:
         Total trainable parameter count.
+
+    Notes:
+        For MoE expert layers, Tinker uses a shared-outer LoRA scheme: the LoRA factor connected to the model hidden dimension is shared across experts, while the other factor remains expert-specific. This reduces LoRA parameter count and optimizer state while preserving per-expert adaptation. The parameter count returned by this function reflects this sharing.
     """
     if not (train_mlp or train_attn or train_unembed):
         raise ValueError("At least one of train_mlp, train_attn, or train_unembed must be True.")


### PR DESCRIPTION
The notes were originally updated in Tinker docs. But because the docstring itself wasn't updated, when the two were synced the notes were lost.

Adding them to the docstring now to fix this moving forward.