### PR TITLE
tokendb: chat agent with tokendb tools and generated live visuals

### DIFF
--- a/tinker_cookbook/tokendb/README.md
+++ b/tinker_cookbook/tokendb/README.md
@@ -68,8 +68,10 @@ The viewer has a chat mode: ask questions about your training data in plain lang
 
 To enable it, give the server an API key for one of the supported providers:
 
-- Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` in the server's environment, or
+- Set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `TINKER_API_KEY` in the server's environment, or
 - Configure the provider, model, and key at runtime in the UI settings (backed by `POST /api/agent/config`; the key is held in server memory only and is never written to disk or returned by the API).
+
+The `tinker` provider runs the agent on any model served by Tinker: the model dropdown is populated from `get_server_capabilities().supported_models` (fetched lazily and cached, so it needs `TINKER_API_KEY`), prompts are built with the model's recommended renderer, and tool calls use the renderer's native tool-call format when it has one (Qwen3, DeepSeek, Kimi, GPT-OSS, ...). For models whose renderer has no tool convention, the agent falls back to a documented JSON-in-text protocol (a fenced ```` ```json {"tool": ..., "arguments": ...}```` block).
 
 Published visuals are single HTML files with inline JS/SVG (no external CDNs). For live views the visual polls the read-only SQL endpoint on an interval and re-renders in place, so a chart of, say, reward by iteration keeps updating while training runs. The files are standalone and shareable.
 

--- a/tinker_cookbook/tokendb/README.md
+++ b/tinker_cookbook/tokendb/README.md
@@ -62,6 +62,19 @@ In registry mode the server exposes:
 
 Pointing the server at a specific `log_path` still works exactly as before and does not need the registry.
 
+## Chat
+
+The viewer has a chat mode: ask questions about your training data in plain language and an LLM agent answers by querying the token DB for you. No SQL required. The agent can run read-only DuckDB queries (`sql`), search by regex or token-ID subsequence (`search`), pull whole trajectories (`get_rollout`), and publish self-contained HTML visuals (`publish_visual`) that render inline in the chat and in a gallery. In registry mode there is also a global cross-run chat (with `list_runs` and `dashboard` tools for comparing experiments) alongside the per-run chats.
+
+To enable it, give the server an API key for one of the supported providers:
+
+- Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` in the server's environment, or
+- Configure the provider, model, and key at runtime in the UI settings (backed by `POST /api/agent/config`; the key is held in server memory only and is never written to disk or returned by the API).
+
+Published visuals are single HTML files with inline JS/SVG (no external CDNs). For live views the visual polls the read-only SQL endpoint on an interval and re-renders in place, so a chart of, say, reward by iteration keeps updating while training runs. The files are standalone and shareable.
+
+On-disk layout: conversations are appended as JSONL to `{log_path}/tokens/chats/{conversation_id}.jsonl` and visuals are written to `{log_path}/tokens/visuals/`. The registry-level chat stores both under the registry directory (`chats/` and `visuals/`) instead. Like everything else, this goes through the `Storage` protocol, so cloud `log_path`s work.
+
 ## Python API
 
 No server needed. `TokenDB` reads the segment files directly:

--- a/tinker_cookbook/tokendb/agent.py
+++ b/tinker_cookbook/tokendb/agent.py
@@ -1,0 +1,620 @@
+"""Chat agent for the token DB viewer: tool-use loop over tokendb tools.
+
+The viewer's chat mode runs this server-side loop: the user's question goes to
+an LLM (:mod:`tinker_cookbook.tokendb.llm`) together with tool definitions
+bound to a run's :class:`~tinker_cookbook.tokendb.reader.ParquetSegmentReader`
+(``sql`` / ``search`` / ``get_rollout`` / ``publish_visual``; registry mode
+adds ``list_runs`` / ``dashboard`` and per-run variants taking a ``run_id``).
+Tool results are fed back until the model answers, up to
+:data:`MAX_TOOL_ITERATIONS` rounds. :func:`run_chat_turn` streams the whole
+exchange as JSON-ready event dicts (text deltas, tool calls/results, published
+visuals, done/error) that the websocket handler forwards verbatim.
+
+Persistence, all through the ``Storage`` protocol:
+
+- Conversations: append-only JSONL, one message or event per line, under
+  ``{log_path}/tokens/chats/{conversation_id}.jsonl`` (:class:`ChatStore`).
+- Visuals: self-contained HTML files under ``{log_path}/tokens/visuals/``
+  (:class:`VisualStore`), served by the viewer and rendered in sandboxed
+  iframes. The registry-level (cross-run) chat stores both under the registry
+  directory instead.
+
+Results sent to the model are capped (row counts, long strings, long token
+lists) so a broad ``SELECT *`` cannot blow the context window; truncation is
+always reported so the model knows to aggregate instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import secrets
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from tinker_cookbook.stores.storage import Storage
+from tinker_cookbook.tokendb.llm import (
+    ErrorEvent,
+    LLMClient,
+    Message,
+    TextDelta,
+    ToolCall,
+    ToolCallEvent,
+    ToolDef,
+)
+from tinker_cookbook.tokendb.reader import ParquetSegmentReader, reconstruct_full_ob
+
+logger = logging.getLogger(__name__)
+
+MAX_TOOL_ITERATIONS = 20
+MAX_SQL_ROWS_FOR_MODEL = 200
+MAX_SEARCH_ROWS_FOR_MODEL = 50
+MAX_STRING_CHARS_FOR_MODEL = 2000
+MAX_LIST_ITEMS_FOR_MODEL = 200
+MAX_VISUAL_BYTES = 512 * 1024
+TOOL_RESULT_PREVIEW_CHARS = 400
+
+CHATS_PREFIX = "tokens/chats"
+VISUALS_PREFIX = "tokens/visuals"
+
+_CONVERSATION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_VISUAL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+\.html$")
+
+
+class ToolExecutionError(Exception):
+    """Tool failure whose message goes back to the model as an error result."""
+
+
+def new_conversation_id() -> str:
+    return f"{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(4)}"
+
+
+def valid_conversation_id(conversation_id: str) -> bool:
+    return bool(_CONVERSATION_ID_RE.match(conversation_id))
+
+
+def valid_visual_name(name: str) -> bool:
+    return bool(_VISUAL_NAME_RE.match(name))
+
+
+# --- Truncation of tool results for the model ---
+
+
+def _truncate_value(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > MAX_STRING_CHARS_FOR_MODEL:
+        omitted = len(value) - MAX_STRING_CHARS_FOR_MODEL
+        return value[:MAX_STRING_CHARS_FOR_MODEL] + f"... [truncated, {omitted} more chars]"
+    if isinstance(value, (list, tuple)) and len(value) > MAX_LIST_ITEMS_FOR_MODEL:
+        head = [_truncate_value(v) for v in value[:MAX_LIST_ITEMS_FOR_MODEL]]
+        return [*head, f"... [truncated, {len(value) - MAX_LIST_ITEMS_FOR_MODEL} more items]"]
+    if isinstance(value, dict):
+        return {k: _truncate_value(v) for k, v in value.items()}
+    return value
+
+
+def _rows_for_model(rows: list[dict[str, Any]], max_rows: int) -> dict[str, Any]:
+    """Cap row count and elide long values; report what was truncated."""
+    payload: dict[str, Any] = {
+        "n_rows": len(rows),
+        "rows": [_truncate_value(row) for row in rows[:max_rows]],
+    }
+    if len(rows) > max_rows:
+        payload["truncated"] = True
+        payload["note"] = (
+            f"Showing the first {max_rows} of {len(rows)} rows; refine the query "
+            "or aggregate in SQL instead of paging."
+        )
+    return payload
+
+
+def _to_json(value: Any) -> str:
+    return json.dumps(value, default=str)
+
+
+# --- Visual publication ---
+
+
+class VisualStore:
+    """Published HTML visuals under a store prefix (append-only files)."""
+
+    def __init__(self, storage: Storage, url_base: str, prefix: str = VISUALS_PREFIX) -> None:
+        self._storage = storage
+        self._prefix = prefix
+        self._url_base = url_base.rstrip("/")
+
+    def publish(self, title: str, description: str, html: str) -> dict[str, Any]:
+        if not title or not html:
+            raise ToolExecutionError("publish_visual needs a non-empty title and html")
+        data = html.encode()
+        if len(data) > MAX_VISUAL_BYTES:
+            raise ToolExecutionError(
+                f"visual is {len(data)} bytes; the limit is {MAX_VISUAL_BYTES} "
+                "(keep visuals small and query the SQL endpoint for data)"
+            )
+        slug = re.sub(r"[^A-Za-z0-9]+", "-", title.lower()).strip("-")[:60] or "visual"
+        name = f"{slug}-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}-{secrets.token_hex(3)}.html"
+        self._storage.write(f"{self._prefix}/{name}", data)
+        return {
+            "name": name,
+            "url": f"{self._url_base}/{name}",
+            "title": title,
+            "description": description,
+        }
+
+    def list(self) -> list[dict[str, Any]]:
+        try:
+            names = [n for n in self._storage.list_dir(self._prefix) if valid_visual_name(n)]
+        except FileNotFoundError:
+            return []
+        visuals = []
+        for name in sorted(names):
+            stat = self._storage.stat(f"{self._prefix}/{name}")
+            visuals.append(
+                {
+                    "name": name,
+                    "url": f"{self._url_base}/{name}",
+                    "size": stat.size if stat else None,
+                    "mtime": stat.mtime if stat else None,
+                }
+            )
+        visuals.sort(key=lambda v: v["mtime"] or 0, reverse=True)
+        return visuals
+
+    def read(self, name: str) -> bytes:
+        if not valid_visual_name(name):
+            raise FileNotFoundError(name)
+        return self._storage.read(f"{self._prefix}/{name}")
+
+
+# --- Conversation persistence ---
+
+
+class ChatStore:
+    """Append-only JSONL conversation transcripts under a store prefix.
+
+    One record per line: ``{"kind": "message", "role": ..., ...}`` for
+    conversation messages (reloaded as model context on the next turn) and
+    ``{"kind": "event", ...}`` for UI events worth replaying (published
+    visuals). Appends go through ``Storage.append``.
+    """
+
+    def __init__(self, storage: Storage, prefix: str = CHATS_PREFIX) -> None:
+        self._storage = storage
+        self._prefix = prefix
+
+    def _path(self, conversation_id: str) -> str:
+        if not valid_conversation_id(conversation_id):
+            raise ValueError(f"bad conversation id {conversation_id!r}")
+        return f"{self._prefix}/{conversation_id}.jsonl"
+
+    def append_message(self, conversation_id: str, message: Message) -> None:
+        record: dict[str, Any] = {
+            "kind": "message",
+            "role": message.role,
+            "content": message.content,
+            "ts": datetime.now(UTC).isoformat(),
+        }
+        if message.tool_calls:
+            record["tool_calls"] = [
+                {"id": c.id, "name": c.name, "arguments": c.arguments} for c in message.tool_calls
+            ]
+        if message.tool_call_id is not None:
+            record["tool_call_id"] = message.tool_call_id
+        self._append(conversation_id, record)
+
+    def append_event(self, conversation_id: str, event: dict[str, Any]) -> None:
+        self._append(
+            conversation_id, {"kind": "event", "ts": datetime.now(UTC).isoformat(), **event}
+        )
+
+    def _append(self, conversation_id: str, record: dict[str, Any]) -> None:
+        self._storage.append(self._path(conversation_id), (_to_json(record) + "\n").encode())
+
+    def load_records(self, conversation_id: str) -> list[dict[str, Any]]:
+        try:
+            raw = self._storage.read(self._path(conversation_id)).decode()
+        except FileNotFoundError:
+            return []
+        records = []
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                logger.warning("Skipping corrupt chat line in %s", conversation_id)
+        return records
+
+    def load_messages(self, conversation_id: str) -> list[Message]:
+        """Reconstruct the model-context messages from the transcript."""
+        messages = []
+        for record in self.load_records(conversation_id):
+            if record.get("kind") != "message":
+                continue
+            messages.append(
+                Message(
+                    role=str(record.get("role", "user")),
+                    content=str(record.get("content") or ""),
+                    tool_calls=[
+                        ToolCall(
+                            id=str(c.get("id", "")),
+                            name=str(c.get("name", "")),
+                            arguments=dict(c.get("arguments") or {}),
+                        )
+                        for c in record.get("tool_calls", [])
+                    ],
+                    tool_call_id=record.get("tool_call_id"),
+                )
+            )
+        return messages
+
+    def list_conversations(self) -> list[dict[str, Any]]:
+        """List conversations, newest activity first, with a title preview."""
+        try:
+            names = [n for n in self._storage.list_dir(self._prefix) if n.endswith(".jsonl")]
+        except FileNotFoundError:
+            return []
+        conversations = []
+        for name in names:
+            conversation_id = name[: -len(".jsonl")]
+            if not valid_conversation_id(conversation_id):
+                continue
+            stat = self._storage.stat(f"{self._prefix}/{name}")
+            records = self.load_records(conversation_id)
+            title = next(
+                (
+                    str(r.get("content", ""))[:120]
+                    for r in records
+                    if r.get("kind") == "message" and r.get("role") == "user"
+                ),
+                "",
+            )
+            conversations.append(
+                {
+                    "conversation_id": conversation_id,
+                    "title": title,
+                    "n_records": len(records),
+                    "mtime": stat.mtime if stat else None,
+                }
+            )
+        conversations.sort(key=lambda c: c["mtime"] or 0, reverse=True)
+        return conversations
+
+
+# --- Tool boxes ---
+
+
+_SQL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "One read-only SELECT (or WITH ... SELECT) DuckDB statement.",
+        }
+    },
+    "required": ["query"],
+}
+_SEARCH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "regex": {"type": "string", "description": "Regex over the decoded text fields."},
+        "fields": {
+            "type": "array",
+            "items": {"type": "string", "enum": ["ac_text", "ob_text", "metrics", "logs"]},
+            "description": "Text fields the regex applies to (default ac_text and ob_text).",
+        },
+        "token_subsequence": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": "Contiguous token-ID subsequence to find inside ac_tokens.",
+        },
+        "limit": {"type": "integer", "description": "Max rows to return (default 50)."},
+    },
+}
+_GET_ROLLOUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "split": {"type": "string"},
+        "iteration": {"type": "integer"},
+        "group_idx": {"type": "integer"},
+        "traj_idx": {"type": "integer"},
+        "run_attempt": {
+            "type": "integer",
+            "description": "Specific attempt; omit for the latest.",
+        },
+    },
+    "required": ["split", "iteration", "group_idx", "traj_idx"],
+}
+_PUBLISH_VISUAL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "description": {"type": "string", "description": "One-line summary shown in the UI."},
+        "html": {
+            "type": "string",
+            "description": "Complete self-contained HTML document (inline JS/SVG, no CDNs).",
+        },
+    },
+    "required": ["title", "description", "html"],
+}
+
+
+def _with_run_id(schema: dict[str, Any]) -> dict[str, Any]:
+    """Registry-mode variant of a tool schema: adds a required run_id."""
+    properties = {
+        "run_id": {"type": "string", "description": "Run to query (see list_runs)."},
+        **schema.get("properties", {}),
+    }
+    required = ["run_id", *schema.get("required", [])]
+    return {"type": "object", "properties": properties, "required": required}
+
+
+@dataclass
+class ToolOutcome:
+    """One executed tool call: model-facing content plus optional UI frames."""
+
+    content: str
+    is_error: bool = False
+    frames: list[dict[str, Any]] | None = None
+
+
+def _execute_sql(reader: ParquetSegmentReader, arguments: dict[str, Any]) -> dict[str, Any]:
+    query = arguments.get("query")
+    if not query or not isinstance(query, str):
+        raise ToolExecutionError("sql needs a 'query' string")
+    rows = reader.sql(query)  # SELECT-only guard lives in the reader
+    return _rows_for_model(rows, MAX_SQL_ROWS_FOR_MODEL)
+
+
+def _execute_search(reader: ParquetSegmentReader, arguments: dict[str, Any]) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if arguments.get("regex"):
+        kwargs["regex"] = str(arguments["regex"])
+    if arguments.get("fields"):
+        kwargs["fields"] = [str(f) for f in arguments["fields"]]
+    if arguments.get("token_subsequence"):
+        kwargs["token_subsequence"] = [int(t) for t in arguments["token_subsequence"]]
+    if not kwargs:
+        raise ToolExecutionError("search needs a regex and/or a token_subsequence")
+    limit = int(arguments.get("limit") or MAX_SEARCH_ROWS_FOR_MODEL)
+    rows = reader.search(limit=limit, **kwargs)
+    payload = _rows_for_model(rows, MAX_SEARCH_ROWS_FOR_MODEL)
+    payload["hit_counts_by_iteration"] = {
+        str(k): v for k, v in sorted(reader.search_hit_counts(**kwargs).items())
+    }
+    return payload
+
+
+def _execute_get_rollout(reader: ParquetSegmentReader, arguments: dict[str, Any]) -> dict[str, Any]:
+    try:
+        split = str(arguments["split"])
+        iteration = int(arguments["iteration"])
+        group_idx = int(arguments["group_idx"])
+        traj_idx = int(arguments["traj_idx"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise ToolExecutionError(
+            f"get_rollout needs split/iteration/group_idx/traj_idx: {e}"
+        ) from e
+    run_attempt = arguments.get("run_attempt")
+    steps = reader.get_rollout(
+        split, iteration, group_idx, traj_idx, int(run_attempt) if run_attempt is not None else None
+    )
+    if not steps:
+        raise ToolExecutionError(f"rollout {split}/{iteration}/{group_idx}/{traj_idx} not found")
+    for step, full_ob in zip(steps, reconstruct_full_ob(steps)):
+        step["ob_full_tokens"] = full_ob
+    return {"n_steps": len(steps), "steps": [_truncate_value(step) for step in steps]}
+
+
+class RunToolbox:
+    """Tools bound to one run's reader (single-run and per-run chats)."""
+
+    def __init__(self, reader: ParquetSegmentReader, visual_store: VisualStore) -> None:
+        self._reader = reader
+        self._visual_store = visual_store
+
+    def tool_defs(self) -> list[ToolDef]:
+        return [
+            ToolDef("sql", "Run a read-only DuckDB SELECT over this run's token DB.", _SQL_SCHEMA),
+            ToolDef(
+                "search",
+                "Search rollout rows by text regex and/or contiguous token-ID subsequence.",
+                _SEARCH_SCHEMA,
+            ),
+            ToolDef(
+                "get_rollout",
+                "Fetch every turn of one trajectory, with full observations reconstructed.",
+                _GET_ROLLOUT_SCHEMA,
+            ),
+            ToolDef(
+                "publish_visual",
+                "Publish a self-contained HTML visual; returns the URL it is served at.",
+                _PUBLISH_VISUAL_SCHEMA,
+            ),
+        ]
+
+    def execute(self, call: ToolCall) -> ToolOutcome:
+        try:
+            if call.name == "sql":
+                return ToolOutcome(_to_json(_execute_sql(self._reader, call.arguments)))
+            if call.name == "search":
+                return ToolOutcome(_to_json(_execute_search(self._reader, call.arguments)))
+            if call.name == "get_rollout":
+                return ToolOutcome(_to_json(_execute_get_rollout(self._reader, call.arguments)))
+            if call.name == "publish_visual":
+                return _publish_visual_outcome(self._visual_store, call.arguments)
+            raise ToolExecutionError(f"unknown tool {call.name!r}")
+        except ToolExecutionError as e:
+            return ToolOutcome(_to_json({"error": str(e)}), is_error=True)
+        except Exception as e:  # DuckDB errors on model-written SQL, bad regexes, ...
+            return ToolOutcome(_to_json({"error": str(e)}), is_error=True)
+
+
+class RegistryToolbox:
+    """Cross-run tools for the registry-level chat: per-run tools take run_id."""
+
+    def __init__(
+        self,
+        list_runs_fn: Callable[[], list[dict[str, Any]]],
+        dashboard_fn: Callable[[], list[dict[str, Any]]],
+        resolve_reader: Callable[[str], ParquetSegmentReader],
+        visual_store: VisualStore,
+    ) -> None:
+        self._list_runs_fn = list_runs_fn
+        self._dashboard_fn = dashboard_fn
+        self._resolve_reader = resolve_reader
+        self._visual_store = visual_store
+
+    def tool_defs(self) -> list[ToolDef]:
+        empty = {"type": "object", "properties": {}}
+        return [
+            ToolDef("list_runs", "List every registered run with liveness status.", empty),
+            ToolDef(
+                "dashboard",
+                "Per-run aggregates: row counts, latest iteration, reward trend.",
+                empty,
+            ),
+            ToolDef(
+                "sql",
+                "Run a read-only DuckDB SELECT over one run's token DB.",
+                _with_run_id(_SQL_SCHEMA),
+            ),
+            ToolDef(
+                "search",
+                "Search one run's rows by text regex and/or token-ID subsequence.",
+                _with_run_id(_SEARCH_SCHEMA),
+            ),
+            ToolDef(
+                "get_rollout",
+                "Fetch every turn of one trajectory of one run.",
+                _with_run_id(_GET_ROLLOUT_SCHEMA),
+            ),
+            ToolDef(
+                "publish_visual",
+                "Publish a self-contained HTML visual; returns the URL it is served at.",
+                _PUBLISH_VISUAL_SCHEMA,
+            ),
+        ]
+
+    def execute(self, call: ToolCall) -> ToolOutcome:
+        try:
+            if call.name == "list_runs":
+                return ToolOutcome(_to_json({"runs": self._list_runs_fn()}))
+            if call.name == "dashboard":
+                return ToolOutcome(_to_json({"runs": self._dashboard_fn()}))
+            if call.name == "publish_visual":
+                return _publish_visual_outcome(self._visual_store, call.arguments)
+            if call.name in ("sql", "search", "get_rollout"):
+                run_id = call.arguments.get("run_id")
+                if not run_id:
+                    raise ToolExecutionError(f"{call.name} needs a run_id (see list_runs)")
+                reader = self._resolve_reader(str(run_id))
+                executor = {
+                    "sql": _execute_sql,
+                    "search": _execute_search,
+                    "get_rollout": _execute_get_rollout,
+                }[call.name]
+                return ToolOutcome(_to_json(executor(reader, call.arguments)))
+            raise ToolExecutionError(f"unknown tool {call.name!r}")
+        except ToolExecutionError as e:
+            return ToolOutcome(_to_json({"error": str(e)}), is_error=True)
+        except Exception as e:
+            return ToolOutcome(_to_json({"error": str(e)}), is_error=True)
+
+
+def _publish_visual_outcome(visual_store: VisualStore, arguments: dict[str, Any]) -> ToolOutcome:
+    visual = visual_store.publish(
+        str(arguments.get("title") or ""),
+        str(arguments.get("description") or ""),
+        str(arguments.get("html") or ""),
+    )
+    return ToolOutcome(
+        _to_json({"published": True, "url": visual["url"], "name": visual["name"]}),
+        frames=[{"type": "visual_published", **visual}],
+    )
+
+
+Toolbox = RunToolbox | RegistryToolbox
+
+
+# --- The agent loop ---
+
+
+async def run_chat_turn(
+    client: LLMClient,
+    toolbox: Toolbox,
+    chat_store: ChatStore,
+    conversation_id: str,
+    user_text: str,
+    system_prompt: str,
+) -> AsyncIterator[dict[str, Any]]:
+    """Run one user turn of the chat agent, streaming UI event frames.
+
+    Frames: ``text_delta`` (assistant text), ``tool_call`` / ``tool_result``
+    (activity summaries), ``visual_published`` (with the served URL), and a
+    terminal ``done`` or ``error``. Every message is persisted to the
+    conversation's JSONL as it happens, so a reconnecting client can replay
+    the transcript via the chats endpoints.
+    """
+    messages = chat_store.load_messages(conversation_id)
+    user_message = Message(role="user", content=user_text)
+    messages.append(user_message)
+    chat_store.append_message(conversation_id, user_message)
+
+    tool_defs = toolbox.tool_defs()
+    for _ in range(MAX_TOOL_ITERATIONS):
+        text_parts: list[str] = []
+        calls: list[ToolCall] = []
+        async for event in client.stream(system_prompt, messages, tool_defs):
+            if isinstance(event, TextDelta):
+                text_parts.append(event.text)
+                yield {"type": "text_delta", "text": event.text}
+            elif isinstance(event, ToolCallEvent):
+                calls.append(event.call)
+                yield {
+                    "type": "tool_call",
+                    "id": event.call.id,
+                    "name": event.call.name,
+                    "arguments": event.call.arguments,
+                }
+            elif isinstance(event, ErrorEvent):
+                if text_parts:  # keep any partial assistant text in the transcript
+                    partial = Message(role="assistant", content="".join(text_parts))
+                    chat_store.append_message(conversation_id, partial)
+                yield {"type": "error", "error": event.message}
+                return
+            # Done carries only the stop reason; the presence/absence of tool
+            # calls decides whether the loop continues.
+
+        assistant = Message(role="assistant", content="".join(text_parts), tool_calls=calls)
+        messages.append(assistant)
+        chat_store.append_message(conversation_id, assistant)
+        if not calls:
+            yield {"type": "done", "conversation_id": conversation_id}
+            return
+
+        for call in calls:
+            outcome = await asyncio.to_thread(toolbox.execute, call)
+            for frame in outcome.frames or []:
+                chat_store.append_event(conversation_id, frame)
+                yield frame
+            preview = outcome.content[:TOOL_RESULT_PREVIEW_CHARS]
+            yield {
+                "type": "tool_result",
+                "id": call.id,
+                "name": call.name,
+                "is_error": outcome.is_error,
+                "preview": preview,
+            }
+            tool_message = Message(role="tool", content=outcome.content, tool_call_id=call.id)
+            messages.append(tool_message)
+            chat_store.append_message(conversation_id, tool_message)
+
+    yield {
+        "type": "error",
+        "error": f"stopped after {MAX_TOOL_ITERATIONS} tool iterations without a final answer",
+    }

--- a/tinker_cookbook/tokendb/agent_prompt.py
+++ b/tinker_cookbook/tokendb/agent_prompt.py
@@ -1,0 +1,198 @@
+"""System prompt for the tokendb chat agent.
+
+:func:`build_system_prompt` teaches the model the token DB (row schema and
+semantics, views, DuckDB dialect notes, canonical recipes) and how to publish
+self-contained live-updating HTML visuals, then injects the runtime context
+(the SQL endpoint base path and, when known, run metadata).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_SCHEMA_AND_SEMANTICS = """\
+You are the tokendb analysis agent inside the tinker-cookbook token DB viewer.
+Users ask questions in plain language about reinforcement-learning training
+data (rollouts captured token by token during training). You answer by calling
+tools that query the token DB, and by publishing small HTML visuals when a
+chart or table explains the answer better than prose. Never ask the user to
+write SQL; that is your job.
+
+## Data model
+
+One row per TURN of a trajectory (a "rollout" here is one trajectory: the
+steps of one episode for one sample in one group). Row identity is
+(run_id, run_attempt, split, iteration, group_idx, traj_idx, step_idx).
+
+Key columns of the `rollouts` view:
+
+- `ob_tokens` (list<int>): the observation (prompt/context) token IDs fed to
+  the model for this turn.
+- `ob_is_delta` (bool): observations are delta-encoded. When true,
+  `ob_tokens` holds only the NEW suffix relative to the previous turn's full
+  sequence (previous full ob + previous ac). When you need the full context of
+  a later step, use the `get_rollout` tool, which returns reconstructed
+  `ob_full_tokens`; do not treat a delta row's `ob_tokens` as the whole prompt.
+- `ac_tokens` (list<int>) / `ac_logprobs` (list<float> or null): the action,
+  i.e. what the policy sampled this turn, with per-token logprobs.
+- `ob_text` / `ac_text` (nullable strings): decoded text conveniences. Token
+  IDs are canonical; text may be null if the run disabled text storage.
+  Search for special tokens by ID (`list_contains(ac_tokens, <id>)`), since
+  special-token decodings can be unstable.
+- `reward` (this turn), `total_reward` and `final_reward` (trajectory-level,
+  repeated on every row of the trajectory), `episode_done`, `stop_reason`
+  (e.g. 'stop_token', 'length'; null mid-trajectory).
+- `source`: 'rollout' (normal RL rollouts), 'filtered' (groups the training
+  pipeline dropped before optimization, e.g. constant-reward groups; their
+  reward fields are placeholders, so EXCLUDE source = 'filtered' from reward
+  statistics), or 'sample' (synthetic-data / sampling captures).
+- `filtered_reason` (nullable): why a 'filtered' row was dropped, e.g.
+  'constant_reward' or an error tag from the rollout pipeline.
+- `run_attempt` and `superseded`: when a run crashes and resumes, the
+  coordinator increments `run_attempt` and may re-run iterations. `superseded`
+  (computed in the view) is true when a later attempt produced rows for the
+  same (split, iteration). Both attempts are visible by default; when the user
+  asks about "the run", prefer non-superseded rows (or `rollouts_latest`), and
+  mention it if superseded data changes the story.
+- `split` ('train', 'test', ...), `iteration` (training step; -1 can appear
+  for out-of-loop captures), `sampling_client_step`, `tags` (list<string>),
+  `env_row_id` (dataset row identity, useful for comparing the same problem
+  across iterations), `ts` (UTC timestamp), `metrics` / `logs` / `extra`
+  (JSON strings; parse with DuckDB's JSON functions, e.g.
+  `json_extract_string(metrics, '$.foo')`).
+
+## Views
+
+- `rollouts`: all rows, plus the computed `superseded` flag.
+- `rollouts_latest`: only rows from the latest attempt per (split, iteration).
+- `trajectories`: one row per trajectory with `n_steps`, `n_ac_tokens`,
+  `total_reward`, `final_reward`, `stop_reason`, `filtered_reason`,
+  `env_row_id`, `ts`.
+- `labels`: human/agent annotations, keyed like rollouts (step_idx null means
+  whole trajectory) with `label_key`, `label_value` (JSON), `author`, `note`.
+
+## SQL dialect (DuckDB)
+
+Read-only: exactly one SELECT (or WITH ... SELECT) statement per `sql` call.
+Useful DuckDB idioms: `list_contains(ac_tokens, 128009)`,
+`regexp_matches(coalesce(ac_text, ''), 'pattern')`, `len(ac_tokens)`,
+window functions (`avg(x) OVER (ORDER BY iteration ROWS BETWEEN 9 PRECEDING
+AND CURRENT ROW)`), `arg_max(col, step_idx)`, `any_value(col)`,
+`count(*) FILTER (WHERE ...)`, `unnest(...)` for exploding lists.
+
+## Canonical recipes
+
+Reward over iterations (trajectory-grain, excluding filtered rows):
+
+    SELECT iteration, avg(total_reward) AS mean_reward, count(*) AS n
+    FROM (SELECT iteration, any_value(total_reward) AS total_reward
+          FROM rollouts_latest
+          WHERE source <> 'filtered' AND iteration >= 0
+          GROUP BY split, iteration, group_idx, traj_idx)
+    GROUP BY iteration ORDER BY iteration
+
+Filtered counts by reason:
+
+    SELECT filtered_reason, count(DISTINCT (iteration, group_idx, traj_idx)) AS n
+    FROM rollouts WHERE source = 'filtered' GROUP BY 1 ORDER BY n DESC
+
+Find rollouts containing a token ID or a regex:
+
+    SELECT split, iteration, group_idx, traj_idx, total_reward, ac_text
+    FROM rollouts_latest
+    WHERE list_contains(ac_tokens, 128009)
+       OR regexp_matches(coalesce(ac_text, ''), 'I give up')
+    ORDER BY iteration DESC LIMIT 50
+
+Compare run attempts on a re-run iteration:
+
+    SELECT run_attempt, avg(total_reward) AS mean_reward
+    FROM (SELECT run_attempt, any_value(total_reward) AS total_reward
+          FROM rollouts WHERE iteration = 12 AND source <> 'filtered'
+          GROUP BY run_attempt, split, group_idx, traj_idx)
+    GROUP BY run_attempt ORDER BY run_attempt
+
+## Working style
+
+- Start from small aggregate queries; drill into individual rollouts with
+  `get_rollout` only when the question needs turn-level detail.
+- Cite rollouts as `split/iteration/group/traj` keys (for example
+  `train/12/3/1`) so the UI can link them.
+- SQL results shown to you are capped (about 200 rows, long values elided);
+  aggregate in SQL instead of paging through raw rows.
+- State your assumptions (e.g. "excluding filtered rows", "latest attempt
+  only") in the answer.
+- Prefer several small focused visuals over one dense dashboard.
+"""
+
+_VISUAL_GUIDE = """\
+## Publishing visuals
+
+Use `publish_visual(title, description, html)` when a chart, table, or
+highlight view would explain the answer. Requirements for the HTML:
+
+- One single self-contained file: inline `<style>` and `<script>`, draw with
+  plain JavaScript and inline SVG (or HTML tables). No external CDNs, no
+  remote scripts, no images from the network. Keep it under 512 KB.
+- It renders inside a sandboxed iframe and must also work opened standalone.
+- Fetch data by POSTing the SQL to the viewer's read-only endpoint. Use this
+  exact pattern (the base path below is already correct for this chat):
+
+      const SQL_URL = "{sql_url}";
+      async function runQuery(query) {{
+        const resp = await fetch(SQL_URL, {{
+          method: "POST",
+          headers: {{"Content-Type": "application/json"}},
+          body: JSON.stringify({{query}}),
+        }});
+        const payload = await resp.json();
+        if (!resp.ok) throw new Error(payload.error || resp.statusText);
+        return payload.rows;
+      }}
+
+- For live views (the user wants to watch training as it runs), re-run the
+  query on an interval (e.g. `setInterval(refresh, 5000)`) and re-render in
+  place; render an error state instead of crashing if a poll fails.
+- For static answers, query once on load; do not poll.
+- Keep each visual small and focused: one question, one chart. Include the
+  title, axis labels, and the assumptions the query makes.
+"""
+
+
+def build_system_prompt(
+    *,
+    sql_url: str,
+    mode: str = "run",
+    run_info: dict[str, Any] | None = None,
+) -> str:
+    """Assemble the system prompt with runtime context injected.
+
+    Args:
+        sql_url: Base path of the read-only SQL endpoint visuals should POST
+            to (e.g. ``/api/sql`` or ``/api/runs/{run_id}/sql``). In registry
+            mode this is a template: ``{run_id}`` must be substituted by the
+            visual's JS (the prompt tells the model so).
+        mode: ``"run"`` for a single-run chat, ``"registry"`` for the global
+            cross-run chat (extra tools: ``list_runs`` / ``dashboard``; data
+            tools take a ``run_id``).
+        run_info: Optional run metadata (``run.json`` content) shown to the
+            model for a single-run chat.
+    """
+    parts = [_SCHEMA_AND_SEMANTICS, _VISUAL_GUIDE.format(sql_url=sql_url)]
+    if mode == "registry":
+        parts.append(
+            "## Registry mode\n\n"
+            "This chat spans EVERY registered run. Start with `list_runs` or\n"
+            "`dashboard` to see what exists (run_id, model, recipe, liveness,\n"
+            "reward trends), then pass the relevant `run_id` to `sql`, `search`,\n"
+            "and `get_rollout`. In visual HTML, replace `{run_id}` in the SQL\n"
+            "endpoint template above with the actual run ID you are charting.\n"
+            "When comparing runs, query each run separately and align by\n"
+            "iteration."
+        )
+    if run_info:
+        parts.append(
+            "## This run\n\n```json\n" + json.dumps(run_info, indent=2, default=str) + "\n```"
+        )
+    return "\n\n".join(parts)

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -37,7 +37,7 @@ from tinker_cookbook.tokendb.llm import (
     ToolCallEvent,
     ToolDef,
     build_anthropic_request,
-    build_openai_request,
+    build_openai_responses_request,
     detect_default_provider,
 )
 from tinker_cookbook.tokendb.reader import ParquetSegmentReader
@@ -209,41 +209,49 @@ def test_anthropic_request_shape():
 def test_openai_request_shape():
     config = LLMConfig(provider="openai", model="my-model")
     messages, tools = _sample_conversation()
-    url, headers, payload = build_openai_request(config, "sk-test", "SYSTEM", messages, tools)
-    assert url == "https://api.openai.com/v1/chat/completions"
+    url, headers, payload = build_openai_responses_request(
+        config, "sk-test", "SYSTEM", messages, tools
+    )
+    assert url == "https://api.openai.com/v1/responses"
     assert headers["authorization"] == "Bearer sk-test"
     assert payload["model"] == "my-model"
     assert payload["stream"] is True
-    assert payload["max_completion_tokens"] == config.max_tokens
-    assert "max_tokens" not in payload
-    assert payload["messages"][0] == {"role": "system", "content": "SYSTEM"}
-    assert payload["messages"][1] == {"role": "user", "content": "how is reward trending?"}
-    assert payload["messages"][2] == {
-        "role": "assistant",
-        "content": "Let me query.",
-        "tool_calls": [
-            {
-                "id": "call_1",
-                "type": "function",
-                "function": {"name": "sql", "arguments": '{"query": "SELECT 1"}'},
-            }
-        ],
+    assert payload["max_output_tokens"] == config.max_tokens
+    assert payload["store"] is False
+    # System prompt travels as top-level instructions, not an input item.
+    assert payload["instructions"] == "SYSTEM"
+    # Reasoning stays at the API default unless explicitly configured.
+    assert "reasoning" not in payload
+    assert payload["input"][0] == {"role": "user", "content": "how is reward trending?"}
+    # Assistant text and its tool calls are separate input items.
+    assert payload["input"][1] == {"role": "assistant", "content": "Let me query."}
+    assert payload["input"][2] == {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": "sql",
+        "arguments": '{"query": "SELECT 1"}',
     }
-    assert payload["messages"][3] == {
-        "role": "tool",
-        "tool_call_id": "call_1",
-        "content": '{"rows": []}',
+    assert payload["input"][3] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": '{"rows": []}',
     }
+    # Responses API function tools are flat (no nested "function" object).
     assert payload["tools"] == [
         {
             "type": "function",
-            "function": {
-                "name": "sql",
-                "description": "Run SQL.",
-                "parameters": tools[0].input_schema,
-            },
+            "name": "sql",
+            "description": "Run SQL.",
+            "parameters": tools[0].input_schema,
         }
     ]
+
+
+def test_openai_request_reasoning_effort_passthrough():
+    config = LLMConfig(provider="openai", reasoning_effort="low")
+    messages, tools = _sample_conversation()
+    _, _, payload = build_openai_responses_request(config, "sk-test", "SYSTEM", messages, tools)
+    assert payload["reasoning"] == {"effort": "low"}
 
 
 # --- Stream normalization ---
@@ -262,44 +270,82 @@ def test_anthropic_stream_normalization():
 
 
 def test_openai_stream_normalization():
+    """Responses SSE: text deltas, function-call args split across deltas."""
     chunks: list[tuple[str | None, dict]] = [
-        (None, {"choices": [{"delta": {"content": "Hel"}, "finish_reason": None}]}),
-        (None, {"choices": [{"delta": {"content": "lo"}, "finish_reason": None}]}),
+        ("response.created", {"type": "response.created", "response": {"id": "resp_1"}}),
         (
-            None,
+            "response.output_item.added",
             {
-                "choices": [
-                    {
-                        "delta": {
-                            "tool_calls": [
-                                {
-                                    "index": 0,
-                                    "id": "t1",
-                                    "function": {"name": "sql", "arguments": '{"que'},
-                                }
-                            ]
-                        },
-                        "finish_reason": None,
-                    }
-                ]
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"type": "message", "id": "msg_1", "role": "assistant"},
             },
         ),
         (
-            None,
+            "response.output_text.delta",
+            {"type": "response.output_text.delta", "item_id": "msg_1", "delta": "Hel"},
+        ),
+        (
+            "response.output_text.delta",
+            {"type": "response.output_text.delta", "item_id": "msg_1", "delta": "lo"},
+        ),
+        (
+            "response.output_item.done",
             {
-                "choices": [
-                    {
-                        "delta": {
-                            "tool_calls": [
-                                {"index": 0, "function": {"arguments": 'ry": "SELECT 1"}'}}
-                            ]
-                        },
-                        "finish_reason": None,
-                    }
-                ]
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {"type": "message", "id": "msg_1", "role": "assistant"},
             },
         ),
-        (None, {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]}),
+        (
+            "response.output_item.added",
+            {
+                "type": "response.output_item.added",
+                "output_index": 1,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "t1",
+                    "name": "sql",
+                    "arguments": "",
+                },
+            },
+        ),
+        # Arguments arrive as string fragments that must be joined.
+        (
+            "response.function_call_arguments.delta",
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "delta": '{"que',
+            },
+        ),
+        (
+            "response.function_call_arguments.delta",
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "delta": 'ry": "SELECT 1"}',
+            },
+        ),
+        (
+            "response.output_item.done",
+            {
+                "type": "response.output_item.done",
+                "output_index": 1,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "t1",
+                    "name": "sql",
+                    "arguments": '{"query": "SELECT 1"}',
+                },
+            },
+        ),
+        (
+            "response.completed",
+            {"type": "response.completed", "response": {"id": "resp_1", "status": "completed"}},
+        ),
     ]
     client = LLMClient(
         LLMConfig(provider="openai", api_key="k"), transport=ScriptedTransport([chunks])
@@ -310,6 +356,35 @@ def test_openai_stream_normalization():
     assert isinstance(events[2], ToolCallEvent)
     assert events[2].call == ToolCall(id="t1", name="sql", arguments={"query": "SELECT 1"})
     assert events[-1] == Done("tool_calls")
+
+
+def test_openai_stream_error_frame():
+    chunks: list[tuple[str | None, dict]] = [
+        ("response.created", {"type": "response.created", "response": {"id": "resp_1"}}),
+        ("error", {"type": "error", "code": "server_error", "message": "boom", "param": None}),
+    ]
+    client = LLMClient(
+        LLMConfig(provider="openai", api_key="k"), transport=ScriptedTransport([chunks])
+    )
+    events = collect(client.stream("sys", [Message(role="user", content="hi")]))
+    assert events == [ErrorEvent("boom")]
+
+
+def test_openai_stream_failed_response():
+    chunks: list[tuple[str | None, dict]] = [
+        (
+            "response.failed",
+            {
+                "type": "response.failed",
+                "response": {"status": "failed", "error": {"message": "quota exceeded"}},
+            },
+        ),
+    ]
+    client = LLMClient(
+        LLMConfig(provider="openai", api_key="k"), transport=ScriptedTransport([chunks])
+    )
+    events = collect(client.stream("sys", [Message(role="user", content="hi")]))
+    assert events == [ErrorEvent("quota exceeded")]
 
 
 def test_missing_api_key_yields_error_event():

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -1,0 +1,548 @@
+"""Tests for the tokendb chat agent: LLM client wire formats, tool executors,
+and the tool-use loop. No network: a scripted SSE transport stands in for the
+provider APIs."""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyarrow")
+pytest.importorskip("duckdb")
+pytest.importorskip("aiohttp")
+
+from tinker_cookbook.stores.storage import storage_from_uri
+from tinker_cookbook.tokendb.agent import (
+    MAX_LIST_ITEMS_FOR_MODEL,
+    MAX_SQL_ROWS_FOR_MODEL,
+    MAX_STRING_CHARS_FOR_MODEL,
+    MAX_VISUAL_BYTES,
+    ChatStore,
+    RegistryToolbox,
+    RunToolbox,
+    ToolExecutionError,
+    VisualStore,
+    run_chat_turn,
+)
+from tinker_cookbook.tokendb.llm import (
+    Done,
+    ErrorEvent,
+    LLMClient,
+    LLMConfig,
+    Message,
+    TextDelta,
+    ToolCall,
+    ToolCallEvent,
+    ToolDef,
+    build_anthropic_request,
+    build_openai_request,
+)
+from tinker_cookbook.tokendb.reader import ParquetSegmentReader
+from tinker_cookbook.tokendb.schema import TokenRow
+from tinker_cookbook.tokendb.writer import TokenDbWriter
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keys must come from the test, never the developer's environment."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def make_row(**overrides) -> TokenRow:
+    defaults: dict = {
+        "split": "train",
+        "iteration": 0,
+        "group_idx": 0,
+        "traj_idx": 0,
+        "step_idx": 0,
+        "ob_tokens": [1, 2, 3],
+        "ac_tokens": [4, 5],
+    }
+    defaults.update(overrides)
+    return TokenRow(**defaults)
+
+
+# --- Scripted transport (shared with serve tests) ---
+
+
+class ScriptedTransport:
+    """SSETransport stub: replays scripted SSE event lists, records requests."""
+
+    def __init__(self, scripts: list[list[tuple[str | None, dict]]]) -> None:
+        self.scripts = list(scripts)
+        self.requests: list[tuple[str, dict, dict]] = []
+
+    async def stream_sse(self, url: str, headers: dict, payload: dict):
+        self.requests.append((url, headers, payload))
+        if not self.scripts:
+            raise AssertionError("ScriptedTransport ran out of scripted responses")
+        for event in self.scripts.pop(0):
+            yield event
+
+
+def anthropic_script(
+    text: str | None = None, tool_calls: list[tuple[str, str, dict]] = ()
+) -> list[tuple[str | None, dict]]:
+    """Anthropic-shaped SSE events for one model turn."""
+    events: list[tuple[str | None, dict]] = [("message_start", {"type": "message_start"})]
+    index = 0
+    if text is not None:
+        events += [
+            (
+                "content_block_start",
+                {"type": "content_block_start", "index": index, "content_block": {"type": "text"}},
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {"type": "text_delta", "text": text},
+                },
+            ),
+            ("content_block_stop", {"type": "content_block_stop", "index": index}),
+        ]
+        index += 1
+    for call_id, name, arguments in tool_calls:
+        raw = json.dumps(arguments)
+        events += [
+            (
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {"type": "tool_use", "id": call_id, "name": name},
+                },
+            ),
+            # Input arrives as split partial-JSON deltas that must be joined.
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {"type": "input_json_delta", "partial_json": raw[: len(raw) // 2]},
+                },
+            ),
+            (
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {"type": "input_json_delta", "partial_json": raw[len(raw) // 2 :]},
+                },
+            ),
+            ("content_block_stop", {"type": "content_block_stop", "index": index}),
+        ]
+        index += 1
+    stop = "tool_use" if tool_calls else "end_turn"
+    events += [
+        ("message_delta", {"type": "message_delta", "delta": {"stop_reason": stop}}),
+        ("message_stop", {"type": "message_stop"}),
+    ]
+    return events
+
+
+def collect(aiter):
+    async def main():
+        return [event async for event in aiter]
+
+    return asyncio.run(main())
+
+
+# --- Provider wire formats ---
+
+
+def _sample_conversation() -> tuple[list[Message], list[ToolDef]]:
+    messages = [
+        Message(role="user", content="how is reward trending?"),
+        Message(
+            role="assistant",
+            content="Let me query.",
+            tool_calls=[ToolCall(id="call_1", name="sql", arguments={"query": "SELECT 1"})],
+        ),
+        Message(role="tool", content='{"rows": []}', tool_call_id="call_1"),
+    ]
+    tools = [
+        ToolDef(
+            "sql",
+            "Run SQL.",
+            {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+        )
+    ]
+    return messages, tools
+
+
+def test_anthropic_request_shape():
+    config = LLMConfig(provider="anthropic", max_tokens=1234)
+    messages, tools = _sample_conversation()
+    url, headers, payload = build_anthropic_request(config, "sk-test", "SYSTEM", messages, tools)
+    assert url == "https://api.anthropic.com/v1/messages"
+    assert headers["x-api-key"] == "sk-test"
+    assert headers["anthropic-version"]
+    assert payload["model"] == "claude-sonnet-4-6"
+    assert payload["max_tokens"] == 1234
+    assert payload["system"] == "SYSTEM"
+    assert payload["stream"] is True
+    assert payload["tools"] == [
+        {"name": "sql", "description": "Run SQL.", "input_schema": tools[0].input_schema}
+    ]
+    assert payload["messages"][0] == {"role": "user", "content": "how is reward trending?"}
+    assert payload["messages"][1] == {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Let me query."},
+            {"type": "tool_use", "id": "call_1", "name": "sql", "input": {"query": "SELECT 1"}},
+        ],
+    }
+    # Tool results are user-role tool_result blocks.
+    assert payload["messages"][2] == {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "call_1", "content": '{"rows": []}'}],
+    }
+
+
+def test_openai_request_shape():
+    config = LLMConfig(provider="openai", model="my-model")
+    messages, tools = _sample_conversation()
+    url, headers, payload = build_openai_request(config, "sk-test", "SYSTEM", messages, tools)
+    assert url == "https://api.openai.com/v1/chat/completions"
+    assert headers["authorization"] == "Bearer sk-test"
+    assert payload["model"] == "my-model"
+    assert payload["stream"] is True
+    assert payload["messages"][0] == {"role": "system", "content": "SYSTEM"}
+    assert payload["messages"][1] == {"role": "user", "content": "how is reward trending?"}
+    assert payload["messages"][2] == {
+        "role": "assistant",
+        "content": "Let me query.",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "sql", "arguments": '{"query": "SELECT 1"}'},
+            }
+        ],
+    }
+    assert payload["messages"][3] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": '{"rows": []}',
+    }
+    assert payload["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "sql",
+                "description": "Run SQL.",
+                "parameters": tools[0].input_schema,
+            },
+        }
+    ]
+
+
+# --- Stream normalization ---
+
+
+def test_anthropic_stream_normalization():
+    transport = ScriptedTransport(
+        [anthropic_script(text="Hello", tool_calls=[("t1", "sql", {"query": "SELECT 1"})])]
+    )
+    client = LLMClient(LLMConfig(provider="anthropic", api_key="k"), transport=transport)
+    events = collect(client.stream("sys", [Message(role="user", content="hi")]))
+    assert events[0] == TextDelta("Hello")
+    assert isinstance(events[1], ToolCallEvent)
+    assert events[1].call == ToolCall(id="t1", name="sql", arguments={"query": "SELECT 1"})
+    assert events[-1] == Done("tool_use")
+
+
+def test_openai_stream_normalization():
+    chunks = [
+        (None, {"choices": [{"delta": {"content": "Hel"}, "finish_reason": None}]}),
+        (None, {"choices": [{"delta": {"content": "lo"}, "finish_reason": None}]}),
+        (
+            None,
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "t1",
+                                    "function": {"name": "sql", "arguments": '{"que'},
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+        ),
+        (
+            None,
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "function": {"arguments": 'ry": "SELECT 1"}'}}
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+        ),
+        (None, {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]}),
+    ]
+    client = LLMClient(
+        LLMConfig(provider="openai", api_key="k"), transport=ScriptedTransport([chunks])
+    )
+    events = collect(client.stream("sys", [Message(role="user", content="hi")]))
+    assert events[0] == TextDelta("Hel")
+    assert events[1] == TextDelta("lo")
+    assert isinstance(events[2], ToolCallEvent)
+    assert events[2].call == ToolCall(id="t1", name="sql", arguments={"query": "SELECT 1"})
+    assert events[-1] == Done("tool_calls")
+
+
+def test_missing_api_key_yields_error_event():
+    client = LLMClient(LLMConfig(provider="anthropic"), transport=ScriptedTransport([]))
+    events = collect(client.stream("sys", [Message(role="user", content="hi")]))
+    assert len(events) == 1
+    assert isinstance(events[0], ErrorEvent)
+    assert "ANTHROPIC_API_KEY" in events[0].message
+
+
+# --- Tool executors ---
+
+
+@pytest.fixture
+def store_toolbox(tmp_path: Path):
+    """A RunToolbox over a store with many rows and one long-fields rollout."""
+    log_path = tmp_path / "run"
+    long_text = "x" * (MAX_STRING_CHARS_FOR_MODEL + 500)
+    long_tokens = list(range(MAX_LIST_ITEMS_FOR_MODEL + 50))
+    with TokenDbWriter(log_path, context={"model_name": "test-model"}) as writer:
+        writer.append_rows(
+            [
+                make_row(traj_idx=i, total_reward=float(i))
+                for i in range(MAX_SQL_ROWS_FOR_MODEL + 50)
+            ]
+        )
+        writer.append_rows(
+            [
+                make_row(
+                    iteration=7,
+                    ob_text=long_text,
+                    ac_tokens=long_tokens,
+                    ac_text="I give up",
+                )
+            ]
+        )
+    storage = storage_from_uri(str(log_path))
+    reader = ParquetSegmentReader(storage)
+    visual_store = VisualStore(storage, url_base="/visuals")
+    return RunToolbox(reader, visual_store), storage, visual_store
+
+
+def _run_tool(toolbox, name: str, arguments: dict):
+    outcome = toolbox.execute(ToolCall(id="t", name=name, arguments=arguments))
+    return outcome, json.loads(outcome.content)
+
+
+def test_sql_tool_truncates_and_guards(store_toolbox):
+    toolbox, _, _ = store_toolbox
+    outcome, payload = _run_tool(toolbox, "sql", {"query": "SELECT * FROM rollouts"})
+    assert not outcome.is_error
+    assert payload["n_rows"] == MAX_SQL_ROWS_FOR_MODEL + 51
+    assert len(payload["rows"]) == MAX_SQL_ROWS_FOR_MODEL
+    assert payload["truncated"] is True
+    assert "aggregate" in payload["note"]
+
+    # SELECT-only guard is the reader's; surfaces as an error result.
+    outcome, payload = _run_tool(toolbox, "sql", {"query": "DROP TABLE segment_rows"})
+    assert outcome.is_error
+    assert "SELECT" in payload["error"]
+
+    outcome, payload = _run_tool(toolbox, "sql", {})
+    assert outcome.is_error
+
+
+def test_search_tool(store_toolbox):
+    toolbox, _, _ = store_toolbox
+    outcome, payload = _run_tool(toolbox, "search", {"regex": "give up"})
+    assert not outcome.is_error
+    assert payload["n_rows"] == 1
+    assert payload["hit_counts_by_iteration"] == {"7": 1}
+
+    outcome, payload = _run_tool(toolbox, "search", {})
+    assert outcome.is_error
+
+
+def test_get_rollout_truncates_long_fields(store_toolbox):
+    toolbox, _, _ = store_toolbox
+    outcome, payload = _run_tool(
+        toolbox, "get_rollout", {"split": "train", "iteration": 7, "group_idx": 0, "traj_idx": 0}
+    )
+    assert not outcome.is_error
+    step = payload["steps"][0]
+    assert "truncated" in step["ob_text"]
+    assert len(step["ob_text"]) < MAX_STRING_CHARS_FOR_MODEL + 100
+    assert len(step["ac_tokens"]) == MAX_LIST_ITEMS_FOR_MODEL + 1  # head + truncation marker
+    assert "truncated" in step["ac_tokens"][-1]
+
+    outcome, payload = _run_tool(
+        toolbox, "get_rollout", {"split": "train", "iteration": 99, "group_idx": 0, "traj_idx": 0}
+    )
+    assert outcome.is_error and "not found" in payload["error"]
+
+
+def test_publish_visual_writes_file_and_size_guard(store_toolbox):
+    toolbox, storage, visual_store = store_toolbox
+    html = "<!doctype html><html><body>hi</body></html>"
+    outcome, payload = _run_tool(
+        toolbox, "publish_visual", {"title": "Reward Trend!", "description": "d", "html": html}
+    )
+    assert not outcome.is_error
+    assert payload["published"] is True
+    assert payload["url"].startswith("/visuals/reward-trend-")
+    name = payload["name"]
+    assert storage.read(f"tokens/visuals/{name}").decode() == html
+    assert outcome.frames and outcome.frames[0]["type"] == "visual_published"
+    assert visual_store.list()[0]["name"] == name
+
+    with pytest.raises(ToolExecutionError, match="limit"):
+        visual_store.publish("big", "d", "x" * (MAX_VISUAL_BYTES + 1))
+    outcome, payload = _run_tool(
+        toolbox,
+        "publish_visual",
+        {"title": "big", "description": "d", "html": "x" * (MAX_VISUAL_BYTES + 1)},
+    )
+    assert outcome.is_error
+
+
+def test_visual_store_rejects_bad_names(store_toolbox):
+    _, _, visual_store = store_toolbox
+    with pytest.raises(FileNotFoundError):
+        visual_store.read("../../etc/passwd")
+    with pytest.raises(FileNotFoundError):
+        visual_store.read("no-such.html")
+
+
+# --- The agent loop ---
+
+
+def test_chat_turn_multi_tool_and_persistence(store_toolbox, tmp_path: Path):
+    toolbox, storage, _ = store_toolbox
+    chat_store = ChatStore(storage)
+    transport = ScriptedTransport(
+        [
+            anthropic_script(
+                text="Let me look.",
+                tool_calls=[
+                    ("t1", "sql", {"query": "SELECT count(*) AS n FROM rollouts"}),
+                    (
+                        "t2",
+                        "publish_visual",
+                        {"title": "Counts", "description": "d", "html": "<html>ok</html>"},
+                    ),
+                ],
+            ),
+            anthropic_script(text="All done."),
+        ]
+    )
+    client = LLMClient(LLMConfig(provider="anthropic", api_key="k"), transport=transport)
+    frames = collect(
+        run_chat_turn(client, toolbox, chat_store, "conv-1", "count rows please", "SYSTEM")
+    )
+    types = [f["type"] for f in frames]
+    assert types == [
+        "text_delta",
+        "tool_call",
+        "tool_call",
+        "tool_result",
+        "visual_published",
+        "tool_result",
+        "text_delta",
+        "done",
+    ]
+    sql_result = next(f for f in frames if f["type"] == "tool_result" and f["name"] == "sql")
+    assert not sql_result["is_error"]
+    assert '"n"' in sql_result["preview"]
+
+    # The second model call got the tool results threaded back.
+    second_payload = transport.requests[1][2]
+    roles = [m["role"] for m in second_payload["messages"]]
+    assert roles == ["user", "assistant", "user", "user"]  # tool results as user blocks
+
+    # Transcript: JSONL, one message/event per line, reloadable.
+    records = chat_store.load_records("conv-1")
+    kinds = [(r["kind"], r.get("role")) for r in records]
+    assert kinds == [
+        ("message", "user"),
+        ("message", "assistant"),
+        ("message", "tool"),
+        ("event", None),  # visual_published
+        ("message", "tool"),
+        ("message", "assistant"),
+    ]
+    assert records[1]["tool_calls"][0]["name"] == "sql"
+    messages = chat_store.load_messages("conv-1")
+    assert messages[-1].content == "All done."
+    assert chat_store.list_conversations()[0]["conversation_id"] == "conv-1"
+    assert chat_store.list_conversations()[0]["title"] == "count rows please"
+
+
+def test_chat_turn_llm_error_frame(store_toolbox):
+    toolbox, storage, _ = store_toolbox
+    chat_store = ChatStore(storage)
+    client = LLMClient(
+        LLMConfig(provider="anthropic", api_key="k"),
+        transport=ScriptedTransport([[("error", {"error": {"message": "overloaded"}})]]),
+    )
+    frames = collect(run_chat_turn(client, toolbox, chat_store, "conv-2", "hi", "SYSTEM"))
+    assert frames == [{"type": "error", "error": "overloaded"}]
+
+
+def test_registry_toolbox_routes_by_run_id(tmp_path: Path):
+    log_path = tmp_path / "run-a"
+    with TokenDbWriter(log_path, context={"model_name": "m"}) as writer:
+        writer.append_rows([make_row(total_reward=1.5)])
+        run_id = writer.run_id
+    readers = {run_id: ParquetSegmentReader(storage_from_uri(str(log_path)))}
+
+    def resolve(rid: str) -> ParquetSegmentReader:
+        from tinker_cookbook.tokendb.agent import ToolExecutionError
+
+        if rid not in readers:
+            raise ToolExecutionError(f"unknown run_id {rid!r}")
+        return readers[rid]
+
+    toolbox = RegistryToolbox(
+        list_runs_fn=lambda: [{"run_id": run_id, "status": {"live": True}}],
+        dashboard_fn=lambda: [{"run_id": run_id, "n_rows": 1}],
+        resolve_reader=resolve,
+        visual_store=VisualStore(
+            storage_from_uri(str(tmp_path)), url_base="/visuals", prefix="visuals"
+        ),
+    )
+    names = [t.name for t in toolbox.tool_defs()]
+    assert names == ["list_runs", "dashboard", "sql", "search", "get_rollout", "publish_visual"]
+    assert (
+        "run_id" in next(t for t in toolbox.tool_defs() if t.name == "sql").input_schema["required"]
+    )
+
+    outcome, payload = _run_tool(toolbox, "list_runs", {})
+    assert payload["runs"][0]["run_id"] == run_id
+    outcome, payload = _run_tool(toolbox, "dashboard", {})
+    assert payload["runs"][0]["n_rows"] == 1
+    outcome, payload = _run_tool(
+        toolbox, "sql", {"run_id": run_id, "query": "SELECT count(*) AS n FROM rollouts"}
+    )
+    assert payload["rows"][0]["n"] == 1
+    outcome, payload = _run_tool(toolbox, "sql", {"query": "SELECT 1"})
+    assert outcome.is_error and "run_id" in payload["error"]
+    outcome, payload = _run_tool(toolbox, "sql", {"run_id": "nope", "query": "SELECT 1"})
+    assert outcome.is_error and "unknown run_id" in payload["error"]

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -181,7 +181,7 @@ def test_anthropic_request_shape():
     assert url == "https://api.anthropic.com/v1/messages"
     assert headers["x-api-key"] == "sk-test"
     assert headers["anthropic-version"]
-    assert payload["model"] == "claude-sonnet-4-6"
+    assert payload["model"] == "claude-fable-5"
     assert payload["max_tokens"] == 1234
     assert payload["system"] == "SYSTEM"
     assert payload["stream"] is True

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -4,6 +4,7 @@ provider APIs."""
 
 import asyncio
 import json
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -48,6 +49,7 @@ def _no_ambient_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keys must come from the test, never the developer's environment."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
 
 
 def make_row(**overrides) -> TokenRow:
@@ -83,7 +85,7 @@ class ScriptedTransport:
 
 
 def anthropic_script(
-    text: str | None = None, tool_calls: tuple[tuple[str, str, dict], ...] = ()
+    text: str | None = None, tool_calls: Sequence[tuple[str, str, dict]] = ()
 ) -> list[tuple[str | None, dict]]:
     """Anthropic-shaped SSE events for one model turn."""
     events: list[tuple[str | None, dict]] = [("message_start", {"type": "message_start"})]

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -38,6 +38,7 @@ from tinker_cookbook.tokendb.llm import (
     ToolDef,
     build_anthropic_request,
     build_openai_request,
+    detect_default_provider,
 )
 from tinker_cookbook.tokendb.reader import ParquetSegmentReader
 from tinker_cookbook.tokendb.schema import TokenRow
@@ -315,6 +316,28 @@ def test_missing_api_key_yields_error_event():
     assert len(events) == 1
     assert isinstance(events[0], ErrorEvent)
     assert "ANTHROPIC_API_KEY" in events[0].message
+
+
+def test_detect_default_provider(monkeypatch: pytest.MonkeyPatch):
+    # No keys at all (the autouse fixture cleared the env): anthropic fallback.
+    assert detect_default_provider() == "anthropic"
+    # Only openai has a key.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    assert detect_default_provider() == "openai"
+    # Only tinker has a key.
+    monkeypatch.delenv("OPENAI_API_KEY")
+    monkeypatch.setenv("TINKER_API_KEY", "tml-key")
+    assert detect_default_provider() == "tinker"
+    # Preference order: anthropic > openai > tinker.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    assert detect_default_provider() == "openai"
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic")
+    assert detect_default_provider() == "anthropic"
+    # A runtime key counts for every provider, so the first preference wins.
+    monkeypatch.delenv("ANTHROPIC_API_KEY")
+    monkeypatch.delenv("OPENAI_API_KEY")
+    monkeypatch.delenv("TINKER_API_KEY")
+    assert detect_default_provider(api_key="sk-runtime") == "anthropic"
 
 
 # --- Tool executors ---

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -214,6 +214,8 @@ def test_openai_request_shape():
     assert headers["authorization"] == "Bearer sk-test"
     assert payload["model"] == "my-model"
     assert payload["stream"] is True
+    assert payload["max_completion_tokens"] == config.max_tokens
+    assert "max_tokens" not in payload
     assert payload["messages"][0] == {"role": "system", "content": "SYSTEM"}
     assert payload["messages"][1] == {"role": "user", "content": "how is reward trending?"}
     assert payload["messages"][2] == {

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -83,7 +83,7 @@ class ScriptedTransport:
 
 
 def anthropic_script(
-    text: str | None = None, tool_calls: list[tuple[str, str, dict]] = ()
+    text: str | None = None, tool_calls: tuple[tuple[str, str, dict], ...] = ()
 ) -> list[tuple[str | None, dict]]:
     """Anthropic-shaped SSE events for one model turn."""
     events: list[tuple[str | None, dict]] = [("message_start", {"type": "message_start"})]
@@ -257,7 +257,7 @@ def test_anthropic_stream_normalization():
 
 
 def test_openai_stream_normalization():
-    chunks = [
+    chunks: list[tuple[str | None, dict]] = [
         (None, {"choices": [{"delta": {"content": "Hel"}, "finish_reason": None}]}),
         (None, {"choices": [{"delta": {"content": "lo"}, "finish_reason": None}]}),
         (

--- a/tinker_cookbook/tokendb/llm.py
+++ b/tinker_cookbook/tokendb/llm.py
@@ -254,7 +254,9 @@ def build_openai_request(
             wire_messages.append({"role": "user", "content": msg.content})
     payload: dict[str, Any] = {
         "model": config.resolved_model(),
-        "max_tokens": config.max_tokens,
+        # OpenAI deprecated "max_tokens" for chat completions; current models
+        # (gpt-5.x and later) reject it outright.
+        "max_completion_tokens": config.max_tokens,
         "messages": wire_messages,
         "stream": True,
     }

--- a/tinker_cookbook/tokendb/llm.py
+++ b/tinker_cookbook/tokendb/llm.py
@@ -1,8 +1,11 @@
 """Minimal provider-agnostic chat-completions client for the tokendb chat agent.
 
 Speaks the Anthropic Messages API and the OpenAI Chat Completions API over
-plain HTTP (aiohttp + server-sent events); no provider SDK dependencies. Both
-providers are normalized into one internal representation:
+plain HTTP (aiohttp + server-sent events); no provider SDK dependencies. A
+third provider, ``tinker``, samples from any Tinker-served model through the
+tinker SDK and the cookbook's renderer machinery (see
+:mod:`tinker_cookbook.tokendb.tinker_llm`). All providers are normalized into
+one internal representation:
 
 - :class:`Message` / :class:`ToolCall` / :class:`ToolDef` describe the
   conversation and tools once; ``build_anthropic_request`` /
@@ -13,7 +16,7 @@ providers are normalized into one internal representation:
 
 API key resolution order: an explicitly configured key (held in memory, e.g.
 set through the viewer's settings endpoint), then the provider's environment
-variable (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY``).
+variable (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``TINKER_API_KEY``).
 
 The HTTP layer is behind the small :class:`SSETransport` protocol so tests can
 inject a scripted transport and exercise the full parsing path offline.
@@ -35,21 +38,26 @@ ANTHROPIC_VERSION = "2023-06-01"
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
 
 # Plain-constant defaults; override via LLMConfig(model=...) or the viewer's
-# agent-config endpoint.
+# agent-config endpoint. The tinker default is a static fallback; the viewer
+# usually resolves a better one from the fetched supported-model list.
 DEFAULT_MODELS = {
     "anthropic": "claude-fable-5",
     "openai": "gpt-5.6-sol",
+    "tinker": "Qwen/Qwen3-30B-A3B-Instruct-2507",
 }
 # Curated per-provider suggestions surfaced by the viewer's settings UI.
 # Not exhaustive; any model id the provider accepts still works via the
-# "custom" option / LLMConfig(model=...).
+# "custom" option / LLMConfig(model=...). The tinker list is dynamic (server
+# capabilities), so it is empty here and filled in by the config endpoint.
 KNOWN_MODELS = {
     "anthropic": ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
     "openai": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+    "tinker": [],
 }
 API_KEY_ENV_VARS = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "tinker": "TINKER_API_KEY",
 }
 DEFAULT_MAX_TOKENS = 8192
 
@@ -122,7 +130,7 @@ LLMEvent = TextDelta | ToolCallEvent | Done | ErrorEvent
 class LLMConfig:
     """Provider, model, and key configuration for :class:`LLMClient`."""
 
-    provider: str = "anthropic"  # "anthropic" | "openai"
+    provider: str = "anthropic"  # "anthropic" | "openai" | "tinker"
     model: str | None = None  # None resolves to DEFAULT_MODELS[provider]
     api_key: str | None = None  # explicit key beats the environment variable
     max_tokens: int = DEFAULT_MAX_TOKENS
@@ -403,13 +411,22 @@ async def _stream_openai(
 class LLMClient:
     """Streaming chat-completions client over an :class:`SSETransport`."""
 
-    def __init__(self, config: LLMConfig, transport: SSETransport | None = None) -> None:
+    def __init__(
+        self,
+        config: LLMConfig,
+        transport: SSETransport | None = None,
+        tinker_session_factory: Any = None,
+    ) -> None:
         if config.provider not in DEFAULT_MODELS:
             raise ValueError(
-                f"Unknown provider {config.provider!r} (expected 'anthropic' or 'openai')"
+                f"Unknown provider {config.provider!r} "
+                "(expected 'anthropic', 'openai', or 'tinker')"
             )
         self.config = config
         self.transport: SSETransport = transport or AiohttpSSETransport()
+        # Test seam for the tinker provider (tinker_llm.SessionFactory);
+        # None uses the real SDK + renderer machinery.
+        self.tinker_session_factory = tinker_session_factory
 
     async def stream(
         self, system: str, messages: Sequence[Message], tools: Sequence[ToolDef] = ()
@@ -427,6 +444,25 @@ class LLMClient:
                 f"No API key configured for provider {self.config.provider!r}: "
                 f"set {env_var} or configure a key in the viewer settings."
             )
+            return
+        if self.config.provider == "tinker":
+            # Renderer + SDK path (see tinker_llm); imported lazily to keep
+            # the HTTP providers importable without the tinker/renderer stack.
+            from tinker_cookbook.tokendb import tinker_llm
+
+            try:
+                async for event in tinker_llm.stream_tinker(
+                    self.config,
+                    api_key,
+                    system,
+                    messages,
+                    tools,
+                    session_factory=self.tinker_session_factory,
+                ):
+                    yield event
+            except Exception as e:
+                logger.warning("Tinker LLM turn failed: %s", e)
+                yield ErrorEvent(str(e))
             return
         build = (
             build_anthropic_request if self.config.provider == "anthropic" else build_openai_request

--- a/tinker_cookbook/tokendb/llm.py
+++ b/tinker_cookbook/tokendb/llm.py
@@ -1,0 +1,434 @@
+"""Minimal provider-agnostic chat-completions client for the tokendb chat agent.
+
+Speaks the Anthropic Messages API and the OpenAI Chat Completions API over
+plain HTTP (aiohttp + server-sent events); no provider SDK dependencies. Both
+providers are normalized into one internal representation:
+
+- :class:`Message` / :class:`ToolCall` / :class:`ToolDef` describe the
+  conversation and tools once; ``build_anthropic_request`` /
+  ``build_openai_request`` serialize them into each provider's wire format.
+- :meth:`LLMClient.stream` yields typed :data:`LLMEvent` objects
+  (:class:`TextDelta`, :class:`ToolCallEvent`, :class:`Done`,
+  :class:`ErrorEvent`) regardless of provider.
+
+API key resolution order: an explicitly configured key (held in memory, e.g.
+set through the viewer's settings endpoint), then the provider's environment
+variable (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY``).
+
+The HTTP layer is behind the small :class:`SSETransport` protocol so tests can
+inject a scripted transport and exercise the full parsing path offline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+
+# Plain-constant defaults; override via LLMConfig(model=...) or the viewer's
+# agent-config endpoint.
+DEFAULT_MODELS = {
+    "anthropic": "claude-sonnet-4-6",
+    "openai": "gpt-5.2",
+}
+API_KEY_ENV_VARS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
+DEFAULT_MAX_TOKENS = 8192
+
+
+# --- Internal message / tool representation ---
+
+
+@dataclass
+class ToolDef:
+    """One tool the model may call, with a JSON-schema parameter spec."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+@dataclass
+class ToolCall:
+    """A tool invocation requested by the model."""
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass
+class Message:
+    """One conversation message in the provider-neutral representation.
+
+    Roles: ``user``, ``assistant`` (may carry ``tool_calls``), and ``tool``
+    (a tool result; ``tool_call_id`` links it to the assistant's call).
+    """
+
+    role: str
+    content: str = ""
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    tool_call_id: str | None = None
+
+
+# --- Streaming events ---
+
+
+@dataclass
+class TextDelta:
+    text: str
+
+
+@dataclass
+class ToolCallEvent:
+    call: ToolCall
+
+
+@dataclass
+class Done:
+    stop_reason: str | None = None
+
+
+@dataclass
+class ErrorEvent:
+    message: str
+
+
+LLMEvent = TextDelta | ToolCallEvent | Done | ErrorEvent
+
+
+# --- Config / key resolution ---
+
+
+@dataclass
+class LLMConfig:
+    """Provider, model, and key configuration for :class:`LLMClient`."""
+
+    provider: str = "anthropic"  # "anthropic" | "openai"
+    model: str | None = None  # None resolves to DEFAULT_MODELS[provider]
+    api_key: str | None = None  # explicit key beats the environment variable
+    max_tokens: int = DEFAULT_MAX_TOKENS
+    base_url: str | None = None  # override for proxies / compatible servers
+
+    def resolved_model(self) -> str:
+        return self.model or DEFAULT_MODELS[self.provider]
+
+    def resolve_api_key(self) -> str | None:
+        """Explicit runtime key first, then the provider's env var."""
+        if self.api_key:
+            return self.api_key
+        env_var = API_KEY_ENV_VARS.get(self.provider)
+        return os.environ.get(env_var) if env_var else None
+
+
+# --- Provider wire formats ---
+
+
+def build_anthropic_request(
+    config: LLMConfig,
+    api_key: str,
+    system: str,
+    messages: Sequence[Message],
+    tools: Sequence[ToolDef],
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """Serialize a conversation into an Anthropic Messages API request."""
+    wire_messages: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.role == "assistant":
+            content: list[dict[str, Any]] = []
+            if msg.content:
+                content.append({"type": "text", "text": msg.content})
+            for call in msg.tool_calls:
+                content.append(
+                    {"type": "tool_use", "id": call.id, "name": call.name, "input": call.arguments}
+                )
+            wire_messages.append({"role": "assistant", "content": content})
+        elif msg.role == "tool":
+            # Tool results are user-role content blocks in the Messages API.
+            wire_messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": msg.tool_call_id,
+                            "content": msg.content,
+                        }
+                    ],
+                }
+            )
+        else:
+            wire_messages.append({"role": "user", "content": msg.content})
+    payload: dict[str, Any] = {
+        "model": config.resolved_model(),
+        "max_tokens": config.max_tokens,
+        "system": system,
+        "messages": wire_messages,
+        "stream": True,
+    }
+    if tools:
+        payload["tools"] = [
+            {"name": t.name, "description": t.description, "input_schema": t.input_schema}
+            for t in tools
+        ]
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+    }
+    return config.base_url or ANTHROPIC_API_URL, headers, payload
+
+
+def build_openai_request(
+    config: LLMConfig,
+    api_key: str,
+    system: str,
+    messages: Sequence[Message],
+    tools: Sequence[ToolDef],
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """Serialize a conversation into an OpenAI Chat Completions request."""
+    wire_messages: list[dict[str, Any]] = [{"role": "system", "content": system}]
+    for msg in messages:
+        if msg.role == "assistant":
+            entry: dict[str, Any] = {"role": "assistant", "content": msg.content or None}
+            if msg.tool_calls:
+                entry["tool_calls"] = [
+                    {
+                        "id": call.id,
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": json.dumps(call.arguments),
+                        },
+                    }
+                    for call in msg.tool_calls
+                ]
+            wire_messages.append(entry)
+        elif msg.role == "tool":
+            wire_messages.append(
+                {"role": "tool", "tool_call_id": msg.tool_call_id, "content": msg.content}
+            )
+        else:
+            wire_messages.append({"role": "user", "content": msg.content})
+    payload: dict[str, Any] = {
+        "model": config.resolved_model(),
+        "max_tokens": config.max_tokens,
+        "messages": wire_messages,
+        "stream": True,
+    }
+    if tools:
+        payload["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.input_schema,
+                },
+            }
+            for t in tools
+        ]
+    headers = {
+        "authorization": f"Bearer {api_key}",
+        "content-type": "application/json",
+    }
+    return config.base_url or OPENAI_API_URL, headers, payload
+
+
+# --- Transport (aiohttp SSE; injectable for tests) ---
+
+
+class SSETransport(Protocol):
+    """POST a JSON payload and yield ``(event_name, data)`` per SSE event.
+
+    ``event_name`` is the SSE ``event:`` field (``None`` when absent, as in
+    OpenAI streams) and ``data`` is the parsed JSON of the ``data:`` field.
+    OpenAI's ``data: [DONE]`` sentinel is not yielded; the stream just ends.
+    """
+
+    def stream_sse(
+        self, url: str, headers: dict[str, str], payload: dict[str, Any]
+    ) -> AsyncIterator[tuple[str | None, dict[str, Any]]]: ...
+
+
+class AiohttpSSETransport:
+    """Default transport: aiohttp POST with incremental SSE parsing."""
+
+    async def stream_sse(
+        self, url: str, headers: dict[str, str], payload: dict[str, Any]
+    ) -> AsyncIterator[tuple[str | None, dict[str, Any]]]:
+        import aiohttp
+
+        parser = _SSEParser()
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(url, headers=headers, json=payload) as resp,
+        ):
+            if resp.status != 200:
+                body = (await resp.text())[:2000]
+                raise RuntimeError(f"LLM API error {resp.status}: {body}")
+            async for raw_line in resp.content:
+                event = parser.feed(raw_line.decode("utf-8", errors="replace").rstrip("\r\n"))
+                if event is not None:
+                    yield event
+
+
+class _SSEParser:
+    """Incremental SSE parser: ``event:`` / ``data:`` lines into events.
+
+    Comment lines and unknown fields are ignored; a blank line terminates one
+    event. OpenAI's ``data: [DONE]`` sentinel is swallowed.
+    """
+
+    def __init__(self) -> None:
+        self.event_name: str | None = None
+        self.data_lines: list[str] = []
+
+    def feed(self, line: str) -> tuple[str | None, dict[str, Any]] | None:
+        """Feed one line (no trailing newline); return a completed event or None."""
+        if line == "":
+            data = "\n".join(self.data_lines)
+            name = self.event_name
+            self.event_name = None
+            self.data_lines = []
+            if not data or data == "[DONE]":
+                return None
+            return (name, json.loads(data))
+        if line.startswith("event:"):
+            self.event_name = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            self.data_lines.append(line[len("data:") :].strip())
+        return None
+
+
+# --- Stream normalization ---
+
+
+async def _stream_anthropic(
+    sse: AsyncIterator[tuple[str | None, dict[str, Any]]],
+) -> AsyncIterator[LLMEvent]:
+    """Normalize Anthropic Messages streaming events."""
+    stop_reason: str | None = None
+    # In-flight tool_use blocks by content-block index (input arrives as
+    # partial JSON deltas that must be accumulated).
+    pending_tools: dict[int, dict[str, Any]] = {}
+    async for name, data in sse:
+        event_type = name or data.get("type")
+        if event_type == "content_block_start":
+            block = data.get("content_block", {})
+            if block.get("type") == "tool_use":
+                pending_tools[int(data["index"])] = {
+                    "id": block.get("id", ""),
+                    "name": block.get("name", ""),
+                    "json": "",
+                }
+        elif event_type == "content_block_delta":
+            delta = data.get("delta", {})
+            if delta.get("type") == "text_delta":
+                yield TextDelta(delta.get("text", ""))
+            elif delta.get("type") == "input_json_delta":
+                pending = pending_tools.get(int(data["index"]))
+                if pending is not None:
+                    pending["json"] += delta.get("partial_json", "")
+        elif event_type == "content_block_stop":
+            pending = pending_tools.pop(int(data["index"]), None)
+            if pending is not None:
+                arguments = json.loads(pending["json"]) if pending["json"].strip() else {}
+                yield ToolCallEvent(ToolCall(pending["id"], pending["name"], arguments))
+        elif event_type == "message_delta":
+            stop_reason = data.get("delta", {}).get("stop_reason") or stop_reason
+        elif event_type == "error":
+            error = data.get("error", data)
+            yield ErrorEvent(str(error.get("message", error)))
+            return
+    yield Done(stop_reason)
+
+
+async def _stream_openai(
+    sse: AsyncIterator[tuple[str | None, dict[str, Any]]],
+) -> AsyncIterator[LLMEvent]:
+    """Normalize OpenAI Chat Completions streaming chunks."""
+    stop_reason: str | None = None
+    # Tool-call fragments accumulate by index across chunks.
+    pending_tools: dict[int, dict[str, Any]] = {}
+    async for _, data in sse:
+        if "error" in data:
+            error = data["error"]
+            message = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+            yield ErrorEvent(str(message))
+            return
+        choices = data.get("choices") or []
+        if not choices:
+            continue
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+        if delta.get("content"):
+            yield TextDelta(delta["content"])
+        for fragment in delta.get("tool_calls") or []:
+            index = int(fragment.get("index", 0))
+            pending = pending_tools.setdefault(index, {"id": "", "name": "", "json": ""})
+            if fragment.get("id"):
+                pending["id"] = fragment["id"]
+            function = fragment.get("function") or {}
+            if function.get("name"):
+                pending["name"] += function["name"]
+            if function.get("arguments"):
+                pending["json"] += function["arguments"]
+        if choice.get("finish_reason"):
+            stop_reason = choice["finish_reason"]
+    for _, pending in sorted(pending_tools.items()):
+        arguments = json.loads(pending["json"]) if pending["json"].strip() else {}
+        yield ToolCallEvent(ToolCall(pending["id"], pending["name"], arguments))
+    yield Done(stop_reason)
+
+
+class LLMClient:
+    """Streaming chat-completions client over an :class:`SSETransport`."""
+
+    def __init__(self, config: LLMConfig, transport: SSETransport | None = None) -> None:
+        if config.provider not in DEFAULT_MODELS:
+            raise ValueError(
+                f"Unknown provider {config.provider!r} (expected 'anthropic' or 'openai')"
+            )
+        self.config = config
+        self.transport: SSETransport = transport or AiohttpSSETransport()
+
+    async def stream(
+        self, system: str, messages: Sequence[Message], tools: Sequence[ToolDef] = ()
+    ) -> AsyncIterator[LLMEvent]:
+        """Stream one model turn as normalized :data:`LLMEvent` objects.
+
+        Always terminates with :class:`Done` or :class:`ErrorEvent`; transport
+        and parse failures surface as :class:`ErrorEvent` rather than raising,
+        so callers can render them.
+        """
+        api_key = self.config.resolve_api_key()
+        if not api_key:
+            env_var = API_KEY_ENV_VARS[self.config.provider]
+            yield ErrorEvent(
+                f"No API key configured for provider {self.config.provider!r}: "
+                f"set {env_var} or configure a key in the viewer settings."
+            )
+            return
+        build = (
+            build_anthropic_request if self.config.provider == "anthropic" else build_openai_request
+        )
+        url, headers, payload = build(self.config, api_key, system, messages, tools)
+        normalize = _stream_anthropic if self.config.provider == "anthropic" else _stream_openai
+        try:
+            async for event in normalize(self.transport.stream_sse(url, headers, payload)):
+                yield event
+        except Exception as e:
+            logger.warning("LLM stream failed: %s", e)
+            yield ErrorEvent(str(e))

--- a/tinker_cookbook/tokendb/llm.py
+++ b/tinker_cookbook/tokendb/llm.py
@@ -37,8 +37,15 @@ OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
 # Plain-constant defaults; override via LLMConfig(model=...) or the viewer's
 # agent-config endpoint.
 DEFAULT_MODELS = {
-    "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-5.2",
+    "anthropic": "claude-fable-5",
+    "openai": "gpt-5.6-sol",
+}
+# Curated per-provider suggestions surfaced by the viewer's settings UI.
+# Not exhaustive; any model id the provider accepts still works via the
+# "custom" option / LLMConfig(model=...).
+KNOWN_MODELS = {
+    "anthropic": ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
+    "openai": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
 }
 API_KEY_ENV_VARS = {
     "anthropic": "ANTHROPIC_API_KEY",

--- a/tinker_cookbook/tokendb/llm.py
+++ b/tinker_cookbook/tokendb/llm.py
@@ -1,15 +1,16 @@
-"""Minimal provider-agnostic chat-completions client for the tokendb chat agent.
+"""Minimal provider-agnostic chat client for the tokendb chat agent.
 
-Speaks the Anthropic Messages API and the OpenAI Chat Completions API over
-plain HTTP (aiohttp + server-sent events); no provider SDK dependencies. A
-third provider, ``tinker``, samples from any Tinker-served model through the
+Speaks the Anthropic Messages API and the OpenAI Responses API over plain
+HTTP (aiohttp + server-sent events); no provider SDK dependencies. A third
+provider, ``tinker``, samples from any Tinker-served model through the
 tinker SDK and the cookbook's renderer machinery (see
 :mod:`tinker_cookbook.tokendb.tinker_llm`). All providers are normalized into
 one internal representation:
 
 - :class:`Message` / :class:`ToolCall` / :class:`ToolDef` describe the
   conversation and tools once; ``build_anthropic_request`` /
-  ``build_openai_request`` serialize them into each provider's wire format.
+  ``build_openai_responses_request`` serialize them into each provider's wire
+  format.
 - :meth:`LLMClient.stream` yields typed :data:`LLMEvent` objects
   (:class:`TextDelta`, :class:`ToolCallEvent`, :class:`Done`,
   :class:`ErrorEvent`) regardless of provider.
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
-OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_API_URL = "https://api.openai.com/v1/responses"
 
 # Plain-constant defaults; override via LLMConfig(model=...) or the viewer's
 # agent-config endpoint. The tinker default is a static fallback; the viewer
@@ -138,6 +139,9 @@ class LLMConfig:
     api_key: str | None = None  # explicit key beats the environment variable
     max_tokens: int = DEFAULT_MAX_TOKENS
     base_url: str | None = None  # override for proxies / compatible servers
+    # OpenAI Responses API reasoning effort ("none" | "low" | "medium" | ...).
+    # None omits the field entirely, leaving the model's default in place.
+    reasoning_effort: str | None = None
 
     def resolved_model(self) -> str:
         return self.model or DEFAULT_MODELS[self.provider]
@@ -221,54 +225,64 @@ def build_anthropic_request(
     return config.base_url or ANTHROPIC_API_URL, headers, payload
 
 
-def build_openai_request(
+def build_openai_responses_request(
     config: LLMConfig,
     api_key: str,
     system: str,
     messages: Sequence[Message],
     tools: Sequence[ToolDef],
 ) -> tuple[str, dict[str, str], dict[str, Any]]:
-    """Serialize a conversation into an OpenAI Chat Completions request."""
-    wire_messages: list[dict[str, Any]] = [{"role": "system", "content": system}]
+    """Serialize a conversation into an OpenAI Responses API request.
+
+    The Responses API (unlike Chat Completions) supports function tools on
+    reasoning models without forcing ``reasoning_effort`` to ``"none"``. The
+    system prompt travels as top-level ``instructions``; assistant tool calls
+    and tool results become ``function_call`` / ``function_call_output`` input
+    items linked by ``call_id``.
+    """
+    input_items: list[dict[str, Any]] = []
     for msg in messages:
         if msg.role == "assistant":
-            entry: dict[str, Any] = {"role": "assistant", "content": msg.content or None}
-            if msg.tool_calls:
-                entry["tool_calls"] = [
+            if msg.content:
+                input_items.append({"role": "assistant", "content": msg.content})
+            for call in msg.tool_calls:
+                input_items.append(
                     {
-                        "id": call.id,
-                        "type": "function",
-                        "function": {
-                            "name": call.name,
-                            "arguments": json.dumps(call.arguments),
-                        },
+                        "type": "function_call",
+                        "call_id": call.id,
+                        "name": call.name,
+                        "arguments": json.dumps(call.arguments),
                     }
-                    for call in msg.tool_calls
-                ]
-            wire_messages.append(entry)
+                )
         elif msg.role == "tool":
-            wire_messages.append(
-                {"role": "tool", "tool_call_id": msg.tool_call_id, "content": msg.content}
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.tool_call_id,
+                    "output": msg.content,
+                }
             )
         else:
-            wire_messages.append({"role": "user", "content": msg.content})
+            input_items.append({"role": "user", "content": msg.content})
     payload: dict[str, Any] = {
         "model": config.resolved_model(),
-        # OpenAI deprecated "max_tokens" for chat completions; current models
-        # (gpt-5.x and later) reject it outright.
-        "max_completion_tokens": config.max_tokens,
-        "messages": wire_messages,
+        "instructions": system,
+        "input": input_items,
+        "max_output_tokens": config.max_tokens,
         "stream": True,
+        # The full conversation is threaded client-side, so opt out of
+        # server-side response storage.
+        "store": False,
     }
+    if config.reasoning_effort:
+        payload["reasoning"] = {"effort": config.reasoning_effort}
     if tools:
         payload["tools"] = [
             {
                 "type": "function",
-                "function": {
-                    "name": t.name,
-                    "description": t.description,
-                    "parameters": t.input_schema,
-                },
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.input_schema,
             }
             for t in tools
         ]
@@ -285,9 +299,9 @@ def build_openai_request(
 class SSETransport(Protocol):
     """POST a JSON payload and yield ``(event_name, data)`` per SSE event.
 
-    ``event_name`` is the SSE ``event:`` field (``None`` when absent, as in
-    OpenAI streams) and ``data`` is the parsed JSON of the ``data:`` field.
-    OpenAI's ``data: [DONE]`` sentinel is not yielded; the stream just ends.
+    ``event_name`` is the SSE ``event:`` field (``None`` when absent) and
+    ``data`` is the parsed JSON of the ``data:`` field. A ``data: [DONE]``
+    sentinel is not yielded; the stream just ends.
     """
 
     def stream_sse(
@@ -388,46 +402,67 @@ async def _stream_anthropic(
     yield Done(stop_reason)
 
 
-async def _stream_openai(
+async def _stream_openai_responses(
     sse: AsyncIterator[tuple[str | None, dict[str, Any]]],
 ) -> AsyncIterator[LLMEvent]:
-    """Normalize OpenAI Chat Completions streaming chunks."""
+    """Normalize OpenAI Responses API streaming events.
+
+    Function-call arguments arrive as string deltas keyed by ``item_id`` and
+    are accumulated until the item's ``response.output_item.done``, which also
+    carries the authoritative complete ``arguments`` string.
+    """
     stop_reason: str | None = None
-    # Tool-call fragments accumulate by index across chunks.
-    pending_tools: dict[int, dict[str, Any]] = {}
-    async for _, data in sse:
-        if "error" in data:
-            error = data["error"]
-            message = error.get("message", str(error)) if isinstance(error, dict) else str(error)
-            yield ErrorEvent(str(message))
+    emitted_tool_call = False
+    # In-flight function_call output items by item id (arguments accumulate
+    # across response.function_call_arguments.delta events).
+    pending_tools: dict[str, dict[str, Any]] = {}
+    async for name, data in sse:
+        event_type = name or data.get("type")
+        if event_type == "response.output_text.delta":
+            yield TextDelta(data.get("delta", ""))
+        elif event_type == "response.output_item.added":
+            item = data.get("item", {})
+            if item.get("type") == "function_call":
+                pending_tools[str(item.get("id", ""))] = {
+                    "call_id": item.get("call_id", ""),
+                    "name": item.get("name", ""),
+                    "json": item.get("arguments") or "",
+                }
+        elif event_type == "response.function_call_arguments.delta":
+            pending = pending_tools.get(str(data.get("item_id", "")))
+            if pending is not None:
+                pending["json"] += data.get("delta", "")
+        elif event_type == "response.output_item.done":
+            item = data.get("item", {})
+            if item.get("type") == "function_call":
+                pending = pending_tools.pop(str(item.get("id", "")), None) or {
+                    "call_id": "",
+                    "name": "",
+                    "json": "",
+                }
+                raw = item.get("arguments") or pending["json"]
+                arguments = json.loads(raw) if raw.strip() else {}
+                call_id = item.get("call_id") or pending["call_id"]
+                tool_name = item.get("name") or pending["name"]
+                yield ToolCallEvent(ToolCall(call_id, tool_name, arguments))
+                emitted_tool_call = True
+        elif event_type == "response.completed":
+            stop_reason = "tool_calls" if emitted_tool_call else "stop"
+        elif event_type == "response.incomplete":
+            details = (data.get("response") or {}).get("incomplete_details") or {}
+            stop_reason = details.get("reason") or "incomplete"
+        elif event_type == "response.failed":
+            error = (data.get("response") or {}).get("error") or {}
+            yield ErrorEvent(str(error.get("message", error)))
             return
-        choices = data.get("choices") or []
-        if not choices:
-            continue
-        choice = choices[0]
-        delta = choice.get("delta") or {}
-        if delta.get("content"):
-            yield TextDelta(delta["content"])
-        for fragment in delta.get("tool_calls") or []:
-            index = int(fragment.get("index", 0))
-            pending = pending_tools.setdefault(index, {"id": "", "name": "", "json": ""})
-            if fragment.get("id"):
-                pending["id"] = fragment["id"]
-            function = fragment.get("function") or {}
-            if function.get("name"):
-                pending["name"] += function["name"]
-            if function.get("arguments"):
-                pending["json"] += function["arguments"]
-        if choice.get("finish_reason"):
-            stop_reason = choice["finish_reason"]
-    for _, pending in sorted(pending_tools.items()):
-        arguments = json.loads(pending["json"]) if pending["json"].strip() else {}
-        yield ToolCallEvent(ToolCall(pending["id"], pending["name"], arguments))
+        elif event_type == "error":
+            yield ErrorEvent(str(data.get("message", data)))
+            return
     yield Done(stop_reason)
 
 
 class LLMClient:
-    """Streaming chat-completions client over an :class:`SSETransport`."""
+    """Streaming chat client over an :class:`SSETransport`."""
 
     def __init__(
         self,
@@ -483,10 +518,14 @@ class LLMClient:
                 yield ErrorEvent(str(e))
             return
         build = (
-            build_anthropic_request if self.config.provider == "anthropic" else build_openai_request
+            build_anthropic_request
+            if self.config.provider == "anthropic"
+            else build_openai_responses_request
         )
         url, headers, payload = build(self.config, api_key, system, messages, tools)
-        normalize = _stream_anthropic if self.config.provider == "anthropic" else _stream_openai
+        normalize = (
+            _stream_anthropic if self.config.provider == "anthropic" else _stream_openai_responses
+        )
         try:
             async for event in normalize(self.transport.stream_sse(url, headers, payload)):
                 yield event

--- a/tinker_cookbook/tokendb/llm.py
+++ b/tinker_cookbook/tokendb/llm.py
@@ -60,6 +60,9 @@ API_KEY_ENV_VARS = {
     "tinker": "TINKER_API_KEY",
 }
 DEFAULT_MAX_TOKENS = 8192
+# Order in which providers are considered when picking a default (first one
+# with an available API key wins).
+PROVIDER_PREFERENCE = ("anthropic", "openai", "tinker")
 
 
 # --- Internal message / tool representation ---
@@ -145,6 +148,19 @@ class LLMConfig:
             return self.api_key
         env_var = API_KEY_ENV_VARS.get(self.provider)
         return os.environ.get(env_var) if env_var else None
+
+
+def detect_default_provider(api_key: str | None = None) -> str:
+    """The first provider (in PROVIDER_PREFERENCE order) with an available key.
+
+    A key is available if ``api_key`` (a runtime-configured key) is set or the
+    provider's environment variable is. Falls back to ``"anthropic"`` when no
+    provider has a key, so the viewer still has something to prompt for.
+    """
+    for provider in PROVIDER_PREFERENCE:
+        if LLMConfig(provider=provider, api_key=api_key).resolve_api_key() is not None:
+            return provider
+    return "anthropic"
 
 
 # --- Provider wire formats ---

--- a/tinker_cookbook/tokendb/serve.py
+++ b/tinker_cookbook/tokendb/serve.py
@@ -34,6 +34,7 @@ text plus raw token IDs (both stored, so nothing is lost).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import functools
 import json
@@ -47,7 +48,19 @@ from typing import Any
 import chz
 from aiohttp import WSMsgType, web
 
-from tinker_cookbook.stores.storage import storage_from_uri
+from tinker_cookbook.stores.storage import Storage, storage_from_uri
+from tinker_cookbook.tokendb.agent import (
+    ChatStore,
+    RegistryToolbox,
+    RunToolbox,
+    ToolExecutionError,
+    VisualStore,
+    new_conversation_id,
+    run_chat_turn,
+    valid_conversation_id,
+)
+from tinker_cookbook.tokendb.agent_prompt import build_system_prompt
+from tinker_cookbook.tokendb.llm import API_KEY_ENV_VARS, LLMClient, LLMConfig, SSETransport
 from tinker_cookbook.tokendb.reader import (
     LABELS_PATH,
     ParquetSegmentReader,
@@ -87,6 +100,10 @@ class RunContext:
     tokenizer_error: str = "not loaded"
     tokenizer_task: asyncio.Task[None] | None = None
     tokenizer_started: bool = False
+    # Chat tools run in a worker thread (asyncio.to_thread) and DuckDB
+    # connections are not thread-safe, so the chat gets its own reader
+    # instead of sharing `reader` with the event-loop HTTP handlers.
+    chat_reader: ParquetSegmentReader | None = None
 
 
 # Typed application-state keys (aiohttp's recommended alternative to str keys).
@@ -99,6 +116,9 @@ DASHBOARD_CACHE_KEY: web.AppKey[dict[str, tuple[float, dict[str, Any]]]] = web.A
 DASHBOARD_TTL_KEY = web.AppKey("dashboard_ttl_s", float)
 LIVE_WINDOW_KEY = web.AppKey("live_window_s", float)
 LOAD_TOKENIZER_KEY = web.AppKey("load_tokenizer", bool)
+# Chat agent: provider/model/api_key held in server memory only (never persisted).
+AGENT_STATE_KEY: web.AppKey[dict[str, Any]] = web.AppKey("agent_state")
+LLM_TRANSPORT_KEY: web.AppKey[SSETransport | None] = web.AppKey("llm_transport")
 
 
 def _json_response(data: Any, status: int = 200) -> web.Response:
@@ -645,6 +665,307 @@ async def _handle_ws_dashboard(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
+# --- Chat agent: scope resolution, config, chats, visuals, websocket ---
+
+
+@dataclasses.dataclass
+class ChatScope:
+    """Everything one chat (or its chats/visuals endpoints) is bound to."""
+
+    toolbox: RunToolbox | RegistryToolbox
+    chat_store: ChatStore
+    visual_store: VisualStore
+    system_prompt: str = ""
+
+
+def _registry_storage(app: web.Application) -> Storage:
+    directory = resolve_registry_dir(app[REGISTRY_DIR_KEY])
+    if directory is None:  # build_app rejects this configuration up front
+        raise web.HTTPNotFound(
+            text=_json_dumps({"error": "run registry is disabled"}),
+            content_type="application/json",
+        )
+    return storage_from_uri(str(directory))
+
+
+def _chat_reader(ctx: RunContext) -> ParquetSegmentReader:
+    """The run's chat-dedicated reader (see the ``chat_reader`` field note)."""
+    if ctx.chat_reader is None:
+        ctx.chat_reader = ParquetSegmentReader(ctx.log_path)
+    return ctx.chat_reader
+
+
+def _run_info(ctx: RunContext) -> dict[str, Any] | None:
+    """Best-effort ``run.json`` content for the system prompt."""
+    try:
+        if ctx.storage.exists(RUN_JSON_PATH):
+            return json.loads(ctx.storage.read(RUN_JSON_PATH).decode())
+    except Exception:
+        logger.warning("Could not read %s for the chat prompt", RUN_JSON_PATH, exc_info=True)
+    return None
+
+
+def _chat_scope(request: web.Request, *, include_prompt: bool = False) -> ChatScope:
+    """Resolve the chat scope for this request.
+
+    Single-run mode and the registry per-run mount bind to that run's reader
+    and store the conversation/visuals under the run's ``tokens/`` directory.
+    The registry-level chat (no ``run_id``) spans every run: cross-run tools,
+    with conversations/visuals stored under the registry directory.
+    """
+    app = request.app
+    ctx = app[SINGLE_CTX_KEY]
+    run_id = request.match_info.get("run_id")
+    if ctx is None and run_id is not None:
+        ctx = _get_or_create_ctx(app, run_id)
+    if ctx is not None:
+        api_base = f"/api/runs/{run_id}" if run_id is not None else "/api"
+        visuals_base = f"{api_base}/visuals" if run_id is not None else "/visuals"
+        prompt = ""
+        if include_prompt:
+            prompt = build_system_prompt(
+                sql_url=f"{api_base}/sql", mode="run", run_info=_run_info(ctx)
+            )
+        return ChatScope(
+            toolbox=RunToolbox(_chat_reader(ctx), VisualStore(ctx.storage, url_base=visuals_base)),
+            chat_store=ChatStore(ctx.storage),
+            visual_store=VisualStore(ctx.storage, url_base=visuals_base),
+            system_prompt=prompt,
+        )
+    # Registry-level (cross-run) chat.
+    storage = _registry_storage(app)
+    visual_store = VisualStore(storage, url_base="/visuals", prefix="visuals")
+
+    def _resolve_reader(rid: str) -> ParquetSegmentReader:
+        try:
+            return _chat_reader(_get_or_create_ctx(app, rid))
+        except web.HTTPNotFound as e:
+            raise ToolExecutionError(f"unknown run_id {rid!r} (see list_runs)") from e
+
+    toolbox = RegistryToolbox(
+        list_runs_fn=lambda: list_runs(app[REGISTRY_DIR_KEY], live_window_s=app[LIVE_WINDOW_KEY]),
+        dashboard_fn=lambda: _dashboard_rows(app),
+        resolve_reader=_resolve_reader,
+        visual_store=visual_store,
+    )
+    prompt = ""
+    if include_prompt:
+        prompt = build_system_prompt(sql_url="/api/runs/{run_id}/sql", mode="registry")
+    return ChatScope(
+        toolbox=toolbox,
+        chat_store=ChatStore(storage, prefix="chats"),
+        visual_store=visual_store,
+        system_prompt=prompt,
+    )
+
+
+async def _handle_agent_config_get(request: web.Request) -> web.Response:
+    state = request.app[AGENT_STATE_KEY]
+    config = LLMConfig(provider=state["provider"], model=state["model"], api_key=state["api_key"])
+    # The key itself is never returned, only whether one is available.
+    return _json_response(
+        {
+            "provider": config.provider,
+            "model": config.resolved_model(),
+            "has_key": config.resolve_api_key() is not None,
+        }
+    )
+
+
+async def _handle_agent_config_post(request: web.Request) -> web.Response:
+    state = request.app[AGENT_STATE_KEY]
+    try:
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise ValueError("body must be an object")
+        if "provider" in body:
+            provider = str(body["provider"])
+            if provider not in API_KEY_ENV_VARS:
+                raise ValueError(
+                    f"unknown provider {provider!r} (expected 'anthropic' or 'openai')"
+                )
+            state["provider"] = provider
+        if "model" in body:
+            state["model"] = str(body["model"]) or None
+        if "api_key" in body:
+            # In server memory only; empty string clears the runtime key.
+            state["api_key"] = str(body["api_key"]) or None
+    except (json.JSONDecodeError, TypeError, ValueError) as e:
+        return _error_response(str(e), 400)
+    return await _handle_agent_config_get(request)
+
+
+async def _handle_chats_list(request: web.Request) -> web.Response:
+    scope = _chat_scope(request)
+    return _json_response(
+        {"conversations": await asyncio.to_thread(scope.chat_store.list_conversations)}
+    )
+
+
+async def _handle_chat_detail(request: web.Request) -> web.Response:
+    scope = _chat_scope(request)
+    conversation_id = request.match_info["conversation_id"]
+    if not valid_conversation_id(conversation_id):
+        return _error_response(f"bad conversation id {conversation_id!r}", 400)
+    records = await asyncio.to_thread(scope.chat_store.load_records, conversation_id)
+    if not records:
+        return _error_response("conversation not found", 404)
+    return _json_response({"conversation_id": conversation_id, "records": records})
+
+
+async def _handle_visuals_list(request: web.Request) -> web.Response:
+    scope = _chat_scope(request)
+    return _json_response({"visuals": await asyncio.to_thread(scope.visual_store.list)})
+
+
+async def _handle_visual_file(request: web.Request) -> web.Response:
+    scope = _chat_scope(request)
+    name = request.match_info["name"]
+    try:
+        data = await asyncio.to_thread(scope.visual_store.read, name)
+    except FileNotFoundError:
+        return _error_response("visual not found", 404)
+    # Rendered in sandboxed iframes by the UI; still pin the content type and
+    # keep caches out of the way so live-updating visuals stay fresh.
+    return web.Response(
+        body=data,
+        content_type="text/html",
+        headers={"X-Content-Type-Options": "nosniff", "Cache-Control": "no-cache"},
+    )
+
+
+async def _pump_chat_turn(
+    ws: web.WebSocketResponse,
+    client: LLMClient,
+    scope: ChatScope,
+    conversation_id: str,
+    text: str,
+) -> None:
+    try:
+        async for frame in run_chat_turn(
+            client, scope.toolbox, scope.chat_store, conversation_id, text, scope.system_prompt
+        ):
+            await ws.send_str(_json_dumps(frame))
+    except asyncio.CancelledError:
+        with contextlib.suppress(Exception):
+            await ws.send_str(
+                _json_dumps({"type": "cancelled", "conversation_id": conversation_id})
+            )
+        raise
+    except Exception as e:
+        logger.warning("Chat turn failed: %s", e, exc_info=True)
+        with contextlib.suppress(Exception):
+            await ws.send_str(_json_dumps({"type": "error", "error": str(e)}))
+
+
+async def _handle_chat_ws(request: web.Request) -> web.WebSocketResponse:
+    """Chat websocket.
+
+    Client frames: ``{"type": "user_message", "conversation_id"?: str,
+    "text": str}`` starts a turn; ``{"type": "cancel"}`` cancels the running
+    turn. Server frames are the agent's event stream (``conversation``,
+    ``text_delta``, ``tool_call``, ``tool_result``, ``visual_published``,
+    ``done`` / ``error`` / ``cancelled``). Missing API key yields a structured
+    ``{"type": "error", "code": "no_api_key"}`` frame the UI can render as a
+    setup hint.
+    """
+    ws = web.WebSocketResponse(heartbeat=30)
+    await ws.prepare(request)
+    turn_task: asyncio.Task[None] | None = None
+    try:
+        async for msg in ws:
+            if msg.type != WSMsgType.TEXT:
+                continue
+            try:
+                data = json.loads(msg.data)
+            except json.JSONDecodeError as e:
+                await ws.send_str(_json_dumps({"type": "error", "error": str(e)}))
+                continue
+            msg_type = data.get("type")
+            if msg_type == "cancel":
+                if turn_task is not None and not turn_task.done():
+                    turn_task.cancel()
+                continue
+            if msg_type != "user_message":
+                await ws.send_str(
+                    _json_dumps({"type": "error", "error": f"unknown message type {msg_type!r}"})
+                )
+                continue
+            if turn_task is not None and not turn_task.done():
+                await ws.send_str(
+                    _json_dumps({"type": "error", "error": "a turn is already running"})
+                )
+                continue
+            text = data.get("text")
+            conversation_id = data.get("conversation_id") or new_conversation_id()
+            if (
+                not text
+                or not isinstance(text, str)
+                or not valid_conversation_id(str(conversation_id))
+            ):
+                await ws.send_str(
+                    _json_dumps(
+                        {
+                            "type": "error",
+                            "error": "user_message needs non-empty 'text' (and a well-formed conversation_id)",
+                        }
+                    )
+                )
+                continue
+            state = request.app[AGENT_STATE_KEY]
+            config = LLMConfig(
+                provider=state["provider"], model=state["model"], api_key=state["api_key"]
+            )
+            if config.resolve_api_key() is None:
+                env_var = API_KEY_ENV_VARS[config.provider]
+                await ws.send_str(
+                    _json_dumps(
+                        {
+                            "type": "error",
+                            "code": "no_api_key",
+                            "provider": config.provider,
+                            "error": (
+                                f"No API key configured for {config.provider!r}. Set {env_var} "
+                                "in the server environment or add a key in the viewer settings."
+                            ),
+                        }
+                    )
+                )
+                continue
+            try:
+                scope = _chat_scope(request, include_prompt=True)
+            except web.HTTPNotFound as e:
+                await ws.send_str(_json_dumps({"type": "error", "error": e.text or "not found"}))
+                continue
+            client = LLMClient(config, transport=request.app[LLM_TRANSPORT_KEY])
+            await ws.send_str(
+                _json_dumps({"type": "conversation", "conversation_id": str(conversation_id)})
+            )
+            turn_task = asyncio.create_task(
+                _pump_chat_turn(ws, client, scope, str(conversation_id), text)
+            )
+    finally:
+        if turn_task is not None:
+            turn_task.cancel()
+    return ws
+
+
+def _add_chat_routes(
+    app: web.Application, api_base: str, visuals_file_path: str | None = None
+) -> None:
+    """Mount the chat/transcript/visuals endpoints under ``api_base``.
+
+    Visual files are served at ``{api_base}/visuals/{name}`` unless
+    ``visuals_file_path`` overrides it (the top-level chats use the shorter
+    ``/visuals/{name}``).
+    """
+    app.router.add_get(f"{api_base}/chat", _handle_chat_ws)
+    app.router.add_get(f"{api_base}/chats", _handle_chats_list)
+    app.router.add_get(f"{api_base}/chats/{{conversation_id}}", _handle_chat_detail)
+    app.router.add_get(f"{api_base}/visuals", _handle_visuals_list)
+    app.router.add_get(visuals_file_path or f"{api_base}/visuals/{{name}}", _handle_visual_file)
+
+
 # --- Tokenizer (best-effort, background) ---
 
 
@@ -686,6 +1007,7 @@ def build_app(
     load_tokenizer: bool = True,
     dashboard_ttl_s: float = DEFAULT_DASHBOARD_TTL_S,
     live_window_s: float = DEFAULT_LIVE_WINDOW_S,
+    llm_transport: SSETransport | None = None,
 ) -> web.Application:
     """Build the viewer application.
 
@@ -705,6 +1027,8 @@ def build_app(
             cache.
         live_window_s: A run is "live" if a manifest was modified within
             this many seconds.
+        llm_transport: Override for the chat agent's LLM HTTP transport
+            (tests inject a scripted transport; ``None`` uses aiohttp).
     """
     app = web.Application()
     app[LOAD_TOKENIZER_KEY] = load_tokenizer
@@ -713,6 +1037,10 @@ def build_app(
     app[DASHBOARD_TTL_KEY] = dashboard_ttl_s
     app[LIVE_WINDOW_KEY] = live_window_s
     app[REGISTRY_DIR_KEY] = registry_dir
+    app[AGENT_STATE_KEY] = {"provider": "anthropic", "model": None, "api_key": None}
+    app[LLM_TRANSPORT_KEY] = llm_transport
+    app.router.add_get("/api/agent/config", _handle_agent_config_get)
+    app.router.add_post("/api/agent/config", _handle_agent_config_post)
 
     if log_path is not None:
         # Single-run mode: endpoints at their original paths.
@@ -728,6 +1056,7 @@ def build_app(
         app.router.add_post("/api/labels", _handle_labels_post)
         app.router.add_post("/api/tokens/decode", _handle_decode)
         app.router.add_get("/ws", _handle_ws)
+        _add_chat_routes(app, "/api", visuals_file_path="/visuals/{name}")
         if load_tokenizer:
             app.on_startup.append(_start_tokenizer_load)
     else:
@@ -755,6 +1084,9 @@ def build_app(
         app.router.add_get(f"{prefix}/ws", _handle_ws)
         app.router.add_get("/ws", _handle_ws)
         app.router.add_get("/ws/dashboard", _handle_ws_dashboard)
+        # Chat: a registry-level cross-run chat at /api/chat plus per-run chats.
+        _add_chat_routes(app, "/api", visuals_file_path="/visuals/{name}")
+        _add_chat_routes(app, prefix)
 
     if static_dir is not None and (static_dir / "index.html").is_file():
         index_path = static_dir / "index.html"

--- a/tinker_cookbook/tokendb/serve.py
+++ b/tinker_cookbook/tokendb/serve.py
@@ -60,7 +60,14 @@ from tinker_cookbook.tokendb.agent import (
     valid_conversation_id,
 )
 from tinker_cookbook.tokendb.agent_prompt import build_system_prompt
-from tinker_cookbook.tokendb.llm import API_KEY_ENV_VARS, LLMClient, LLMConfig, SSETransport
+from tinker_cookbook.tokendb.llm import (
+    API_KEY_ENV_VARS,
+    DEFAULT_MODELS,
+    KNOWN_MODELS,
+    LLMClient,
+    LLMConfig,
+    SSETransport,
+)
 from tinker_cookbook.tokendb.reader import (
     LABELS_PATH,
     ParquetSegmentReader,
@@ -768,6 +775,10 @@ async def _handle_agent_config_get(request: web.Request) -> web.Response:
             "provider": config.provider,
             "model": config.resolved_model(),
             "has_key": config.resolve_api_key() is not None,
+            # Per-provider curated suggestions + defaults so the UI can
+            # prefill its model dropdown without hardcoding model ids.
+            "models": KNOWN_MODELS,
+            "default_model": DEFAULT_MODELS,
         }
     )
 

--- a/tinker_cookbook/tokendb/serve.py
+++ b/tinker_cookbook/tokendb/serve.py
@@ -126,6 +126,10 @@ LOAD_TOKENIZER_KEY = web.AppKey("load_tokenizer", bool)
 # Chat agent: provider/model/api_key held in server memory only (never persisted).
 AGENT_STATE_KEY: web.AppKey[dict[str, Any]] = web.AppKey("agent_state")
 LLM_TRANSPORT_KEY: web.AppKey[SSETransport | None] = web.AppKey("llm_transport")
+# Tinker model list: fetched lazily from server capabilities and cached.
+TINKER_MODELS_TTL_S = 300.0
+TINKER_MODELS_FETCHER_KEY: web.AppKey[Any] = web.AppKey("tinker_models_fetcher")
+TINKER_MODELS_CACHE_KEY: web.AppKey[dict[str, Any]] = web.AppKey("tinker_models_cache")
 
 
 def _json_response(data: Any, status: int = 200) -> web.Response:
@@ -766,21 +770,63 @@ def _chat_scope(request: web.Request, *, include_prompt: bool = False) -> ChatSc
     )
 
 
+async def _get_tinker_models(
+    app: web.Application, state: dict[str, Any]
+) -> tuple[list[str], str | None]:
+    """The tinker supported-model list, cached for TINKER_MODELS_TTL_S.
+
+    Returns ``(models, error)``. No key configured means an empty list with
+    an explanatory error; fetch failures are cached too, so a flapping
+    service is not hammered on every config poll.
+    """
+    api_key = LLMConfig(provider="tinker", api_key=state["api_key"]).resolve_api_key()
+    if not api_key:
+        return [], "TINKER_API_KEY is not set on the server (and no runtime key is configured)."
+    cache = app[TINKER_MODELS_CACHE_KEY]
+    now = time.monotonic()
+    if cache.get("api_key") == api_key and now - cache.get("ts", 0.0) < TINKER_MODELS_TTL_S:
+        return cache["models"], cache["error"]
+    from tinker_cookbook.tokendb.tinker_llm import fetch_tinker_models
+
+    fetcher = app[TINKER_MODELS_FETCHER_KEY] or fetch_tinker_models
+    models: list[str] = []
+    error: str | None = None
+    try:
+        models = list(await asyncio.to_thread(fetcher, api_key))
+    except Exception as e:
+        logger.warning("Fetching tinker supported models failed: %s", e)
+        error = str(e)
+    cache.clear()
+    cache.update({"api_key": api_key, "ts": now, "models": models, "error": error})
+    return models, error
+
+
 async def _handle_agent_config_get(request: web.Request) -> web.Response:
     state = request.app[AGENT_STATE_KEY]
     config = LLMConfig(provider=state["provider"], model=state["model"], api_key=state["api_key"])
+    # Per-provider curated suggestions + defaults so the UI can prefill its
+    # model dropdown without hardcoding model ids. The tinker list is fetched
+    # from server capabilities, but only when the tinker provider is actually
+    # in play (configured, or requested via ?provider=tinker) so the config
+    # GET never blocks on it otherwise.
+    models = dict(KNOWN_MODELS)
+    default_model = dict(DEFAULT_MODELS)
     # The key itself is never returned, only whether one is available.
-    return _json_response(
-        {
-            "provider": config.provider,
-            "model": config.resolved_model(),
-            "has_key": config.resolve_api_key() is not None,
-            # Per-provider curated suggestions + defaults so the UI can
-            # prefill its model dropdown without hardcoding model ids.
-            "models": KNOWN_MODELS,
-            "default_model": DEFAULT_MODELS,
-        }
-    )
+    payload: dict[str, Any] = {
+        "provider": config.provider,
+        "model": config.resolved_model(),
+        "has_key": config.resolve_api_key() is not None,
+        "models": models,
+        "default_model": default_model,
+    }
+    if config.provider == "tinker" or request.query.get("provider") == "tinker":
+        from tinker_cookbook.tokendb.tinker_llm import pick_default_model
+
+        tinker_models, tinker_error = await _get_tinker_models(request.app, state)
+        models["tinker"] = tinker_models
+        default_model["tinker"] = pick_default_model(tinker_models) or DEFAULT_MODELS["tinker"]
+        payload["tinker_models_error"] = tinker_error
+    return _json_response(payload)
 
 
 async def _handle_agent_config_post(request: web.Request) -> web.Response:
@@ -793,7 +839,7 @@ async def _handle_agent_config_post(request: web.Request) -> web.Response:
             provider = str(body["provider"])
             if provider not in API_KEY_ENV_VARS:
                 raise ValueError(
-                    f"unknown provider {provider!r} (expected 'anthropic' or 'openai')"
+                    f"unknown provider {provider!r} (expected 'anthropic', 'openai', or 'tinker')"
                 )
             state["provider"] = provider
         if "model" in body:
@@ -1019,6 +1065,7 @@ def build_app(
     dashboard_ttl_s: float = DEFAULT_DASHBOARD_TTL_S,
     live_window_s: float = DEFAULT_LIVE_WINDOW_S,
     llm_transport: SSETransport | None = None,
+    tinker_models_fetcher: Any = None,
 ) -> web.Application:
     """Build the viewer application.
 
@@ -1040,6 +1087,9 @@ def build_app(
             this many seconds.
         llm_transport: Override for the chat agent's LLM HTTP transport
             (tests inject a scripted transport; ``None`` uses aiohttp).
+        tinker_models_fetcher: Override for the tinker supported-model
+            fetch, a blocking ``(api_key) -> list[str]`` callable (tests
+            inject a stub; ``None`` uses the tinker SDK).
     """
     app = web.Application()
     app[LOAD_TOKENIZER_KEY] = load_tokenizer
@@ -1050,6 +1100,8 @@ def build_app(
     app[REGISTRY_DIR_KEY] = registry_dir
     app[AGENT_STATE_KEY] = {"provider": "anthropic", "model": None, "api_key": None}
     app[LLM_TRANSPORT_KEY] = llm_transport
+    app[TINKER_MODELS_FETCHER_KEY] = tinker_models_fetcher
+    app[TINKER_MODELS_CACHE_KEY] = {}
     app.router.add_get("/api/agent/config", _handle_agent_config_get)
     app.router.add_post("/api/agent/config", _handle_agent_config_post)
 

--- a/tinker_cookbook/tokendb/serve.py
+++ b/tinker_cookbook/tokendb/serve.py
@@ -67,6 +67,7 @@ from tinker_cookbook.tokendb.llm import (
     LLMClient,
     LLMConfig,
     SSETransport,
+    detect_default_provider,
 )
 from tinker_cookbook.tokendb.reader import (
     LABELS_PATH,
@@ -801,9 +802,21 @@ async def _get_tinker_models(
     return models, error
 
 
+def _agent_llm_config(state: dict[str, Any]) -> LLMConfig:
+    """The effective LLM config for the chat agent.
+
+    ``state["provider"]`` is None until a provider is explicitly POSTed to the
+    config endpoint; until then the effective provider is auto-detected from
+    key availability (so e.g. a server with only OPENAI_API_KEY set chats via
+    openai out of the box).
+    """
+    provider = state["provider"] or detect_default_provider(api_key=state["api_key"])
+    return LLMConfig(provider=provider, model=state["model"], api_key=state["api_key"])
+
+
 async def _handle_agent_config_get(request: web.Request) -> web.Response:
     state = request.app[AGENT_STATE_KEY]
-    config = LLMConfig(provider=state["provider"], model=state["model"], api_key=state["api_key"])
+    config = _agent_llm_config(state)
     # Per-provider curated suggestions + defaults so the UI can prefill its
     # model dropdown without hardcoding model ids. The tinker list is fetched
     # from server capabilities, but only when the tinker provider is actually
@@ -816,6 +829,15 @@ async def _handle_agent_config_get(request: web.Request) -> web.Response:
         "provider": config.provider,
         "model": config.resolved_model(),
         "has_key": config.resolve_api_key() is not None,
+        # Per-provider key availability, so the UI can show which providers
+        # are ready without switching to each one.
+        "providers": {
+            provider: {
+                "has_key": LLMConfig(provider=provider, api_key=state["api_key"]).resolve_api_key()
+                is not None
+            }
+            for provider in API_KEY_ENV_VARS
+        },
         "models": models,
         "default_model": default_model,
     }
@@ -970,9 +992,7 @@ async def _handle_chat_ws(request: web.Request) -> web.WebSocketResponse:
                 )
                 continue
             state = request.app[AGENT_STATE_KEY]
-            config = LLMConfig(
-                provider=state["provider"], model=state["model"], api_key=state["api_key"]
-            )
+            config = _agent_llm_config(state)
             if config.resolve_api_key() is None:
                 env_var = API_KEY_ENV_VARS[config.provider]
                 await ws.send_str(
@@ -1098,7 +1118,9 @@ def build_app(
     app[DASHBOARD_TTL_KEY] = dashboard_ttl_s
     app[LIVE_WINDOW_KEY] = live_window_s
     app[REGISTRY_DIR_KEY] = registry_dir
-    app[AGENT_STATE_KEY] = {"provider": "anthropic", "model": None, "api_key": None}
+    # provider=None means "not explicitly chosen": the effective provider is
+    # auto-detected from key availability until a POST pins one.
+    app[AGENT_STATE_KEY] = {"provider": None, "model": None, "api_key": None}
     app[LLM_TRANSPORT_KEY] = llm_transport
     app[TINKER_MODELS_FETCHER_KEY] = tinker_models_fetcher
     app[TINKER_MODELS_CACHE_KEY] = {}

--- a/tinker_cookbook/tokendb/serve_test.py
+++ b/tinker_cookbook/tokendb/serve_test.py
@@ -644,6 +644,11 @@ def test_agent_config_endpoint_never_leaks_key(populated_store: Path):
             "provider": "anthropic",
             "model": "claude-fable-5",
             "has_key": False,
+            "providers": {
+                "anthropic": {"has_key": False},
+                "openai": {"has_key": False},
+                "tinker": {"has_key": False},
+            },
             "models": KNOWN_MODELS,
             "default_model": DEFAULT_MODELS,
         }
@@ -686,6 +691,95 @@ def test_agent_config_has_key_from_environment(
     run_with_client(populated_store, fn)
 
 
+def test_agent_config_default_provider_from_openai_env(
+    populated_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Only OPENAI_API_KEY set: the effective default provider is openai."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-env")
+
+    async def fn(client):
+        resp = await client.get("/api/agent/config")
+        payload = await resp.json()
+        assert payload["provider"] == "openai"
+        assert payload["model"] == DEFAULT_MODELS["openai"]
+        assert payload["has_key"] is True
+        assert payload["providers"] == {
+            "anthropic": {"has_key": False},
+            "openai": {"has_key": True},
+            "tinker": {"has_key": False},
+        }
+
+    run_with_client(populated_store, fn)
+
+
+def test_agent_config_default_provider_preference_order(
+    populated_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Both anthropic and openai keys set: anthropic wins (preference order)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic-env")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-env")
+
+    async def fn(client):
+        resp = await client.get("/api/agent/config")
+        payload = await resp.json()
+        assert payload["provider"] == "anthropic"
+        assert payload["has_key"] is True
+        assert payload["providers"]["anthropic"] == {"has_key": True}
+        assert payload["providers"]["openai"] == {"has_key": True}
+
+    run_with_client(populated_store, fn)
+
+
+def test_agent_config_default_provider_no_keys(populated_store: Path):
+    """No keys anywhere: falls back to anthropic with has_key false."""
+
+    async def fn(client):
+        resp = await client.get("/api/agent/config")
+        payload = await resp.json()
+        assert payload["provider"] == "anthropic"
+        assert payload["has_key"] is False
+
+    run_with_client(populated_store, fn)
+
+
+def test_agent_config_explicit_provider_pins(
+    populated_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An explicit POST pins the provider even when it has no key."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-env")
+
+    async def fn(client):
+        resp = await client.post("/api/agent/config", json={"provider": "anthropic"})
+        payload = await resp.json()
+        assert payload["provider"] == "anthropic"
+        assert payload["has_key"] is False
+        # Sticks across subsequent GETs despite openai having a key.
+        resp = await client.get("/api/agent/config")
+        payload = await resp.json()
+        assert payload["provider"] == "anthropic"
+        assert payload["has_key"] is False
+        assert payload["providers"]["openai"] == {"has_key": True}
+
+    run_with_client(populated_store, fn)
+
+
+def test_agent_config_runtime_key_counts_for_all_providers(populated_store: Path):
+    """A runtime-configured key marks every provider as ready."""
+
+    async def fn(client):
+        resp = await client.post("/api/agent/config", json={"api_key": "sk-runtime"})
+        payload = await resp.json()
+        assert payload["provider"] == "anthropic"  # first in preference order
+        assert payload["has_key"] is True
+        assert payload["providers"] == {
+            "anthropic": {"has_key": True},
+            "openai": {"has_key": True},
+            "tinker": {"has_key": True},
+        }
+
+    run_with_client(populated_store, fn)
+
+
 class CountingModelsFetcher:
     """Stub for the tinker supported-models fetch; counts calls."""
 
@@ -702,6 +796,9 @@ class CountingModelsFetcher:
 
 
 def test_agent_config_tinker_models(populated_store: Path, monkeypatch: pytest.MonkeyPatch):
+    # An anthropic key too, so the auto-detected default provider stays
+    # non-tinker and the plain GET below exercises the "no fetch" path.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
     monkeypatch.setenv("TINKER_API_KEY", "tml-test")
     fetcher = CountingModelsFetcher(
         models=["meta-llama/Llama-3.1-8B", "Qwen/Qwen3-30B-A3B-Instruct-2507", "Qwen/Qwen3-8B"]

--- a/tinker_cookbook/tokendb/serve_test.py
+++ b/tinker_cookbook/tokendb/serve_test.py
@@ -549,6 +549,7 @@ def _no_ambient_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     """Chat tests must control key presence themselves."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
 
 
 async def _chat_frames(ws, text: str, conversation_id: str | None = None) -> list[dict]:
@@ -683,6 +684,96 @@ def test_agent_config_has_key_from_environment(
         assert (await resp.json())["has_key"] is False
 
     run_with_client(populated_store, fn)
+
+
+class CountingModelsFetcher:
+    """Stub for the tinker supported-models fetch; counts calls."""
+
+    def __init__(self, models=None, error: Exception | None = None) -> None:
+        self.models = models or []
+        self.error = error
+        self.calls: list[str] = []
+
+    def __call__(self, api_key: str) -> list[str]:
+        self.calls.append(api_key)
+        if self.error is not None:
+            raise self.error
+        return list(self.models)
+
+
+def test_agent_config_tinker_models(populated_store: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TINKER_API_KEY", "tml-test")
+    fetcher = CountingModelsFetcher(
+        models=["meta-llama/Llama-3.1-8B", "Qwen/Qwen3-30B-A3B-Instruct-2507", "Qwen/Qwen3-8B"]
+    )
+
+    async def main():
+        app = build_app(
+            populated_store, static_dir=None, load_tokenizer=False, tinker_models_fetcher=fetcher
+        )
+        async with TestClient(TestServer(app)) as client:
+            # Plain GET with a non-tinker provider never touches the fetcher.
+            resp = await client.get("/api/agent/config")
+            payload = await resp.json()
+            assert payload["models"]["tinker"] == []
+            assert "tinker_models_error" not in payload
+            assert fetcher.calls == []
+
+            # ?provider=tinker fetches the list and picks an instruct default.
+            resp = await client.get("/api/agent/config?provider=tinker")
+            payload = await resp.json()
+            assert payload["models"]["tinker"] == fetcher.models
+            assert payload["default_model"]["tinker"] == "Qwen/Qwen3-30B-A3B-Instruct-2507"
+            assert payload["tinker_models_error"] is None
+            assert len(fetcher.calls) == 1
+
+            # Cached: a second GET within the TTL does not refetch. Switching
+            # the configured provider to tinker also serves from the cache.
+            await client.get("/api/agent/config?provider=tinker")
+            resp = await client.post("/api/agent/config", json={"provider": "tinker"})
+            payload = await resp.json()
+            assert payload["models"]["tinker"] == fetcher.models
+            assert payload["has_key"] is True
+            assert len(fetcher.calls) == 1
+
+    asyncio.run(main())
+
+
+def test_agent_config_tinker_without_key(populated_store: Path):
+    fetcher = CountingModelsFetcher(models=["Qwen/Qwen3-8B"])
+
+    async def main():
+        app = build_app(
+            populated_store, static_dir=None, load_tokenizer=False, tinker_models_fetcher=fetcher
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/agent/config?provider=tinker")
+            payload = await resp.json()
+            assert payload["models"]["tinker"] == []
+            assert "TINKER_API_KEY" in payload["tinker_models_error"]
+            assert fetcher.calls == []  # no key, nothing to fetch
+
+    asyncio.run(main())
+
+
+def test_agent_config_tinker_fetch_error(populated_store: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TINKER_API_KEY", "tml-test")
+    fetcher = CountingModelsFetcher(error=RuntimeError("capabilities unavailable"))
+
+    async def main():
+        app = build_app(
+            populated_store, static_dir=None, load_tokenizer=False, tinker_models_fetcher=fetcher
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/agent/config?provider=tinker")
+            payload = await resp.json()
+            assert payload["models"]["tinker"] == []
+            assert "capabilities unavailable" in payload["tinker_models_error"]
+            # The failure is cached too (no hammering on config polls).
+            await client.get("/api/agent/config?provider=tinker")
+            assert len(fetcher.calls) == 1
+
+    asyncio.run(main())
 
 
 def test_visuals_publish_list_and_serve(populated_store: Path):

--- a/tinker_cookbook/tokendb/serve_test.py
+++ b/tinker_cookbook/tokendb/serve_test.py
@@ -536,3 +536,239 @@ def test_registry_mode_requires_registry(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("TINKER_TOKENDB_REGISTRY", "")
     with pytest.raises(ValueError, match="registry is disabled"):
         build_app(None, static_dir=None, load_tokenizer=False)
+
+
+# --- Chat agent endpoints (websocket chat, config, visuals) ---
+
+from tinker_cookbook.tokendb.agent_test import ScriptedTransport, anthropic_script  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chat tests must control key presence themselves."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+async def _chat_frames(ws, text: str, conversation_id: str | None = None) -> list[dict]:
+    """Send a user_message and collect frames through the terminal one."""
+    message: dict = {"type": "user_message", "text": text}
+    if conversation_id is not None:
+        message["conversation_id"] = conversation_id
+    await ws.send_str(json.dumps(message))
+    frames = []
+    while True:
+        frames.append(json.loads((await ws.receive(timeout=10.0)).data))
+        if frames[-1]["type"] in ("done", "error", "cancelled"):
+            return frames
+
+
+def test_chat_ws_end_to_end(populated_store: Path):
+    transport = ScriptedTransport(
+        [
+            anthropic_script(
+                text="Checking.",
+                tool_calls=[("t1", "sql", {"query": "SELECT count(*) AS n FROM rollouts"})],
+            ),
+            anthropic_script(text="There are 6 rows."),
+        ]
+    )
+
+    async def main():
+        app = build_app(
+            populated_store, static_dir=None, load_tokenizer=False, llm_transport=transport
+        )
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.post("/api/agent/config", json={"api_key": "sk-test"})
+            assert (await resp.json())["has_key"] is True
+            async with client.ws_connect("/api/chat") as ws:
+                frames = await _chat_frames(ws, "how many rows?")
+            assert frames[0]["type"] == "conversation"
+            conversation_id = frames[0]["conversation_id"]
+            types = [f["type"] for f in frames]
+            assert types == [
+                "conversation",
+                "text_delta",
+                "tool_call",
+                "tool_result",
+                "text_delta",
+                "done",
+            ]
+            assert frames[1]["text"] == "Checking."
+            assert frames[2]["name"] == "sql"
+            assert not frames[3]["is_error"]
+            assert frames[4]["text"] == "There are 6 rows."
+
+            # The system prompt carried the run's SQL endpoint and schema docs.
+            system = transport.requests[0][2]["system"]
+            assert "/api/sql" in system
+            assert "ob_is_delta" in system
+
+            # Transcript endpoints.
+            resp = await client.get("/api/chats")
+            conversations = (await resp.json())["conversations"]
+            assert [c["conversation_id"] for c in conversations] == [conversation_id]
+            assert conversations[0]["title"] == "how many rows?"
+            resp = await client.get(f"/api/chats/{conversation_id}")
+            records = (await resp.json())["records"]
+            assert [r.get("role") for r in records if r["kind"] == "message"] == [
+                "user",
+                "assistant",
+                "tool",
+                "assistant",
+            ]
+            resp = await client.get("/api/chats/nope-id")
+            assert resp.status == 404
+
+    asyncio.run(main())
+
+
+def test_chat_ws_missing_key_error_frame(populated_store: Path):
+    async def fn(client):
+        async with client.ws_connect("/api/chat") as ws:
+            frames = await _chat_frames(ws, "hello?")
+        assert len(frames) == 1
+        assert frames[0]["type"] == "error"
+        assert frames[0]["code"] == "no_api_key"
+        assert "ANTHROPIC_API_KEY" in frames[0]["error"]
+
+    run_with_client(populated_store, fn)
+
+
+def test_agent_config_endpoint_never_leaks_key(populated_store: Path):
+    async def fn(client):
+        resp = await client.get("/api/agent/config")
+        assert await resp.json() == {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "has_key": False,
+        }
+        resp = await client.post(
+            "/api/agent/config",
+            json={"provider": "openai", "model": "my-model", "api_key": "sk-supersecret"},
+        )
+        payload = await resp.json()
+        assert payload == {"provider": "openai", "model": "my-model", "has_key": True}
+        resp = await client.get("/api/agent/config")
+        assert "sk-supersecret" not in await resp.text()
+        assert (await resp.json())["has_key"] is True
+        # Clearing the key and rejecting unknown providers.
+        resp = await client.post("/api/agent/config", json={"api_key": ""})
+        assert (await resp.json())["has_key"] is False
+        resp = await client.post("/api/agent/config", json={"provider": "nope"})
+        assert resp.status == 400
+
+    run_with_client(populated_store, fn)
+
+
+def test_visuals_publish_list_and_serve(populated_store: Path):
+    html = "<!doctype html><html><body><svg></svg></body></html>"
+    transport = ScriptedTransport(
+        [
+            anthropic_script(
+                tool_calls=[
+                    ("t1", "publish_visual", {"title": "Reward", "description": "d", "html": html})
+                ]
+            ),
+            anthropic_script(text="Published."),
+        ]
+    )
+
+    async def main():
+        app = build_app(
+            populated_store, static_dir=None, load_tokenizer=False, llm_transport=transport
+        )
+        async with TestClient(TestServer(app)) as client:
+            await client.post("/api/agent/config", json={"api_key": "sk-test"})
+            async with client.ws_connect("/api/chat") as ws:
+                frames = await _chat_frames(ws, "chart the reward")
+            visual = next(f for f in frames if f["type"] == "visual_published")
+            assert visual["title"] == "Reward"
+            assert visual["url"].startswith("/visuals/reward-")
+
+            resp = await client.get("/api/visuals")
+            visuals = (await resp.json())["visuals"]
+            assert [v["name"] for v in visuals] == [visual["name"]]
+
+            resp = await client.get(visual["url"])
+            assert resp.status == 200
+            assert resp.headers["Content-Type"].startswith("text/html")
+            assert resp.headers["X-Content-Type-Options"] == "nosniff"
+            assert resp.headers["Cache-Control"] == "no-cache"
+            assert await resp.text() == html
+
+            resp = await client.get("/visuals/does-not-exist.html")
+            assert resp.status == 404
+            resp = await client.get("/visuals/..%2Frun.json")
+            assert resp.status == 404
+
+    asyncio.run(main())
+
+
+def test_registry_global_chat_lists_runs(registry_stores: dict):
+    live_id = registry_stores["live_id"]
+    transport = ScriptedTransport(
+        [
+            anthropic_script(text="Looking.", tool_calls=[("t1", "list_runs", {})]),
+            anthropic_script(
+                tool_calls=[
+                    (
+                        "t2",
+                        "sql",
+                        {"run_id": live_id, "query": "SELECT count(*) AS n FROM rollouts"},
+                    )
+                ]
+            ),
+            anthropic_script(text="The live run has 3 rows."),
+        ]
+    )
+
+    async def main():
+        app = build_app(None, static_dir=None, load_tokenizer=False, llm_transport=transport)
+        async with TestClient(TestServer(app)) as client:
+            await client.post("/api/agent/config", json={"api_key": "sk-test"})
+            async with client.ws_connect("/api/chat") as ws:
+                frames = await _chat_frames(ws, "what runs exist?")
+            assert frames[-1]["type"] == "done"
+            list_result = next(
+                f for f in frames if f["type"] == "tool_result" and f["name"] == "list_runs"
+            )
+            assert '"runs"' in list_result["preview"]
+            # The model saw the full (untruncated-by-preview) run listing.
+            conversation_id = frames[0]["conversation_id"]
+            records = (await (await client.get(f"/api/chats/{conversation_id}")).json())["records"]
+            list_runs_record = next(
+                r for r in records if r["kind"] == "message" and r.get("role") == "tool"
+            )
+            assert live_id in list_runs_record["content"]
+            sql_result = next(
+                f for f in frames if f["type"] == "tool_result" and f["name"] == "sql"
+            )
+            assert '"n": 3' in sql_result["preview"]
+            # Registry-mode prompt teaches the per-run SQL endpoint template.
+            assert "/api/runs/{run_id}/sql" in transport.requests[0][2]["system"]
+
+            # The conversation is stored under the registry directory.
+            registry_dir = Path(os.environ["TINKER_TOKENDB_REGISTRY"])
+            assert list((registry_dir / "chats").glob("*.jsonl"))
+
+            # Per-run chat endpoints are mounted too.
+            resp = await client.get(f"/api/runs/{live_id}/chats")
+            assert resp.status == 200
+            assert (await resp.json())["conversations"] == []
+
+    asyncio.run(main())
+
+
+def test_chat_ws_cancel(populated_store: Path):
+    """A cancel frame while no turn is running is a no-op; bad frames error."""
+
+    async def fn(client):
+        async with client.ws_connect("/api/chat") as ws:
+            await ws.send_str(json.dumps({"type": "cancel"}))
+            await ws.send_str(json.dumps({"type": "bogus"}))
+            msg = json.loads((await ws.receive(timeout=5.0)).data)
+            assert msg["type"] == "error"
+            assert "bogus" in msg["error"]
+
+    run_with_client(populated_store, fn)

--- a/tinker_cookbook/tokendb/serve_test.py
+++ b/tinker_cookbook/tokendb/serve_test.py
@@ -541,6 +541,7 @@ def test_registry_mode_requires_registry(monkeypatch: pytest.MonkeyPatch):
 # --- Chat agent endpoints (websocket chat, config, visuals) ---
 
 from tinker_cookbook.tokendb.agent_test import ScriptedTransport, anthropic_script  # noqa: E402
+from tinker_cookbook.tokendb.llm import DEFAULT_MODELS, KNOWN_MODELS  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -640,15 +641,19 @@ def test_agent_config_endpoint_never_leaks_key(populated_store: Path):
         resp = await client.get("/api/agent/config")
         assert await resp.json() == {
             "provider": "anthropic",
-            "model": "claude-sonnet-4-6",
+            "model": "claude-fable-5",
             "has_key": False,
+            "models": KNOWN_MODELS,
+            "default_model": DEFAULT_MODELS,
         }
         resp = await client.post(
             "/api/agent/config",
             json={"provider": "openai", "model": "my-model", "api_key": "sk-supersecret"},
         )
         payload = await resp.json()
-        assert payload == {"provider": "openai", "model": "my-model", "has_key": True}
+        assert payload["provider"] == "openai"
+        assert payload["model"] == "my-model"
+        assert payload["has_key"] is True
         resp = await client.get("/api/agent/config")
         assert "sk-supersecret" not in await resp.text()
         assert (await resp.json())["has_key"] is True
@@ -657,6 +662,25 @@ def test_agent_config_endpoint_never_leaks_key(populated_store: Path):
         assert (await resp.json())["has_key"] is False
         resp = await client.post("/api/agent/config", json={"provider": "nope"})
         assert resp.status == 400
+
+    run_with_client(populated_store, fn)
+
+
+def test_agent_config_has_key_from_environment(
+    populated_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An env-var key counts as configured, so the UI skips its setup card."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
+
+    async def fn(client):
+        resp = await client.get("/api/agent/config")
+        payload = await resp.json()
+        assert payload["has_key"] is True
+        assert "sk-from-env" not in await resp.text()
+        # The other provider has no key.
+        await client.post("/api/agent/config", json={"provider": "openai"})
+        resp = await client.get("/api/agent/config")
+        assert (await resp.json())["has_key"] is False
 
     run_with_client(populated_store, fn)
 

--- a/tinker_cookbook/tokendb/tinker_llm.py
+++ b/tinker_cookbook/tokendb/tinker_llm.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     import tinker
 
     from tinker_cookbook.renderers.base import Message as RendererMessage
-    from tinker_cookbook.renderers.base import Renderer
+    from tinker_cookbook.renderers.base import Renderer, ToolSpec
 
 logger = logging.getLogger(__name__)
 
@@ -175,10 +175,12 @@ def pick_default_model(models: Sequence[str]) -> str | None:
 # --- Conversation rendering ---
 
 
-def _tool_specs(tools: Sequence[ToolDef]) -> list[dict[str, Any]]:
-    """Our ToolDefs as renderer ToolSpec dicts (OpenAI function format)."""
+def _tool_specs(tools: Sequence[ToolDef]) -> list[ToolSpec]:
+    """Our ToolDefs as renderer ToolSpecs (OpenAI function format)."""
+    from tinker_cookbook.renderers.base import ToolSpec
+
     return [
-        {"name": t.name, "description": t.description, "parameters": t.input_schema} for t in tools
+        ToolSpec(name=t.name, description=t.description, parameters=t.input_schema) for t in tools
     ]
 
 

--- a/tinker_cookbook/tokendb/tinker_llm.py
+++ b/tinker_cookbook/tokendb/tinker_llm.py
@@ -1,0 +1,359 @@
+"""Tinker provider for the tokendb chat agent.
+
+Lets the chat agent run against any model served by Tinker: the model list
+comes from ``service_client.get_server_capabilities().supported_models`` and
+sampling goes through a ``tinker.SamplingClient``. Prompts are built with the
+cookbook's renderer machinery (``model_info.get_recommended_renderer_name`` +
+``renderers.get_renderer``), the same pattern as the tool-use recipes.
+
+Tool calling has two paths:
+
+- **Renderer-native**: if the model's renderer implements
+  ``create_conversation_prefix_with_tools`` (Qwen3, DeepSeek, Kimi, GPT-OSS,
+  Nemotron, ...), tool schemas are injected in the renderer's own format and
+  tool calls are parsed out of the sampled tokens by
+  ``renderer.parse_response`` (``message["tool_calls"]``).
+- **JSON-in-text fallback**: for renderers with no tool convention (e.g.
+  ``role_colon`` for base models), the system prompt documents a fenced
+  `````json {"tool": ..., "arguments": ...}````` protocol and
+  :func:`parse_json_tool_blocks` extracts those blocks from the sampled text.
+
+There is no token-level streaming: one sample per model turn, emitted as a
+single ``TextDelta`` followed by any ``ToolCallEvent``s and ``Done``.
+
+The SDK + renderer boundary is behind :class:`TinkerSession` /
+``SessionFactory`` so tests can inject a fake sampler and an offline renderer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import AsyncIterator, Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from tinker_cookbook.tokendb.llm import (
+    Done,
+    LLMConfig,
+    LLMEvent,
+    Message,
+    TextDelta,
+    ToolCall,
+    ToolCallEvent,
+    ToolDef,
+)
+
+if TYPE_CHECKING:
+    import tinker
+
+    from tinker_cookbook.renderers.base import Message as RendererMessage
+    from tinker_cookbook.renderers.base import Renderer
+
+logger = logging.getLogger(__name__)
+
+# The agent writes SQL and HTML; sample well below temperature 1.0.
+TINKER_TEMPERATURE = 0.7
+
+_JSON_TOOL_BLOCK_RE = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
+
+FALLBACK_TOOL_INSTRUCTIONS = """\
+# Tools
+
+You can call tools. The available tools are described by the JSON schemas \
+below:
+
+{tool_schemas}
+
+To call a tool, emit a fenced JSON block of the form:
+
+```json
+{{"tool": "<tool name>", "arguments": {{...}}}}
+```
+
+Emit at most one such block per response and nothing after it; the tool \
+result will arrive in the next user message. When you have the final answer, \
+reply without any JSON tool block."""
+
+
+# --- SDK / renderer boundary (injectable in tests) ---
+
+
+class TinkerSampler(Protocol):
+    """One sampled completion from the chosen model (test seam)."""
+
+    async def sample(
+        self, prompt: tinker.ModelInput, max_tokens: int, stop: list[str] | list[int]
+    ) -> list[int]: ...
+
+
+@dataclass
+class TinkerSession:
+    """Renderer + sampler for one model, ready to run chat turns."""
+
+    renderer: Renderer
+    sampler: TinkerSampler
+
+
+# (model_name, api_key) -> session. May block (tokenizer load, SDK client
+# construction); called via asyncio.to_thread.
+SessionFactory = Callable[[str, str], TinkerSession]
+
+
+class _SdkSampler:
+    """Default sampler over a ``tinker.SamplingClient``."""
+
+    def __init__(self, sampling_client: Any) -> None:
+        self._sampling_client = sampling_client
+
+    async def sample(
+        self, prompt: tinker.ModelInput, max_tokens: int, stop: list[str] | list[int]
+    ) -> list[int]:
+        import tinker
+
+        result = await self._sampling_client.sample_async(
+            prompt=prompt,
+            num_samples=1,
+            sampling_params=tinker.SamplingParams(
+                max_tokens=max_tokens, temperature=TINKER_TEMPERATURE, stop=stop
+            ),
+        )
+        return list(result.sequences[0].tokens)
+
+
+def base_model_name(model_name: str) -> str:
+    """Strip capability suffixes (``:peft:...`` context variants) for
+    renderer/tokenizer lookup."""
+    return model_name.split(":", 1)[0]
+
+
+def build_tinker_session(model_name: str, api_key: str) -> TinkerSession:
+    """Real session factory: cookbook renderer + SDK sampling client."""
+    import tinker
+
+    from tinker_cookbook import model_info, renderers
+    from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+    base = base_model_name(model_name)
+    try:
+        renderer_name = model_info.get_recommended_renderer_name(base)
+    except Exception:
+        # Model not in the cookbook registry: fall back to the plain
+        # role-colon format (tool calls then use the JSON-in-text protocol).
+        renderer_name = "role_colon"
+    tokenizer = get_tokenizer(base)
+    renderer = renderers.get_renderer(renderer_name, tokenizer, model_name=base)
+    service_client = tinker.ServiceClient(api_key=api_key)
+    sampling_client = service_client.create_sampling_client(base_model=model_name)
+    return TinkerSession(renderer=renderer, sampler=_SdkSampler(sampling_client))
+
+
+# --- Model listing ---
+
+
+def fetch_tinker_models(api_key: str) -> list[str]:
+    """Fetch the supported model names from the Tinker service (blocking)."""
+    import tinker
+
+    service_client = tinker.ServiceClient(api_key=api_key)
+    capabilities = service_client.get_server_capabilities()
+    return [m.model_name for m in capabilities.supported_models if m.model_name]
+
+
+def pick_default_model(models: Sequence[str]) -> str | None:
+    """A sensible chat default: the first Qwen3+ instruct-ish model, else the
+    first entry."""
+    for model in models:
+        lowered = model.lower()
+        if "qwen3" in lowered and "instruct" in lowered and "base" not in lowered:
+            return model
+    return models[0] if models else None
+
+
+# --- Conversation rendering ---
+
+
+def _tool_specs(tools: Sequence[ToolDef]) -> list[dict[str, Any]]:
+    """Our ToolDefs as renderer ToolSpec dicts (OpenAI function format)."""
+    return [
+        {"name": t.name, "description": t.description, "parameters": t.input_schema} for t in tools
+    ]
+
+
+def _renderer_tool_call(call: ToolCall) -> Any:
+    from tinker_cookbook.renderers.base import ToolCall as RToolCall
+
+    return RToolCall(
+        id=call.id or None,
+        function=RToolCall.FunctionBody(name=call.name, arguments=json.dumps(call.arguments)),
+    )
+
+
+def _fallback_system_prompt(system: str, tools: Sequence[ToolDef]) -> str:
+    if not tools:
+        return system
+    schemas = "\n".join(
+        json.dumps({"name": t.name, "description": t.description, "parameters": t.input_schema})
+        for t in tools
+    )
+    instructions = FALLBACK_TOOL_INSTRUCTIONS.format(tool_schemas=schemas)
+    return f"{system}\n\n{instructions}" if system else instructions
+
+
+def _tool_call_as_json_block(call: ToolCall) -> str:
+    payload = json.dumps({"tool": call.name, "arguments": call.arguments})
+    return f"```json\n{payload}\n```"
+
+
+def render_conversation(
+    renderer: Renderer,
+    system: str,
+    messages: Sequence[Message],
+    tools: Sequence[ToolDef],
+) -> tuple[list[RendererMessage], bool]:
+    """Convert the provider-neutral conversation into renderer messages.
+
+    Returns ``(renderer_messages, native_tools)``. ``native_tools`` is True
+    when the renderer's own tool-call format is in play; False means the
+    JSON-in-text fallback protocol (tool calls rendered as fenced JSON blocks,
+    tool results as plain user messages).
+    """
+    from tinker_cookbook.renderers.base import Message as RMessage
+
+    try:
+        prefix = renderer.create_conversation_prefix_with_tools(
+            tools=_tool_specs(tools), system_prompt=system
+        )
+        native = True
+    except NotImplementedError:
+        prefix = [RMessage(role="system", content=_fallback_system_prompt(system, tools))]
+        native = False
+
+    rendered: list[RendererMessage] = list(prefix)
+    call_names: dict[str, str] = {}  # tool_call_id -> tool name (for results)
+    for msg in messages:
+        if msg.role == "assistant":
+            if native:
+                entry = RMessage(role="assistant", content=msg.content)
+                if msg.tool_calls:
+                    entry["tool_calls"] = [_renderer_tool_call(c) for c in msg.tool_calls]
+            else:
+                parts = [msg.content] if msg.content else []
+                parts.extend(_tool_call_as_json_block(c) for c in msg.tool_calls)
+                entry = RMessage(role="assistant", content="\n\n".join(parts))
+            for call in msg.tool_calls:
+                call_names[call.id] = call.name
+            rendered.append(entry)
+        elif msg.role == "tool":
+            name = call_names.get(msg.tool_call_id or "", "")
+            if native:
+                entry = RMessage(role="tool", content=msg.content)
+                if msg.tool_call_id:
+                    entry["tool_call_id"] = msg.tool_call_id
+                if name:
+                    entry["name"] = name
+                rendered.append(entry)
+            else:
+                label = f"Tool result for {name or 'tool call'}:\n"
+                rendered.append(RMessage(role="user", content=label + msg.content))
+        else:
+            rendered.append(RMessage(role="user", content=msg.content))
+    return rendered, native
+
+
+# --- Response parsing ---
+
+
+def parse_json_tool_blocks(text: str) -> tuple[str, list[ToolCall]]:
+    """Extract fenced ``json`` tool blocks from sampled text (fallback path).
+
+    A block parses into a tool call when it is valid JSON of the form
+    ``{"tool": <str>, "arguments": <dict>}``; parsed blocks are removed from
+    the text. Anything else (invalid JSON, missing/odd fields) is left in the
+    text verbatim so the failure is visible in the chat.
+    """
+    calls: list[ToolCall] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            return match.group(0)
+        if not isinstance(payload, dict) or not isinstance(payload.get("tool"), str):
+            return match.group(0)
+        arguments = payload.get("arguments")
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            return match.group(0)
+        calls.append(
+            ToolCall(id=f"tinker_call_{len(calls)}", name=payload["tool"], arguments=arguments)
+        )
+        return ""
+
+    remaining = _JSON_TOOL_BLOCK_RE.sub(_replace, text)
+    return remaining.strip(), calls
+
+
+def _normalize_native_tool_calls(parsed: RendererMessage) -> list[ToolCall]:
+    """Renderer ToolCalls (JSON-string arguments) into normalized ToolCalls."""
+    calls: list[ToolCall] = []
+    for index, rcall in enumerate(parsed.get("tool_calls") or []):
+        try:
+            arguments = json.loads(rcall.function.arguments) if rcall.function.arguments else {}
+        except json.JSONDecodeError:
+            logger.warning("Dropping tool call with invalid arguments JSON: %s", rcall)
+            continue
+        if not isinstance(arguments, dict):
+            logger.warning("Dropping tool call with non-object arguments: %s", rcall)
+            continue
+        calls.append(
+            ToolCall(
+                id=rcall.id or f"tinker_call_{index}",
+                name=rcall.function.name,
+                arguments=arguments,
+            )
+        )
+    return calls
+
+
+# --- The provider ---
+
+
+async def stream_tinker(
+    config: LLMConfig,
+    api_key: str,
+    system: str,
+    messages: Sequence[Message],
+    tools: Sequence[ToolDef],
+    session_factory: SessionFactory | None = None,
+) -> AsyncIterator[LLMEvent]:
+    """One model turn against a Tinker-served model, as normalized events.
+
+    Exceptions propagate to the caller (:meth:`LLMClient.stream` converts
+    them into ``ErrorEvent``s).
+    """
+    factory = session_factory or build_tinker_session
+    session = await asyncio.to_thread(factory, config.resolved_model(), api_key)
+    renderer = session.renderer
+    rendered, native = render_conversation(renderer, system, messages, tools)
+    prompt = renderer.build_generation_prompt(rendered)
+    tokens = await session.sampler.sample(
+        prompt, max_tokens=config.max_tokens, stop=renderer.get_stop_sequences()
+    )
+    parsed, _termination = renderer.parse_response(tokens)
+
+    from tinker_cookbook.renderers import get_text_content
+
+    text = get_text_content(parsed)
+    if native:
+        calls = _normalize_native_tool_calls(parsed)
+    else:
+        text, calls = parse_json_tool_blocks(text)
+    if text:
+        yield TextDelta(text)
+    for call in calls:
+        yield ToolCallEvent(call)
+    yield Done("tool_use" if calls else "end_turn")

--- a/tinker_cookbook/tokendb/tinker_llm_test.py
+++ b/tinker_cookbook/tokendb/tinker_llm_test.py
@@ -5,6 +5,7 @@ end to end."""
 
 import asyncio
 import json
+from typing import cast
 
 import pytest
 
@@ -33,6 +34,7 @@ from tinker_cookbook.tokendb.tinker_llm import (
     pick_default_model,
     render_conversation,
 )
+from tinker_cookbook.tokenizer_utils import Tokenizer
 
 
 @pytest.fixture(autouse=True)
@@ -72,6 +74,10 @@ class FakeTokenizer:
             self._by_id[t] if t in self._by_id else chr(t - self._offset) for t in tokens
         )
 
+    def as_tokenizer(self) -> Tokenizer:
+        """This fake covers the tokenizer surface the renderers use."""
+        return cast(Tokenizer, self)
+
 
 class ScriptedSampler:
     """TinkerSampler stub: records prompts, replays scripted completions."""
@@ -83,7 +89,12 @@ class ScriptedSampler:
         self.stops: list[object] = []
 
     async def sample(self, prompt: tinker.ModelInput, max_tokens: int, stop) -> list[int]:
-        tokens = [t for chunk in prompt.chunks for t in chunk.tokens]
+        tokens = [
+            t
+            for chunk in prompt.chunks
+            if isinstance(chunk, tinker.EncodedTextChunk)
+            for t in chunk.tokens
+        ]
         self.prompts.append(self._tokenizer.decode(tokens))
         self.stops.append(stop)
         if not self._completions:
@@ -126,7 +137,7 @@ def collect(aiter):
 
 def test_native_prompt_and_tool_call_parse():
     tokenizer = FakeTokenizer()
-    renderer = Qwen3Renderer(tokenizer)
+    renderer = Qwen3Renderer(tokenizer.as_tokenizer())
     completion = (
         '<tool_call>\n{"name": "sql", "arguments": {"query": "SELECT 1"}}\n</tool_call><|im_end|>'
     )
@@ -157,7 +168,7 @@ def test_native_prompt_and_tool_call_parse():
 
 def test_native_history_renders_tool_calls_and_results():
     tokenizer = FakeTokenizer()
-    renderer = Qwen3Renderer(tokenizer)
+    renderer = Qwen3Renderer(tokenizer.as_tokenizer())
     sampler = ScriptedSampler(tokenizer, ["There is 1 row.<|im_end|>"])
     client = make_client(renderer, sampler)
     messages = [
@@ -182,7 +193,7 @@ def test_native_history_renders_tool_calls_and_results():
 
 def test_fallback_prompt_documents_protocol_and_parses_block():
     tokenizer = FakeTokenizer()
-    renderer = RoleColonRenderer(tokenizer)
+    renderer = RoleColonRenderer(tokenizer.as_tokenizer())
     completion = (
         'Let me check.\n\n```json\n{"tool": "sql", "arguments": {"query": "SELECT 1"}}\n```'
         "\n\nUser:"
@@ -203,7 +214,7 @@ def test_fallback_prompt_documents_protocol_and_parses_block():
 
 def test_fallback_history_rendering():
     tokenizer = FakeTokenizer()
-    renderer = RoleColonRenderer(tokenizer)
+    renderer = RoleColonRenderer(tokenizer.as_tokenizer())
     messages = [
         Message(role="user", content="count rows"),
         Message(
@@ -219,7 +230,9 @@ def test_fallback_history_rendering():
     # Prior tool calls become fenced JSON blocks; results become user messages.
     assert '```json\n{"tool": "sql"' in rendered[2]["content"]
     assert rendered[3]["role"] == "user"
-    assert rendered[3]["content"].startswith("Tool result for sql:")
+    result_content = rendered[3]["content"]
+    assert isinstance(result_content, str)
+    assert result_content.startswith("Tool result for sql:")
 
 
 def test_parse_json_tool_blocks():
@@ -264,7 +277,7 @@ def test_sampler_failure_surfaces_as_error_event():
         async def sample(self, prompt, max_tokens, stop):
             raise RuntimeError("service unavailable")
 
-    client = make_client(RoleColonRenderer(FakeTokenizer()), FailingSampler())
+    client = make_client(RoleColonRenderer(FakeTokenizer().as_tokenizer()), FailingSampler())
     events = collect(client.stream("sys", [Message(role="user", content="hi")]))
     assert isinstance(events[-1], ErrorEvent)
     assert "service unavailable" in events[-1].message
@@ -290,7 +303,7 @@ def test_pick_default_model_prefers_qwen3_instruct():
 def test_native_arguments_json_roundtrip():
     """Arguments survive the renderer's JSON-string encoding round trip."""
     tokenizer = FakeTokenizer()
-    renderer = Qwen3Renderer(tokenizer)
+    renderer = Qwen3Renderer(tokenizer.as_tokenizer())
     messages = [
         Message(
             role="assistant",
@@ -300,5 +313,7 @@ def test_native_arguments_json_roundtrip():
     ]
     rendered, native = render_conversation(renderer, "SYS", messages, [SQL_TOOL])
     assert native is True
-    rcall = rendered[-1]["tool_calls"][0]
+    rendered_calls = rendered[-1].get("tool_calls")
+    assert rendered_calls is not None
+    rcall = rendered_calls[0]
     assert json.loads(rcall.function.arguments) == {"query": 'SELECT "x"'}

--- a/tinker_cookbook/tokendb/tinker_llm_test.py
+++ b/tinker_cookbook/tokendb/tinker_llm_test.py
@@ -1,0 +1,304 @@
+"""Tests for the tinker chat-agent provider. No network: sampling is a
+scripted fake behind the ``TinkerSession`` seam and renderers run on a tiny
+offline tokenizer, so the real renderer prompt/parse machinery is exercised
+end to end."""
+
+import asyncio
+import json
+
+import pytest
+
+pytest.importorskip("aiohttp")
+pytest.importorskip("tinker")
+
+import tinker
+
+from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
+from tinker_cookbook.renderers.role_colon import RoleColonRenderer
+from tinker_cookbook.tokendb.llm import (
+    Done,
+    ErrorEvent,
+    LLMClient,
+    LLMConfig,
+    Message,
+    TextDelta,
+    ToolCall,
+    ToolCallEvent,
+    ToolDef,
+)
+from tinker_cookbook.tokendb.tinker_llm import (
+    TinkerSession,
+    base_model_name,
+    parse_json_tool_blocks,
+    pick_default_model,
+    render_conversation,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+
+
+class FakeTokenizer:
+    """Reversible offline tokenizer: special strings are single tokens,
+    everything else is one token per character."""
+
+    def __init__(self, specials: tuple[str, ...] = ("<|im_start|>", "<|im_end|>")) -> None:
+        self._specials = {s: i for i, s in enumerate(specials)}
+        self._by_id = {i: s for s, i in self._specials.items()}
+        self._offset = len(specials)
+        self.bos_token = None
+        self.eos_token_id = self._specials.get("<|im_end|>")
+        self.name_or_path = "fake-tokenizer"
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        tokens: list[int] = []
+        i = 0
+        while i < len(text):
+            for special, token_id in self._specials.items():
+                if text.startswith(special, i):
+                    tokens.append(token_id)
+                    i += len(special)
+                    break
+            else:
+                tokens.append(ord(text[i]) + self._offset)
+                i += 1
+        return tokens
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(
+            self._by_id[t] if t in self._by_id else chr(t - self._offset) for t in tokens
+        )
+
+
+class ScriptedSampler:
+    """TinkerSampler stub: records prompts, replays scripted completions."""
+
+    def __init__(self, tokenizer: FakeTokenizer, completions: list[str]) -> None:
+        self._tokenizer = tokenizer
+        self._completions = list(completions)
+        self.prompts: list[str] = []
+        self.stops: list[object] = []
+
+    async def sample(self, prompt: tinker.ModelInput, max_tokens: int, stop) -> list[int]:
+        tokens = [t for chunk in prompt.chunks for t in chunk.tokens]
+        self.prompts.append(self._tokenizer.decode(tokens))
+        self.stops.append(stop)
+        if not self._completions:
+            raise AssertionError("ScriptedSampler ran out of completions")
+        return self._tokenizer.encode(self._completions.pop(0))
+
+
+SQL_TOOL = ToolDef(
+    "sql",
+    "Run SQL.",
+    {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+)
+
+
+def make_client(renderer, sampler, model: str = "test/model") -> LLMClient:
+    session = TinkerSession(renderer=renderer, sampler=sampler)
+    factories: list[tuple[str, str]] = []
+
+    def factory(model_name: str, api_key: str) -> TinkerSession:
+        factories.append((model_name, api_key))
+        return session
+
+    client = LLMClient(
+        LLMConfig(provider="tinker", model=model, api_key="tml-test"),
+        tinker_session_factory=factory,
+    )
+    client._factory_calls = factories  # type: ignore[attr-defined]
+    return client
+
+
+def collect(aiter):
+    async def main():
+        return [event async for event in aiter]
+
+    return asyncio.run(main())
+
+
+# --- Renderer-native tool calling (Qwen3) ---
+
+
+def test_native_prompt_and_tool_call_parse():
+    tokenizer = FakeTokenizer()
+    renderer = Qwen3Renderer(tokenizer)
+    completion = (
+        '<tool_call>\n{"name": "sql", "arguments": {"query": "SELECT 1"}}\n</tool_call><|im_end|>'
+    )
+    sampler = ScriptedSampler(tokenizer, [completion])
+    client = make_client(renderer, sampler)
+    events = collect(
+        client.stream(
+            "You analyze token DBs.", [Message(role="user", content="count rows")], [SQL_TOOL]
+        )
+    )
+    calls = [e for e in events if isinstance(e, ToolCallEvent)]
+    assert len(calls) == 1
+    assert calls[0].call.name == "sql"
+    assert calls[0].call.arguments == {"query": "SELECT 1"}
+    assert calls[0].call.id  # generated when the renderer format has none
+    assert events[-1] == Done("tool_use")
+
+    # The prompt went through the renderer: system prompt + tool schemas in
+    # Qwen's <tools> block + the conversation + the assistant header.
+    prompt = sampler.prompts[0]
+    assert "You analyze token DBs." in prompt
+    assert "<tools>" in prompt and '"name": "sql"' in prompt
+    assert "<|im_start|>user\ncount rows<|im_end|>" in prompt
+    assert prompt.endswith("<|im_start|>assistant\n")
+    assert sampler.stops[0] == renderer.get_stop_sequences()
+    assert client._factory_calls == [("test/model", "tml-test")]  # type: ignore[attr-defined]
+
+
+def test_native_history_renders_tool_calls_and_results():
+    tokenizer = FakeTokenizer()
+    renderer = Qwen3Renderer(tokenizer)
+    sampler = ScriptedSampler(tokenizer, ["There is 1 row.<|im_end|>"])
+    client = make_client(renderer, sampler)
+    messages = [
+        Message(role="user", content="count rows"),
+        Message(
+            role="assistant",
+            content="Checking.",
+            tool_calls=[ToolCall(id="c1", name="sql", arguments={"query": "SELECT 1"})],
+        ),
+        Message(role="tool", content='{"n_rows": 1}', tool_call_id="c1"),
+    ]
+    events = collect(client.stream("SYS", messages, [SQL_TOOL]))
+    assert events == [TextDelta("There is 1 row."), Done("end_turn")]
+    prompt = sampler.prompts[0]
+    # Prior tool call rendered in Qwen's native format, result as tool_response.
+    assert "<tool_call>" in prompt and '"SELECT 1"' in prompt
+    assert '<tool_response>\n{"n_rows": 1}\n</tool_response>' in prompt
+
+
+# --- JSON-in-text fallback (renderers without a tool convention) ---
+
+
+def test_fallback_prompt_documents_protocol_and_parses_block():
+    tokenizer = FakeTokenizer()
+    renderer = RoleColonRenderer(tokenizer)
+    completion = (
+        'Let me check.\n\n```json\n{"tool": "sql", "arguments": {"query": "SELECT 1"}}\n```'
+        "\n\nUser:"
+    )
+    sampler = ScriptedSampler(tokenizer, [completion])
+    client = make_client(renderer, sampler)
+    events = collect(client.stream("SYS", [Message(role="user", content="count rows")], [SQL_TOOL]))
+    assert events[0] == TextDelta("Let me check.")
+    assert isinstance(events[1], ToolCallEvent)
+    assert events[1].call.name == "sql"
+    assert events[1].call.arguments == {"query": "SELECT 1"}
+    assert events[-1] == Done("tool_use")
+    prompt = sampler.prompts[0]
+    assert "SYS" in prompt
+    assert '{"tool": "<tool name>", "arguments": {...}}' in prompt  # protocol docs
+    assert '"name": "sql"' in prompt  # tool schema
+
+
+def test_fallback_history_rendering():
+    tokenizer = FakeTokenizer()
+    renderer = RoleColonRenderer(tokenizer)
+    messages = [
+        Message(role="user", content="count rows"),
+        Message(
+            role="assistant",
+            content="Checking.",
+            tool_calls=[ToolCall(id="c1", name="sql", arguments={"query": "SELECT 1"})],
+        ),
+        Message(role="tool", content='{"n_rows": 1}', tool_call_id="c1"),
+    ]
+    rendered, native = render_conversation(renderer, "SYS", messages, [SQL_TOOL])
+    assert native is False
+    assert rendered[0]["role"] == "system"
+    # Prior tool calls become fenced JSON blocks; results become user messages.
+    assert '```json\n{"tool": "sql"' in rendered[2]["content"]
+    assert rendered[3]["role"] == "user"
+    assert rendered[3]["content"].startswith("Tool result for sql:")
+
+
+def test_parse_json_tool_blocks():
+    text, calls = parse_json_tool_blocks(
+        'Before.\n```json\n{"tool": "sql", "arguments": {"query": "SELECT 1"}}\n```\nAfter.'
+    )
+    assert text == "Before.\n\nAfter."
+    assert calls == [ToolCall(id="tinker_call_0", name="sql", arguments={"query": "SELECT 1"})]
+
+    # Invalid JSON stays in the text so the failure is visible.
+    text, calls = parse_json_tool_blocks('```json\n{"tool": "sql", oops}\n```')
+    assert calls == []
+    assert "oops" in text
+
+    # Valid JSON that is not a tool call also stays.
+    text, calls = parse_json_tool_blocks('```json\n{"data": [1, 2]}\n```')
+    assert calls == []
+    assert '"data"' in text
+
+    # Missing arguments defaults to {}.
+    _, calls = parse_json_tool_blocks('```json\n{"tool": "list_runs"}\n```')
+    assert calls == [ToolCall(id="tinker_call_0", name="list_runs", arguments={})]
+
+    # No block: plain text passthrough.
+    text, calls = parse_json_tool_blocks("Just an answer.")
+    assert text == "Just an answer." and calls == []
+
+
+# --- Error paths and helpers ---
+
+
+def test_missing_tinker_key_yields_error_event():
+    client = LLMClient(LLMConfig(provider="tinker"))
+    events = collect(client.stream("sys", [Message(role="user", content="hi")]))
+    assert len(events) == 1
+    assert isinstance(events[0], ErrorEvent)
+    assert "TINKER_API_KEY" in events[0].message
+
+
+def test_sampler_failure_surfaces_as_error_event():
+    class FailingSampler:
+        async def sample(self, prompt, max_tokens, stop):
+            raise RuntimeError("service unavailable")
+
+    client = make_client(RoleColonRenderer(FakeTokenizer()), FailingSampler())
+    events = collect(client.stream("sys", [Message(role="user", content="hi")]))
+    assert isinstance(events[-1], ErrorEvent)
+    assert "service unavailable" in events[-1].message
+
+
+def test_base_model_name_strips_capability_suffix():
+    assert base_model_name("Qwen/Qwen3-8B") == "Qwen/Qwen3-8B"
+    assert base_model_name("moonshotai/Kimi-K2.5:peft:131072") == "moonshotai/Kimi-K2.5"
+
+
+def test_pick_default_model_prefers_qwen3_instruct():
+    models = [
+        "meta-llama/Llama-3.1-8B",
+        "Qwen/Qwen3-8B-Base",
+        "Qwen/Qwen3-30B-A3B-Instruct-2507",
+        "Qwen/Qwen3-4B-Instruct-2507",
+    ]
+    assert pick_default_model(models) == "Qwen/Qwen3-30B-A3B-Instruct-2507"
+    assert pick_default_model(["a/b", "c/d"]) == "a/b"
+    assert pick_default_model([]) is None
+
+
+def test_native_arguments_json_roundtrip():
+    """Arguments survive the renderer's JSON-string encoding round trip."""
+    tokenizer = FakeTokenizer()
+    renderer = Qwen3Renderer(tokenizer)
+    messages = [
+        Message(
+            role="assistant",
+            content="",
+            tool_calls=[ToolCall(id="c1", name="sql", arguments={"query": 'SELECT "x"'})],
+        )
+    ]
+    rendered, native = render_conversation(renderer, "SYS", messages, [SQL_TOOL])
+    assert native is True
+    rcall = rendered[-1]["tool_calls"][0]
+    assert json.loads(rcall.function.arguments) == {"query": 'SELECT "x"'}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #821
* #820
* #819
* #818
* #817
* #816
* #815
* #814
* #813
* #812
* #811
* __->__ #810
* #809
* #808
* #807
* #806
* #805
* #804

Adds a server-side chat agent to the viewer: users ask questions in plain
language and an LLM answers by calling tokendb tools (sql, search, get_rollout,
publish_visual; plus list_runs/dashboard and per-run variants in registry mode)
and publishing self-contained live-updating HTML visuals.

- llm.py: minimal provider-agnostic streaming client over plain HTTP (aiohttp
  SSE) for the Anthropic Messages and OpenAI Chat Completions APIs, normalized
  into one message/tool-call representation and typed stream events. Keys come
  from a runtime-set in-memory value or ANTHROPIC_API_KEY/OPENAI_API_KEY.
- agent.py: the tool-use loop (capped iterations, results truncated for the
  model with truncation reported), JSONL conversation persistence under
  tokens/chats/, and visuals under tokens/visuals/ (size-guarded), all through
  the Storage protocol.
- agent_prompt.py: system prompt teaching the row schema and semantics, views,
  DuckDB idioms, canonical recipes, and single-file HTML visual guidance with
  the run's SQL endpoint injected at runtime.
- serve.py: WS /api/chat (per-run and registry-level), chats/visuals listing
  and serving endpoints, and GET/POST /api/agent/config (never returns the
  key). Chats get a dedicated per-run reader since tools run in a worker
  thread and DuckDB connections are not thread-safe.
- Tests use a scripted SSE transport (no network): provider wire formats,
  stream normalization, tool executors, the loop with persistence, and
  websocket end-to-end coverage in both modes.