### PR TITLE
recipes: populate tokendb metadata across recipe families

### DIFF
--- a/tinker_cookbook/recipes/code_rl/code_env.py
+++ b/tinker_cookbook/recipes/code_rl/code_env.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, cast
 
 import chz
@@ -35,8 +35,14 @@ def _load_deepcoder_split(split: Literal["train", "test"]) -> Dataset:
     datasets = []
     for name in names:
         logger.info(f"  Loading {name}...")
-        ds = load_dataset("agentica-org/DeepCoder-Preview-Dataset", name=name, split=split)
-        datasets.append(cast(Dataset, ds))
+        ds = cast(
+            Dataset, load_dataset("agentica-org/DeepCoder-Preview-Dataset", name=name, split=split)
+        )
+        # Tag each row with its sub-dataset before concatenating, so the source
+        # survives the shuffle. Row order (and therefore training behavior) is
+        # unchanged; the tag is used for token DB capture dimensions only.
+        ds = ds.add_column("__subset", [name] * len(ds))
+        datasets.append(ds)
 
     return cast(Dataset, concatenate_datasets(datasets))
 
@@ -140,11 +146,13 @@ def load_deepcoder_tasks(
         if isinstance(starter_code, str) and not starter_code.strip():
             starter_code = None
 
+        source = row.get("__subset")
         tasks.append(
             DeepcoderTask(
                 problem=problem,
                 tests=tests,
                 starter_code=starter_code if isinstance(starter_code, str) else None,
+                source=str(source) if source is not None else None,
             )
         )
 
@@ -215,6 +223,12 @@ class DeepcoderEnvGroupBuilder(EnvGroupBuilder):
 
     def logging_tags(self) -> list[str]:
         return ["deepcoder"]
+
+    def metadata(self) -> Mapping[str, str | int | float]:
+        meta: dict[str, str | int | float] = {"dataset": "deepcoder"}
+        if self.task.source is not None:
+            meta["source"] = self.task.source
+        return meta
 
 
 class DeepcoderDataset(RLDataset):

--- a/tinker_cookbook/recipes/code_rl/code_env_test.py
+++ b/tinker_cookbook/recipes/code_rl/code_env_test.py
@@ -1,0 +1,136 @@
+"""Tests for code_rl token DB capture wiring (builder metadata, grading capture).
+
+These exercise pure logic with the sandbox call stubbed out; no network or
+Docker dependencies.
+"""
+
+import asyncio
+import json
+from typing import Any
+
+from tinker_cookbook.recipes.code_rl.code_env import DeepcoderEnvGroupBuilder
+from tinker_cookbook.recipes.code_rl.deepcoder_tool import (
+    DeepcoderReward,
+    DeepcoderTask,
+    _grading_details_summary,
+)
+
+_TESTS: list[dict[str, Any]] = [
+    {"input": "1\n", "output": "2\n", "testtype": "stdin_stdout", "metadata": {"func_name": None}},
+    {"input": "2\n", "output": "3\n", "testtype": "stdin_stdout", "metadata": {"func_name": None}},
+]
+
+
+class TestBuilderMetadata:
+    def _builder(self, source: str | None) -> DeepcoderEnvGroupBuilder:
+        return DeepcoderEnvGroupBuilder(
+            task=DeepcoderTask(problem="p", tests=_TESTS, source=source),
+            model_name="m",
+            renderer_name=None,
+            max_turns=1,
+            group_size=1,
+            sandbox_backend=None,
+        )
+
+    def test_metadata_with_source(self):
+        assert self._builder("taco").metadata() == {"dataset": "deepcoder", "source": "taco"}
+
+    def test_metadata_without_source(self):
+        assert self._builder(None).metadata() == {"dataset": "deepcoder"}
+
+
+class TestGradingDetailsSummary:
+    def test_keeps_verdict_error_and_timing_drops_output(self):
+        details = {
+            "status": "Failed",
+            "run_result": {
+                "status": "Finished",
+                "execution_time": 0.5,
+                "return_code": 255,
+                "stdout": "huge test harness output",
+                "stderr": "traceback ...",
+            },
+        }
+        summary = _grading_details_summary(details)
+        assert summary["status"] == "Failed"
+        assert summary["run_result"] == {
+            "status": "Finished",
+            "execution_time": 0.5,
+            "return_code": 255,
+        }
+
+    def test_error_payload(self):
+        assert _grading_details_summary({"error": "boom"}) == {"error": "boom"}
+
+
+class TestDeepcoderRewardCapture:
+    def _grade(
+        self,
+        monkeypatch,
+        response: str,
+        sandbox_result: tuple[bool, dict[str, Any]] | None = None,
+        sandbox_error: Exception | None = None,
+    ):
+        async def fake_check(tests, code, timeout=6, backend=None):
+            if sandbox_error is not None:
+                raise sandbox_error
+            assert sandbox_result is not None
+            return sandbox_result
+
+        monkeypatch.setattr(
+            "tinker_cookbook.recipes.code_rl.deepcoder_tool.sandbox_check_correctness",
+            fake_check,
+        )
+        reward_fn = DeepcoderReward(task=DeepcoderTask(problem="p", tests=_TESTS))
+        return asyncio.run(reward_fn([{"role": "assistant", "content": response}]))
+
+    def test_passed_metrics_and_grading_logs(self, monkeypatch):
+        reward, metrics, logs = self._grade(
+            monkeypatch,
+            "```python\nprint(2)\n```",
+            sandbox_result=(
+                True,
+                {
+                    "status": "Success",
+                    "run_result": {
+                        "status": "Finished",
+                        "execution_time": 0.25,
+                        "return_code": 0,
+                        "stdout": "should be dropped",
+                    },
+                },
+            ),
+        )
+        assert reward == 1.0
+        assert metrics == {"format": 1.0, "correct": 1.0, "tests_total": 2.0}
+        assert logs["grading/verdict"] == "passed"
+        details = json.loads(str(logs["grading/details"]))
+        assert details["status"] == "Success"
+        assert details["run_result"]["execution_time"] == 0.25
+        assert "stdout" not in details["run_result"]
+
+    def test_failed_run_verdict(self, monkeypatch):
+        reward, metrics, logs = self._grade(
+            monkeypatch,
+            "```python\nprint(1)\n```",
+            sandbox_result=(False, {"status": "Failed"}),
+        )
+        assert metrics["correct"] == 0.0
+        assert metrics["tests_total"] == 2.0
+        assert logs["grading/verdict"] == "failed"
+
+    def test_no_code_block(self, monkeypatch):
+        reward, metrics, logs = self._grade(monkeypatch, "no code here")
+        assert reward == -0.1
+        assert metrics == {"format": 0.0, "correct": 0.0, "tests_total": 2.0}
+        assert logs["grading/verdict"] == "no_code_block"
+
+    def test_sandbox_error_records_error_class(self, monkeypatch):
+        reward, metrics, logs = self._grade(
+            monkeypatch,
+            "```python\nprint(1)\n```",
+            sandbox_error=RuntimeError("sandbox down"),
+        )
+        assert metrics["correct"] == 0.0
+        assert logs["grading/verdict"] == "error"
+        assert logs["grading/error_type"] == "RuntimeError"

--- a/tinker_cookbook/recipes/code_rl/deepcoder_tool.py
+++ b/tinker_cookbook/recipes/code_rl/deepcoder_tool.py
@@ -10,6 +10,7 @@ from tinker_cookbook.recipes.code_rl.code_grading import (
 )
 from tinker_cookbook.renderers import get_text_content
 from tinker_cookbook.renderers.base import Message
+from tinker_cookbook.rl.types import Logs
 from tinker_cookbook.sandbox import SandboxBackend
 from tinker_cookbook.tool_use import ToolResult, simple_tool_result, tool
 from tinker_cookbook.utils import logtree
@@ -22,6 +23,9 @@ class DeepcoderTask:
     problem: str
     tests: list[dict[str, Any]]
     starter_code: str | None = None
+    source: str | None = None
+    """Sub-dataset the task came from (e.g. ``"taco"``, ``"lcbv5"``); used for
+    token DB capture dimensions only."""
 
 
 class DeepcoderTool:
@@ -65,6 +69,28 @@ class DeepcoderTool:
             return simple_tool_result(json.dumps({"error": str(e), "passed": False}))
 
 
+# Keys kept when summarizing sandbox grading details for StepResult.logs.
+# stdout/stderr are dropped: they are bulky run output, and the same test
+# harness output is already rendered into the model's observation whenever the
+# model exercises the check_solution tool.
+_GRADING_DETAIL_KEYS = ("status", "message", "error", "exit_code", "return_code", "execution_time")
+
+
+def _grading_details_summary(details: dict[str, Any]) -> dict[str, Any]:
+    """Keep the verdict / error-class / timing fields of a sandbox result."""
+    summary: dict[str, Any] = {
+        key: details[key] for key in _GRADING_DETAIL_KEYS if details.get(key) is not None
+    }
+    run_result = details.get("run_result")
+    if isinstance(run_result, dict):
+        nested = {
+            key: run_result[key] for key in _GRADING_DETAIL_KEYS if run_result.get(key) is not None
+        }
+        if nested:
+            summary["run_result"] = nested
+    return summary
+
+
 @dataclass
 class DeepcoderReward:
     """Reward function for code tasks.
@@ -82,8 +108,15 @@ class DeepcoderReward:
     timeout: int = 6
     format_coef: float = 0.1
 
-    async def __call__(self, history: list[Message]) -> tuple[float, dict[str, float]]:
-        """Grade the completed episode by extracting code from final assistant message."""
+    async def __call__(self, history: list[Message]) -> tuple[float, dict[str, float], Logs]:
+        """Grade the completed episode by extracting code from final assistant message.
+
+        Returns ``(reward, metrics, logs)``: metrics carry the reward components
+        plus ``tests_total``; logs carry a grading-details summary (verdict,
+        error class, timing) for display/capture.
+        """
+        tests_total = float(len(self.task.tests))
+
         # Find the last assistant message
         final_message = None
         for msg in reversed(history):
@@ -93,7 +126,7 @@ class DeepcoderReward:
 
         if final_message is None:
             logtree.log_text("No assistant message found in history.")
-            return 0.0, {"format": 0.0, "correct": 0.0}
+            return 0.0, {"format": 0.0, "correct": 0.0, "tests_total": tests_total}, {}
 
         # Use get_text_content to properly handle thinking models (o1, o3)
         content = get_text_content(final_message)
@@ -103,21 +136,31 @@ class DeepcoderReward:
         has_code_block = code is not None
 
         # Grade the code by running tests
+        grading_logs: Logs = {}
         if code is not None:
             try:
-                passed, _details = await sandbox_check_correctness(
+                passed, details = await sandbox_check_correctness(
                     self.task.tests,
                     code,
                     timeout=self.timeout,
                     backend=self.sandbox_backend,
                 )
                 correct = float(passed)
+                grading_logs["grading/verdict"] = "passed" if passed else "failed"
+                summary = _grading_details_summary(details)
+                if summary:
+                    grading_logs["grading/details"] = json.dumps(
+                        summary, ensure_ascii=False, default=str
+                    )
             except Exception as e:
                 logtree.log_text(f"Error running tests: {e}")
                 correct = 0.0
+                grading_logs["grading/verdict"] = "error"
+                grading_logs["grading/error_type"] = type(e).__name__
         else:
             logtree.log_text("No code block detected in response.")
             correct = 0.0
+            grading_logs["grading/verdict"] = "no_code_block"
 
         # Reward formula
         format_score = float(has_code_block)
@@ -132,4 +175,8 @@ class DeepcoderReward:
             f"Reward: {reward:.2f}"
         )
 
-        return reward, {"format": format_score, "correct": correct}
+        return (
+            reward,
+            {"format": format_score, "correct": correct, "tests_total": tests_total},
+            grading_logs,
+        )

--- a/tinker_cookbook/recipes/math_rl/arithmetic_env.py
+++ b/tinker_cookbook/recipes/math_rl/arithmetic_env.py
@@ -87,6 +87,9 @@ class ArithmeticDataset(RLDataset):
                 ArithmeticEnv, x, y, convo_prefix=convo_prefix, renderer=self.renderer
             ),
             num_envs=self.group_size,
+            # Token DB capture dimensions: the (x, y) pair is the problem
+            # identity for this generated dataset.
+            group_metadata={"dataset": "arithmetic", "row_id": f"arithmetic-{x}+{y}"},
         )
 
     def __len__(self) -> int:

--- a/tinker_cookbook/recipes/math_rl/math_env.py
+++ b/tinker_cookbook/recipes/math_rl/math_env.py
@@ -1,8 +1,8 @@
 import math
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from functools import partial
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import chz
 from datasets import Dataset, concatenate_datasets, get_dataset_config_names, load_dataset
@@ -117,6 +117,42 @@ def extract_gsm8k_final_answer(text: str) -> str:
     raise ValueError("No GSM8K final answer found")
 
 
+def _coerce_difficulty(value: Any) -> str | int | float:
+    """Coerce a dataset difficulty/level field to a number when possible.
+
+    Hendrycks MATH stores levels as strings like ``"Level 3"``; MATH-500 and
+    DeepMath store plain numbers. Numeric values route to the token DB
+    ``metrics`` map, so parse out the number when there is one.
+    """
+    if isinstance(value, (int, float)):
+        return value
+    text = str(value)
+    match = re.search(r"\d+(?:\.\d+)?", text)
+    if match is None:
+        return text
+    number = float(match.group(0))
+    return int(number) if number.is_integer() else number
+
+
+def _problem_row_metadata(
+    dataset: str, split: str, row_idx: int, x: Mapping[str, Any]
+) -> dict[str, str | int | float]:
+    """Group metadata for one dataset row (token DB capture only).
+
+    Includes the dataset name, a ``row_id`` (the dataset's own id when the
+    row carries one, else the row's position in the shuffled split), and the
+    difficulty/level when the row has one.
+    """
+    meta: dict[str, str | int | float] = {"dataset": dataset}
+    unique_id = x.get("unique_id")
+    meta["row_id"] = str(unique_id) if unique_id else f"{dataset}-{split}-{row_idx}"
+    for key in ("level", "difficulty"):
+        value = x.get(key)
+        if value is not None:
+            meta[key] = _coerce_difficulty(value)
+    return meta
+
+
 def _get_hendrycks_math_test() -> Dataset:
     test_dataset = load_dataset("HuggingFaceH4/MATH-500", name="default", split="test")
     return cast(Dataset, test_dataset)
@@ -165,6 +201,7 @@ class MathDataset(RLDataset):
         self.group_size = group_size if split == "train" else 1
         self.renderer = renderer
         self.convo_prefix = convo_prefix
+        self.split = split
 
     def get_batch(self, index: int) -> Sequence[EnvGroupBuilder]:
         batch_start = index * self.batch_size
@@ -172,15 +209,22 @@ class MathDataset(RLDataset):
         assert batch_start < batch_end, "Incorrect batch size"
         return [
             builder
-            for row in self.ds.select(range(batch_start, batch_end))
-            if (builder := self._make_env_group_builder(row, self.group_size)) is not None  # pyright: ignore[reportArgumentType]
+            for offset, row in enumerate(self.ds.select(range(batch_start, batch_end)))
+            if (
+                builder := self._make_env_group_builder(
+                    row,  # pyright: ignore[reportArgumentType]
+                    self.group_size,
+                    batch_start + offset,
+                )
+            )
+            is not None
         ]
 
     def __len__(self) -> int:
         return math.ceil(len(self.ds) / self.batch_size)
 
     def _make_env_group_builder(
-        self, x: dict[str, str], group_size: int
+        self, x: dict[str, str], group_size: int, row_idx: int
     ) -> ProblemGroupBuilder | None:
         try:
             answer = extract_boxed(x["solution"])
@@ -192,6 +236,7 @@ class MathDataset(RLDataset):
                 MathEnv, x["problem"], answer, self.renderer, convo_prefix=self.convo_prefix
             ),
             num_envs=group_size,
+            group_metadata=_problem_row_metadata("math", self.split, row_idx, x),
         )
 
 
@@ -242,9 +287,10 @@ class PolarisDataset(MathDataset):
         self.group_size = group_size
         self.renderer = renderer
         self.convo_prefix = convo_prefix
+        self.split = "train"
 
     def _make_env_group_builder(
-        self, x: dict[str, str], group_size: int
+        self, x: dict[str, str], group_size: int, row_idx: int
     ) -> ProblemGroupBuilder | None:
         # Extract problem and answer from the dataset
         problem = x.get("problem", "")
@@ -257,6 +303,7 @@ class PolarisDataset(MathDataset):
             ),
             num_envs=group_size,
             dataset_name="polaris",
+            group_metadata=_problem_row_metadata("polaris", self.split, row_idx, x),
         )
 
 
@@ -293,9 +340,10 @@ class DeepMathDataset(MathDataset):
         self.group_size = group_size
         self.renderer = renderer
         self.convo_prefix = convo_prefix
+        self.split = "train"
 
     def _make_env_group_builder(
-        self, x: dict[str, str], group_size: int
+        self, x: dict[str, str], group_size: int, row_idx: int
     ) -> ProblemGroupBuilder | None:
         # Extract problem and answer from the dataset
         problem = x.get("question", "")
@@ -308,6 +356,7 @@ class DeepMathDataset(MathDataset):
             ),
             num_envs=group_size,
             dataset_name="deepmath",
+            group_metadata=_problem_row_metadata("deepmath", self.split, row_idx, x),
         )
 
 
@@ -348,6 +397,7 @@ class Gsm8kDataset(RLDataset):
         self.group_size = group_size if split == "train" else 1
         self.renderer = renderer
         self.convo_prefix = convo_prefix
+        self.split = split
 
     @classmethod
     def question_suffix(cls) -> str:
@@ -359,15 +409,22 @@ class Gsm8kDataset(RLDataset):
         assert batch_start < batch_end, "Incorrect batch size"
         return [
             builder
-            for row in self.ds.select(range(batch_start, batch_end))
-            if (builder := self._make_env_group_builder(row, self.group_size)) is not None  # pyright: ignore[reportArgumentType]
+            for offset, row in enumerate(self.ds.select(range(batch_start, batch_end)))
+            if (
+                builder := self._make_env_group_builder(
+                    row,  # pyright: ignore[reportArgumentType]
+                    self.group_size,
+                    batch_start + offset,
+                )
+            )
+            is not None
         ]
 
     def __len__(self) -> int:
         return math.ceil(len(self.ds) / self.batch_size)
 
     def _make_env_group_builder(
-        self, x: dict[str, str], group_size: int
+        self, x: dict[str, str], group_size: int, row_idx: int
     ) -> ProblemGroupBuilder | None:
         try:
             problem = x["question"]
@@ -380,6 +437,7 @@ class Gsm8kDataset(RLDataset):
                 MathEnv, problem, answer, self.renderer, convo_prefix=self.convo_prefix
             ),
             num_envs=group_size,
+            group_metadata=_problem_row_metadata("gsm8k", self.split, row_idx, x),
         )
 
 

--- a/tinker_cookbook/recipes/math_rl/math_env_test.py
+++ b/tinker_cookbook/recipes/math_rl/math_env_test.py
@@ -5,15 +5,36 @@ The MathDatasetBuilder integration test (which downloads from HuggingFace)
 lives in tests/integration/test_math_dataset_builder.py.
 """
 
+from typing import Any, cast
+
 import pytest
 
-from tinker_cookbook.recipes.math_rl.math_env import extract_gsm8k_final_answer
+from tinker_cookbook.recipes.math_rl.math_env import (
+    DeepMathDataset,
+    Gsm8kDataset,
+    MathDataset,
+    PolarisDataset,
+    _coerce_difficulty,
+    _problem_row_metadata,
+    extract_gsm8k_final_answer,
+)
 from tinker_cookbook.recipes.math_rl.math_grading import (
     extract_boxed,
     grade_answer,
     normalize_answer,
     split_tuple,
 )
+
+
+def _dataset_stub(cls: Any, split: str = "train") -> Any:
+    """Build a dataset instance without loading the HF dataset."""
+    ds = cls.__new__(cls)
+    ds.renderer = cast(Any, None)
+    ds.convo_prefix = None
+    ds.batch_size = 1
+    ds.group_size = 4
+    ds.split = split
+    return ds
 
 
 class TestExtractBoxed:
@@ -128,6 +149,154 @@ class TestGradeAnswer:
 
     def test_with_text_wrapper(self):
         assert grade_answer("\\text{yes}", "yes") is True
+
+
+class TestCoerceDifficulty:
+    def test_numeric_passthrough(self):
+        assert _coerce_difficulty(3) == 3
+        assert _coerce_difficulty(4.5) == 4.5
+
+    def test_hendrycks_level_string(self):
+        assert _coerce_difficulty("Level 3") == 3
+
+    def test_decimal_string(self):
+        assert _coerce_difficulty("difficulty 2.5") == 2.5
+
+    def test_non_numeric_string_kept(self):
+        assert _coerce_difficulty("Level ?") == "Level ?"
+
+
+class TestBuilderMetadata:
+    """Group metadata wired through ProblemGroupBuilder for token DB capture."""
+
+    def test_math_row_metadata(self):
+        row = {"problem": "1+1?", "solution": "\\boxed{2}", "level": "Level 3", "type": "Algebra"}
+        builder = _dataset_stub(MathDataset)._make_env_group_builder(row, 4, 12)
+        assert builder is not None
+        assert builder.metadata() == {"dataset": "math", "row_id": "math-train-12", "level": 3}
+
+    def test_math500_unique_id_wins_over_row_index(self):
+        row = {
+            "problem": "p",
+            "solution": "\\boxed{2}",
+            "unique_id": "test/algebra/1.json",
+            "level": 4,
+        }
+        builder = _dataset_stub(MathDataset, split="test")._make_env_group_builder(row, 1, 0)
+        assert builder is not None
+        assert builder.metadata() == {
+            "dataset": "math",
+            "row_id": "test/algebra/1.json",
+            "level": 4,
+        }
+
+    def test_gsm8k_row_metadata(self):
+        row = {"question": "How many?", "answer": "reasoning\n#### 42"}
+        builder = _dataset_stub(Gsm8kDataset)._make_env_group_builder(row, 4, 3)
+        assert builder is not None
+        assert builder.metadata() == {"dataset": "gsm8k", "row_id": "gsm8k-train-3"}
+
+    def test_deepmath_difficulty_kept_numeric(self):
+        row = {"question": "q", "final_answer": "2", "difficulty": 4.5}
+        builder = _dataset_stub(DeepMathDataset)._make_env_group_builder(row, 4, 9)
+        assert builder is not None
+        assert builder.metadata() == {
+            "dataset": "deepmath",
+            "row_id": "deepmath-train-9",
+            "difficulty": 4.5,
+        }
+        assert builder.logging_tags() == ["deepmath"]
+
+    def test_polaris_without_difficulty(self):
+        row = {"problem": "q", "answer": "2"}
+        builder = _dataset_stub(PolarisDataset)._make_env_group_builder(row, 4, 1)
+        assert builder is not None
+        assert builder.metadata() == {"dataset": "polaris", "row_id": "polaris-train-1"}
+
+    def test_arithmetic_metadata(self):
+        import numpy as np
+
+        from tinker_cookbook.recipes.math_rl.arithmetic_env import ArithmeticDataset
+
+        dataset = ArithmeticDataset(
+            batch_size=1, renderer=cast(Any, None), group_size=2, n_batches=1
+        )
+        rng = np.random.RandomState(0)
+        builder = dataset._make_env_group_builder(rng)
+        meta = dict(builder.metadata())
+        assert meta["dataset"] == "arithmetic"
+        assert str(meta["row_id"]).startswith("arithmetic-")
+
+    def test_problem_row_metadata_skips_absent_fields(self):
+        meta = _problem_row_metadata("math", "train", 5, {"problem": "p"})
+        assert meta == {"dataset": "math", "row_id": "math-train-5"}
+
+
+class TestCaptureEndToEnd:
+    """A MathEnv rollout captured to parquet carries the routed dimensions."""
+
+    def test_math_rollout_rows_carry_metadata(self, tmp_path):
+        pytest.importorskip("pyarrow")
+        import asyncio
+        from unittest.mock import MagicMock
+
+        import tinker
+
+        from tinker_cookbook.completers import StopCondition, TokenCompleter, TokensWithLogprobs
+        from tinker_cookbook.renderers.base import ParseTermination
+        from tinker_cookbook.rl.rollout_logging import RolloutSummaryGroup
+        from tinker_cookbook.rl.rollouts import do_single_rollout
+        from tinker_cookbook.rl.types import TrajectoryGroup
+        from tinker_cookbook.tokendb.capture import record_groups
+        from tinker_cookbook.tokendb.writer import TokenDbWriter
+        from tinker_cookbook.tokendb.writer_test import read_all_segments
+
+        renderer = MagicMock()
+        renderer.build_generation_prompt = MagicMock(
+            return_value=tinker.ModelInput.from_ints([1, 2, 3])
+        )
+        renderer.get_stop_sequences = MagicMock(return_value=["\n"])
+        renderer.parse_response = MagicMock(
+            return_value=(
+                {"role": "assistant", "content": "\\boxed{2}"},
+                ParseTermination.STOP_SEQUENCE,
+            )
+        )
+
+        dataset = _dataset_stub(MathDataset)
+        dataset.renderer = renderer
+        row = {"problem": "1+1?", "solution": "\\boxed{2}", "level": "Level 3"}
+        builder = dataset._make_env_group_builder(row, 1, 7)
+        assert builder is not None
+        envs = asyncio.run(builder.make_envs())
+
+        class FixedPolicy(TokenCompleter):
+            async def __call__(
+                self, model_input: tinker.ModelInput, stop: StopCondition
+            ) -> TokensWithLogprobs:
+                return TokensWithLogprobs(tokens=[7], maybe_logprobs=[-0.1])
+
+        trajectory = asyncio.run(do_single_rollout(FixedPolicy(), envs[0]))
+        group = TrajectoryGroup(trajectories_G=[trajectory], final_rewards_G=[0.0], metrics_G=[{}])
+        with TokenDbWriter(tmp_path, flush_interval_s=3600.0) as writer:
+            record_groups(
+                writer,
+                [
+                    RolloutSummaryGroup(
+                        trajectory_group=group,
+                        tags=list(builder.logging_tags()),
+                        metadata=builder.metadata(),
+                    )
+                ],
+                split="train",
+                iteration=0,
+            )
+        got = read_all_segments(tmp_path).to_pylist()[0]
+        assert dict(got["attrs"]) == {"dataset": "math"}
+        metrics = dict(got["metrics"])
+        assert metrics["level"] == 3.0
+        assert metrics["correct"] == 1.0
+        assert got["env_row_id"] == "math-train-7"
 
 
 class TestSplitTuple:

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/env.py
@@ -1,6 +1,6 @@
 import random
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 import chz
@@ -114,6 +114,11 @@ class GuessNumberEnvGroupBuilder(EnvGroupBuilder):
 
     async def make_envs(self) -> Sequence[Env]:
         return [GuessNumberEnv(self.answer, self.renderer) for _ in range(self.num_envs)]
+
+    def metadata(self) -> Mapping[str, str | int | float]:
+        # Token DB capture dimensions: the target number is the dataset row
+        # identity (the dataset indexes into the list of possible answers).
+        return {"game": "guess_number", "row_id": f"guess_number-{self.answer}"}
 
 
 # The dataset just indexes into the list of possible answers.

--- a/tinker_cookbook/recipes/multiplayer_rl/guess_number/guess_number_env_test.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/guess_number/guess_number_env_test.py
@@ -1,0 +1,10 @@
+"""Tests for guess_number token DB capture metadata."""
+
+from typing import Any, cast
+
+from tinker_cookbook.recipes.multiplayer_rl.guess_number.env import GuessNumberEnvGroupBuilder
+
+
+def test_metadata_game_and_row_id():
+    builder = GuessNumberEnvGroupBuilder(answer=17, renderer=cast(Any, None), num_envs=2)
+    assert builder.metadata() == {"game": "guess_number", "row_id": "guess_number-17"}

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/env.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/env.py
@@ -1,7 +1,7 @@
 """General two-player TextArena environment and dataset builders for tinker RL."""
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -163,6 +163,7 @@ class TwoPlayerEnv(Env):
             next_observation=self.get_observation(),
             next_stop_condition=self.stop_condition,
             metrics={},
+            attrs={"player_id": str(self.player_id)},
         )
 
     def get_done_step(self) -> StepResult:
@@ -172,6 +173,7 @@ class TwoPlayerEnv(Env):
             next_observation=types.ModelInput.empty(),
             next_stop_condition=STOP_CONDITION,
             metrics={},
+            attrs={"player_id": str(self.player_id)},
         )
 
     def compute_reward(self) -> float:
@@ -201,6 +203,9 @@ class TwoPlayerEnvGroupBuilder(EnvGroupBuilder):
     self_play: bool
     num_players: ClassVar[int] = 2
     opponent_policy: MessageCompleter | None = None
+    opponent_name: str | None = None
+    """Human-readable name of the fixed opponent policy (e.g. the
+    ``OpponentType``); used for token DB capture dimensions only."""
 
     async def make_envs(self) -> Sequence[Env]:
         """Create a group of environments sharing the same TextArena game."""
@@ -234,6 +239,13 @@ class TwoPlayerEnvGroupBuilder(EnvGroupBuilder):
                 for i in range(2)
             ]
         return envs
+
+    def metadata(self) -> Mapping[str, str | int | float]:
+        if self.self_play:
+            opponent = "self_play"
+        else:
+            opponent = self.opponent_name or "fixed_policy"
+        return {"game": self.game_name, "opponent": opponent}
 
 
 class TwoPlayerTextArenaDataset(RLDataset):
@@ -298,6 +310,7 @@ class TwoPlayerTextArenaDatasetBuilder(RLDatasetBuilder):
             num_envs=2,
             self_play=False,
             opponent_policy=self._construct_opponent_policy(renderer),
+            opponent_name=str(self.test_opponent),
         )
         test_dataset = TwoPlayerTextArenaDataset(
             batch_size=self.num_test_datapoints,

--- a/tinker_cookbook/recipes/multiplayer_rl/text_arena/env_test.py
+++ b/tinker_cookbook/recipes/multiplayer_rl/text_arena/env_test.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from tinker_cookbook.recipes.multiplayer_rl.text_arena.tictactoe import (
     OptimalOpponent,
     RandomOpponent,
@@ -105,7 +107,7 @@ def test_optimal_vs_optimal_always_draws():
     opponent_x = OptimalOpponent()
 
     # Simulate a full game
-    import textarena as ta
+    ta = pytest.importorskip("textarena")
 
     env = ta.make("TicTacToe-v0")
     env.reset(num_players=2)
@@ -128,3 +130,53 @@ def test_optimal_vs_optimal_always_draws():
     rewards = env.state.rewards
     assert rewards is not None
     assert rewards[0] == 0 and rewards[1] == 0, f"Expected draw, got {rewards}"
+
+
+def test_two_player_builder_metadata_self_play():
+    pytest.importorskip("textarena")
+    from typing import Any, cast
+
+    from tinker_cookbook.recipes.multiplayer_rl.text_arena.env import TwoPlayerEnvGroupBuilder
+
+    builder = TwoPlayerEnvGroupBuilder(
+        game_name="TicTacToe-v0", renderer=cast(Any, None), num_envs=2, self_play=True
+    )
+    assert builder.metadata() == {"game": "TicTacToe-v0", "opponent": "self_play"}
+
+
+def test_two_player_builder_metadata_fixed_opponent():
+    pytest.importorskip("textarena")
+    from typing import Any, cast
+
+    from tinker_cookbook.recipes.multiplayer_rl.text_arena.env import TwoPlayerEnvGroupBuilder
+
+    builder = TwoPlayerEnvGroupBuilder(
+        game_name="TicTacToe-v0",
+        renderer=cast(Any, None),
+        num_envs=2,
+        self_play=False,
+        opponent_policy=cast(Any, object()),
+        opponent_name="optimal",
+    )
+    assert builder.metadata() == {"game": "TicTacToe-v0", "opponent": "optimal"}
+
+
+def test_step_attrs_carry_player_id():
+    pytest.importorskip("textarena")
+    from typing import Any, cast
+    from unittest.mock import MagicMock
+
+    from tinker_cookbook.recipes.multiplayer_rl.text_arena.env import TwoPlayerEnv
+
+    coordinator = MagicMock()
+    coordinator.game_done = True
+    env = TwoPlayerEnv(
+        player_id=1,
+        coordinator=coordinator,
+        self_play=True,
+        renderer=cast(Any, None),
+        opponent_policy=None,
+    )
+    result = asyncio.run(env.step([1]))
+    assert result.episode_done
+    assert result.attrs == {"player_id": "1"}

--- a/tinker_cookbook/recipes/prompt_distillation/create_data.py
+++ b/tinker_cookbook/recipes/prompt_distillation/create_data.py
@@ -12,6 +12,11 @@ from tinker_cookbook import renderers
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 
+# Teacher model whose samples are distilled into the training data. Also
+# recorded on captured token DB rows so downstream analysis can attribute
+# rows to the teacher.
+TEACHER_MODEL = "Qwen/Qwen3.6-35B-A3B"
+
 LANGUAGE_CLASSIFICATION_PROMPT = """You are a precise language classifier.
 
 Goal: Classify the language of the provided text into exactly one of these labels:
@@ -96,8 +101,8 @@ def setup_clients():
         user_metadata=recipe_user_metadata("dataset_prompt_distillation"),
     )
     print("Creating sampling client")
-    sampling_client = service_client.create_sampling_client(base_model="Qwen/Qwen3.6-35B-A3B")
-    tokenizer = get_tokenizer("Qwen/Qwen3.6-35B-A3B")
+    sampling_client = service_client.create_sampling_client(base_model=TEACHER_MODEL)
+    tokenizer = get_tokenizer(TEACHER_MODEL)
     renderer = renderers.get_renderer("qwen3_5_disable_thinking", tokenizer)
 
     return sampling_client, tokenizer, renderer
@@ -136,6 +141,8 @@ async def create_data_async(
                 group_idx=sentence_idx,
                 tokenizer=tokenizer,
                 sentence=sentence,
+                teacher_model=TEACHER_MODEL,
+                source_dataset="multilingual.txt",
             )
         response = tokenizer.decode(result.sequences[0].tokens)
         # parse the final answer from the response using regex for example: Final Answer: xx where xx is two character label for each language and nothing else. xx is one of the following: en, fr, es, hi, ja, ko, ru, ot.

--- a/tinker_cookbook/recipes/rubric/env.py
+++ b/tinker_cookbook/recipes/rubric/env.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 import chz
@@ -190,6 +190,11 @@ class RubricGradedEnvGroupBuilder(EnvGroupBuilder):
             )
             for _ in range(self.group_size)
         ]
+
+    def metadata(self) -> Mapping[str, str | int | float]:
+        # Token DB capture dimensions. RubricBasedDatapoint carries no id
+        # field, so there is no row_id to promote yet.
+        return {"num_rubrics": len(self.datapoint.rubric_items)}
 
 
 @dataclass(frozen=True)

--- a/tinker_cookbook/recipes/rubric/rubric_env_test.py
+++ b/tinker_cookbook/recipes/rubric/rubric_env_test.py
@@ -1,0 +1,20 @@
+"""Tests for rubric env token DB capture metadata."""
+
+from typing import Any, cast
+
+from tinker_cookbook.recipes.rubric.data import Rubric, RubricBasedDatapoint
+from tinker_cookbook.recipes.rubric.env import RubricGradedEnvGroupBuilder
+
+
+def test_metadata_reports_num_rubrics():
+    datapoint = RubricBasedDatapoint(
+        convo=[{"role": "user", "content": "hi"}],
+        rubric_items=[Rubric(rubric_str="clear"), Rubric(rubric_str="correct")],
+    )
+    builder = RubricGradedEnvGroupBuilder(
+        renderer=cast(Any, None),
+        datapoint=datapoint,
+        grader_llm=cast(Any, None),
+        group_size=2,
+    )
+    assert builder.metadata() == {"num_rubrics": 2}

--- a/tinker_cookbook/recipes/search_tool/search_env.py
+++ b/tinker_cookbook/recipes/search_tool/search_env.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import random
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Literal, TypedDict, cast
 
@@ -178,6 +178,14 @@ class SearchEnvGroupBuilder(EnvGroupBuilder):
 
     def logging_tags(self) -> list[str]:
         return [self.datum.get("data_source", "unknown")]
+
+    def metadata(self) -> Mapping[str, str | int | float]:
+        # Token DB capture dimensions. Per-call tool usage flows separately
+        # through AgentToolMessageEnv's structured tool_calls records.
+        return {
+            "data_source": self.datum.get("data_source", "unknown"),
+            "corpus": self.chroma_tool.collection_name,
+        }
 
 
 class SearchRLDataset(RLDataset):

--- a/tinker_cookbook/recipes/search_tool/search_env_test.py
+++ b/tinker_cookbook/recipes/search_tool/search_env_test.py
@@ -1,0 +1,34 @@
+"""Tests for search_tool token DB capture metadata.
+
+Per-call tool usage (name, args, error type) flows through
+``AgentToolMessageEnv``'s structured ``tool_calls`` records, covered by
+``tool_use/agent_tool_message_env_test.py`` and
+``tokendb/capture_test.py::TestAgentToolEnvEndToEnd``.
+"""
+
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("chromadb")
+pytest.importorskip("google.genai")
+
+from tinker_cookbook.recipes.search_tool.search_env import (
+    SearchEnvGroupBuilder,
+    SearchR1Datum,
+)
+from tinker_cookbook.recipes.search_tool.tools import ChromaTool, RetrievalConfig
+
+
+def test_metadata_data_source_and_corpus():
+    tool = ChromaTool(cast(Any, None), cast(Any, None), "wiki_2018", RetrievalConfig(), 1, 1)
+    datum: SearchR1Datum = {"question": "q", "answer": ["a"], "data_source": "nq"}
+    builder = SearchEnvGroupBuilder(
+        datum=datum,
+        model_name="m",
+        renderer_name=None,
+        max_turns=1,
+        group_size=1,
+        chroma_tool=tool,
+    )
+    assert builder.metadata() == {"data_source": "nq", "corpus": "wiki_2018"}

--- a/tinker_cookbook/recipes/search_tool/tools.py
+++ b/tinker_cookbook/recipes/search_tool/tools.py
@@ -94,6 +94,11 @@ class ChromaTool:
         self._chroma_host = chroma_host
         self._chroma_port = chroma_port
 
+    @property
+    def collection_name(self) -> str:
+        """Name of the ChromaDB collection queried by this tool."""
+        return self._collection_name
+
     def __getstate__(self) -> dict:
         """Exclude non-pickleable async clients from pickle state."""
         state = self.__dict__.copy()

--- a/tinker_cookbook/rl/preference_envs.py
+++ b/tinker_cookbook/rl/preference_envs.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -343,7 +343,13 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
         return [
             (
                 (win_minus_loss / mc if mc > 0 else 0.0) + format_coef * (float(is_valid) - 1.0),
-                {"win_minus_loss": win_minus_loss / mc if mc > 0 else 0.0, "format": is_valid},
+                {
+                    "win_minus_loss": win_minus_loss / mc if mc > 0 else 0.0,
+                    "format": is_valid,
+                    # Number of pairwise matchups this trajectory took part in
+                    # (capture/logging only; the reward is already normalized).
+                    "matchup_count": mc,
+                },
             )
             for win_minus_loss, is_valid, mc in safezip(
                 win_minus_loss_list, is_valid_list, matchup_count
@@ -357,6 +363,13 @@ class PairwisePreferenceGroupBuilder(EnvGroupBuilder):
             list[str]: A single-element list ``["pair_pref"]``.
         """
         return ["pair_pref"]
+
+    def metadata(self) -> Mapping[str, str | int | float]:
+        """Return capture dimensions describing how matchup pairs are formed."""
+        return {
+            "tournament_pattern": self.tournament_pattern.value,
+            "matchup_group_size": self.matchup_group_size,
+        }
 
 
 class PairwisePreferenceDataset(RLDataset):

--- a/tinker_cookbook/rl/preference_envs_test.py
+++ b/tinker_cookbook/rl/preference_envs_test.py
@@ -1,0 +1,78 @@
+"""Tests for pairwise preference capture dimensions (metadata, matchup metrics)."""
+
+import asyncio
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import tinker
+
+from tinker_cookbook.completers import TokensWithLogprobs
+from tinker_cookbook.preference.types import Comparison, PreferenceModel
+from tinker_cookbook.renderers.base import ParseTermination
+from tinker_cookbook.rl.preference_envs import (
+    PairwisePreferenceGroupBuilder,
+    TournamentPattern,
+)
+from tinker_cookbook.rl.types import Trajectory, Transition
+
+
+class AlwaysPrefersB(PreferenceModel):
+    async def __call__(self, comparison: Comparison) -> float:
+        return 1.0
+
+
+def _renderer() -> MagicMock:
+    renderer = MagicMock()
+    renderer.parse_response = MagicMock(
+        return_value=({"role": "assistant", "content": "hi"}, ParseTermination.STOP_SEQUENCE)
+    )
+    return renderer
+
+
+def _trajectory() -> Trajectory:
+    return Trajectory(
+        transitions=[
+            Transition(
+                ob=tinker.ModelInput.from_ints([1]),
+                ac=TokensWithLogprobs(tokens=[2], maybe_logprobs=[-0.1]),
+                reward=0.0,
+                episode_done=True,
+            )
+        ],
+        final_ob=tinker.ModelInput.from_ints([]),
+    )
+
+
+def _builder() -> PairwisePreferenceGroupBuilder:
+    return PairwisePreferenceGroupBuilder(
+        convo_prefix=[{"role": "user", "content": "q"}],
+        policy_renderer=cast(Any, _renderer()),
+        tournament_pattern=TournamentPattern.ALL_PAIRS_ONE_WAY,
+        preference_model=AlwaysPrefersB(),
+        num_envs=2,
+    )
+
+
+class TestMetadata:
+    def test_matchup_structure_dimensions(self):
+        assert _builder().metadata() == {
+            "tournament_pattern": "all_pairs_one_way",
+            "matchup_group_size": 4,
+        }
+
+
+class TestMatchupCountMetric:
+    def test_matchup_count_reported_and_rewards_unchanged(self):
+        builder = _builder()
+        results = asyncio.run(
+            builder.compute_group_rewards([_trajectory(), _trajectory()], env_group=[])
+        )
+        assert len(results) == 2
+        (reward_a, metrics_a), (reward_b, metrics_b) = results
+        # One matchup between the two completions; B is always preferred.
+        assert metrics_a["matchup_count"] == 1
+        assert metrics_b["matchup_count"] == 1
+        assert reward_a == -1.0
+        assert reward_b == 1.0
+        assert metrics_a["win_minus_loss"] == -1.0
+        assert metrics_b["win_minus_loss"] == 1.0

--- a/tinker_cookbook/rl/problem_env.py
+++ b/tinker_cookbook/rl/problem_env.py
@@ -1,7 +1,7 @@
 import logging
 from abc import abstractmethod
-from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
 
 import tinker
 
@@ -165,6 +165,11 @@ class ProblemGroupBuilder(EnvGroupBuilder):
     env_thunk: Callable[[], ProblemEnv]
     num_envs: int
     dataset_name: str = "problems"
+    group_metadata: Mapping[str, str | int | float] = field(default_factory=dict)
+    """Passthrough for :meth:`EnvGroupBuilder.metadata`: group-scoped dimensions
+    (dataset name, difficulty, the reserved ``row_id``) captured with every row
+    of the group when token DB capture is enabled. Capture-only; does not
+    affect training."""
 
     async def make_envs(self) -> Sequence[Env]:
         """Create ``num_envs`` ProblemEnv instances using the factory callable."""
@@ -178,3 +183,6 @@ class ProblemGroupBuilder(EnvGroupBuilder):
 
     def logging_tags(self) -> list[str]:
         return [self.dataset_name]
+
+    def metadata(self) -> Mapping[str, str | int | float]:
+        return dict(self.group_metadata)

--- a/tinker_cookbook/tool_use/agent_tool_message_env.py
+++ b/tinker_cookbook/tool_use/agent_tool_message_env.py
@@ -18,7 +18,10 @@ from tinker_cookbook.rl.message_env import EnvFromMessageEnv, MessageEnv, Messag
 from tinker_cookbook.tool_use.tools import handle_tool_call
 from tinker_cookbook.tool_use.types import Tool, ToolResult
 
-RewardResult = tuple[float, dict[str, float]]
+# Reward functions return (reward, metrics) or (reward, metrics, logs). The
+# optional third element carries grading diagnostics (e.g. test-run details)
+# into ``StepResult.logs`` for display/capture; it does not affect training.
+RewardResult = tuple[float, dict[str, float]] | tuple[float, dict[str, float], types.Logs]
 RewardFn = Callable[[list[Message]], Awaitable[RewardResult]]
 # TODO(tyler): Consider supporting stateful tools that need to grade rollouts based on
 # information not contained in the message history (e.g., internal tool state that changes
@@ -132,8 +135,11 @@ class AgentToolMessageEnv(MessageEnv):
 
         reward = 0.0
         if done:
-            reward, reward_metrics = await self.reward_fn(self.history)
-            metrics.update(reward_metrics)
+            reward_result = await self.reward_fn(self.history)
+            reward = reward_result[0]
+            metrics.update(reward_result[1])
+            if len(reward_result) == 3:
+                logs.update(reward_result[2])
 
         return MessageStepResult(
             reward=reward,

--- a/tinker_cookbook/tool_use/agent_tool_message_env_test.py
+++ b/tinker_cookbook/tool_use/agent_tool_message_env_test.py
@@ -176,6 +176,45 @@ class TestStepLogs:
         assert "tool_result_0" not in result.logs
 
 
+class TestRewardFnLogs:
+    """Reward functions may return (reward, metrics, logs); logs merge into
+    the step result's logs at episode end."""
+
+    def test_three_tuple_reward_fn_merges_logs(self):
+        async def grading_reward(
+            history: list[Message],
+        ) -> tuple[float, dict[str, float], dict[str, str | int | float]]:
+            return 0.5, {"tests_total": 3.0}, {"grading/verdict": "failed"}
+
+        env = AgentToolMessageEnv(
+            tools=[],
+            initial_messages=[{"role": "user", "content": "hi"}],
+            max_turns=5,
+            reward_fn=grading_reward,
+        )
+        asyncio.run(env.initial_observation())
+        result = asyncio.run(env.step({"role": "assistant", "content": "done"}))
+
+        assert result.episode_done
+        assert result.reward == 0.5
+        assert result.metrics["tests_total"] == 3.0
+        assert result.logs["grading/verdict"] == "failed"
+        assert result.logs["assistant_content"] == "done"
+
+    def test_two_tuple_reward_fn_unchanged(self):
+        env = AgentToolMessageEnv(
+            tools=[],
+            initial_messages=[{"role": "user", "content": "hi"}],
+            max_turns=5,
+            reward_fn=_noop_reward,
+        )
+        asyncio.run(env.initial_observation())
+        result = asyncio.run(env.step({"role": "assistant", "content": "done"}))
+
+        assert result.reward == 1.0
+        assert result.logs == {"assistant_content": "done"}
+
+
 class TestStructuredToolCalls:
     """AgentToolMessageEnv.step() should emit structured tool_calls records."""
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #821
* #820
* #819
* #818
* __->__ #817
* #816
* #815
* #814
* #813
* #812
* #811
* #810
* #809
* #808
* #807
* #806
* #805
* #804

Wire the EnvGroupBuilder.metadata() / StepResult.attrs capture API through
the recipe families. All additions are capture-only: rewards, observations,
and env step logic are unchanged.

- ProblemGroupBuilder: group_metadata passthrough field + metadata().
- math_rl: dataset name, row_id (dataset id or shuffled-split position), and
  level/difficulty (numeric when parseable) for MATH/MATH-500, GSM8K,
  DeepMath, Polaris, and arithmetic.
- code_rl: tag DeepCoder rows with their sub-dataset before concatenation
  (order unchanged) and surface it via builder metadata; DeepcoderReward now
  reports tests_total in metrics and a grading-details summary (verdict,
  error class, timing; stdout/stderr dropped) in logs. AgentToolMessageEnv
  reward functions may return an optional third logs element.
- multiplayer_rl: game/row_id metadata for guess_number; game/opponent
  metadata and per-step player_id attrs for text_arena.
- preference: tournament_pattern/matchup_group_size metadata and per-
  trajectory matchup_count metric on pairwise groups.
- rubric: num_rubrics metadata.
- prompt_distillation: record teacher_model/source_dataset on captured
  sample rows.
- search_tool: data_source/corpus metadata (new ChromaTool.collection_name
  property); per-call tool usage already flows via structured tool_calls.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>