### PR TITLE
Add missing blank lines before Markdown lists in recipe READMEs

### DIFF
--- a/tinker_cookbook/recipes/README.md
+++ b/tinker_cookbook/recipes/README.md
@@ -6,10 +6,12 @@ We will first introduce a few simple training scripts to help you get started, a
 ## Getting Started
 
 Tinker Cookbook comes with useful abstractions so you can flexibly customize your experiments. Here are some minimal launch scripts:
+
 - [`rl_basic.py`](./rl_basic.py): a template script to configure reinforcement learning.
 - [`sl_basic.py`](./sl_basic.py): a template script to configure supervised learning.
 
 To explain what goes under-the-hood, we also provide minimal, self-contained scripts that directly use the Tinker API to train LLMs.
+
 - [`rl_loop.py`](./rl_loop.py): a minimal reinforcement learning training loop.
 - [`sl_loop.py`](./sl_loop.py): a minimal supervised learning training loop.
 
@@ -17,6 +19,7 @@ To explain what goes under-the-hood, we also provide minimal, self-contained scr
 
 Building on Tinker and Tinker Cookbook, we can easily customize a wide range of training environments for LLMs.
 We provide the following examples:
+
 - **[Chat supervised learning](./chat_sl/)**: supervised fine-tuning on conversational datasets like Tulu3.
 - **[Math reasoning](./math_rl/)**: improve LLM reasoning capability by rewarding it for answering math questions correctly.
 - **[Code reasoning](./code_rl/)**: train LLMs on competitive programming problems with sandboxed code execution (DeepCoder replication).
@@ -40,8 +43,8 @@ Our examples support the following CLI arguments to log the results.
 
 1. `wandb_project`: When provided, logs will be sent to your Weights & Biases project. Without this argument, training scripts save logs locally only.
 2. `log_path`: Controls where training artifacts are saved.
-  - Default behavior: If not specified, each run generates a unique name and saves to `/tmp/tinker-examples`
-  - Output files:
-    - `{log_path}/metrics.jsonl` saves training metrics.
-    - `{log_path}/checkpoints.jsonl` records all the checkpoints saved during training. You can share these checkpoints for model release, offline evaluation, etc.
-  - Resuming: When using an existing `log_path`, you can either overwrite the previous run or resume training. This is particularly useful for recovering from runtime interruptions.
+    - Default behavior: If not specified, each run generates a unique name and saves to `/tmp/tinker-examples`
+    - Output files:
+        - `{log_path}/metrics.jsonl` saves training metrics.
+        - `{log_path}/checkpoints.jsonl` records all the checkpoints saved during training. You can share these checkpoints for model release, offline evaluation, etc.
+    - Resuming: When using an existing `log_path`, you can either overwrite the previous run or resume training. This is particularly useful for recovering from runtime interruptions.

--- a/tinker_cookbook/recipes/chat_sl/README.md
+++ b/tinker_cookbook/recipes/chat_sl/README.md
@@ -36,6 +36,7 @@ Performance can be further improved by training longer with a higher `lora_rank`
 ## Adding your own dataset
 
 The base classes in [tinker_cookbook/supervised/data.py](../../supervised/data.py) support loading new data in the following way:
+
 - `SupervisedDatasetFromHFDataset` loads dataset on Hugging Face hub with a postprocessing function
 - `StreamingSupervisedDatasetFromHFDataset` works similarly, but supports streaming
 - `FromConversationFileBuilder` supports data loading from a JSONL file

--- a/tinker_cookbook/recipes/code_rl/README.md
+++ b/tinker_cookbook/recipes/code_rl/README.md
@@ -44,6 +44,7 @@ python -m tinker_cookbook.recipes.code_rl.train \
 ```
 
 Optional environment variables for Modal:
+
 - `MODAL_POOL_SIZE`: Number of concurrent sandboxes (default: 32)
 - `MODAL_CREATION_RATE_LIMIT`: Max sandboxes created per second (default: 4)
 

--- a/tinker_cookbook/recipes/distillation/README.md
+++ b/tinker_cookbook/recipes/distillation/README.md
@@ -9,6 +9,7 @@ Specifically, we provide the scripts needed to reproduce our experiments from th
 ## Distillation for reasoning
 
 Our results can be reproduced by running:
+
 1. Supervised fine-tuning on [OpenThoughts3](https://huggingface.co/datasets/open-thoughts/OpenThoughts3-1.2M)
 2. On-policy distillation on [DeepMath](https://huggingface.co/datasets/zwhe99/DeepMath-103K)
 
@@ -60,6 +61,7 @@ See the on-policy distillation launch command above for an example of how to loa
 ## Distillation for personalization
 
 In this section, we ran:
+
 1. Supervised fine-tuning on internal documents + resampled Tulu3 data
 2. On-policy distillation on [Tulu3](https://huggingface.co/datasets/allenai/tulu-3-sft-mixture) prompts
 

--- a/tinker_cookbook/recipes/multiplayer_rl/README.md
+++ b/tinker_cookbook/recipes/multiplayer_rl/README.md
@@ -4,6 +4,7 @@ Often we not only want large language models (LLMs) to generate a single respons
 To help Tinker users easily customize their own training, we provide the *Environment* abstraction.
 
 We cover three examples, with increasing complexity.
+
 1. [Guess the number](./guess_number/): where the policy learns to guess the target number with multiple tries, given feedback on whether the number is too high or low.
 2. [Twenty Questions](./twenty_questions): where the policy learns to guess an underlying object by asking yes/no questions.
 3. [Tic-Tac-Toe](./text_arena): where the policy learns by playing against itself.

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/README.md
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/README.md
@@ -9,6 +9,7 @@ The `test/env/all/reward/total` should increase from roughly 0 (slightly negativ
 ### Background: Guess the Number
 
 In this task, we train an LLM to guess a hidden integer number between 0 and 1024.
+
 - If the LLM guess correctly, the task is done
 - If the LLM guesses incorrectly, the LLM will be given the chance to guess again and information whether the guessed number is too low or high.
 - The interaction automatically ends after 10 guesses.
@@ -45,6 +46,7 @@ To customize your own training environment, you need to write a file like `recip
 We have already implemented the abstract class `Env` for you, so you can focus on implementing the initial observation, transition function, and reward function.
 
 We will start by explaining the `step` function, which is the "core" of the environment: it determines
+
 - how the LLM-generated action will influence the environment,
 - what is the reward of this action,
 - whether the game will end with this action, and

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/README.md
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/README.md
@@ -142,11 +142,13 @@ Therefore, in the `Env.step` function, we need to receive the opponent's action,
 This motivates the design of the `Coordinator` class, which passes the LLM-generated text between two `Environment` objects and synchronizes the two `Environment` objects to alternate taking steps.
 
 In our implementation, the `TwoPlayerCoordinator` object is shared across two `Environment` objects, and it:
+
 - wraps the tic-tac-toe environment from the TextArena [1],
 - waits for a specific player's turn to begin, and
 - allows one player to `make_move` on the board, and notifies the other player that the move is complete.
 
 As a result, in the `Environment.step` function, we can:
+
 - determine when to start the next move, since `TwoPlayerCoordinator` informs us when the opponent has finished.
 - compute the next observation, since `TwoPlayerCoordinator` passes the move from the opponent.
 

--- a/tinker_cookbook/recipes/preference/README.md
+++ b/tinker_cookbook/recipes/preference/README.md
@@ -7,6 +7,7 @@ Many applications involve learning from preferences beyond scalar rewards. We pr
 3. [DPO](./dpo/): we optimize for human preferences using the Direct Preference Optimization algorithm [3], which requires a custom loss function.
 
 **References:**
+
 1. Bai, Y., Kadavath, S., Kundu, S., Askell, A., Kernion, J., Jones, A., Chen, A., Goldie, A., Mirhoseini, A., McKinnon, C., Chen, C., Olsson, C., Olah, C., Hernandez, D., Drain, D., Ganguli, D., Li, D., Tran-Johnson, E., Perez, E., Kerr, J., Mueller, J., Ladish, J., Landau, J., Ndousse, K., Lukošiūtė, K., Lovitt, L., Sellitto, M., Elhage, N., Schiefer, N., Mercado, N., ... Kaplan, J. (2022). Training a helpful and harmless assistant with reinforcement learning from human feedback. arXiv. https://arxiv.org/abs/2204.05862
 2. Ouyang, L., Wu, J., Jiang, X., Almeida, D., Wainwright, C. L., Mishkin, P., Zhang, C., Agarwal, S., Slama, K., Ray, A., Schulman, J., Hilton, J., Kelton, F., Miller, L., Simens, M., Askell, A., Welinder, P., Christiano, P. F., Leike, J., & Lowe, R. (2022). Training language models to follow instructions with human feedback. Advances in Neural Information Processing Systems, 35, 27730-27744. https://arxiv.org/abs/2203.02155
 3. Rafailov, R., Sharma, A., Mitchell, E., Ermon, S., Manning, C. D., & Finn, C. (2023). Direct preference optimization: Your language model is secretly a reward model. arXiv. https://arxiv.org/abs/2305.18290

--- a/tinker_cookbook/recipes/preference/rlhf/README.md
+++ b/tinker_cookbook/recipes/preference/rlhf/README.md
@@ -5,6 +5,7 @@ python -m tinker_cookbook.recipes.preference.rlhf.rlhf_pipeline
 ```
 
 There are three stages:
+
 1. Policy SFT stage: this stage is short, and `test/nll` should decrease from 1.87 to 1.63 in 20 steps.
 2. Reward model SFT stage: this stage is longer, and `test/nll` should drastically decrease from 3.0 to around 0.58 in the first 40 steps, slowly decrease to 0.54 at around step 300, and converge to around 0.53 in 600 steps. This stage needs to finish before the next stage.
 3. Policy RL stage: `test/win_rate` should increase from ~46% to ~94% in 100 steps.

--- a/tinker_cookbook/recipes/preference/shorter/README.md
+++ b/tinker_cookbook/recipes/preference/shorter/README.md
@@ -11,10 +11,12 @@ python -m tinker_cookbook.recipes.preference.shorter.train
 We implement the `PairwisePreferenceRLDatasetBuilder` class to make it easier to learn from preference pairs, rather than scalar rewards for an individual trajectory. The key objects you need to implement are: (1) PreferenceModelBuilder, and (2) ComparisonBuilder.
 
 **PreferenceModelBuilder** will build a *PreferenceModel* when called (via its `__call__()` method), which determines what responses are preferred. Concretely, `PreferenceModel.__call__`
+
 - accepts a `Comparison` object, which contains (1) `prompt_conversation`: a list of input messages that the policy model receives, and (2) `completion_A` and `completion_B`, each a list of messages that the policy model generates.
 - returns a floating point number; a larger number means that `completion_B` is better.
 
 **ComparisonBuilder** will be used in our code to create a list of `Comparison` objects. We need to implement two functions
+
 - `get_train_and_test_datasets`: which returns training and test Hugging Face `Dataset` objects
 - `example_to_labeled_comparison`: which converts each datapoint (a `dict` in the `Dataset` object) to a `Comparison` object.
 

--- a/tinker_cookbook/recipes/prompt_distillation/README.md
+++ b/tinker_cookbook/recipes/prompt_distillation/README.md
@@ -14,6 +14,7 @@ Response: ja
 ```
 
 At a high level, this method involves two stages:
+
 1. **Creating data for distillation**: A teacher language model uses $p$ to generate responses $r$ on a set of queries $q$; i.e. $r \sim \text{teacher}(\cdot|p, q)$
 2. **Training the student model**: A student model is fine-tuned to predict the responses $r$ to the query $q$ but without accessing $p$, hence learning to behave as if the target prompt is in its context; i.e. $\text{student}(\cdot | q)$ should predict $r$
 
@@ -41,6 +42,7 @@ python -m tinker_cookbook.recipes.prompt_distillation.create_data \
 ```
 
 This command will:
+
 - Use the configured teacher model to generate language classification examples
 - Save the distilled dataset to the specified output file
 - Create diverse training examples suitable for student model fine-tuning
@@ -54,6 +56,7 @@ python -m tinker_cookbook.recipes.prompt_distillation.train
 ```
 
 The training script will:
+
 - Load the generated distillation dataset
 - Apply optimized training configurations
 - Fine-tune the student model for language classification

--- a/tinker_cookbook/recipes/rubric/README.md
+++ b/tinker_cookbook/recipes/rubric/README.md
@@ -27,6 +27,7 @@ python -m tinker_cookbook.recipes.rubric.generate_data
 ```
 
 Then you will see two `jsonl` files generated, one for training, one for testing. For example, if you look into `tinker_cookbook/example_data/example_rubric_train.jsonl`, each datapoint consists of
+
 - a convo (the conversation prefix that the policy sees)
 - rubric_items: a list of rubric items that specify what is a good response, how the grader should format the response, and how the grading result should be extracted.
 

--- a/tinker_cookbook/recipes/true_thinking_score/README.md
+++ b/tinker_cookbook/recipes/true_thinking_score/README.md
@@ -167,6 +167,7 @@ python -m tinker_cookbook.recipes.true_thinking_score.analyze \
 ```
 
 Results are saved to `/tmp/tinker-examples/tts/<run-name>/`:
+
 - `tts_per_problem.jsonl` — per-problem details (steps, TTS scores)
 - `tts_summary.json` — aggregate statistics
 

--- a/tinker_cookbook/recipes/verifiers_rl/README.md
+++ b/tinker_cookbook/recipes/verifiers_rl/README.md
@@ -10,6 +10,7 @@ prime env install user/env-id # ex. prime env install primeintellect/reverse-tex
 ```
 
 Examples:
+
 - [primeintellect/reverse-text](https://app.primeintellect.ai/dashboard/environments/primeintellect/reverse-text)
 - [primeintellect/alphabet-sort](https://app.primeintellect.ai/dashboard/environments/primeintellect/alphabet-sort)
 - [primeintellect/math-python](https://app.primeintellect.ai/dashboard/environments/primeintellect/math-python)
@@ -32,4 +33,5 @@ python -m tinker_cookbook.recipes.verifiers_rl.evaluate vf_env_id=env-id vf_env_
 This recipe also includes a standalone `AsyncOpenAI`-compatible client implemented with Tinker, which can be adapted for other applications.
 
 **Potential footgun:**
+
 - Some Environments Hub implementations involve users writing their own `<think>` parsers (e.g. for use with reasoning RL starting on Instruct models). Despite being Instruct models, the Qwen3 models/tokenizers all use the same tokenizer chat template, which will strip any observed `<think>` sections automatically (which may be inadvertently penalized by reward functions). Users should either modify the renderer, tokenizer chat template, or environment module if observing issues with thinking sections from Qwen3 models.

--- a/tinker_cookbook/scripts/save_audit_log.py
+++ b/tinker_cookbook/scripts/save_audit_log.py
@@ -16,6 +16,7 @@ Days other than "today (UTC)" are treated as immutable once written. Today's
 file is rewritten on every poll because new events are still arriving.
 
 Requirements:
+
 - The caller's API key must have the `VIEW_AUDIT_LOG` capability
   (tinker-admin RBAC role).
 


### PR DESCRIPTION
This fixes lists in our cookbook docs which otherwise get completely messed up:
<img width="1663" height="942" alt="Screenshot 2026-07-09 at 6 33 21 PM" src="https://github.com/user-attachments/assets/765fa91f-4b3d-411b-949b-aa65cdead3e8" />

Python-Markdown, which renders these READMEs when they are synced to the tinker docs site, requires a blank line before a list; without one the bullets collapse into a single run-together paragraph. GitHub's renderer is unaffected. Also re-indent the nested list in recipes/README.md to 4-space nesting so it renders as sub-items instead of extra top-level ones.