### PR TITLE
Add missing blank line before Markdown table

### DIFF
--- a/tinker_cookbook/recipes/search_tool/README.md
+++ b/tinker_cookbook/recipes/search_tool/README.md
@@ -32,6 +32,7 @@ python -m tinker_cookbook.recipes.search_tool.train
 ```
 
 With the default hyperparameters, you can expect performance like:
+
 | | Natural Questions | Trivia QA | HotpotQA | 2WikiMultihopQA |
 |---|---|---|---|---|
 | Qwen3-4B-Instruct-2507 | 51.8 | 70.2 | 52.0 | 47.7 |


### PR DESCRIPTION
This fixes cookbook docs to fix a table render in MkDocs.
https://tinker-docs.thinkingmachines.ai/cookbook/recipes/search-tool/

This is similar to the fix: https://github.com/thinking-machines-lab/tinker-cookbook/pull/802

Screenshot:
-------------------------------
<img width="801" height="161" alt="Screenshot 2026-07-10 at 5 10 58 PM" src="https://github.com/user-attachments/assets/023f7e63-ebb1-4fbe-9cf6-43a0ebc89a3e" />

<br/>
<br/>

