### PR TITLE
tokendb: parquet segment schema and buffered writer

### DIFF
--- a/tinker_cookbook/tokendb/__init__.py
+++ b/tinker_cookbook/tokendb/__init__.py
@@ -1,0 +1,27 @@
+"""Token DB: persist every raw token exchanged during rollouts.
+
+Parquet segments written through the ``Storage`` protocol, behind the
+storage-agnostic :class:`TokenStoreBackend` protocol. See ``schema.py`` for
+the row model and ``writer.py`` for the segment/manifest layout.
+"""
+
+from tinker_cookbook.tokendb.interface import TokenStoreBackend, TokenWriter
+from tinker_cookbook.tokendb.schema import (
+    SCHEMA_VERSION,
+    TokenRow,
+    arrow_schema,
+    compute_ob_delta,
+)
+from tinker_cookbook.tokendb.writer import ParquetSegmentBackend, TokenDbWriter, make_writer_id
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ParquetSegmentBackend",
+    "TokenDbWriter",
+    "TokenRow",
+    "TokenStoreBackend",
+    "TokenWriter",
+    "arrow_schema",
+    "compute_ob_delta",
+    "make_writer_id",
+]

--- a/tinker_cookbook/tokendb/interface.py
+++ b/tinker_cookbook/tokendb/interface.py
@@ -1,0 +1,88 @@
+"""Backend protocol for token stores.
+
+Both halves of the token DB live behind a single :class:`TokenStoreBackend`
+protocol so the capture layer, viewer, and agent API never know what's
+underneath. :class:`~tinker_cookbook.tokendb.writer.ParquetSegmentBackend` is
+the default implementation (parquet segments through the ``Storage``
+protocol); a hosted backend can implement the same protocol later with no
+changes to callers.
+
+Only the write half (:meth:`TokenStoreBackend.open_writer` and
+:class:`TokenWriter`) is implemented so far; the read-half methods are
+declared here and arrive with the reader in a later phase. Raw SQL is
+deliberately not part of the protocol — it stays a backend-specific escape
+hatch, and the portable surface is the structured methods.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping, Sequence
+from typing import Any, Protocol, runtime_checkable
+
+from tinker_cookbook.tokendb.schema import TokenRow
+
+
+@runtime_checkable
+class TokenWriter(Protocol):
+    """Write handle for a token store: buffered row appends with flush/close."""
+
+    def append_rows(self, rows: Sequence[TokenRow]) -> None:
+        """Buffer rows for writing. May trigger a flush when the buffer fills."""
+        ...
+
+    def flush(self) -> None:
+        """Persist all buffered rows. Safe to call concurrently; no-op if empty."""
+        ...
+
+    def close(self) -> None:
+        """Flush remaining rows and release resources. Idempotent."""
+        ...
+
+
+class TokenStoreBackend(Protocol):
+    """Storage-agnostic interface to a token store (write + read halves)."""
+
+    def open_writer(self, run_context: Mapping[str, Any]) -> TokenWriter:
+        """Open a writer for this store.
+
+        Args:
+            run_context: Identity and capture config recorded with the run
+                (e.g. ``model_name``, ``recipe_name``). Workers on other
+                processes/hosts pass explicit ``run_id`` / ``run_attempt``
+                here; the coordinator owns ``run.json``.
+        """
+        ...
+
+    # --- Read half: declared here, implemented in a later phase. ---
+
+    def query(self, **filters: Any) -> Any:
+        """Structured row query (split, iteration range, tags, reward range, ...)."""
+        ...
+
+    def get_rollout(self, split: str, iteration: int, group_idx: int, traj_idx: int) -> Any:
+        """Fetch all rows (turns) for one trajectory."""
+        ...
+
+    def search(self, pattern: str, *, text_field: str = "ac_text") -> Any:
+        """Regex search over text columns, or token-ID-subsequence match."""
+        ...
+
+    def subscribe(self, **filters: Any) -> AsyncIterator[Any]:
+        """Async iterator over newly written rows matching the filters."""
+        ...
+
+    def add_label(
+        self,
+        key: Mapping[str, Any],
+        label_key: str,
+        label_value: Any,
+        *,
+        author: str,
+        note: str | None = None,
+    ) -> None:
+        """Append an annotation for a rollout (last-write-wins by timestamp)."""
+        ...
+
+    def labels(self, **filters: Any) -> Any:
+        """Fetch annotations matching the filters."""
+        ...

--- a/tinker_cookbook/tokendb/schema.py
+++ b/tinker_cookbook/tokendb/schema.py
@@ -1,0 +1,186 @@
+"""Arrow schema and row model for the token DB.
+
+The token DB stores one row per :class:`~tinker_cookbook.rl.types.Transition`
+(i.e. per turn): the raw prompt and sampled token IDs, per-token logprobs,
+rewards, and identity keys (run/split/iteration/group/traj/step). Token IDs
+are canonical; decoded text columns are a denormalized convenience.
+
+pyarrow is imported lazily so that importing this module (e.g. from the
+training path when the token DB is disabled) does not require it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+SCHEMA_VERSION = 1
+
+
+def arrow_schema() -> pa.Schema:
+    """Return the arrow schema for token DB rows (``schema_version = 1``).
+
+    Imports pyarrow lazily; only called on the write/read paths, never at
+    module import time.
+    """
+    import pyarrow as pa
+
+    return pa.schema(
+        [
+            # Identity / writer context
+            pa.field("run_id", pa.string(), nullable=False),
+            pa.field("run_attempt", pa.int32(), nullable=False),
+            pa.field("writer_id", pa.string(), nullable=False),
+            pa.field("split", pa.string(), nullable=False),
+            pa.field("iteration", pa.int32(), nullable=False),
+            pa.field("sampling_client_step", pa.int32(), nullable=True),
+            pa.field("group_idx", pa.int32(), nullable=False),
+            pa.field("traj_idx", pa.int32(), nullable=False),
+            pa.field("step_idx", pa.int32(), nullable=False),
+            pa.field("tags", pa.list_(pa.string()), nullable=False),
+            pa.field("env_row_id", pa.string(), nullable=True),
+            pa.field("ts", pa.timestamp("us", tz="UTC"), nullable=False),
+            pa.field("source", pa.string(), nullable=False),
+            # Tokens (canonical)
+            pa.field("ob_tokens", pa.list_(pa.int32()), nullable=False),
+            pa.field("ob_is_delta", pa.bool_(), nullable=False),
+            pa.field("ac_tokens", pa.list_(pa.int32()), nullable=False),
+            pa.field("ac_logprobs", pa.list_(pa.float32()), nullable=True),
+            pa.field("stop_reason", pa.string(), nullable=True),
+            pa.field("has_images", pa.bool_(), nullable=False),
+            # Outcomes
+            pa.field("reward", pa.float32(), nullable=False),
+            pa.field("episode_done", pa.bool_(), nullable=False),
+            pa.field("total_reward", pa.float32(), nullable=False),
+            pa.field("final_reward", pa.float32(), nullable=False),
+            # Browsing (denormalized text, optional)
+            pa.field("ob_text", pa.string(), nullable=True),
+            pa.field("ac_text", pa.string(), nullable=True),
+            # Extensible
+            pa.field("metrics", pa.string(), nullable=False),  # JSON
+            pa.field("logs", pa.string(), nullable=False),  # JSON
+            pa.field("extra", pa.string(), nullable=False),  # JSON
+            pa.field("filtered_reason", pa.string(), nullable=True),
+        ]
+    )
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+@dataclass
+class TokenRow:
+    """One token DB row: a single Transition (turn) of a trajectory.
+
+    ``run_id`` / ``run_attempt`` / ``writer_id`` are stamped by the writer on
+    append; callers only need to fill the per-row fields.
+    """
+
+    # Per-row identity
+    split: str
+    iteration: int
+    group_idx: int
+    traj_idx: int
+    step_idx: int
+    # Tokens (canonical)
+    ob_tokens: list[int]
+    ac_tokens: list[int]
+    ob_is_delta: bool = False
+    ac_logprobs: list[float] | None = None
+    stop_reason: str | None = None
+    has_images: bool = False
+    # Outcomes
+    reward: float = 0.0
+    episode_done: bool = False
+    total_reward: float = 0.0
+    final_reward: float = 0.0
+    # Browsing (denormalized text)
+    ob_text: str | None = None
+    ac_text: str | None = None
+    # Extensible
+    metrics: dict[str, Any] = field(default_factory=dict)
+    logs: dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
+    filtered_reason: str | None = None
+    # Context
+    sampling_client_step: int | None = None
+    tags: list[str] = field(default_factory=list)
+    env_row_id: str | None = None
+    source: str = "rollout"  # "rollout" | "filtered" | "sample"
+    ts: datetime = field(default_factory=_utc_now)
+    # Writer identity (stamped by TokenDbWriter.append_rows)
+    run_id: str = ""
+    run_attempt: int = 0
+    writer_id: str = ""
+
+
+def row_to_record(row: TokenRow) -> dict[str, Any]:
+    """Convert a :class:`TokenRow` to a plain dict matching :func:`arrow_schema`.
+
+    The ``metrics`` / ``logs`` / ``extra`` dicts are serialized to JSON
+    strings (non-JSON-safe values fall back to ``str()``).
+    """
+    return {
+        "run_id": row.run_id,
+        "run_attempt": row.run_attempt,
+        "writer_id": row.writer_id,
+        "split": row.split,
+        "iteration": row.iteration,
+        "sampling_client_step": row.sampling_client_step,
+        "group_idx": row.group_idx,
+        "traj_idx": row.traj_idx,
+        "step_idx": row.step_idx,
+        "tags": list(row.tags),
+        "env_row_id": row.env_row_id,
+        "ts": row.ts,
+        "source": row.source,
+        "ob_tokens": list(row.ob_tokens),
+        "ob_is_delta": row.ob_is_delta,
+        "ac_tokens": list(row.ac_tokens),
+        "ac_logprobs": list(row.ac_logprobs) if row.ac_logprobs is not None else None,
+        "stop_reason": row.stop_reason,
+        "has_images": row.has_images,
+        "reward": row.reward,
+        "episode_done": row.episode_done,
+        "total_reward": row.total_reward,
+        "final_reward": row.final_reward,
+        "ob_text": row.ob_text,
+        "ac_text": row.ac_text,
+        "metrics": json.dumps(row.metrics, default=str),
+        "logs": json.dumps(row.logs, default=str),
+        "extra": json.dumps(row.extra, default=str),
+        "filtered_reason": row.filtered_reason,
+    }
+
+
+def _is_prefix(seq1: list[int], seq2: list[int]) -> bool:
+    """Check if seq1 is a prefix of seq2."""
+    return len(seq1) <= len(seq2) and seq2[: len(seq1)] == seq1
+
+
+def compute_ob_delta(prev_sequence: list[int], ob_tokens: list[int]) -> tuple[list[int], bool]:
+    """Delta-encode an observation against the previous full sequence.
+
+    Mirrors the prefix check in ``rl/data_processing.trajectory_to_data``:
+    when ``prev_sequence`` (the previous observation + action tokens) is a
+    prefix of ``ob_tokens``, only the new suffix is stored and
+    ``ob_is_delta=True``. On a non-prefix reset (or the first step) the full
+    observation is stored with ``ob_is_delta=False``.
+
+    Args:
+        prev_sequence: Token IDs of the full sequence so far (ob + ac of all
+            previous steps in the trajectory). Empty for the first step.
+        ob_tokens: Token IDs of the current observation.
+
+    Returns:
+        ``(stored_ob_tokens, ob_is_delta)``.
+    """
+    if prev_sequence and _is_prefix(prev_sequence, ob_tokens):
+        return ob_tokens[len(prev_sequence) :], True
+    return list(ob_tokens), False

--- a/tinker_cookbook/tokendb/writer.py
+++ b/tinker_cookbook/tokendb/writer.py
@@ -1,0 +1,316 @@
+"""Buffered parquet segment writer for the token DB.
+
+Layout under the run's ``log_path`` (all I/O through the ``Storage``
+protocol, so S3/GCS log dirs work)::
+
+    {log_path}/tokens/
+      run.json                                   # run identity, coordinator-owned
+      segments/seg-{writer_id}-{seq:06d}.parquet # immutable, one file per flush
+      manifest-{writer_id}.jsonl                 # 1 line per segment (< 4KB appends)
+      labels.jsonl                               # annotations (written by readers/agents)
+
+Writer discipline: a segment file is fully written **before** its manifest
+line is appended, so a crash between the two leaves an orphan segment, never
+a dangling manifest entry. Segments are immutable per-writer files and each
+manifest has exactly one appender, so multiple writers (other processes or
+hosts) can share one store without coordination; readers glob
+``manifest-*.jsonl`` and treat manifests as a liveness hint (the directory
+listing is the source of truth).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import hashlib
+import io
+import json
+import logging
+import os
+import re
+import secrets
+import socket
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from tinker_cookbook.stores.storage import Storage, storage_from_uri
+from tinker_cookbook.tokendb.schema import SCHEMA_VERSION, TokenRow, arrow_schema, row_to_record
+
+logger = logging.getLogger(__name__)
+
+TOKENS_DIR = "tokens"
+SEGMENTS_DIR = f"{TOKENS_DIR}/segments"
+RUN_JSON_PATH = f"{TOKENS_DIR}/run.json"
+
+DEFAULT_BUFFER_ROWS = 2048
+DEFAULT_FLUSH_INTERVAL_S = 5.0
+
+
+def make_writer_id() -> str:
+    """Return a writer ID unique across processes and hosts.
+
+    ``hostname-pid-suffix``: hostname + pid disambiguate concurrent writers
+    across hosts, and the random suffix guards against pid reuse (e.g. a
+    restarted worker on the same host).
+    """
+    host = re.sub(r"[^A-Za-z0-9]+", "-", socket.gethostname()).strip("-")
+    return f"{host}-{os.getpid()}-{secrets.token_hex(3)}"
+
+
+def _encode_parquet(rows: Sequence[TokenRow]) -> bytes:
+    """Encode rows as a zstd-compressed parquet file in memory."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.Table.from_pylist([row_to_record(row) for row in rows], schema=arrow_schema())
+    sink = io.BytesIO()
+    pq.write_table(table, sink, compression="zstd")
+    return sink.getvalue()
+
+
+class TokenDbWriter:
+    """Buffered token DB writer: rows in, immutable parquet segments out.
+
+    Buffered rows are flushed to a **new** segment when the buffer reaches
+    ``buffer_rows``, every ``flush_interval_s`` seconds (via a daemon
+    thread), or on :meth:`close`. Thread-safe: appends may come from
+    multiple threads or event-loop tasks; the flush swaps the buffer under a
+    lock so encoding never touches a live buffer, and flushes are serialized
+    so segment sequence numbers stay monotonic.
+
+    Identity: the coordinator constructs the writer without ``run_id`` /
+    ``run_attempt`` in *context*; it then owns ``run.json``, incrementing
+    ``run_attempt`` each construction (a run resumed from a checkpoint
+    re-runs iterations, so rows are stamped with the attempt that produced
+    them). Workers on other processes/hosts are handed explicit ``run_id``
+    and ``run_attempt`` in *context* and never touch ``run.json``.
+
+    Args:
+        storage_or_log_path: A ``Storage`` backend, or a path/URI for
+            ``storage_from_uri`` (local path, ``s3://``, ``gs://``, ...).
+        writer_id: Override the auto-generated writer ID.
+        context: Run metadata recorded in ``run.json`` (e.g. ``model_name``).
+            If it contains ``run_id`` and ``run_attempt``, this writer acts
+            as a worker and does not touch ``run.json``.
+        buffer_rows: Flush when the buffer reaches this many rows.
+        flush_interval_s: Background flush period in seconds.
+    """
+
+    def __init__(
+        self,
+        storage_or_log_path: Storage | str | Path,
+        *,
+        writer_id: str | None = None,
+        context: Mapping[str, Any] | None = None,
+        buffer_rows: int = DEFAULT_BUFFER_ROWS,
+        flush_interval_s: float = DEFAULT_FLUSH_INTERVAL_S,
+    ) -> None:
+        if isinstance(storage_or_log_path, (str, Path)):
+            self._storage: Storage = storage_from_uri(str(storage_or_log_path))
+        else:
+            self._storage = storage_or_log_path
+        self.writer_id = writer_id if writer_id is not None else make_writer_id()
+        self._context: dict[str, Any] = dict(context or {})
+        self._buffer_rows = buffer_rows
+        self._flush_interval_s = flush_interval_s
+
+        self._buffer: list[TokenRow] = []
+        self._buffer_lock = threading.Lock()  # guards _buffer
+        self._flush_lock = threading.Lock()  # serializes flushes (monotonic seq)
+        self._seq = 0
+        self._closed = False
+
+        if "run_id" in self._context and "run_attempt" in self._context:
+            # Worker: identity passed in explicitly; run.json stays
+            # coordinator-owned.
+            self.run_id = str(self._context["run_id"])
+            self.run_attempt = int(self._context["run_attempt"])
+        else:
+            self.run_id, self.run_attempt = self._init_run_json()
+
+        self._manifest_path = f"{TOKENS_DIR}/manifest-{self.writer_id}.jsonl"
+
+        atexit.register(self._atexit_close)
+        self._stop_event = threading.Event()
+        self._flush_thread = threading.Thread(
+            target=self._flush_loop, name=f"tokendb-flush-{self.writer_id}", daemon=True
+        )
+        self._flush_thread.start()
+
+    def _init_run_json(self) -> tuple[str, int]:
+        """Read/create ``run.json``, incrementing ``run_attempt`` on resume."""
+        run_id: str | None = None
+        run_attempt = 1
+        if self._storage.exists(RUN_JSON_PATH):
+            try:
+                existing = json.loads(self._storage.read(RUN_JSON_PATH).decode())
+                run_id = existing.get("run_id")
+                run_attempt = int(existing.get("run_attempt", 0)) + 1
+            except Exception:
+                logger.exception(
+                    "Failed to read existing %s; starting a new run identity", RUN_JSON_PATH
+                )
+        if not run_id:
+            seed = f"{self._storage.url('')}:{time.time_ns()}"
+            run_id = hashlib.sha1(seed.encode()).hexdigest()[:16]
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": run_id,
+            "run_attempt": run_attempt,
+            "writer_id": self.writer_id,
+            "context": self._context,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        self._storage.write(RUN_JSON_PATH, (json.dumps(payload, default=str) + "\n").encode())
+        return run_id, run_attempt
+
+    def append_rows(self, rows: Sequence[TokenRow]) -> None:
+        """Stamp writer identity on *rows* and buffer them for writing."""
+        if self._closed:
+            raise RuntimeError("append_rows() called on a closed TokenDbWriter")
+        for row in rows:
+            row.run_id = self.run_id
+            row.run_attempt = self.run_attempt
+            row.writer_id = self.writer_id
+        with self._buffer_lock:
+            self._buffer.extend(rows)
+            should_flush = len(self._buffer) >= self._buffer_rows
+        if should_flush:
+            self.flush()
+
+    def flush(self) -> None:
+        """Write buffered rows to a new segment, then append its manifest line.
+
+        No-op when the buffer is empty. Safe to call from any thread; when
+        called from async code, prefer :meth:`aflush` to keep the parquet
+        encode off the event loop.
+        """
+        with self._flush_lock:
+            with self._buffer_lock:
+                rows, self._buffer = self._buffer, []
+            if not rows:
+                return
+            seq = self._seq
+            self._seq += 1
+            segment_name = f"seg-{self.writer_id}-{seq:06d}.parquet"
+            data = _encode_parquet(rows)
+            # Segment fully written BEFORE its manifest line: a crash between
+            # the two leaves an orphan segment, never a dangling manifest entry.
+            self._storage.write(f"{SEGMENTS_DIR}/{segment_name}", data)
+            manifest_line = {
+                "path": f"segments/{segment_name}",
+                "n_rows": len(rows),
+                "min_iteration": min(row.iteration for row in rows),
+                "max_iteration": max(row.iteration for row in rows),
+                "min_ts": min(row.ts for row in rows).isoformat(),
+                "max_ts": max(row.ts for row in rows).isoformat(),
+                "run_attempt": self.run_attempt,
+                "writer_id": self.writer_id,
+                "schema_version": SCHEMA_VERSION,
+            }
+            self._storage.append(self._manifest_path, (json.dumps(manifest_line) + "\n").encode())
+
+    async def aflush(self) -> None:
+        """Async :meth:`flush` — runs the parquet encode + write in a thread."""
+        await asyncio.to_thread(self.flush)
+
+    def close(self) -> None:
+        """Flush remaining rows and stop the background flusher. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        self._stop_event.set()
+        self._flush_thread.join(timeout=self._flush_interval_s + 1.0)
+        self.flush()
+        self._storage.flush()
+        atexit.unregister(self._atexit_close)
+
+    def _atexit_close(self) -> None:
+        """Best-effort flush at interpreter exit (crash paths that skip close())."""
+        try:
+            self.close()
+        except Exception:
+            logger.exception("Best-effort token DB flush at exit failed")
+
+    def _flush_loop(self) -> None:
+        while not self._stop_event.wait(self._flush_interval_s):
+            try:
+                self.flush()
+            except Exception:
+                logger.exception("Background token DB flush failed")
+
+    def __enter__(self) -> TokenDbWriter:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+class ParquetSegmentBackend:
+    """Parquet-segments-through-``Storage`` implementation of ``TokenStoreBackend``.
+
+    The default (v1) backend: the writer is a buffered segment flusher
+    (:class:`TokenDbWriter`); the read half (DuckDB over the segment glob)
+    arrives in a later phase.
+    """
+
+    def __init__(
+        self,
+        storage_or_log_path: Storage | str | Path,
+        *,
+        buffer_rows: int = DEFAULT_BUFFER_ROWS,
+        flush_interval_s: float = DEFAULT_FLUSH_INTERVAL_S,
+    ) -> None:
+        if isinstance(storage_or_log_path, (str, Path)):
+            self._storage: Storage = storage_from_uri(str(storage_or_log_path))
+        else:
+            self._storage = storage_or_log_path
+        self._buffer_rows = buffer_rows
+        self._flush_interval_s = flush_interval_s
+
+    def open_writer(self, run_context: Mapping[str, Any]) -> TokenDbWriter:
+        """See :meth:`TokenStoreBackend.open_writer`."""
+        return TokenDbWriter(
+            self._storage,
+            context=run_context,
+            buffer_rows=self._buffer_rows,
+            flush_interval_s=self._flush_interval_s,
+        )
+
+    # --- Read half: implemented in a later phase. ---
+
+    def query(self, **filters: Any) -> Any:
+        """See :meth:`TokenStoreBackend.query`."""
+        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+
+    def get_rollout(self, split: str, iteration: int, group_idx: int, traj_idx: int) -> Any:
+        """See :meth:`TokenStoreBackend.get_rollout`."""
+        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+
+    def search(self, pattern: str, *, text_field: str = "ac_text") -> Any:
+        """See :meth:`TokenStoreBackend.search`."""
+        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+
+    def subscribe(self, **filters: Any) -> Any:
+        """See :meth:`TokenStoreBackend.subscribe`."""
+        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+
+    def add_label(
+        self,
+        key: Mapping[str, Any],
+        label_key: str,
+        label_value: Any,
+        *,
+        author: str,
+        note: str | None = None,
+    ) -> None:
+        """See :meth:`TokenStoreBackend.add_label`."""
+        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+
+    def labels(self, **filters: Any) -> Any:
+        """See :meth:`TokenStoreBackend.labels`."""
+        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")

--- a/tinker_cookbook/tokendb/writer_test.py
+++ b/tinker_cookbook/tokendb/writer_test.py
@@ -1,0 +1,320 @@
+"""Tests for the token DB schema and parquet segment writer."""
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from tinker_cookbook.stores.storage import LocalStorage
+from tinker_cookbook.tokendb.schema import SCHEMA_VERSION, TokenRow, compute_ob_delta
+from tinker_cookbook.tokendb.writer import (
+    RUN_JSON_PATH,
+    SEGMENTS_DIR,
+    TOKENS_DIR,
+    TokenDbWriter,
+)
+
+
+def make_row(**overrides) -> TokenRow:
+    defaults: dict = {
+        "split": "train",
+        "iteration": 0,
+        "group_idx": 0,
+        "traj_idx": 0,
+        "step_idx": 0,
+        "ob_tokens": [1, 2, 3],
+        "ac_tokens": [4, 5],
+    }
+    defaults.update(overrides)
+    return TokenRow(**defaults)
+
+
+def read_all_segments(log_path: Path) -> pa.Table:
+    segments_dir = log_path / SEGMENTS_DIR
+    tables = [pq.read_table(p) for p in sorted(segments_dir.glob("*.parquet"))]
+    assert tables, f"no segments under {segments_dir}"
+    return pa.concat_tables(tables)
+
+
+def list_segments(log_path: Path) -> list[Path]:
+    return sorted((log_path / SEGMENTS_DIR).glob("*.parquet"))
+
+
+class TestComputeObDelta:
+    def test_first_step_is_full_ob(self):
+        stored, is_delta = compute_ob_delta([], [1, 2, 3])
+        assert stored == [1, 2, 3]
+        assert is_delta is False
+
+    def test_prefix_extension_stores_suffix(self):
+        stored, is_delta = compute_ob_delta([1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7])
+        assert stored == [6, 7]
+        assert is_delta is True
+
+    def test_exact_match_stores_empty_delta(self):
+        stored, is_delta = compute_ob_delta([1, 2, 3], [1, 2, 3])
+        assert stored == []
+        assert is_delta is True
+
+    def test_non_prefix_reset_stores_full_ob(self):
+        stored, is_delta = compute_ob_delta([1, 2, 3], [9, 8, 7, 6])
+        assert stored == [9, 8, 7, 6]
+        assert is_delta is False
+
+    def test_shorter_ob_is_not_a_prefix_extension(self):
+        stored, is_delta = compute_ob_delta([1, 2, 3], [1, 2])
+        assert stored == [1, 2]
+        assert is_delta is False
+
+
+class TestRoundtrip:
+    def test_parquet_roundtrip_fidelity(self, tmp_path: Path):
+        row = make_row(
+            iteration=7,
+            group_idx=2,
+            traj_idx=1,
+            step_idx=3,
+            ob_tokens=[10, 20, 30],
+            ob_is_delta=True,
+            ac_tokens=[40, 50, 60],
+            ac_logprobs=[-0.5, -1.25, -2.0],
+            stop_reason="stop",
+            reward=1.5,
+            episode_done=True,
+            total_reward=2.5,
+            final_reward=1.0,
+            ob_text="hello",
+            ac_text="world",
+            metrics={"format_ok": 1},
+            logs={"env/row_id": "gsm8k-42"},
+            tags=["gsm", "math"],
+            env_row_id="gsm8k-42",
+            sampling_client_step=12,
+        )
+        with TokenDbWriter(tmp_path) as writer:
+            writer.append_rows([row])
+        table = read_all_segments(tmp_path)
+        assert table.num_rows == 1
+        got = table.to_pylist()[0]
+        assert got["ob_tokens"] == [10, 20, 30]
+        assert got["ob_is_delta"] is True
+        assert got["ac_tokens"] == [40, 50, 60]
+        assert got["ac_logprobs"] == pytest.approx([-0.5, -1.25, -2.0])
+        assert got["stop_reason"] == "stop"
+        assert got["has_images"] is False
+        assert got["reward"] == pytest.approx(1.5)
+        assert got["episode_done"] is True
+        assert got["total_reward"] == pytest.approx(2.5)
+        assert got["final_reward"] == pytest.approx(1.0)
+        assert got["ob_text"] == "hello"
+        assert got["ac_text"] == "world"
+        assert json.loads(got["metrics"]) == {"format_ok": 1}
+        assert json.loads(got["logs"]) == {"env/row_id": "gsm8k-42"}
+        assert json.loads(got["extra"]) == {}
+        assert got["tags"] == ["gsm", "math"]
+        assert got["env_row_id"] == "gsm8k-42"
+        assert got["sampling_client_step"] == 12
+        assert got["split"] == "train"
+        assert got["iteration"] == 7
+        assert (got["group_idx"], got["traj_idx"], got["step_idx"]) == (2, 1, 3)
+        assert got["source"] == "rollout"
+        assert got["filtered_reason"] is None
+        # Writer identity stamped on every row
+        assert got["run_id"] == writer.run_id
+        assert got["run_attempt"] == 1
+        assert got["writer_id"] == writer.writer_id
+
+    def test_nullable_columns_roundtrip_as_none(self, tmp_path: Path):
+        row = make_row(ac_logprobs=None, ob_text=None, ac_text=None)
+        with TokenDbWriter(tmp_path) as writer:
+            writer.append_rows([row])
+        got = read_all_segments(tmp_path).to_pylist()[0]
+        assert got["ac_logprobs"] is None
+        assert got["ob_text"] is None
+        assert got["ac_text"] is None
+        assert got["env_row_id"] is None
+        assert got["sampling_client_step"] is None
+
+
+class TestFlushTriggers:
+    def test_flush_on_buffer_rows(self, tmp_path: Path):
+        writer = TokenDbWriter(tmp_path, buffer_rows=3, flush_interval_s=3600.0)
+        try:
+            writer.append_rows([make_row(step_idx=i) for i in range(2)])
+            assert not list_segments(tmp_path)
+            writer.append_rows([make_row(step_idx=2)])
+            segments = list_segments(tmp_path)
+            assert len(segments) == 1
+            assert pq.read_table(segments[0]).num_rows == 3
+        finally:
+            writer.close()
+
+    def test_flush_on_close(self, tmp_path: Path):
+        writer = TokenDbWriter(tmp_path, flush_interval_s=3600.0)
+        writer.append_rows([make_row(), make_row(step_idx=1)])
+        assert not list_segments(tmp_path)
+        writer.close()
+        assert read_all_segments(tmp_path).num_rows == 2
+
+    def test_flush_on_interval(self, tmp_path: Path):
+        writer = TokenDbWriter(tmp_path, flush_interval_s=0.05)
+        try:
+            writer.append_rows([make_row()])
+            deadline = time.monotonic() + 5.0
+            while not list_segments(tmp_path):
+                assert time.monotonic() < deadline, "interval flush never happened"
+                time.sleep(0.01)
+        finally:
+            writer.close()
+        assert read_all_segments(tmp_path).num_rows == 1
+
+    def test_close_is_idempotent(self, tmp_path: Path):
+        writer = TokenDbWriter(tmp_path)
+        writer.append_rows([make_row()])
+        writer.close()
+        writer.close()
+        assert read_all_segments(tmp_path).num_rows == 1
+        with pytest.raises(RuntimeError):
+            writer.append_rows([make_row()])
+
+
+class _RecordingStorage(LocalStorage):
+    """LocalStorage that records the order of write/append calls."""
+
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.calls: list[tuple[str, str]] = []
+
+    def write(self, path: str, data: bytes) -> None:
+        self.calls.append(("write", path))
+        super().write(path, data)
+
+    def append(self, path: str, data: bytes) -> None:
+        self.calls.append(("append", path))
+        super().append(path, data)
+
+
+class TestSegmentManifestOrdering:
+    def test_segment_written_before_manifest_line(self, tmp_path: Path):
+        storage = _RecordingStorage(tmp_path)
+        with TokenDbWriter(storage, flush_interval_s=3600.0) as writer:
+            writer.append_rows([make_row()])
+            writer.flush()
+            writer.append_rows([make_row(iteration=1)])
+        segment_calls = [
+            (idx, path)
+            for idx, (op, path) in enumerate(storage.calls)
+            if op == "write" and path.startswith(SEGMENTS_DIR)
+        ]
+        manifest_calls = [
+            (idx, path)
+            for idx, (op, path) in enumerate(storage.calls)
+            if op == "append" and "manifest-" in path
+        ]
+        assert len(segment_calls) == 2
+        assert len(manifest_calls) == 2
+        for (seg_idx, _), (man_idx, _) in zip(segment_calls, manifest_calls):
+            assert seg_idx < man_idx
+
+    def test_manifest_lines_reference_existing_segments(self, tmp_path: Path):
+        with TokenDbWriter(tmp_path, flush_interval_s=3600.0) as writer:
+            writer.append_rows([make_row(iteration=3), make_row(iteration=5, step_idx=1)])
+        manifest_path = tmp_path / TOKENS_DIR / f"manifest-{writer.writer_id}.jsonl"
+        lines = [json.loads(line) for line in manifest_path.read_text().splitlines()]
+        assert len(lines) == 1
+        entry = lines[0]
+        segment_path = tmp_path / TOKENS_DIR / entry["path"]
+        assert segment_path.exists()
+        assert pq.read_table(segment_path).num_rows == entry["n_rows"] == 2
+        assert entry["min_iteration"] == 3
+        assert entry["max_iteration"] == 5
+        assert entry["writer_id"] == writer.writer_id
+        assert entry["schema_version"] == SCHEMA_VERSION
+
+
+class TestMultiWriter:
+    def test_distinct_writer_ids_do_not_collide(self, tmp_path: Path):
+        w1 = TokenDbWriter(tmp_path, flush_interval_s=3600.0)
+        w2 = TokenDbWriter(
+            tmp_path,
+            flush_interval_s=3600.0,
+            context={"run_id": w1.run_id, "run_attempt": w1.run_attempt},
+        )
+        try:
+            assert w1.writer_id != w2.writer_id
+            w1.append_rows([make_row(group_idx=0)])
+            w2.append_rows([make_row(group_idx=1)])
+        finally:
+            w1.close()
+            w2.close()
+        segments = list_segments(tmp_path)
+        assert len(segments) == 2
+        assert read_all_segments(tmp_path).num_rows == 2
+        manifests = sorted((tmp_path / TOKENS_DIR).glob("manifest-*.jsonl"))
+        assert {m.name for m in manifests} == {
+            f"manifest-{w1.writer_id}.jsonl",
+            f"manifest-{w2.writer_id}.jsonl",
+        }
+
+    def test_worker_context_does_not_touch_run_json(self, tmp_path: Path):
+        worker = TokenDbWriter(
+            tmp_path, flush_interval_s=3600.0, context={"run_id": "abc123", "run_attempt": 4}
+        )
+        try:
+            worker.append_rows([make_row()])
+        finally:
+            worker.close()
+        assert not (tmp_path / RUN_JSON_PATH).exists()
+        got = read_all_segments(tmp_path).to_pylist()[0]
+        assert got["run_id"] == "abc123"
+        assert got["run_attempt"] == 4
+
+
+class TestRunAttempt:
+    def test_run_attempt_increments_on_reconstruction(self, tmp_path: Path):
+        w1 = TokenDbWriter(tmp_path, flush_interval_s=3600.0)
+        w1.append_rows([make_row()])
+        w1.close()
+        w2 = TokenDbWriter(tmp_path, flush_interval_s=3600.0)
+        w2.append_rows([make_row()])
+        w2.close()
+        assert w1.run_attempt == 1
+        assert w2.run_attempt == 2
+        assert w1.run_id == w2.run_id
+        run_json = json.loads((tmp_path / RUN_JSON_PATH).read_text())
+        assert run_json["run_id"] == w1.run_id
+        assert run_json["run_attempt"] == 2
+        attempts = sorted(row["run_attempt"] for row in read_all_segments(tmp_path).to_pylist())
+        assert attempts == [1, 2]
+
+
+class TestConcurrency:
+    def test_concurrent_appends_lose_no_rows(self, tmp_path: Path):
+        n_threads = 8
+        rows_per_thread = 50
+        writer = TokenDbWriter(tmp_path, buffer_rows=16, flush_interval_s=0.02)
+
+        def worker(thread_idx: int) -> None:
+            for i in range(rows_per_thread):
+                writer.append_rows(
+                    [make_row(group_idx=thread_idx, step_idx=i, env_row_id=f"{thread_idx}-{i}")]
+                )
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        writer.close()
+
+        table = read_all_segments(tmp_path)
+        assert table.num_rows == n_threads * rows_per_thread
+        row_ids = {row["env_row_id"] for row in table.to_pylist()}
+        assert len(row_ids) == n_threads * rows_per_thread


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #821
* #820
* #819
* #818
* #817
* #816
* #815
* #814
* #813
* #812
* #811
* #810
* #809
* #808
* #807
* #806
* #805
* __->__ #804

Storage layer for a token DB that records the raw tokens exchanged with tinker
during training. One row per sampled turn: observation and action token IDs
(canonical, no retokenization), logprobs, stop reason, rewards, and extensible
JSON metadata, defined as a versioned arrow schema. The writer buffers rows and
flushes immutable zstd parquet segment files plus a per-writer manifest through
the Storage protocol, so local and cloud log paths both work. Segment names carry
a unique writer_id and identity is passed explicitly, which makes concurrent
writers (multiple processes or hosts sharing a store) safe by construction, and
run.json tracks a run_attempt counter so resumed runs are distinguishable. The
TokenStoreBackend protocol declares both the write and read halves; this commit
implements the write half.