### PR TITLE
tokendb: reader with DuckDB views and query API

### DIFF
--- a/tinker_cookbook/tokendb/__init__.py
+++ b/tinker_cookbook/tokendb/__init__.py
@@ -24,6 +24,11 @@ from tinker_cookbook.tokendb.config import (
     check_token_db_dependencies,
 )
 from tinker_cookbook.tokendb.interface import TokenStoreBackend, TokenWriter
+from tinker_cookbook.tokendb.reader import (
+    ParquetSegmentReader,
+    TokenDB,
+    reconstruct_full_ob,
+)
 from tinker_cookbook.tokendb.schema import (
     SCHEMA_VERSION,
     TokenRow,
@@ -37,6 +42,8 @@ __all__ = [
     "ActiveCapture",
     "CaptureContext",
     "ParquetSegmentBackend",
+    "ParquetSegmentReader",
+    "TokenDB",
     "TokenDbConfig",
     "TokenDbWriter",
     "TokenRow",
@@ -51,6 +58,7 @@ __all__ = [
     "get_capture_context",
     "get_filtered_group_sink",
     "make_writer_id",
+    "reconstruct_full_ob",
     "record_groups",
     "record_groups_to_active_capture",
     "set_active_capture",

--- a/tinker_cookbook/tokendb/interface.py
+++ b/tinker_cookbook/tokendb/interface.py
@@ -7,11 +7,9 @@ the default implementation (parquet segments through the ``Storage``
 protocol); a hosted backend can implement the same protocol later with no
 changes to callers.
 
-Only the write half (:meth:`TokenStoreBackend.open_writer` and
-:class:`TokenWriter`) is implemented so far; the read-half methods are
-declared here and arrive with the reader in a later phase. Raw SQL is
-deliberately not part of the protocol — it stays a backend-specific escape
-hatch, and the portable surface is the structured methods.
+Raw SQL is deliberately not part of the protocol — it stays a
+backend-specific escape hatch, and the portable surface is the structured
+methods.
 """
 
 from __future__ import annotations
@@ -53,18 +51,25 @@ class TokenStoreBackend(Protocol):
         """
         ...
 
-    # --- Read half: declared here, implemented in a later phase. ---
+    # --- Read half. ---
 
     def query(self, **filters: Any) -> Any:
         """Structured row query (split, iteration range, tags, reward range, ...)."""
         ...
 
-    def get_rollout(self, split: str, iteration: int, group_idx: int, traj_idx: int) -> Any:
-        """Fetch all rows (turns) for one trajectory."""
+    def get_rollout(
+        self,
+        split: str,
+        iteration: int,
+        group_idx: int,
+        traj_idx: int,
+        run_attempt: int | None = None,
+    ) -> Any:
+        """Fetch all rows (turns) for one trajectory (latest attempt by default)."""
         ...
 
-    def search(self, pattern: str, *, text_field: str = "ac_text") -> Any:
-        """Regex search over text columns, or token-ID-subsequence match."""
+    def search(self, **kwargs: Any) -> Any:
+        """Regex search over text columns, and/or token-ID-subsequence match."""
         ...
 
     def subscribe(self, **filters: Any) -> AsyncIterator[Any]:

--- a/tinker_cookbook/tokendb/reader.py
+++ b/tinker_cookbook/tokendb/reader.py
@@ -128,7 +128,8 @@ class ParquetSegmentReader:
     # --- Connection / registration ---
 
     def _connection(self) -> duckdb.DuckDBPyConnection:
-        if self._conn is None:
+        conn = self._conn
+        if conn is None:
             duckdb = _require_duckdb()
             import pyarrow as pa
 
@@ -141,7 +142,7 @@ class ParquetSegmentReader:
             conn.unregister("_empty_segment")
             self._create_views(conn)
             self._conn = conn
-        return self._conn
+        return conn
 
     def _create_views(self, conn: duckdb.DuckDBPyConnection) -> None:
         # All rows, tagged: `superseded` is true when a later run_attempt

--- a/tinker_cookbook/tokendb/reader.py
+++ b/tinker_cookbook/tokendb/reader.py
@@ -1,0 +1,656 @@
+"""DuckDB read path for the parquet segment token store.
+
+:class:`ParquetSegmentReader` is the read half of
+:class:`~tinker_cookbook.tokendb.writer.ParquetSegmentBackend`: an in-memory
+DuckDB connection over the immutable segment files, with views for browsing
+(``rollouts`` / ``rollouts_latest`` / ``trajectories`` / ``labels``) and the
+structured ``TokenStoreBackend`` read methods (``query`` / ``get_rollout`` /
+``search`` / ``subscribe`` / ``add_label`` / ``labels``).
+
+Segment registration is incremental: the reader tracks which segment files it
+has loaded and, on refresh, lists the segments directory (the directory
+listing is the source of truth; manifests are only a liveness hint) and loads
+only new files. Segments are immutable, so there is no cache invalidation.
+Segment bytes are read through the ``Storage`` protocol and registered as
+arrow tables, so the reader works against local and cloud stores alike.
+
+:class:`TokenDB` is the thin user-facing facade: ``TokenDB(log_path)``
+constructs the default backend and exposes the structured methods plus
+``sql()`` as the backend-specific, SELECT-only escape hatch (``sql()`` is
+deliberately not part of the ``TokenStoreBackend`` protocol).
+
+DuckDB is imported lazily; importing this module does not require it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+from collections.abc import AsyncIterator, Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tinker_cookbook.stores.storage import LocalStorage, Storage, storage_from_uri
+from tinker_cookbook.tokendb.writer import SEGMENTS_DIR, TOKENS_DIR, ParquetSegmentBackend
+
+if TYPE_CHECKING:
+    import duckdb
+
+logger = logging.getLogger(__name__)
+
+LABELS_PATH = f"{TOKENS_DIR}/labels.jsonl"
+
+DEFAULT_SUBSCRIBE_POLL_INTERVAL_S = 2.0
+
+_LABEL_KEY_FIELDS = ("run_id", "split", "iteration", "group_idx", "traj_idx", "step_idx")
+
+_LABEL_COLUMNS_SQL = (
+    "{run_id: 'VARCHAR', split: 'VARCHAR', iteration: 'INTEGER', group_idx: 'INTEGER', "
+    "traj_idx: 'INTEGER', step_idx: 'INTEGER', label_key: 'VARCHAR', label_value: 'JSON', "
+    "author: 'VARCHAR', ts: 'TIMESTAMP', note: 'VARCHAR'}"
+)
+
+
+def _result_to_dicts(result: Any) -> list[dict[str, Any]]:
+    """Fetch a DuckDB result as a list of dicts (via arrow, so list/ts columns
+    come back as Python lists / datetimes). Tolerates the
+    ``fetch_arrow_table`` -> ``to_arrow_table`` rename across duckdb versions."""
+    to_arrow = getattr(result, "to_arrow_table", None)
+    table = to_arrow() if to_arrow is not None else result.fetch_arrow_table()
+    return table.to_pylist()
+
+
+def _require_duckdb() -> Any:
+    """Import duckdb, raising an actionable error if the extra is missing."""
+    try:
+        import duckdb
+    except ImportError as e:
+        raise ImportError(
+            "duckdb is required for the token DB read path. "
+            "Install the token DB extra with: pip install 'tinker-cookbook[tokendb]'"
+        ) from e
+    return duckdb
+
+
+def reconstruct_full_ob(rows: Sequence[Mapping[str, Any]]) -> list[list[int]]:
+    """Expand delta-encoded observations back to full token sequences.
+
+    Args:
+        rows: The step rows of one trajectory, ordered by ``step_idx`` (as
+            returned by :meth:`ParquetSegmentReader.get_rollout`). Each row
+            needs ``ob_tokens``, ``ob_is_delta``, and ``ac_tokens``.
+
+    Returns:
+        One full observation token list per row. A delta row's observation is
+        the previous full sequence (previous ob + ac) plus the stored suffix;
+        a non-delta row's observation is its stored tokens as-is.
+    """
+    full_obs: list[list[int]] = []
+    prev_sequence: list[int] = []
+    for row in rows:
+        ob_tokens = list(row["ob_tokens"])
+        full_ob = prev_sequence + ob_tokens if row["ob_is_delta"] else ob_tokens
+        full_obs.append(full_ob)
+        prev_sequence = full_ob + list(row["ac_tokens"])
+    return full_obs
+
+
+def _contains_subsequence(haystack: Sequence[int], needle: Sequence[int]) -> bool:
+    """Return True if *needle* appears as a contiguous subsequence of *haystack*."""
+    if not needle:
+        return True
+    n = len(needle)
+    first = needle[0]
+    for i, tok in enumerate(haystack):
+        if tok == first and len(haystack) - i >= n and list(haystack[i : i + n]) == list(needle):
+            return True
+    return False
+
+
+class ParquetSegmentReader:
+    """DuckDB reader over a parquet segment token store.
+
+    Not thread-safe (one DuckDB connection); create one reader per thread if
+    needed. All I/O goes through the ``Storage`` protocol.
+    """
+
+    def __init__(self, storage_or_log_path: Storage | str | Path) -> None:
+        if isinstance(storage_or_log_path, (str, Path)):
+            self._storage: Storage = storage_from_uri(str(storage_or_log_path))
+        else:
+            self._storage = storage_or_log_path
+        self._conn: duckdb.DuckDBPyConnection | None = None
+        self._registered: set[str] = set()
+
+    # --- Connection / registration ---
+
+    def _connection(self) -> duckdb.DuckDBPyConnection:
+        if self._conn is None:
+            duckdb = _require_duckdb()
+            import pyarrow as pa
+
+            from tinker_cookbook.tokendb.schema import arrow_schema
+
+            conn = duckdb.connect(":memory:")
+            empty = pa.Table.from_pylist([], schema=arrow_schema())
+            conn.register("_empty_segment", empty)
+            conn.execute("CREATE TABLE segment_rows AS SELECT * FROM _empty_segment")
+            conn.unregister("_empty_segment")
+            self._create_views(conn)
+            self._conn = conn
+        return self._conn
+
+    def _create_views(self, conn: duckdb.DuckDBPyConnection) -> None:
+        # All rows, tagged: `superseded` is true when a later run_attempt
+        # produced rows for the same (split, iteration). Both attempts are
+        # shown by default (decision: superseded rows are tagged, not hidden).
+        conn.execute(
+            """
+            CREATE VIEW rollouts AS
+            SELECT *,
+                   run_attempt < max(run_attempt) OVER (PARTITION BY split, iteration)
+                       AS superseded
+            FROM segment_rows
+            """
+        )
+        # Dedup convenience: only the latest attempt per (split, iteration).
+        conn.execute("CREATE VIEW rollouts_latest AS SELECT * FROM rollouts WHERE NOT superseded")
+        # Trajectory grain.
+        conn.execute(
+            """
+            CREATE VIEW trajectories AS
+            SELECT run_id, run_attempt, split, iteration, group_idx, traj_idx,
+                   count(*) AS n_steps,
+                   sum(len(ac_tokens)) AS n_ac_tokens,
+                   any_value(total_reward) AS total_reward,
+                   any_value(final_reward) AS final_reward,
+                   arg_max(stop_reason, step_idx) AS stop_reason,
+                   any_value(filtered_reason) AS filtered_reason,
+                   any_value(env_row_id) AS env_row_id,
+                   min(ts) AS ts
+            FROM segment_rows
+            GROUP BY run_id, run_attempt, split, iteration, group_idx, traj_idx
+            """
+        )
+
+    def _list_segment_files(self) -> list[str]:
+        return sorted(
+            name
+            for name in self._storage.list_dir(SEGMENTS_DIR)
+            if name.endswith(".parquet") and name not in self._registered
+        )
+
+    def _load_segment_table(self, name: str) -> Any:
+        import pyarrow.parquet as pq
+
+        data = self._storage.read(f"{SEGMENTS_DIR}/{name}")
+        return pq.read_table(io.BytesIO(data))
+
+    def refresh(self) -> list[str]:
+        """Register segment files that appeared since the last refresh.
+
+        The directory listing is the source of truth (manifests are only a
+        hint); segments are immutable, so already-registered files never need
+        invalidation. Returns the newly registered file names.
+        """
+        conn = self._connection()
+        new_files = self._list_segment_files()
+        for name in new_files:
+            table = self._load_segment_table(name)
+            conn.register("_new_segment", table)
+            conn.execute("INSERT INTO segment_rows SELECT * FROM _new_segment")
+            conn.unregister("_new_segment")
+            self._registered.add(name)
+        return new_files
+
+    # --- Structured query ---
+
+    def _build_where(
+        self,
+        *,
+        run_id: str | None = None,
+        run_attempt: int | None = None,
+        split: str | None = None,
+        iteration: int | None = None,
+        min_iteration: int | None = None,
+        max_iteration: int | None = None,
+        group_idx: int | None = None,
+        traj_idx: int | None = None,
+        min_reward: float | None = None,
+        max_reward: float | None = None,
+        stop_reason: str | None = None,
+        source: str | None = None,
+        filtered_reason: str | None = None,
+        tag: str | None = None,
+        env_row_id: str | None = None,
+        text_regex: str | None = None,
+    ) -> tuple[str, list[Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        for column, value in [
+            ("run_id", run_id),
+            ("run_attempt", run_attempt),
+            ("split", split),
+            ("iteration", iteration),
+            ("group_idx", group_idx),
+            ("traj_idx", traj_idx),
+            ("stop_reason", stop_reason),
+            ("source", source),
+            ("filtered_reason", filtered_reason),
+            ("env_row_id", env_row_id),
+        ]:
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        if min_iteration is not None:
+            clauses.append("iteration >= ?")
+            params.append(min_iteration)
+        if max_iteration is not None:
+            clauses.append("iteration <= ?")
+            params.append(max_iteration)
+        if min_reward is not None:
+            clauses.append("total_reward >= ?")
+            params.append(min_reward)
+        if max_reward is not None:
+            clauses.append("total_reward <= ?")
+            params.append(max_reward)
+        if tag is not None:
+            clauses.append("list_contains(tags, ?)")
+            params.append(tag)
+        if text_regex is not None:
+            clauses.append(
+                "(regexp_matches(coalesce(ob_text, ''), ?)"
+                " OR regexp_matches(coalesce(ac_text, ''), ?))"
+            )
+            params.extend([text_regex, text_regex])
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        return where, params
+
+    def query(
+        self,
+        *,
+        latest_only: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
+        **filters: Any,
+    ) -> list[dict[str, Any]]:
+        """Structured row query over the ``rollouts`` view.
+
+        Filters (all optional, ANDed): ``run_id``, ``run_attempt``, ``split``,
+        ``iteration``, ``min_iteration`` / ``max_iteration``, ``group_idx``,
+        ``traj_idx``, ``min_reward`` / ``max_reward`` (over ``total_reward``),
+        ``stop_reason``, ``source``, ``filtered_reason``, ``tag`` (tags list
+        contains), ``env_row_id``, ``text_regex`` (over ``ob_text`` /
+        ``ac_text``). ``latest_only=True`` queries ``rollouts_latest``
+        (dropping attempts superseded by a resume). Rows are ordered by
+        ``(iteration, ts)`` and include the computed ``superseded`` flag.
+        """
+        self.refresh()
+        where, params = self._build_where(**filters)
+        view = "rollouts_latest" if latest_only else "rollouts"
+        sql = f"SELECT * FROM {view} {where} ORDER BY iteration, ts, group_idx, traj_idx, step_idx"
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        if offset:
+            sql += f" OFFSET {int(offset)}"
+        return self._fetch(sql, params)
+
+    def _fetch(self, sql: str, params: Sequence[Any] = ()) -> list[dict[str, Any]]:
+        conn = self._connection()
+        return _result_to_dicts(conn.execute(sql, list(params)))
+
+    def get_rollout(
+        self,
+        split: str,
+        iteration: int,
+        group_idx: int,
+        traj_idx: int,
+        run_attempt: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch the full trajectory: all step rows ordered by ``step_idx``.
+
+        ``run_attempt=None`` selects the latest attempt that produced rows for
+        this trajectory. Delta-encoded observations are returned as stored;
+        use :func:`reconstruct_full_ob` to expand them.
+        """
+        self.refresh()
+        params: list[Any] = [split, iteration, group_idx, traj_idx]
+        sql = """
+            SELECT * FROM rollouts
+            WHERE split = ? AND iteration = ? AND group_idx = ? AND traj_idx = ?
+        """
+        if run_attempt is None:
+            sql += """
+              AND run_attempt = (
+                  SELECT max(run_attempt) FROM rollouts
+                  WHERE split = ? AND iteration = ? AND group_idx = ? AND traj_idx = ?
+              )
+            """
+            params += [split, iteration, group_idx, traj_idx]
+        else:
+            sql += " AND run_attempt = ?"
+            params.append(run_attempt)
+        sql += " ORDER BY step_idx"
+        return self._fetch(sql, params)
+
+    # --- Search ---
+
+    def search(
+        self,
+        *,
+        regex: str | None = None,
+        fields: Sequence[str] = ("ac_text", "ob_text"),
+        token_subsequence: Sequence[int] | None = None,
+        limit: int | None = None,
+        **filters: Any,
+    ) -> list[dict[str, Any]]:
+        """Search rows by text regex and/or token-ID subsequence.
+
+        ``regex`` matches over the given text ``fields`` (any of ``ac_text``,
+        ``ob_text``, ``metrics``, ``logs``). ``token_subsequence`` matches a
+        contiguous run of token IDs inside ``ac_tokens`` (useful for special
+        tokens with unstable decodings). Additional structured ``filters`` are
+        the same as :meth:`query`. Results are ordered by ``(iteration, ts)``.
+        """
+        allowed_fields = {"ac_text", "ob_text", "metrics", "logs"}
+        bad = set(fields) - allowed_fields
+        if bad:
+            raise ValueError(f"Unsupported search fields: {sorted(bad)}")
+        self.refresh()
+        where, params = self._build_where(**filters)
+        clauses = [where[len("WHERE ") :]] if where else []
+        if regex is not None:
+            field_matches = [f"regexp_matches(coalesce({f}, ''), ?)" for f in fields]
+            clauses.append(f"({' OR '.join(field_matches)})")
+            params.extend([regex] * len(fields))
+        if token_subsequence:
+            # Cheap SQL prefilter on the first token; the exact contiguous
+            # match runs in Python below (portable across backends).
+            clauses.append("list_contains(ac_tokens, ?)")
+            params.append(int(token_subsequence[0]))
+        sql = "SELECT * FROM rollouts"
+        if clauses:
+            sql += f" WHERE {' AND '.join(clauses)}"
+        sql += " ORDER BY iteration, ts, group_idx, traj_idx, step_idx"
+        rows = self._fetch(sql, params)
+        if token_subsequence:
+            needle = [int(t) for t in token_subsequence]
+            rows = [row for row in rows if _contains_subsequence(row["ac_tokens"], needle)]
+        if limit is not None:
+            rows = rows[: int(limit)]
+        return rows
+
+    def search_hit_counts(self, **search_kwargs: Any) -> dict[int, int]:
+        """Grouped-by-iteration hit counts for a :meth:`search` call."""
+        counts: dict[int, int] = {}
+        for row in self.search(**search_kwargs):
+            counts[row["iteration"]] = counts.get(row["iteration"], 0) + 1
+        return counts
+
+    # --- Labels ---
+
+    def add_label(
+        self,
+        key: Mapping[str, Any],
+        label_key: str,
+        label_value: Any,
+        *,
+        author: str,
+        note: str | None = None,
+    ) -> None:
+        """Append an annotation to ``labels.jsonl`` (last-write-wins by ``ts``).
+
+        Args:
+            key: Rollout identity — any of ``run_id``, ``split``,
+                ``iteration``, ``group_idx``, ``traj_idx``, ``step_idx``
+                (``step_idx`` omitted/None means the whole trajectory).
+            label_key: Label name (e.g. ``"quality"``).
+            label_value: JSON-serializable value; ``None`` writes a tombstone
+                that deletes the label.
+            author: Who wrote the label (user name, ``"agent"``, ...).
+            note: Optional free-form note.
+        """
+        bad_keys = set(key) - set(_LABEL_KEY_FIELDS)
+        if bad_keys:
+            raise ValueError(f"Unsupported label key fields: {sorted(bad_keys)}")
+        record: dict[str, Any] = {field: key.get(field) for field in _LABEL_KEY_FIELDS}
+        record.update(
+            {
+                "label_key": label_key,
+                "label_value": label_value,
+                "author": author,
+                "ts": datetime.now(UTC).isoformat(),
+                "note": note,
+            }
+        )
+        self._storage.append(LABELS_PATH, (json.dumps(record, default=str) + "\n").encode())
+
+    def _refresh_labels_source(self, conn: duckdb.DuckDBPyConnection) -> None:
+        """(Re)create the ``labels`` view over the current ``labels.jsonl``.
+
+        Labels are append-only and written by other processes, so the source
+        is re-resolved on every read. For a local store the view reads the
+        file directly via ``read_json``; otherwise the file is fetched through
+        ``Storage`` and registered as an in-memory table.
+        """
+        conn.execute("DROP VIEW IF EXISTS labels")
+        if not self._storage.exists(LABELS_PATH):
+            conn.execute(
+                "CREATE VIEW labels AS SELECT"
+                " NULL::VARCHAR AS run_id, NULL::VARCHAR AS split,"
+                " NULL::INTEGER AS iteration, NULL::INTEGER AS group_idx,"
+                " NULL::INTEGER AS traj_idx, NULL::INTEGER AS step_idx,"
+                " NULL::VARCHAR AS label_key, NULL::JSON AS label_value,"
+                " NULL::VARCHAR AS author, NULL::TIMESTAMP AS ts, NULL::VARCHAR AS note"
+                " WHERE false"
+            )
+            return
+        if isinstance(self._storage, LocalStorage):
+            path = str(self._storage.root / LABELS_PATH).replace("'", "''")
+            source = (
+                f"read_json('{path}', format = 'newline_delimited', columns = {_LABEL_COLUMNS_SQL})"
+            )
+        else:
+            records = [
+                json.loads(line)
+                for line in self._storage.read(LABELS_PATH).decode().splitlines()
+                if line.strip()
+            ]
+            import pyarrow as pa
+
+            table = pa.Table.from_pylist(
+                [
+                    {
+                        **{field: rec.get(field) for field in _LABEL_KEY_FIELDS},
+                        "label_key": rec.get("label_key"),
+                        "label_value": json.dumps(rec.get("label_value")),
+                        "author": rec.get("author"),
+                        "ts": rec.get("ts"),
+                        "note": rec.get("note"),
+                    }
+                    for rec in records
+                ]
+            )
+            conn.register("_labels_raw", table)
+            source = (
+                "(SELECT run_id, split, iteration::INTEGER AS iteration,"
+                " group_idx::INTEGER AS group_idx, traj_idx::INTEGER AS traj_idx,"
+                " step_idx::INTEGER AS step_idx, label_key, label_value::JSON AS label_value,"
+                " author, ts::TIMESTAMP AS ts, note FROM _labels_raw)"
+            )
+        # Last write (by ts) wins per (identity, label_key); tombstones
+        # (null label_value) win first, then drop out of the view.
+        conn.execute(
+            f"""
+            CREATE VIEW labels AS
+            SELECT * EXCLUDE (_rank) FROM (
+                SELECT *,
+                       row_number() OVER (
+                           PARTITION BY run_id, split, iteration, group_idx, traj_idx,
+                                        step_idx, label_key
+                           ORDER BY ts DESC
+                       ) AS _rank
+                FROM {source}
+            )
+            WHERE _rank = 1
+              AND label_value IS NOT NULL
+              AND CAST(label_value AS VARCHAR) <> 'null'
+            """
+        )
+
+    def labels(self, **filters: Any) -> list[dict[str, Any]]:
+        """Fetch current labels (after last-write-wins and tombstone filtering).
+
+        Filters: ``run_id``, ``split``, ``iteration``, ``group_idx``,
+        ``traj_idx``, ``step_idx``, ``label_key``, ``author``. Returned
+        ``label_value`` is decoded back to a Python value.
+        """
+        allowed = set(_LABEL_KEY_FIELDS) | {"label_key", "author"}
+        bad = set(filters) - allowed
+        if bad:
+            raise ValueError(f"Unsupported label filters: {sorted(bad)}")
+        conn = self._connection()
+        self._refresh_labels_source(conn)
+        clauses: list[str] = []
+        params: list[Any] = []
+        for column, value in filters.items():
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        sql = "SELECT * FROM labels"
+        if clauses:
+            sql += f" WHERE {' AND '.join(clauses)}"
+        sql += " ORDER BY ts"
+        rows = self._fetch(sql, params)
+        for row in rows:
+            row["label_value"] = json.loads(row["label_value"])
+        return rows
+
+    # --- Live tail ---
+
+    async def subscribe(
+        self,
+        *,
+        poll_interval_s: float = DEFAULT_SUBSCRIBE_POLL_INTERVAL_S,
+        **filters: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield rows from segment files written after the subscription starts.
+
+        Polls the segments directory every ``poll_interval_s`` seconds for new
+        files (segments are immutable, so a new file is the unit of new data)
+        and yields its rows that match ``filters`` (same as :meth:`query`),
+        ordered by ``(iteration, ts)`` within each batch. Runs until the
+        caller stops iterating.
+        """
+        # Baseline: everything already on disk is "old".
+        await asyncio.to_thread(self.refresh)
+        where, params = self._build_where(**filters)
+        conn = self._connection()
+        while True:
+            await asyncio.sleep(poll_interval_s)
+            new_files = await asyncio.to_thread(self._list_segment_files)
+            for name in sorted(new_files):
+                table = await asyncio.to_thread(self._load_segment_table, name)
+                conn.register("_new_segment", table)
+                conn.execute("INSERT INTO segment_rows SELECT * FROM _new_segment")
+                rows = _result_to_dicts(
+                    conn.execute(
+                        f"SELECT * FROM _new_segment {where}"
+                        " ORDER BY iteration, ts, group_idx, traj_idx, step_idx",
+                        params,
+                    )
+                )
+                conn.unregister("_new_segment")
+                self._registered.add(name)
+                for row in rows:
+                    yield row
+
+    # --- Backend-specific escape hatch (not part of TokenStoreBackend) ---
+
+    def sql(self, query: str, params: Sequence[Any] | None = None) -> list[dict[str, Any]]:
+        """Run a read-only DuckDB SQL query over the store's views.
+
+        Available relations: ``segment_rows`` (raw), ``rollouts``,
+        ``rollouts_latest``, ``trajectories``, ``labels``. Only a single
+        ``SELECT`` (or ``WITH ... SELECT``) statement is allowed; anything
+        else is rejected. Prefer ``?`` placeholders with *params* over string
+        interpolation.
+        """
+        duckdb = _require_duckdb()
+        conn = self._connection()
+        self.refresh()
+        self._refresh_labels_source(conn)
+        statements = conn.extract_statements(query)
+        if len(statements) != 1:
+            raise ValueError("sql() accepts exactly one statement")
+        if statements[0].type != duckdb.StatementType.SELECT:
+            raise ValueError(f"sql() only accepts SELECT statements, got {statements[0].type}")
+        return self._fetch(query, params or [])
+
+
+class TokenDB:
+    """Thin facade over a token store backend for agent/programmatic access.
+
+    ``TokenDB(log_path)`` opens the default :class:`ParquetSegmentBackend` for
+    that run's log directory (local path or cloud URI). All methods delegate
+    to the backend's structured read half; :meth:`sql` is the backend-specific
+    escape hatch (SELECT-only) and is not part of the portable protocol.
+    """
+
+    def __init__(self, log_path_or_backend: str | Path | Storage | ParquetSegmentBackend) -> None:
+        if isinstance(log_path_or_backend, ParquetSegmentBackend):
+            self._backend = log_path_or_backend
+        else:
+            self._backend = ParquetSegmentBackend(log_path_or_backend)
+
+    def query(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """See :meth:`ParquetSegmentReader.query`."""
+        return self._backend.query(**kwargs)
+
+    def get_rollout(
+        self,
+        split: str,
+        iteration: int,
+        group_idx: int,
+        traj_idx: int,
+        run_attempt: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """See :meth:`ParquetSegmentReader.get_rollout`."""
+        return self._backend.get_rollout(split, iteration, group_idx, traj_idx, run_attempt)
+
+    def search(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """See :meth:`ParquetSegmentReader.search`."""
+        return self._backend.search(**kwargs)
+
+    def search_hit_counts(self, **kwargs: Any) -> dict[int, int]:
+        """See :meth:`ParquetSegmentReader.search_hit_counts`."""
+        return self._backend.search_hit_counts(**kwargs)
+
+    def add_label(
+        self,
+        key: Mapping[str, Any],
+        label_key: str,
+        label_value: Any,
+        *,
+        author: str,
+        note: str | None = None,
+    ) -> None:
+        """See :meth:`ParquetSegmentReader.add_label`."""
+        self._backend.add_label(key, label_key, label_value, author=author, note=note)
+
+    def labels(self, **filters: Any) -> list[dict[str, Any]]:
+        """See :meth:`ParquetSegmentReader.labels`."""
+        return self._backend.labels(**filters)
+
+    def iter_new(self, **kwargs: Any) -> AsyncIterator[dict[str, Any]]:
+        """Async iterator over newly written rows; see
+        :meth:`ParquetSegmentReader.subscribe`."""
+        return self._backend.subscribe(**kwargs)
+
+    def sql(self, query: str, params: Sequence[Any] | None = None) -> list[dict[str, Any]]:
+        """Backend-specific SQL escape hatch (SELECT-only); see
+        :meth:`ParquetSegmentReader.sql`."""
+        return self._backend.sql(query, params)

--- a/tinker_cookbook/tokendb/reader_test.py
+++ b/tinker_cookbook/tokendb/reader_test.py
@@ -1,0 +1,473 @@
+"""Tests for the token DB read path (DuckDB reader + TokenDB facade)."""
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyarrow")
+pytest.importorskip("duckdb")
+
+from tinker_cookbook.stores.storage import LocalStorage
+from tinker_cookbook.tokendb.reader import (
+    LABELS_PATH,
+    ParquetSegmentReader,
+    TokenDB,
+    reconstruct_full_ob,
+)
+from tinker_cookbook.tokendb.schema import TokenRow, compute_ob_delta
+from tinker_cookbook.tokendb.writer import ParquetSegmentBackend, TokenDbWriter
+
+
+def make_row(**overrides) -> TokenRow:
+    defaults: dict = {
+        "split": "train",
+        "iteration": 0,
+        "group_idx": 0,
+        "traj_idx": 0,
+        "step_idx": 0,
+        "ob_tokens": [1, 2, 3],
+        "ac_tokens": [4, 5],
+    }
+    defaults.update(overrides)
+    return TokenRow(**defaults)
+
+
+def write_label_line(log_path: Path, **fields) -> None:
+    record = {
+        "run_id": None,
+        "split": None,
+        "iteration": None,
+        "group_idx": None,
+        "traj_idx": None,
+        "step_idx": None,
+        "label_key": None,
+        "label_value": None,
+        "author": None,
+        "ts": datetime.now(UTC).isoformat(),
+        "note": None,
+    }
+    record.update(fields)
+    path = log_path / LABELS_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def make_multistep_trajectory(
+    split: str, iteration: int, group_idx: int, traj_idx: int, **overrides
+) -> list[TokenRow]:
+    """A 3-step trajectory with delta-encoded obs (step 2 is a non-prefix reset)."""
+    obs_full = [
+        [10, 11, 12],
+        [10, 11, 12, 20, 21, 30],  # prefix extension of step-0 ob + ac
+        [99, 98],  # non-prefix reset
+    ]
+    acs = [[20, 21], [40, 41], [50]]
+    rows = []
+    prev_sequence: list[int] = []
+    for step_idx, (ob, ac) in enumerate(zip(obs_full, acs)):
+        stored_ob, is_delta = compute_ob_delta(prev_sequence, ob)
+        rows.append(
+            make_row(
+                split=split,
+                iteration=iteration,
+                group_idx=group_idx,
+                traj_idx=traj_idx,
+                step_idx=step_idx,
+                ob_tokens=stored_ob,
+                ob_is_delta=is_delta,
+                ac_tokens=ac,
+                **overrides,
+            )
+        )
+        prev_sequence = ob + ac
+    return rows
+
+
+@pytest.fixture
+def populated_store(tmp_path: Path) -> Path:
+    """A store with two writers, two run attempts, delta obs, filtered rows, labels."""
+    log_path = tmp_path / "run"
+    # Coordinator writer, attempt 1.
+    with TokenDbWriter(log_path, context={"model_name": "test-model"}) as writer_a:
+        writer_a.append_rows(
+            [
+                make_row(
+                    iteration=0,
+                    group_idx=0,
+                    traj_idx=0,
+                    ob_tokens=[1, 2],
+                    ac_tokens=[3, 4, 5],
+                    ac_logprobs=[-0.1, -0.2, -0.3],
+                    stop_reason="stop_token",
+                    total_reward=1.0,
+                    final_reward=1.0,
+                    tags=["easy", "math"],
+                    env_row_id="row-42",
+                    ob_text="what is 2+2",
+                    ac_text="the answer is 4",
+                ),
+                make_row(
+                    iteration=0,
+                    group_idx=0,
+                    traj_idx=1,
+                    ac_tokens=[7, 8],
+                    stop_reason="length",
+                    total_reward=-1.0,
+                    final_reward=-1.0,
+                    ac_text="i give up",
+                ),
+                make_row(
+                    iteration=1,
+                    group_idx=0,
+                    traj_idx=0,
+                    source="filtered",
+                    filtered_reason="constant_reward",
+                    ac_text="all same reward",
+                ),
+                make_row(
+                    iteration=2,
+                    group_idx=0,
+                    traj_idx=0,
+                    total_reward=0.5,
+                    ac_text="attempt one answer",
+                ),
+            ]
+            + make_multistep_trajectory("train", 0, 1, 0, total_reward=2.0, final_reward=2.0)
+        )
+        run_id = writer_a.run_id
+        # Second writer (worker): explicit identity, same attempt.
+        with TokenDbWriter(
+            log_path,
+            context={"run_id": run_id, "run_attempt": writer_a.run_attempt},
+        ) as writer_b:
+            writer_b.append_rows(
+                [
+                    make_row(
+                        iteration=0,
+                        group_idx=2,
+                        traj_idx=0,
+                        split="test",
+                        ac_text="eval rollout",
+                        total_reward=3.0,
+                    )
+                ]
+            )
+    # Coordinator resume: attempt 2 re-runs iteration 2.
+    with TokenDbWriter(log_path, context={"model_name": "test-model"}) as writer_c:
+        assert writer_c.run_attempt == 2
+        writer_c.append_rows(
+            [make_row(iteration=2, group_idx=0, traj_idx=0, ac_text="attempt two answer")]
+        )
+    # Labels: one overwritten value, one tombstoned key.
+    base_key = {"run_id": run_id, "split": "train", "iteration": 0, "group_idx": 0, "traj_idx": 0}
+    write_label_line(
+        log_path,
+        **base_key,
+        label_key="quality",
+        label_value="bad",
+        author="alice",
+        ts="2026-07-11T00:00:00+00:00",
+    )
+    write_label_line(
+        log_path,
+        **base_key,
+        label_key="quality",
+        label_value="good",
+        author="bob",
+        ts="2026-07-11T01:00:00+00:00",
+    )
+    write_label_line(
+        log_path,
+        **base_key,
+        label_key="flagged",
+        label_value=True,
+        author="alice",
+        ts="2026-07-11T00:30:00+00:00",
+    )
+    write_label_line(
+        log_path,
+        **base_key,
+        label_key="flagged",
+        label_value=None,  # tombstone
+        author="alice",
+        ts="2026-07-11T02:00:00+00:00",
+    )
+    return log_path
+
+
+class TestIncrementalRegistration:
+    def test_picks_up_segments_written_after_construction(self, populated_store: Path):
+        reader = ParquetSegmentReader(populated_store)
+        n_before = len(reader.query())
+        assert n_before > 0
+        with TokenDbWriter(populated_store, context={}) as writer:
+            writer.append_rows([make_row(iteration=10, ac_text="late row")])
+        rows = reader.query(iteration=10)
+        assert len(rows) == 1
+        assert rows[0]["ac_text"] == "late row"
+        assert len(reader.query()) == n_before + 1
+
+    def test_refresh_registers_each_file_once(self, populated_store: Path):
+        reader = ParquetSegmentReader(populated_store)
+        first = reader.refresh()
+        assert len(first) > 0
+        assert reader.refresh() == []
+
+
+class TestQueryFilters:
+    @pytest.fixture
+    def db(self, populated_store: Path) -> TokenDB:
+        return TokenDB(populated_store)
+
+    def test_multi_writer_rows_merge(self, db: TokenDB):
+        writer_ids = {row["writer_id"] for row in db.query()}
+        assert len(writer_ids) == 3  # coordinator, worker, resume
+
+    def test_split_filter(self, db: TokenDB):
+        rows = db.query(split="test")
+        assert len(rows) == 1
+        assert rows[0]["ac_text"] == "eval rollout"
+
+    def test_iteration_range(self, db: TokenDB):
+        rows = db.query(min_iteration=1, max_iteration=2)
+        assert rows
+        assert all(1 <= row["iteration"] <= 2 for row in rows)
+
+    def test_exact_iteration_and_group_traj(self, db: TokenDB):
+        rows = db.query(iteration=0, group_idx=0, traj_idx=1)
+        assert len(rows) == 1
+        assert rows[0]["ac_text"] == "i give up"
+
+    def test_reward_range(self, db: TokenDB):
+        rows = db.query(min_reward=0.9, max_reward=2.5)
+        assert rows
+        assert all(0.9 <= row["total_reward"] <= 2.5 for row in rows)
+
+    def test_stop_reason(self, db: TokenDB):
+        rows = db.query(stop_reason="length")
+        assert len(rows) == 1
+        assert rows[0]["traj_idx"] == 1
+
+    def test_source_and_filtered_reason(self, db: TokenDB):
+        rows = db.query(source="filtered")
+        assert len(rows) == 1
+        assert rows[0]["filtered_reason"] == "constant_reward"
+        assert db.query(filtered_reason="constant_reward") == rows
+
+    def test_tag_contains(self, db: TokenDB):
+        rows = db.query(tag="math")
+        assert len(rows) == 1
+        assert rows[0]["env_row_id"] == "row-42"
+
+    def test_env_row_id(self, db: TokenDB):
+        rows = db.query(env_row_id="row-42")
+        assert len(rows) == 1
+
+    def test_run_attempt_filter(self, db: TokenDB):
+        rows = db.query(iteration=2, run_attempt=1)
+        assert [row["ac_text"] for row in rows] == ["attempt one answer"]
+
+    def test_text_regex(self, db: TokenDB):
+        rows = db.query(text_regex=r"answer is \d")
+        assert len(rows) == 1
+        assert rows[0]["ac_text"] == "the answer is 4"
+        # Regex also matches over ob_text.
+        assert len(db.query(text_regex=r"2\+2")) == 1
+
+    def test_limit_offset_and_ordering(self, db: TokenDB):
+        rows = db.query()
+        assert [r["iteration"] for r in rows] == sorted(r["iteration"] for r in rows)
+        page = db.query(limit=2, offset=1)
+        assert page == rows[1:3]
+
+    def test_run_id_filter(self, db: TokenDB):
+        run_id = db.query()[0]["run_id"]
+        assert len(db.query(run_id=run_id)) == len(db.query())
+        assert db.query(run_id="nonexistent") == []
+
+
+class TestSuperseded:
+    def test_superseded_flag_and_latest_view(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        rows = db.query(iteration=2)
+        assert {row["ac_text"]: row["superseded"] for row in rows} == {
+            "attempt one answer": True,
+            "attempt two answer": False,
+        }
+        # Rows at (train, 0) were only produced by attempt 1: not superseded.
+        assert all(not row["superseded"] for row in db.query(iteration=0))
+        latest = db.query(iteration=2, latest_only=True)
+        assert [row["ac_text"] for row in latest] == ["attempt two answer"]
+
+    def test_trajectories_view(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        rows = db.sql(
+            "SELECT * FROM trajectories WHERE split='train' AND iteration=0 AND group_idx=1"
+        )
+        assert len(rows) == 1
+        traj = rows[0]
+        assert traj["n_steps"] == 3
+        assert traj["n_ac_tokens"] == 5  # 2 + 2 + 1
+        assert traj["total_reward"] == pytest.approx(2.0)
+
+
+class TestGetRollout:
+    def test_ordering_and_delta_reconstruction(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        rows = db.get_rollout("train", 0, 1, 0)
+        assert [row["step_idx"] for row in rows] == [0, 1, 2]
+        assert rows[1]["ob_is_delta"] is True
+        assert rows[2]["ob_is_delta"] is False
+        full_obs = reconstruct_full_ob(rows)
+        assert full_obs == [
+            [10, 11, 12],
+            [10, 11, 12, 20, 21, 30],
+            [99, 98],
+        ]
+
+    def test_defaults_to_latest_attempt(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        rows = db.get_rollout("train", 2, 0, 0)
+        assert [row["ac_text"] for row in rows] == ["attempt two answer"]
+        rows_v1 = db.get_rollout("train", 2, 0, 0, run_attempt=1)
+        assert [row["ac_text"] for row in rows_v1] == ["attempt one answer"]
+
+    def test_missing_rollout_is_empty(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        assert db.get_rollout("train", 999, 0, 0) == []
+
+
+class TestSearch:
+    def test_regex_search(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        rows = db.search(regex=r"give up")
+        assert len(rows) == 1
+        assert rows[0]["traj_idx"] == 1
+        # Restricting fields to ob_text misses an ac_text-only match.
+        assert db.search(regex=r"give up", fields=["ob_text"]) == []
+
+    def test_bad_field_rejected(self, populated_store: Path):
+        with pytest.raises(ValueError, match="Unsupported search fields"):
+            TokenDB(populated_store).search(regex="x", fields=["ac_tokens"])
+
+    def test_token_subsequence(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        rows = db.search(token_subsequence=[4, 5])
+        assert len(rows) >= 1
+        assert all(
+            any(row["ac_tokens"][i : i + 2] == [4, 5] for i in range(len(row["ac_tokens"])))
+            for row in rows
+        )
+        # Present individually but never contiguous in this order.
+        assert db.search(token_subsequence=[5, 3]) == []
+        # Contiguity check: [3, 5] never adjacent even though both in [3, 4, 5].
+        assert db.search(token_subsequence=[3, 5]) == []
+
+    def test_hit_counts_grouped_by_iteration(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        counts = db.search_hit_counts(regex=r"answer")
+        assert counts == {0: 1, 2: 2}
+
+
+class TestLabels:
+    def test_last_write_wins_and_tombstone(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        labels = db.labels()
+        assert len(labels) == 1  # "flagged" tombstoned; "quality" deduped
+        assert labels[0]["label_key"] == "quality"
+        assert labels[0]["label_value"] == "good"
+        assert labels[0]["author"] == "bob"
+        assert db.labels(label_key="flagged") == []
+
+    def test_add_label_roundtrip(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        key = {"split": "train", "iteration": 0, "group_idx": 0, "traj_idx": 1}
+        db.add_label(key, "verdict", {"score": 0.9}, author="agent", note="looks wrong")
+        labels = db.labels(label_key="verdict")
+        assert len(labels) == 1
+        assert labels[0]["label_value"] == {"score": 0.9}
+        assert labels[0]["author"] == "agent"
+        assert labels[0]["note"] == "looks wrong"
+        assert labels[0]["traj_idx"] == 1
+        # Tombstone through the API deletes it.
+        db.add_label(key, "verdict", None, author="agent")
+        assert db.labels(label_key="verdict") == []
+
+    def test_add_label_rejects_bad_key_fields(self, populated_store: Path):
+        with pytest.raises(ValueError, match="Unsupported label key"):
+            TokenDB(populated_store).add_label({"bogus": 1}, "k", "v", author="a")
+
+    def test_labels_before_any_label_file(self, tmp_path: Path):
+        log_path = tmp_path / "empty-run"
+        with TokenDbWriter(log_path, context={}) as writer:
+            writer.append_rows([make_row()])
+        assert TokenDB(log_path).labels() == []
+
+
+class TestSql:
+    def test_select_and_with_allowed(self, populated_store: Path):
+        db = TokenDB(populated_store)
+        rows = db.sql("SELECT count(*) AS n FROM rollouts WHERE split = ?", ["train"])
+        assert rows[0]["n"] > 0
+        rows = db.sql(
+            "WITH t AS (SELECT iteration FROM rollouts) SELECT max(iteration) AS m FROM t"
+        )
+        assert rows[0]["m"] == 2
+
+    @pytest.mark.parametrize(
+        "bad_sql",
+        [
+            "INSERT INTO segment_rows SELECT * FROM segment_rows",
+            "UPDATE segment_rows SET split = 'x'",
+            "DELETE FROM segment_rows",
+            "ATTACH ':memory:' AS other",
+            "COPY segment_rows TO '/tmp/out.parquet'",
+            "DROP VIEW rollouts",
+            "CREATE TABLE evil (x INT)",
+            "SELECT 1; SELECT 2",
+            "SELECT 1; DROP VIEW rollouts",
+        ],
+    )
+    def test_non_select_rejected(self, populated_store: Path, bad_sql: str):
+        db = TokenDB(populated_store)
+        with pytest.raises(ValueError, match="sql\\(\\)"):
+            db.sql(bad_sql)
+
+    def test_facade_from_backend(self, populated_store: Path):
+        backend = ParquetSegmentBackend(LocalStorage(populated_store))
+        db = TokenDB(backend)
+        assert db.query(split="test")
+
+
+class TestSubscribe:
+    def test_yields_rows_written_after_subscription(self, populated_store: Path):
+        async def run() -> list[dict]:
+            db = TokenDB(populated_store)
+            received: list[dict] = []
+
+            async def consume() -> None:
+                async for row in db.iter_new(poll_interval_s=0.05, split="train"):
+                    received.append(row)
+                    if len(received) >= 2:
+                        return
+
+            task = asyncio.create_task(consume())
+            await asyncio.sleep(0.15)  # let the subscriber take its baseline
+            with TokenDbWriter(populated_store, context={}) as writer:
+                writer.append_rows(
+                    [
+                        make_row(iteration=20, ac_text="live row 1"),
+                        make_row(iteration=21, ac_text="live row 2"),
+                        make_row(iteration=21, split="test", ac_text="filtered out"),
+                    ]
+                )
+            await asyncio.wait_for(task, timeout=5.0)
+            return received
+
+        received = asyncio.run(run())
+        assert [row["ac_text"] for row in received] == ["live row 1", "live row 2"]
+        assert all(row["split"] == "train" for row in received)

--- a/tinker_cookbook/tokendb/writer.py
+++ b/tinker_cookbook/tokendb/writer.py
@@ -254,8 +254,9 @@ class ParquetSegmentBackend:
     """Parquet-segments-through-``Storage`` implementation of ``TokenStoreBackend``.
 
     The default (v1) backend: the writer is a buffered segment flusher
-    (:class:`TokenDbWriter`); the read half (DuckDB over the segment glob)
-    arrives in a later phase.
+    (:class:`TokenDbWriter`); the read half is a DuckDB reader over the
+    segment files (:class:`~tinker_cookbook.tokendb.reader.ParquetSegmentReader`,
+    constructed lazily so the write path never needs duckdb).
     """
 
     def __init__(
@@ -271,6 +272,7 @@ class ParquetSegmentBackend:
             self._storage = storage_or_log_path
         self._buffer_rows = buffer_rows
         self._flush_interval_s = flush_interval_s
+        self._reader_instance: Any = None
 
     def open_writer(self, run_context: Mapping[str, Any]) -> TokenDbWriter:
         """See :meth:`TokenStoreBackend.open_writer`."""
@@ -281,23 +283,44 @@ class ParquetSegmentBackend:
             flush_interval_s=self._flush_interval_s,
         )
 
-    # --- Read half: implemented in a later phase. ---
+    # --- Read half: delegates to a lazily constructed DuckDB reader. ---
+
+    def _reader(self) -> Any:
+        """Return the (lazily constructed) DuckDB reader for this store."""
+        if self._reader_instance is None:
+            from tinker_cookbook.tokendb.reader import ParquetSegmentReader
+
+            self._reader_instance = ParquetSegmentReader(self._storage)
+        return self._reader_instance
 
     def query(self, **filters: Any) -> Any:
-        """See :meth:`TokenStoreBackend.query`."""
-        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+        """See :meth:`TokenStoreBackend.query` and
+        :meth:`~tinker_cookbook.tokendb.reader.ParquetSegmentReader.query`."""
+        return self._reader().query(**filters)
 
-    def get_rollout(self, split: str, iteration: int, group_idx: int, traj_idx: int) -> Any:
+    def get_rollout(
+        self,
+        split: str,
+        iteration: int,
+        group_idx: int,
+        traj_idx: int,
+        run_attempt: int | None = None,
+    ) -> Any:
         """See :meth:`TokenStoreBackend.get_rollout`."""
-        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+        return self._reader().get_rollout(split, iteration, group_idx, traj_idx, run_attempt)
 
-    def search(self, pattern: str, *, text_field: str = "ac_text") -> Any:
-        """See :meth:`TokenStoreBackend.search`."""
-        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+    def search(self, **kwargs: Any) -> Any:
+        """See :meth:`TokenStoreBackend.search` and
+        :meth:`~tinker_cookbook.tokendb.reader.ParquetSegmentReader.search`."""
+        return self._reader().search(**kwargs)
+
+    def search_hit_counts(self, **kwargs: Any) -> Any:
+        """Grouped-by-iteration hit counts for a :meth:`search` call."""
+        return self._reader().search_hit_counts(**kwargs)
 
     def subscribe(self, **filters: Any) -> Any:
         """See :meth:`TokenStoreBackend.subscribe`."""
-        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+        return self._reader().subscribe(**filters)
 
     def add_label(
         self,
@@ -309,8 +332,15 @@ class ParquetSegmentBackend:
         note: str | None = None,
     ) -> None:
         """See :meth:`TokenStoreBackend.add_label`."""
-        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+        self._reader().add_label(key, label_key, label_value, author=author, note=note)
 
     def labels(self, **filters: Any) -> Any:
         """See :meth:`TokenStoreBackend.labels`."""
-        raise NotImplementedError("ParquetSegmentBackend read path is not implemented yet")
+        return self._reader().labels(**filters)
+
+    # Backend-specific escape hatch, deliberately NOT part of TokenStoreBackend
+    # (SQL dialects differ across backends; the portable surface is above).
+
+    def sql(self, query: str, params: Sequence[Any] | None = None) -> Any:
+        """Read-only (SELECT-only) DuckDB SQL over this store's views."""
+        return self._reader().sql(query, params)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #821
* #820
* #819
* #818
* #817
* #816
* #815
* #814
* #813
* #812
* #811
* #810
* #809
* #808
* #807
* __->__ #806
* #805
* #804

Read side of the token store: an in-memory DuckDB reader over the immutable parquet
segments (read through the Storage protocol, so local and cloud log paths both work)
with incremental segment registration. Provides rollouts / rollouts_latest /
trajectories / labels views (including a computed superseded flag across run
attempts), structured query filters, full-rollout retrieval with delta-observation
reconstruction, regex and token-ID-subsequence search with per-iteration hit counts,
an append-only labels table with last-write-wins semantics, an async subscribe for
tailing new rollouts, and a TokenDB facade with a SELECT-only sql() escape hatch.