### PR TITLE
tokendb: rollout capture layer and RL training loop integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ modal = [
 multiplayer-rl = [
     "textarena>=0.7.4",
 ]
+tokendb = [
+    "duckdb>=1.0.0",
+    "pyarrow>=15.0.0",
+]
 tutorials = [
     "marimo>=0.23.8",
     "matplotlib>=3.7.0",

--- a/tinker_cookbook/rl/metric_util.py
+++ b/tinker_cookbook/rl/metric_util.py
@@ -344,6 +344,22 @@ class RLTestSetEvaluator(SamplingClientEvaluator):
                 records,
                 base_name=rollout_summary_export.base_name,
             )
+            # Tee into the token DB when a capture is active (no-op otherwise).
+            from tinker_cookbook.rl.rollout_logging import RolloutSummaryGroup
+            from tinker_cookbook.tokendb.capture import record_groups_to_active_capture
+
+            record_groups_to_active_capture(
+                [
+                    RolloutSummaryGroup(
+                        trajectory_group=trajectory_group,
+                        tags=tags,
+                        sampling_client_step=rollout_summary_export.sampling_client_step,
+                    )
+                    for trajectory_group, tags in zip(trajectory_groups_P, taglist_P, strict=True)
+                ],
+                split=rollout_summary_export.split,
+                iteration=rollout_summary_export.iteration,
+            )
         num_errors = sum(1 for r in results if r is None)
         if trajectory_groups_P:
             metrics = compute_trajectory_metrics(trajectory_groups_P, taglist_P)

--- a/tinker_cookbook/rl/rollouts.py
+++ b/tinker_cookbook/rl/rollouts.py
@@ -422,6 +422,30 @@ async def do_group_rollout_and_filter_constant_reward(
     )
 
 
+def _notify_filtered_group(
+    trajectory_group: TrajectoryGroup | None,
+    env_group_builder: EnvGroupBuilder,
+    reason: str,
+) -> None:
+    """Invoke the filtered-group sink (if any) for a dropped group.
+
+    The sink is registered via ``tinker_cookbook.tokendb.capture
+    .set_filtered_group_sink`` (same pattern as :func:`set_rollout_executor`).
+    Never raises: capture must not break training. Note: under a
+    cross-process rollout executor this runs in the worker process, where no
+    sink is registered, so dropped groups are not captured there.
+    """
+    try:
+        from tinker_cookbook.tokendb.capture import get_filtered_group_sink
+
+        sink = get_filtered_group_sink()
+        if sink is None:
+            return
+        sink(trajectory_group, env_group_builder.logging_tags(), reason)
+    except Exception:
+        logger.exception("Filtered-group sink failed; continuing")
+
+
 async def _do_group_rollout_and_filter_constant_reward_impl(
     sampling_client: tinker.SamplingClient,
     env_group_builder: EnvGroupBuilder,
@@ -446,14 +470,17 @@ async def _do_group_rollout_and_filter_constant_reward_impl(
     except AllTrajectoriesFailedError as e:
         # All retries exhausted — already logged per-trajectory inside the strategy
         logger.warning(str(e))
+        _notify_filtered_group(None, env_group_builder, "all_failed")
         return None
     except Exception as e:
         if not strategy.catches_group_errors:
             raise
         logger.warning(f"Rollout error ({type(e).__name__}), skipping group: {e}")
+        _notify_filtered_group(None, env_group_builder, "group_error")
         return None
 
     # Remove if all trajectories have the same reward
     if do_remove_constant_reward_groups and all_same(trajectory_group.get_total_rewards()):
+        _notify_filtered_group(trajectory_group, env_group_builder, "constant_reward")
         return None
     return trajectory_group

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -64,6 +64,7 @@ from tinker_cookbook.rl.types import (
     RLDatasetBuilder,
     TrajectoryGroup,
 )
+from tinker_cookbook.tokendb.config import TokenDbConfig
 from tinker_cookbook.tokenizer_utils import Tokenizer
 from tinker_cookbook.utils import logtree, ml_log, trace
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
@@ -146,7 +147,16 @@ def _maybe_export_rollout_summary_jsonl(
     groups_P: Sequence[RolloutSummaryGroup],
     store: TrainingRunStore | None,
 ) -> None:
-    """Write per-trajectory rollout summaries via the store when enabled."""
+    """Write per-trajectory rollout summaries via the store when enabled.
+
+    When the token DB is enabled (``config.token_db``), also tees the same
+    groups into the active token DB writer. The JSONL export behavior is
+    unchanged either way.
+    """
+    if config.token_db is not None:
+        from tinker_cookbook.tokendb.capture import record_groups_to_active_capture
+
+        record_groups_to_active_capture(groups_P, split=split, iteration=iteration)
     if not config.rollout_json_export or store is None:
         return
     from tinker_cookbook.rl.rollout_logging import serialize_rollout_summaries_from_groups
@@ -155,6 +165,31 @@ def _maybe_export_rollout_summary_jsonl(
         split=split, iteration=iteration, groups_P=groups_P
     )
     store.write_rollouts(iteration, records, base_name=base_name)
+
+
+@contextmanager
+def _capture_context_scope(
+    config: Config,
+    *,
+    split: str,
+    iteration: int,
+    sampling_client_step: int | None = None,
+) -> Iterator[None]:
+    """Set the token DB capture context around rollout calls.
+
+    Carries split/iteration identity to capture sites that don't receive it
+    as arguments (the filtered-group sink). No-op (one falsy check) when the
+    token DB is disabled.
+    """
+    if config.token_db is None:
+        yield
+        return
+    from tinker_cookbook.tokendb.capture import CaptureContext, set_capture_context
+
+    with set_capture_context(
+        CaptureContext(split=split, iteration=iteration, sampling_client_step=sampling_client_step)
+    ):
+        yield
 
 
 _LOGTREE_EXPLANATION = (
@@ -522,6 +557,9 @@ class Config:
     rolling_ttl_seconds: int = 7200  # 2 hours
     num_groups_to_log: int = 4  # Number of groups to log per iteration (0 = disable logging)
     rollout_json_export: bool = True
+    # Capture raw rollout tokens to a local token DB (parquet segments under
+    # {log_path}/tokens/). Requires the "tokendb" extra (pyarrow). None = disabled.
+    token_db: TokenDbConfig | None = None
 
     # Maximum number of training iterations. If None, train on the full dataset.
     max_steps: int | None = None
@@ -724,15 +762,18 @@ async def do_sync_training_with_stream_minibatch(
                     worker_metrics: dict[str, Any] = {}
                     t_start = time.time()
                     async with trace.scope_span("trajectory_group_worker"):
-                        trajectory_group = await do_group_rollout_and_filter_constant_reward(
-                            sampling_client,
-                            builder,
-                            max_tokens=config.max_tokens,
-                            temperature=config.temperature,
-                            do_remove_constant_reward_groups=config.remove_constant_reward_groups,
-                            enable_logging=enable_logging,
-                            strategy=strategy,
-                        )
+                        with _capture_context_scope(
+                            config, split="train", iteration=i_batch, sampling_client_step=i_batch
+                        ):
+                            trajectory_group = await do_group_rollout_and_filter_constant_reward(
+                                sampling_client,
+                                builder,
+                                max_tokens=config.max_tokens,
+                                temperature=config.temperature,
+                                do_remove_constant_reward_groups=config.remove_constant_reward_groups,
+                                enable_logging=enable_logging,
+                                strategy=strategy,
+                            )
                     worker_metrics["time/trajectory_group_worker_loop/total"] = (
                         time.time() - t_start
                     )
@@ -994,14 +1035,20 @@ async def do_async_training(
             worker_metrics: dict[str, Any] = {}
             t_start = time.time()
             async with trace.scope_span("trajectory_group_worker"):
-                trajectory_group = await do_group_rollout_and_filter_constant_reward(
-                    sampling_client,
-                    env_group_builder,
-                    max_tokens=config.max_tokens,
-                    temperature=config.temperature,
-                    do_remove_constant_reward_groups=config.remove_constant_reward_groups,
-                    strategy=strategy,
-                )
+                with _capture_context_scope(
+                    config,
+                    split="train",
+                    iteration=sampling_client_step_copy,
+                    sampling_client_step=sampling_client_step_copy,
+                ):
+                    trajectory_group = await do_group_rollout_and_filter_constant_reward(
+                        sampling_client,
+                        env_group_builder,
+                        max_tokens=config.max_tokens,
+                        temperature=config.temperature,
+                        do_remove_constant_reward_groups=config.remove_constant_reward_groups,
+                        strategy=strategy,
+                    )
             worker_metrics["time/trajectory_group_worker_loop/total"] = time.time() - t_start
             # Ingest error info (safe: same event loop thread)
             if error_counter is not None:
@@ -1719,21 +1766,24 @@ async def do_sync_training(
                 ):
                     # Note: do_remove_constant_reward_groups=False here because we remove
                     # constant reward groups after all rollouts are collected (below)
-                    results_P = await gather_with_progress(
-                        (
-                            do_group_rollout_and_filter_constant_reward(
-                                sampling_client,
-                                builder,
-                                max_tokens=config.max_tokens,
-                                temperature=config.temperature,
-                                do_remove_constant_reward_groups=False,
-                                enable_logging=i < config.num_groups_to_log,
-                                strategy=strategy,
-                            )
-                            for i, builder in enumerate(env_group_builders_P)
-                        ),
-                        desc=f"Sampling batch {i_batch}",
-                    )
+                    with _capture_context_scope(
+                        config, split="train", iteration=i_batch, sampling_client_step=i_batch
+                    ):
+                        results_P = await gather_with_progress(
+                            (
+                                do_group_rollout_and_filter_constant_reward(
+                                    sampling_client,
+                                    builder,
+                                    max_tokens=config.max_tokens,
+                                    temperature=config.temperature,
+                                    do_remove_constant_reward_groups=False,
+                                    enable_logging=i < config.num_groups_to_log,
+                                    strategy=strategy,
+                                )
+                                for i, builder in enumerate(env_group_builders_P)
+                            ),
+                            desc=f"Sampling batch {i_batch}",
+                        )
 
             # Ingest error info from results
             if error_counter is not None:
@@ -1850,6 +1900,11 @@ async def main(
         asyncio.run(main(config=config))
     """
 
+    if config.token_db is not None:
+        # Fail fast on a missing optional dependency, never mid-run.
+        from tinker_cookbook.tokendb.config import check_token_db_dependencies
+
+        check_token_db_dependencies()
     if rollout_executor is not None:
         set_rollout_executor(rollout_executor)
     ml_logger = ml_log.setup_logging(
@@ -1859,6 +1914,16 @@ async def main(
         wandb_name=config.wandb_name,
     )
     store = ml_logger.store
+    token_db_writer = None
+    if config.token_db is not None:
+        from tinker_cookbook.tokendb.config import build_token_db_writer
+
+        token_db_writer = build_token_db_writer(
+            config.token_db,
+            store.storage if store is not None else config.log_path,
+            model_name=config.model_name,
+            recipe_name=config.recipe_name,
+        )
     if config.enable_trace:
         # Get and rename the current (main) task
         current_task = asyncio.current_task()
@@ -1918,6 +1983,27 @@ async def main(
     # Get tokenizer from training client
     tokenizer = training_client.get_tokenizer()
 
+    if token_db_writer is not None:
+        assert config.token_db is not None
+        from tinker_cookbook.tokendb.capture import (
+            ActiveCapture,
+            active_capture_filtered_sink,
+            set_active_capture,
+            set_filtered_group_sink,
+        )
+
+        set_active_capture(
+            ActiveCapture(
+                writer=token_db_writer,
+                tokenizer=tokenizer,
+                store_text=config.token_db.store_text,
+            )
+        )
+        if config.token_db.capture_filtered:
+            # Note: with a cross-process rollout executor, groups are dropped
+            # inside worker processes and this sink does not fire there.
+            set_filtered_group_sink(active_capture_filtered_sink)
+
     # Create dataset from thunk
     dataset, maybe_test_dataset = await config.dataset_builder()
     # Build rollout strategy and error counter from config
@@ -1969,21 +2055,32 @@ async def main(
         training_func = do_sync_training_with_stream_minibatch
     else:
         training_func = do_sync_training
-    await training_func(
-        start_batch=start_batch,
-        end_batch=end_batch,
-        num_batches=end_batch,
-        config=config,
-        training_client=training_client,
-        kl_reference_client=kl_reference_client,
-        evaluators=evaluators,
-        dataset=dataset,
-        ml_logger=ml_logger,
-        tokenizer=tokenizer,
-        error_counter=error_counter,
-        strategy=strategy,
-        checkpoint_mgr=checkpoint_mgr,
-    )
+    try:
+        await training_func(
+            start_batch=start_batch,
+            end_batch=end_batch,
+            num_batches=end_batch,
+            config=config,
+            training_client=training_client,
+            kl_reference_client=kl_reference_client,
+            evaluators=evaluators,
+            dataset=dataset,
+            ml_logger=ml_logger,
+            tokenizer=tokenizer,
+            error_counter=error_counter,
+            strategy=strategy,
+            checkpoint_mgr=checkpoint_mgr,
+        )
+    finally:
+        if token_db_writer is not None:
+            from tinker_cookbook.tokendb.capture import (
+                set_active_capture,
+                set_filtered_group_sink,
+            )
+
+            set_active_capture(None)
+            set_filtered_group_sink(None)
+            token_db_writer.close()
 
     # Save final checkpoint
     if start_batch < end_batch:

--- a/tinker_cookbook/tokendb/__init__.py
+++ b/tinker_cookbook/tokendb/__init__.py
@@ -5,6 +5,24 @@ storage-agnostic :class:`TokenStoreBackend` protocol. See ``schema.py`` for
 the row model and ``writer.py`` for the segment/manifest layout.
 """
 
+from tinker_cookbook.tokendb.capture import (
+    ActiveCapture,
+    CaptureContext,
+    active_capture_filtered_sink,
+    get_active_capture,
+    get_capture_context,
+    get_filtered_group_sink,
+    record_groups,
+    record_groups_to_active_capture,
+    set_active_capture,
+    set_capture_context,
+    set_filtered_group_sink,
+)
+from tinker_cookbook.tokendb.config import (
+    TokenDbConfig,
+    build_token_db_writer,
+    check_token_db_dependencies,
+)
 from tinker_cookbook.tokendb.interface import TokenStoreBackend, TokenWriter
 from tinker_cookbook.tokendb.schema import (
     SCHEMA_VERSION,
@@ -16,12 +34,26 @@ from tinker_cookbook.tokendb.writer import ParquetSegmentBackend, TokenDbWriter,
 
 __all__ = [
     "SCHEMA_VERSION",
+    "ActiveCapture",
+    "CaptureContext",
     "ParquetSegmentBackend",
+    "TokenDbConfig",
     "TokenDbWriter",
     "TokenRow",
     "TokenStoreBackend",
     "TokenWriter",
+    "active_capture_filtered_sink",
     "arrow_schema",
+    "build_token_db_writer",
+    "check_token_db_dependencies",
     "compute_ob_delta",
+    "get_active_capture",
+    "get_capture_context",
+    "get_filtered_group_sink",
     "make_writer_id",
+    "record_groups",
+    "record_groups_to_active_capture",
+    "set_active_capture",
+    "set_capture_context",
+    "set_filtered_group_sink",
 ]

--- a/tinker_cookbook/tokendb/capture.py
+++ b/tinker_cookbook/tokendb/capture.py
@@ -1,0 +1,342 @@
+"""Capture layer: convert rollout :class:`TrajectoryGroup`\\ s into token DB rows.
+
+:func:`record_groups` is the funnel between the RL rollout pipeline and the
+token DB writer. It iterates groups/trajectories/transitions with the same
+``group_idx`` / ``traj_idx`` / ``step_idx`` enumeration as
+``rl/rollout_logging.serialize_rollout_summaries``, so token DB keys line up
+1:1 with the rollout-summary JSONL records.
+
+Also here:
+
+- :data:`capture_context` / :func:`set_capture_context`: a ContextVar carrying
+  split/iteration identity for capture sites that don't receive it as
+  arguments (filtered-group and sample sinks, wired in a later step).
+- :func:`set_filtered_group_sink` / :func:`get_filtered_group_sink`: registry
+  for a callback invoked when the rollout pipeline drops a group (constant
+  reward, rollout error) before it reaches the main export funnel. Follows
+  the ``set_rollout_executor`` pattern in ``rl/rollouts.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+import tinker
+
+from tinker_cookbook.rl.rollout_logging import RolloutSummaryGroup
+from tinker_cookbook.rl.types import TrajectoryGroup
+from tinker_cookbook.tokendb.interface import TokenWriter
+from tinker_cookbook.tokendb.schema import TokenRow, compute_ob_delta
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SupportsDecode(Protocol):
+    """Minimal tokenizer surface needed for text denormalization."""
+
+    def decode(self, token_ids: list[int]) -> str: ...
+
+
+def extract_ob_tokens(ob: tinker.ModelInput) -> tuple[list[int], bool]:
+    """Extract text-chunk token IDs from an observation; flag non-text chunks.
+
+    ``ModelInput.to_ints()`` raises on non-text chunks (images), so this
+    collects tokens from ``EncodedTextChunk``\\ s only and reports whether any
+    non-text chunk was present. Never raises.
+
+    Returns:
+        ``(tokens, has_images)`` — text-chunk token IDs in order, and whether
+        the observation contained any non-text (image) chunk.
+    """
+    tokens: list[int] = []
+    has_images = False
+    for chunk in ob.chunks:
+        if isinstance(chunk, tinker.EncodedTextChunk):
+            tokens.extend(chunk.tokens)
+        else:
+            has_images = True
+    return tokens, has_images
+
+
+def _decode(tokenizer: SupportsDecode, tokens: list[int]) -> str | None:
+    """Best-effort decode; text columns are a convenience, never fatal."""
+    try:
+        return tokenizer.decode(tokens)
+    except Exception:
+        return None
+
+
+def record_groups(
+    writer: TokenWriter,
+    groups: Sequence[TrajectoryGroup | RolloutSummaryGroup],
+    *,
+    split: str,
+    iteration: int,
+    sampling_client_step: int | None = None,
+    tags: Sequence[str] = (),
+    tokenizer: SupportsDecode | None = None,
+    store_text: bool = True,
+    source: str = "rollout",
+    filtered_reason: str | None = None,
+) -> list[TokenRow]:
+    """Emit one :class:`TokenRow` per :class:`~tinker_cookbook.rl.types.Transition`.
+
+    Enumeration mirrors ``serialize_rollout_summaries``: ``group_idx`` is the
+    index into *groups*, ``traj_idx`` the index into ``trajectories_G``, and
+    ``step_idx`` the index into ``transitions`` — so a token DB row and a
+    rollout-summary record with equal keys describe the same turn.
+
+    Per row:
+
+    - ``ob_tokens`` are delta-encoded against the previous ob+ac of the same
+      trajectory (:func:`~tinker_cookbook.tokendb.schema.compute_ob_delta`,
+      mirroring ``rl/data_processing.trajectory_to_data``); image chunks set
+      ``has_images`` and contribute no tokens.
+    - ``ac_tokens`` / ``ac_logprobs`` / ``stop_reason`` come from the
+      transition's ``ac``.
+    - ``total_reward`` / ``final_reward`` are denormalized per trajectory.
+    - ``logs["env/row_id"]`` is promoted to the ``env_row_id`` column.
+    - ``ob_text`` / ``ac_text`` are decoded when *store_text* and *tokenizer*
+      are given; for delta rows only the delta portion is decoded.
+
+    Args:
+        writer: Destination writer; rows are passed to ``append_rows``.
+        groups: Trajectory groups, optionally pre-bundled as
+            :class:`RolloutSummaryGroup` (whose ``tags`` /
+            ``sampling_client_step`` then take precedence over the kwargs).
+        split: Dataset split identifier (e.g. ``"train"``).
+        iteration: Training iteration / batch index.
+        sampling_client_step: Fallback sampling-client step for plain
+            :class:`TrajectoryGroup` entries.
+        tags: Fallback logging tags for plain :class:`TrajectoryGroup` entries.
+        tokenizer: Anything with ``decode(list[int]) -> str``.
+        store_text: Store decoded ``ob_text`` / ``ac_text`` columns.
+        source: Row provenance (``"rollout"`` | ``"filtered"`` | ``"sample"``).
+        filtered_reason: Why the group was dropped, for ``source="filtered"``.
+
+    Returns:
+        The rows appended to *writer* (for tests / chaining).
+    """
+    rows: list[TokenRow] = []
+    for group_idx, entry in enumerate(groups):
+        if isinstance(entry, RolloutSummaryGroup):
+            trajectory_group = entry.trajectory_group
+            group_tags = list(entry.tags)
+            group_step = entry.sampling_client_step
+        else:
+            trajectory_group = entry
+            group_tags = list(tags)
+            group_step = sampling_client_step
+        total_rewards_G = trajectory_group.get_total_rewards()
+
+        for traj_idx, trajectory in enumerate(trajectory_group.trajectories_G):
+            prev_sequence: list[int] = []
+            for step_idx, transition in enumerate(trajectory.transitions):
+                ob_tokens, has_images = extract_ob_tokens(transition.ob)
+                stored_ob, ob_is_delta = compute_ob_delta(prev_sequence, ob_tokens)
+                ac_tokens = list(transition.ac.tokens)
+                prev_sequence = ob_tokens + ac_tokens
+
+                ob_text: str | None = None
+                ac_text: str | None = None
+                if store_text and tokenizer is not None:
+                    ob_text = _decode(tokenizer, stored_ob)
+                    ac_text = _decode(tokenizer, ac_tokens)
+
+                env_row_id = transition.logs.get("env/row_id")
+                rows.append(
+                    TokenRow(
+                        split=split,
+                        iteration=iteration,
+                        group_idx=group_idx,
+                        traj_idx=traj_idx,
+                        step_idx=step_idx,
+                        ob_tokens=stored_ob,
+                        ob_is_delta=ob_is_delta,
+                        ac_tokens=ac_tokens,
+                        ac_logprobs=(
+                            list(transition.ac.maybe_logprobs)
+                            if transition.ac.maybe_logprobs is not None
+                            else None
+                        ),
+                        stop_reason=transition.ac.stop_reason,
+                        has_images=has_images,
+                        reward=transition.reward,
+                        episode_done=transition.episode_done,
+                        total_reward=total_rewards_G[traj_idx],
+                        final_reward=trajectory_group.final_rewards_G[traj_idx],
+                        ob_text=ob_text,
+                        ac_text=ac_text,
+                        metrics=dict(transition.metrics),
+                        logs=dict(transition.logs),
+                        env_row_id=str(env_row_id) if env_row_id is not None else None,
+                        sampling_client_step=group_step,
+                        tags=group_tags,
+                        source=source,
+                        filtered_reason=filtered_reason,
+                    )
+                )
+    writer.append_rows(rows)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Active capture — the writer handle registered by the training loop.
+# Registered in rl/train.py main() when Config.token_db is set; the export
+# funnel and the filtered-group sink read it instead of threading the writer
+# through every call site.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ActiveCapture:
+    """The writer (plus decode settings) registered for the current run."""
+
+    writer: TokenWriter
+    tokenizer: SupportsDecode | None = None
+    store_text: bool = True
+
+
+_active_capture: ContextVar[ActiveCapture | None] = ContextVar("active_capture", default=None)
+
+
+def set_active_capture(capture: ActiveCapture | None) -> None:
+    """Register the active capture (``None`` disables; the default)."""
+    _active_capture.set(capture)
+
+
+def get_active_capture() -> ActiveCapture | None:
+    """Return the active capture, or ``None`` when capture is disabled."""
+    return _active_capture.get()
+
+
+def record_groups_to_active_capture(
+    groups: Sequence[TrajectoryGroup | RolloutSummaryGroup],
+    *,
+    split: str,
+    iteration: int,
+    sampling_client_step: int | None = None,
+    tags: Sequence[str] = (),
+    source: str = "rollout",
+    filtered_reason: str | None = None,
+) -> None:
+    """:func:`record_groups` against the active capture; never raises.
+
+    No-op when no capture is registered. Capture failures are logged and
+    swallowed — token DB capture must never break training.
+    """
+    active = get_active_capture()
+    if active is None:
+        return
+    try:
+        record_groups(
+            active.writer,
+            groups,
+            split=split,
+            iteration=iteration,
+            sampling_client_step=sampling_client_step,
+            tags=tags,
+            tokenizer=active.tokenizer,
+            store_text=active.store_text,
+            source=source,
+            filtered_reason=filtered_reason,
+        )
+    except Exception:
+        logger.exception("Token DB capture failed; continuing without capture")
+
+
+# ---------------------------------------------------------------------------
+# Capture context — identity for capture sites without explicit arguments
+# (filtered-group sink, sample sink), set around the rollout calls in
+# rl/train.py.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CaptureContext:
+    """Identity carried to capture sites via :data:`capture_context`."""
+
+    split: str
+    iteration: int
+    sampling_client_step: int | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+capture_context: ContextVar[CaptureContext | None] = ContextVar("capture_context", default=None)
+
+
+@contextmanager
+def set_capture_context(context: CaptureContext) -> Iterator[CaptureContext]:
+    """Set :data:`capture_context` for the duration of the ``with`` block."""
+    token = capture_context.set(context)
+    try:
+        yield context
+    finally:
+        capture_context.reset(token)
+
+
+def get_capture_context() -> CaptureContext | None:
+    """Return the active :class:`CaptureContext`, or ``None`` when unset."""
+    return capture_context.get()
+
+
+# ---------------------------------------------------------------------------
+# Filtered-group sink — registry only; call sites in rl/rollouts.py are wired
+# in a later step. Same pattern as set_rollout_executor in rl/rollouts.py.
+# ---------------------------------------------------------------------------
+
+FilteredGroupSink = Callable[[TrajectoryGroup | None, list[str], str], None]
+"""Callback ``(trajectory_group_or_None, tags, reason)`` invoked when the
+rollout pipeline drops a group before export (constant reward, rollout
+error). ``trajectory_group_or_None`` is ``None`` when the group failed before
+any trajectory was produced."""
+
+_filtered_group_sink: ContextVar[FilteredGroupSink | None] = ContextVar(
+    "filtered_group_sink", default=None
+)
+
+
+def set_filtered_group_sink(sink: FilteredGroupSink | None) -> None:
+    """Set the sink for dropped trajectory groups.
+
+    Pass ``None`` to disable (the default). Follows the
+    ``set_rollout_executor`` pattern in ``rl/rollouts.py``.
+    """
+    _filtered_group_sink.set(sink)
+
+
+def get_filtered_group_sink() -> FilteredGroupSink | None:
+    """Return the active filtered-group sink, or ``None`` when unset."""
+    return _filtered_group_sink.get()
+
+
+def active_capture_filtered_sink(
+    trajectory_group: TrajectoryGroup | None, tags: list[str], reason: str
+) -> None:
+    """Filtered-group sink that records dropped groups to the active capture.
+
+    Registered via :func:`set_filtered_group_sink` when the token DB is
+    enabled with ``capture_filtered=True``. Split/iteration identity comes
+    from :data:`capture_context` (set around the rollout calls in
+    ``rl/train.py``); when unset, rows land under ``iteration=-1``. Groups
+    that failed before producing any trajectory (``trajectory_group is
+    None``) have no tokens to record and are skipped.
+    """
+    if trajectory_group is None:
+        return
+    ctx = get_capture_context()
+    record_groups_to_active_capture(
+        [trajectory_group],
+        split=ctx.split if ctx is not None else "train",
+        iteration=ctx.iteration if ctx is not None else -1,
+        sampling_client_step=ctx.sampling_client_step if ctx is not None else None,
+        tags=tags,
+        source="filtered",
+        filtered_reason=reason,
+    )

--- a/tinker_cookbook/tokendb/capture_test.py
+++ b/tinker_cookbook/tokendb/capture_test.py
@@ -1,0 +1,435 @@
+"""Tests for the token DB capture layer (TrajectoryGroup -> TokenRow)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+import tinker
+
+from tinker_cookbook.completers import TokensWithLogprobs
+from tinker_cookbook.rl.rollout_logging import RolloutSummaryGroup
+from tinker_cookbook.rl.types import Trajectory, TrajectoryGroup, Transition
+from tinker_cookbook.tokendb.capture import (
+    CaptureContext,
+    extract_ob_tokens,
+    get_capture_context,
+    get_filtered_group_sink,
+    record_groups,
+    set_capture_context,
+    set_filtered_group_sink,
+)
+from tinker_cookbook.tokendb.schema import TokenRow
+from tinker_cookbook.tokendb.writer import TokenDbWriter
+from tinker_cookbook.tokendb.writer_test import read_all_segments
+
+
+class FakeTokenizer:
+    """Stub tokenizer: decodes token IDs to a deterministic string."""
+
+    def decode(self, token_ids: list[int]) -> str:
+        return " ".join(f"t{t}" for t in token_ids)
+
+
+class ListWriter:
+    """In-memory TokenWriter capturing appended rows."""
+
+    def __init__(self) -> None:
+        self.rows: list[TokenRow] = []
+
+    def append_rows(self, rows) -> None:
+        self.rows.extend(rows)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def make_transition(
+    ob_tokens: list[int],
+    ac_tokens: list[int],
+    *,
+    logprobs: list[float] | None = None,
+    reward: float = 0.0,
+    episode_done: bool = False,
+    metrics: dict | None = None,
+    logs: dict | None = None,
+    ob: tinker.ModelInput | None = None,
+) -> Transition:
+    if logprobs is None:
+        logprobs = [-0.1] * len(ac_tokens)
+    return Transition(
+        ob=ob if ob is not None else tinker.ModelInput.from_ints(ob_tokens),
+        ac=TokensWithLogprobs(tokens=ac_tokens, maybe_logprobs=logprobs),
+        reward=reward,
+        episode_done=episode_done,
+        metrics=metrics or {},
+        logs=logs or {},
+    )
+
+
+def make_group(
+    trajectories: list[Trajectory], final_rewards: list[float] | None = None
+) -> TrajectoryGroup:
+    if final_rewards is None:
+        final_rewards = [0.0] * len(trajectories)
+    return TrajectoryGroup(
+        trajectories_G=trajectories,
+        final_rewards_G=final_rewards,
+        metrics_G=[{} for _ in trajectories],
+    )
+
+
+def single_step_trajectory(
+    ob_tokens: list[int], ac_tokens: list[int], *, reward: float = 0.0, **kwargs
+) -> Trajectory:
+    return Trajectory(
+        transitions=[
+            make_transition(ob_tokens, ac_tokens, reward=reward, episode_done=True, **kwargs)
+        ],
+        final_ob=tinker.ModelInput.from_ints([]),
+    )
+
+
+class TestEnumeration:
+    def test_row_count_and_keys_match_group_structure(self):
+        groups = [
+            make_group(
+                [
+                    single_step_trajectory([1, 2], [3]),
+                    Trajectory(
+                        transitions=[
+                            make_transition([1, 2], [3, 4]),
+                            make_transition([1, 2, 3, 4, 5], [6], episode_done=True),
+                        ],
+                        final_ob=tinker.ModelInput.from_ints([]),
+                    ),
+                ]
+            ),
+            make_group([single_step_trajectory([9], [8])]),
+        ]
+        writer = ListWriter()
+        rows = record_groups(writer, groups, split="train", iteration=3)
+        assert rows is not None and writer.rows == rows
+        keys = [(r.group_idx, r.traj_idx, r.step_idx) for r in rows]
+        assert keys == [(0, 0, 0), (0, 1, 0), (0, 1, 1), (1, 0, 0)]
+        assert all(r.split == "train" and r.iteration == 3 for r in rows)
+        assert all(r.source == "rollout" and r.filtered_reason is None for r in rows)
+
+    def test_summary_group_tags_and_step_take_precedence(self):
+        summary_groups = [
+            RolloutSummaryGroup(
+                trajectory_group=make_group([single_step_trajectory([1], [2])]),
+                tags=["gsm", "math"],
+                sampling_client_step=7,
+            )
+        ]
+        rows = record_groups(
+            ListWriter(),
+            summary_groups,
+            split="train",
+            iteration=0,
+            tags=["fallback"],
+            sampling_client_step=99,
+        )
+        assert rows[0].tags == ["gsm", "math"]
+        assert rows[0].sampling_client_step == 7
+
+    def test_plain_group_uses_kwarg_tags_and_step(self):
+        rows = record_groups(
+            ListWriter(),
+            [make_group([single_step_trajectory([1], [2])])],
+            split="eval/gsm8k",
+            iteration=1,
+            tags=["gsm"],
+            sampling_client_step=12,
+        )
+        assert rows[0].tags == ["gsm"]
+        assert rows[0].sampling_client_step == 12
+        assert rows[0].split == "eval/gsm8k"
+
+
+class TestDeltaOb:
+    def test_prefix_extension_stores_delta(self):
+        # Turn 2 observation extends turn 1's ob+ac by [30, 31].
+        traj = Trajectory(
+            transitions=[
+                make_transition([1, 2], [10, 11]),
+                make_transition([1, 2, 10, 11, 30, 31], [40], episode_done=True),
+            ],
+            final_ob=tinker.ModelInput.from_ints([]),
+        )
+        rows = record_groups(ListWriter(), [make_group([traj])], split="train", iteration=0)
+        assert rows[0].ob_tokens == [1, 2]
+        assert rows[0].ob_is_delta is False
+        assert rows[1].ob_tokens == [30, 31]
+        assert rows[1].ob_is_delta is True
+
+    def test_non_prefix_reset_stores_full_ob(self):
+        traj = Trajectory(
+            transitions=[
+                make_transition([1, 2], [10]),
+                make_transition([99, 98], [40], episode_done=True),
+            ],
+            final_ob=tinker.ModelInput.from_ints([]),
+        )
+        rows = record_groups(ListWriter(), [make_group([traj])], split="train", iteration=0)
+        assert rows[1].ob_tokens == [99, 98]
+        assert rows[1].ob_is_delta is False
+
+    def test_delta_resets_across_trajectories(self):
+        # Two trajectories with identical obs: the second must not delta
+        # against the first.
+        groups = [
+            make_group([single_step_trajectory([1, 2], [3]), single_step_trajectory([1, 2], [3])])
+        ]
+        rows = record_groups(ListWriter(), groups, split="train", iteration=0)
+        assert rows[1].ob_tokens == [1, 2]
+        assert rows[1].ob_is_delta is False
+
+
+class TestRewards:
+    def test_reward_and_denormalized_totals(self):
+        traj_a = Trajectory(
+            transitions=[
+                make_transition([1], [2], reward=0.25),
+                make_transition([1, 2, 3], [4], reward=0.5, episode_done=True),
+            ],
+            final_ob=tinker.ModelInput.from_ints([]),
+        )
+        traj_b = single_step_trajectory([1], [2], reward=1.0)
+        group = make_group([traj_a, traj_b], final_rewards=[2.0, -1.0])
+        rows = record_groups(ListWriter(), [group], split="train", iteration=0)
+
+        assert [r.reward for r in rows] == [0.25, 0.5, 1.0]
+        assert [r.episode_done for r in rows] == [False, True, True]
+        # total = sum of step rewards + final group reward, same on every row
+        # of the trajectory.
+        assert rows[0].total_reward == rows[1].total_reward == pytest.approx(2.75)
+        assert rows[0].final_reward == rows[1].final_reward == pytest.approx(2.0)
+        assert rows[2].total_reward == pytest.approx(0.0)
+        assert rows[2].final_reward == pytest.approx(-1.0)
+
+    def test_ac_fields_come_from_transition(self):
+        traj = single_step_trajectory([1], [5, 6], logprobs=[-0.5, -1.5])
+        rows = record_groups(ListWriter(), [make_group([traj])], split="train", iteration=0)
+        assert rows[0].ac_tokens == [5, 6]
+        assert rows[0].ac_logprobs == [-0.5, -1.5]
+        assert rows[0].stop_reason == "stop"
+
+    def test_missing_logprobs_stored_as_none(self):
+        traj = Trajectory(
+            transitions=[
+                Transition(
+                    ob=tinker.ModelInput.from_ints([1]),
+                    ac=TokensWithLogprobs(tokens=[2], maybe_logprobs=None),
+                    reward=0.0,
+                    episode_done=True,
+                )
+            ],
+            final_ob=tinker.ModelInput.from_ints([]),
+        )
+        rows = record_groups(ListWriter(), [make_group([traj])], split="train", iteration=0)
+        assert rows[0].ac_logprobs is None
+
+
+class TestLogsAndMetrics:
+    def test_env_row_id_promotion(self):
+        traj = single_step_trajectory([1], [2], logs={"env/row_id": "gsm8k-42", "other": 1})
+        rows = record_groups(ListWriter(), [make_group([traj])], split="train", iteration=0)
+        assert rows[0].env_row_id == "gsm8k-42"
+        assert rows[0].logs == {"env/row_id": "gsm8k-42", "other": 1}
+
+    def test_no_env_row_id(self):
+        traj = single_step_trajectory([1], [2], logs={"other": 1})
+        rows = record_groups(ListWriter(), [make_group([traj])], split="train", iteration=0)
+        assert rows[0].env_row_id is None
+
+    def test_metrics_logs_json_roundtrip_with_non_serializable(self, tmp_path: Path):
+        class Weird:
+            def __repr__(self) -> str:
+                return "<weird>"
+
+        traj = single_step_trajectory(
+            [1],
+            [2],
+            metrics={"format_ok": 1},
+            logs={"env/row_id": "r-1", "obj": Weird()},
+        )
+        with TokenDbWriter(tmp_path, flush_interval_s=3600.0) as writer:
+            record_groups(writer, [make_group([traj])], split="train", iteration=0)
+        got = read_all_segments(tmp_path).to_pylist()[0]
+        assert json.loads(got["metrics"]) == {"format_ok": 1}
+        logs = json.loads(got["logs"])
+        assert logs["env/row_id"] == "r-1"
+        assert logs["obj"] == "<weird>"  # default=str fallback
+
+
+class TestTextDecode:
+    def test_store_text_decodes_whole_turn_and_delta(self):
+        traj = Trajectory(
+            transitions=[
+                make_transition([1, 2], [10]),
+                make_transition([1, 2, 10, 30], [40], episode_done=True),
+            ],
+            final_ob=tinker.ModelInput.from_ints([]),
+        )
+        rows = record_groups(
+            ListWriter(),
+            [make_group([traj])],
+            split="train",
+            iteration=0,
+            tokenizer=FakeTokenizer(),
+        )
+        assert rows[0].ob_text == "t1 t2"
+        assert rows[0].ac_text == "t10"
+        # Delta row decodes only the delta portion.
+        assert rows[1].ob_tokens == [30]
+        assert rows[1].ob_text == "t30"
+        assert rows[1].ac_text == "t40"
+
+    def test_store_text_false_skips_decode(self):
+        rows = record_groups(
+            ListWriter(),
+            [make_group([single_step_trajectory([1], [2])])],
+            split="train",
+            iteration=0,
+            tokenizer=FakeTokenizer(),
+            store_text=False,
+        )
+        assert rows[0].ob_text is None
+        assert rows[0].ac_text is None
+
+    def test_no_tokenizer_skips_decode(self):
+        rows = record_groups(
+            ListWriter(),
+            [make_group([single_step_trajectory([1], [2])])],
+            split="train",
+            iteration=0,
+        )
+        assert rows[0].ob_text is None
+        assert rows[0].ac_text is None
+
+
+class TestImageChunks:
+    def test_extract_ob_tokens_with_image_chunk(self):
+        ob = tinker.ModelInput(
+            chunks=[
+                tinker.EncodedTextChunk(tokens=[1, 2]),
+                tinker.types.ImageChunk(data=b"fake", format="jpeg", expected_tokens=5),
+                tinker.EncodedTextChunk(tokens=[3]),
+            ]
+        )
+        tokens, has_images = extract_ob_tokens(ob)
+        assert tokens == [1, 2, 3]
+        assert has_images is True
+
+    def test_extract_ob_tokens_text_only(self):
+        tokens, has_images = extract_ob_tokens(tinker.ModelInput.from_ints([1, 2]))
+        assert tokens == [1, 2]
+        assert has_images is False
+
+    def test_record_groups_with_image_ob_never_raises(self):
+        ob = tinker.ModelInput(
+            chunks=[
+                tinker.EncodedTextChunk(tokens=[1, 2]),
+                tinker.types.ImageChunk(data=b"fake", format="jpeg", expected_tokens=5),
+            ]
+        )
+        traj = Trajectory(
+            transitions=[make_transition([], [7], ob=ob, episode_done=True)],
+            final_ob=tinker.ModelInput.from_ints([]),
+        )
+        rows = record_groups(
+            ListWriter(),
+            [make_group([traj])],
+            split="train",
+            iteration=0,
+            tokenizer=FakeTokenizer(),
+        )
+        assert rows[0].has_images is True
+        assert rows[0].ob_tokens == [1, 2]  # text-chunk tokens only
+        assert rows[0].ob_text == "t1 t2"
+
+
+class TestSourceAndFiltered:
+    def test_filtered_source_and_reason(self):
+        rows = record_groups(
+            ListWriter(),
+            [make_group([single_step_trajectory([1], [2])])],
+            split="train",
+            iteration=0,
+            source="filtered",
+            filtered_reason="constant_reward",
+        )
+        assert rows[0].source == "filtered"
+        assert rows[0].filtered_reason == "constant_reward"
+
+
+class TestWriterIntegration:
+    def test_rows_reach_parquet_via_token_db_writer(self, tmp_path: Path):
+        groups = [
+            make_group([single_step_trajectory([1, 2], [3], reward=1.0)], final_rewards=[0.5]),
+            make_group([single_step_trajectory([4], [5, 6])]),
+        ]
+        with TokenDbWriter(tmp_path, flush_interval_s=3600.0) as writer:
+            record_groups(
+                writer,
+                groups,
+                split="train",
+                iteration=2,
+                tags=["unit"],
+                tokenizer=FakeTokenizer(),
+            )
+        table = read_all_segments(tmp_path)
+        assert table.num_rows == 2
+        got = sorted(table.to_pylist(), key=lambda r: r["group_idx"])
+        assert got[0]["ob_tokens"] == [1, 2]
+        assert got[0]["ac_tokens"] == [3]
+        assert got[0]["total_reward"] == pytest.approx(1.5)
+        assert got[0]["final_reward"] == pytest.approx(0.5)
+        assert got[0]["ob_text"] == "t1 t2"
+        assert got[0]["tags"] == ["unit"]
+        assert got[0]["iteration"] == 2
+        assert got[1]["ac_tokens"] == [5, 6]
+        assert got[0]["run_id"] == got[1]["run_id"] != ""
+
+
+class TestCaptureContext:
+    def test_set_and_reset(self):
+        assert get_capture_context() is None
+        ctx = CaptureContext(split="train", iteration=5, sampling_client_step=3, tags=("gsm",))
+        with set_capture_context(ctx) as active:
+            assert active is ctx
+            assert get_capture_context() is ctx
+        assert get_capture_context() is None
+
+    def test_nesting(self):
+        outer = CaptureContext(split="train", iteration=1)
+        inner = CaptureContext(split="test", iteration=2)
+        with set_capture_context(outer):
+            with set_capture_context(inner):
+                assert get_capture_context() is inner
+            assert get_capture_context() is outer
+
+
+class TestFilteredGroupSink:
+    def test_registry_set_get_clear(self):
+        assert get_filtered_group_sink() is None
+        calls = []
+
+        def sink(group, tags, reason):
+            calls.append((group, tags, reason))
+
+        set_filtered_group_sink(sink)
+        try:
+            assert get_filtered_group_sink() is sink
+            get_filtered_group_sink()(None, ["gsm"], "rollout_error")  # type: ignore[misc]
+            assert calls == [(None, ["gsm"], "rollout_error")]
+        finally:
+            set_filtered_group_sink(None)
+        assert get_filtered_group_sink() is None

--- a/tinker_cookbook/tokendb/config.py
+++ b/tinker_cookbook/tokendb/config.py
@@ -1,0 +1,103 @@
+"""Token DB capture configuration for training loops.
+
+This module is intentionally lightweight (no pyarrow import) so training
+configs can reference :class:`TokenDbConfig` without the ``tokendb`` extra
+installed; :func:`check_token_db_dependencies` is the config-time gate that
+turns a missing dependency into an actionable error before training starts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import chz
+
+from tinker_cookbook.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from tinker_cookbook.stores.storage import Storage
+    from tinker_cookbook.tokendb.writer import TokenDbWriter
+
+
+@chz.chz
+class TokenDbConfig:
+    """Configuration for token DB capture during training.
+
+    Attributes:
+        store_text (bool): Store decoded ``ob_text`` / ``ac_text`` columns
+            alongside the canonical token IDs.
+        flush_interval_s (float): Background flush period for the writer.
+        buffer_rows (int): Flush to a new segment when the buffer reaches
+            this many rows.
+        capture_filtered (bool): Also capture trajectory groups dropped by
+            the rollout pipeline (constant reward, rollout errors) as
+            ``source="filtered"`` rows. Note: with a cross-process rollout
+            executor, filtered groups are dropped inside worker processes
+            and are not captured (known v1 gap).
+    """
+
+    store_text: bool = True
+    flush_interval_s: float = 5.0
+    buffer_rows: int = 2048
+    capture_filtered: bool = True
+
+
+def check_token_db_dependencies() -> None:
+    """Raise :class:`ConfigurationError` if the token DB write path can't run.
+
+    Called at config/startup time (never mid-run) so a missing optional
+    dependency fails fast with an actionable message.
+    """
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError as e:
+        raise ConfigurationError(
+            "token_db is enabled but pyarrow is not installed. "
+            "Install the token DB extra with: pip install 'tinker-cookbook[tokendb]'"
+        ) from e
+
+
+def build_token_db_writer(
+    config: TokenDbConfig,
+    storage_or_log_path: Storage | str | Path,
+    *,
+    model_name: str | None = None,
+    recipe_name: str | None = None,
+    extra_context: dict[str, Any] | None = None,
+) -> TokenDbWriter:
+    """Construct a :class:`TokenDbWriter` for a training run.
+
+    Run identity (``run_id`` from the resolved log path + start timestamp,
+    ``run_attempt`` incremented on resume) is handled by the writer itself;
+    this helper records provenance (``model_name``, ``recipe_name``, capture
+    config) into ``run.json`` via the writer context.
+
+    Args:
+        config: Capture configuration (buffer/flush knobs recorded in
+            ``run.json``).
+        storage_or_log_path: The run's ``Storage`` backend or ``log_path``.
+        model_name: Model being trained (for tokenizer recovery by readers).
+        recipe_name: Recipe/config provenance.
+        extra_context: Additional metadata to record in ``run.json``.
+    """
+    from tinker_cookbook.tokendb.writer import TokenDbWriter
+
+    context: dict[str, Any] = {
+        "model_name": model_name,
+        "recipe_name": recipe_name,
+        "capture": {
+            "store_text": config.store_text,
+            "flush_interval_s": config.flush_interval_s,
+            "buffer_rows": config.buffer_rows,
+            "capture_filtered": config.capture_filtered,
+        },
+    }
+    if extra_context:
+        context.update(extra_context)
+    return TokenDbWriter(
+        storage_or_log_path,
+        context=context,
+        buffer_rows=config.buffer_rows,
+        flush_interval_s=config.flush_interval_s,
+    )

--- a/tinker_cookbook/tokendb/integration_test.py
+++ b/tinker_cookbook/tokendb/integration_test.py
@@ -1,0 +1,378 @@
+"""Integration tests for the token DB hooks into the RL training loop.
+
+Covers:
+
+- Hook 1: ``rl/train._maybe_export_rollout_summary_jsonl`` teeing summary
+  groups into the active token DB writer while keeping the rollout-summary
+  JSONL byte-identical, and the disabled (``token_db=None``) path leaving no
+  ``tokens/`` directory.
+- Hook 2: the filtered-group sink firing from
+  ``rl/rollouts._do_group_rollout_and_filter_constant_reward_impl`` for the
+  three drop reasons, end-to-end into parquet for constant-reward groups.
+
+A full train-loop smoke (``rl/train.main`` with ``token_db`` enabled) is not
+included: ``main()`` requires a real Tinker backend (``ServiceClient`` +
+training client) and there is no mock-client harness in the unit test suite.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+import chz
+import tinker
+
+from tinker_cookbook.exceptions import AllTrajectoriesFailedError, ConfigurationError
+from tinker_cookbook.rl.rollout_logging import RolloutSummaryGroup
+from tinker_cookbook.rl.rollout_strategy import RetryOnFailure
+from tinker_cookbook.rl.rollouts import _do_group_rollout_and_filter_constant_reward_impl
+from tinker_cookbook.rl.train import Config, _maybe_export_rollout_summary_jsonl
+from tinker_cookbook.rl.types import Env, EnvGroupBuilder, RLDatasetBuilder, StepResult
+from tinker_cookbook.stores.storage import LocalStorage
+from tinker_cookbook.stores.training_store import TrainingRunStore
+from tinker_cookbook.tokendb.capture import (
+    ActiveCapture,
+    CaptureContext,
+    active_capture_filtered_sink,
+    set_active_capture,
+    set_capture_context,
+    set_filtered_group_sink,
+)
+from tinker_cookbook.tokendb.capture_test import FakeTokenizer, make_group, single_step_trajectory
+from tinker_cookbook.tokendb.config import TokenDbConfig
+from tinker_cookbook.tokendb.writer import TOKENS_DIR, TokenDbWriter
+from tinker_cookbook.tokendb.writer_test import read_all_segments
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    """Ensure capture registries never leak between tests."""
+    yield
+    set_active_capture(None)
+    set_filtered_group_sink(None)
+
+
+@chz.chz
+class _FakeDatasetBuilder(RLDatasetBuilder):
+    async def __call__(self):
+        raise NotImplementedError
+
+
+def make_config(log_path: Path, *, token_db: TokenDbConfig | None) -> Config:
+    return Config(
+        learning_rate=1e-4,
+        dataset_builder=_FakeDatasetBuilder(),
+        model_name="test-model",
+        recipe_name="test-recipe",
+        max_tokens=8,
+        log_path=str(log_path),
+        token_db=token_db,
+    )
+
+
+def make_summary_groups() -> list[RolloutSummaryGroup]:
+    group = make_group(
+        [
+            single_step_trajectory([1, 2, 3], [4, 5], reward=1.0),
+            single_step_trajectory([1, 2, 3], [6, 7], reward=0.0),
+        ],
+        final_rewards=[1.0, 0.0],
+    )
+    return [RolloutSummaryGroup(trajectory_group=group, tags=["fake_env"], sampling_client_step=3)]
+
+
+def summary_jsonl_path(log_path: Path, iteration: int) -> Path:
+    return log_path / f"iteration_{iteration:06d}" / "train_rollout_summaries.jsonl"
+
+
+class _FakeSamplingClient:
+    """Minimal stand-in for tinker.SamplingClient (only sample_async is used)."""
+
+    async def sample_async(self, prompt, num_samples, sampling_params):
+        class _Seq:
+            tokens = [4, 5]
+            logprobs = [-0.1, -0.2]
+            stop_reason = "stop"
+
+        class _Result:
+            sequences = [_Seq()]
+
+        return _Result()
+
+
+class _ConstantRewardEnv(Env):
+    async def initial_observation(self):
+        return tinker.ModelInput.from_ints([1, 2, 3]), [0]
+
+    async def step(self, action, *, extra=None):
+        return StepResult(
+            reward=1.0,
+            episode_done=True,
+            next_observation=tinker.ModelInput.from_ints([]),
+            next_stop_condition=[0],
+        )
+
+
+class _ConstantRewardEnvGroupBuilder(EnvGroupBuilder):
+    def __init__(self, n_envs: int = 2):
+        self.n_envs = n_envs
+
+    async def make_envs(self):
+        return [_ConstantRewardEnv() for _ in range(self.n_envs)]
+
+    def logging_tags(self) -> list[str]:
+        return ["constant_env"]
+
+
+def sampling_client() -> tinker.SamplingClient:
+    return cast(tinker.SamplingClient, _FakeSamplingClient())
+
+
+# ---------------------------------------------------------------------------
+# Hook 1: export funnel tee
+# ---------------------------------------------------------------------------
+
+
+class TestExportFunnelTee:
+    def test_tee_writes_parquet_and_keeps_jsonl(self, tmp_path: Path):
+        config = make_config(tmp_path, token_db=TokenDbConfig())
+        store = TrainingRunStore(LocalStorage(tmp_path))
+        writer = TokenDbWriter(tmp_path, flush_interval_s=3600)
+        set_active_capture(ActiveCapture(writer=writer, tokenizer=FakeTokenizer()))
+
+        _maybe_export_rollout_summary_jsonl(
+            config=config,
+            base_name="train",
+            split="train",
+            iteration=7,
+            groups_P=make_summary_groups(),
+            store=store,
+        )
+        writer.close()
+
+        # Rows landed in parquet with the funnel-provided identity.
+        table = read_all_segments(tmp_path)
+        assert table.num_rows == 2
+        assert table.column("split").to_pylist() == ["train", "train"]
+        assert table.column("iteration").to_pylist() == [7, 7]
+        assert table.column("source").to_pylist() == ["rollout", "rollout"]
+        assert table.column("tags").to_pylist() == [["fake_env"], ["fake_env"]]
+        assert table.column("sampling_client_step").to_pylist() == [3, 3]
+        assert table.column("ac_text").to_pylist() == ["t4 t5", "t6 t7"]
+
+        # ... and the summary JSONL is still written as before.
+        jsonl = summary_jsonl_path(tmp_path, 7)
+        assert jsonl.exists()
+        records = [json.loads(line) for line in jsonl.read_text().splitlines()]
+        assert len(records) == 2
+
+    def test_disabled_path_leaves_no_tokens_dir(self, tmp_path: Path):
+        config = make_config(tmp_path, token_db=None)
+        store = TrainingRunStore(LocalStorage(tmp_path))
+
+        _maybe_export_rollout_summary_jsonl(
+            config=config,
+            base_name="train",
+            split="train",
+            iteration=0,
+            groups_P=make_summary_groups(),
+            store=store,
+        )
+
+        assert not (tmp_path / TOKENS_DIR).exists()
+        assert summary_jsonl_path(tmp_path, 0).exists()
+
+    def test_capture_failure_does_not_break_jsonl_export(self, tmp_path: Path):
+        class _BrokenWriter:
+            def append_rows(self, rows):
+                raise RuntimeError("boom")
+
+            def flush(self):
+                pass
+
+            def close(self):
+                pass
+
+        config = make_config(tmp_path, token_db=TokenDbConfig())
+        store = TrainingRunStore(LocalStorage(tmp_path))
+        set_active_capture(ActiveCapture(writer=_BrokenWriter()))
+
+        _maybe_export_rollout_summary_jsonl(
+            config=config,
+            base_name="train",
+            split="train",
+            iteration=1,
+            groups_P=make_summary_groups(),
+            store=store,
+        )
+
+        assert summary_jsonl_path(tmp_path, 1).exists()
+
+    def test_jsonl_bytes_identical_with_and_without_token_db(self, tmp_path: Path):
+        groups = make_summary_groups()
+        outputs: dict[str, bytes] = {}
+        for name, token_db in [("off", None), ("on", TokenDbConfig())]:
+            log_path = tmp_path / name
+            log_path.mkdir()
+            config = make_config(log_path, token_db=token_db)
+            store = TrainingRunStore(LocalStorage(log_path))
+            if token_db is not None:
+                writer = TokenDbWriter(log_path, flush_interval_s=3600)
+                set_active_capture(ActiveCapture(writer=writer, tokenizer=FakeTokenizer()))
+            _maybe_export_rollout_summary_jsonl(
+                config=config,
+                base_name="train",
+                split="train",
+                iteration=2,
+                groups_P=groups,
+                store=store,
+            )
+            if token_db is not None:
+                writer.close()
+                set_active_capture(None)
+            outputs[name] = summary_jsonl_path(log_path, 2).read_bytes()
+        assert outputs["off"] == outputs["on"]
+
+
+# ---------------------------------------------------------------------------
+# Hook 2: filtered-group sink
+# ---------------------------------------------------------------------------
+
+
+class TestFilteredGroupSink:
+    def test_constant_reward_group_lands_in_parquet(self, tmp_path: Path):
+        writer = TokenDbWriter(tmp_path, flush_interval_s=3600)
+        set_active_capture(ActiveCapture(writer=writer, tokenizer=FakeTokenizer()))
+        set_filtered_group_sink(active_capture_filtered_sink)
+
+        async def run():
+            with set_capture_context(
+                CaptureContext(split="train", iteration=5, sampling_client_step=5)
+            ):
+                return await _do_group_rollout_and_filter_constant_reward_impl(
+                    sampling_client(),
+                    _ConstantRewardEnvGroupBuilder(),
+                    max_tokens=8,
+                    temperature=1.0,
+                    do_remove_constant_reward_groups=True,
+                )
+
+        result = asyncio.run(run())
+        writer.close()
+
+        assert result is None
+        table = read_all_segments(tmp_path)
+        assert table.num_rows == 2
+        assert set(table.column("source").to_pylist()) == {"filtered"}
+        assert set(table.column("filtered_reason").to_pylist()) == {"constant_reward"}
+        assert table.column("iteration").to_pylist() == [5, 5]
+        assert table.column("sampling_client_step").to_pylist() == [5, 5]
+        assert table.column("tags").to_pylist() == [["constant_env"], ["constant_env"]]
+
+    def test_all_failed_reason(self):
+        calls: list[tuple[object, list[str], str]] = []
+        set_filtered_group_sink(lambda group, tags, reason: calls.append((group, tags, reason)))
+
+        async def run():
+            with patch(
+                "tinker_cookbook.rl.rollouts.do_group_rollout",
+                side_effect=AllTrajectoriesFailedError("all failed"),
+            ):
+                return await _do_group_rollout_and_filter_constant_reward_impl(
+                    sampling_client(),
+                    _ConstantRewardEnvGroupBuilder(),
+                    max_tokens=8,
+                    temperature=1.0,
+                    do_remove_constant_reward_groups=False,
+                )
+
+        assert asyncio.run(run()) is None
+        assert calls == [(None, ["constant_env"], "all_failed")]
+
+    def test_group_error_reason(self):
+        calls: list[tuple[object, list[str], str]] = []
+        set_filtered_group_sink(lambda group, tags, reason: calls.append((group, tags, reason)))
+
+        async def run():
+            with patch(
+                "tinker_cookbook.rl.rollouts.do_group_rollout",
+                side_effect=RuntimeError("sandbox flake"),
+            ):
+                return await _do_group_rollout_and_filter_constant_reward_impl(
+                    sampling_client(),
+                    _ConstantRewardEnvGroupBuilder(),
+                    max_tokens=8,
+                    temperature=1.0,
+                    do_remove_constant_reward_groups=False,
+                    strategy=RetryOnFailure(max_retries=0),
+                )
+
+        assert asyncio.run(run()) is None
+        assert calls == [(None, ["constant_env"], "group_error")]
+
+    def test_sink_exception_never_breaks_rollout(self):
+        def broken_sink(group, tags, reason):
+            raise RuntimeError("sink boom")
+
+        set_filtered_group_sink(broken_sink)
+
+        async def run():
+            return await _do_group_rollout_and_filter_constant_reward_impl(
+                sampling_client(),
+                _ConstantRewardEnvGroupBuilder(),
+                max_tokens=8,
+                temperature=1.0,
+                do_remove_constant_reward_groups=True,
+            )
+
+        assert asyncio.run(run()) is None  # dropped, but no exception escapes
+
+    def test_no_sink_registered_is_a_noop(self):
+        async def run():
+            return await _do_group_rollout_and_filter_constant_reward_impl(
+                sampling_client(),
+                _ConstantRewardEnvGroupBuilder(),
+                max_tokens=8,
+                temperature=1.0,
+                do_remove_constant_reward_groups=True,
+            )
+
+        assert asyncio.run(run()) is None
+
+
+# ---------------------------------------------------------------------------
+# Config-time dependency check
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyCheck:
+    def test_check_passes_with_pyarrow_installed(self):
+        from tinker_cookbook.tokendb.config import check_token_db_dependencies
+
+        check_token_db_dependencies()
+
+    def test_check_raises_configuration_error_without_pyarrow(self):
+        import builtins
+
+        from tinker_cookbook.tokendb.config import check_token_db_dependencies
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "pyarrow":
+                raise ImportError("No module named 'pyarrow'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with pytest.raises(ConfigurationError, match=r"tinker-cookbook\[tokendb\]"):
+                check_token_db_dependencies()

--- a/tinker_cookbook/tokendb/integration_test.py
+++ b/tinker_cookbook/tokendb/integration_test.py
@@ -226,6 +226,7 @@ class TestExportFunnelTee:
             log_path.mkdir()
             config = make_config(log_path, token_db=token_db)
             store = TrainingRunStore(LocalStorage(log_path))
+            writer: TokenDbWriter | None = None
             if token_db is not None:
                 writer = TokenDbWriter(log_path, flush_interval_s=3600)
                 set_active_capture(ActiveCapture(writer=writer, tokenizer=FakeTokenizer()))
@@ -237,7 +238,7 @@ class TestExportFunnelTee:
                 groups_P=groups,
                 store=store,
             )
-            if token_db is not None:
+            if writer is not None:
                 writer.close()
                 set_active_capture(None)
             outputs[name] = summary_jsonl_path(log_path, 2).read_bytes()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #821
* #820
* #819
* #818
* #817
* #816
* #815
* #814
* #813
* #812
* #811
* #810
* #809
* #808
* #807
* #806
* __->__ #805
* #804

Converts TrajectoryGroups into token DB rows (one row per Transition, observation
tokens delta-encoded against the previous turn, action tokens/logprobs/stop reason,
denormalized rewards, optional decoded text) and wires capture into the RL training
loop behind an opt-in Config.token_db field. The existing rollout summary export
funnel gains a tee that records the same groups into the token store, filtered
groups (constant reward, all failed, group error) are captured with a
filtered_reason before they are dropped, and eval rollouts are captured through the
metrics export path. Disabled by default: when token_db is None every hook is a
single falsy check with no new imports. Adds the tokendb optional extra (pyarrow,
duckdb) with a config-time dependency check.