### PR TITLE
tokendb: registry-level cross-run reader (lazy scans, unified views)

### DIFF
--- a/tinker_cookbook/tokendb/README.md
+++ b/tinker_cookbook/tokendb/README.md
@@ -62,6 +62,32 @@ In registry mode the server exposes:
 
 Pointing the server at a specific `log_path` still works exactly as before and does not need the registry.
 
+### Cross-run SQL (`RegistryBackend`)
+
+Registry mode also exposes one SQL surface spanning **all** registered runs: `POST /api/sql` at the registry root runs read-only DuckDB over cross-run `rollouts` / `rollouts_latest` / `trajectories` / `labels` / `runs` views (plus the promoted `correct` / `parse_errors` / `context_overflows`), with `run_id` as an ordinary column. This is what makes config-vs-outcome questions one query:
+
+```sql
+SELECT r.temperature, avg(t.total_reward) AS mean_reward
+FROM trajectories t JOIN runs r USING (run_id, run_attempt)
+GROUP BY 1 ORDER BY 1
+```
+
+The `superseded` flag is computed per run (`PARTITION BY run_id, split, iteration`), so a resume in one run never hides another run's rows; prefer `rollouts_latest` for cross-run aggregates. The same backend powers the registry chat's `sql` tool (no `run_id` argument means cross-run) and the dashboard aggregation (one `GROUP BY run_id` pass instead of a reader per run). Programmatic use:
+
+```python
+from tinker_cookbook.tokendb import RegistryBackend
+
+backend = RegistryBackend()  # resolves the registry like the viewer does
+rows = backend.sql("SELECT run_id, count(*) AS n FROM rollouts GROUP BY run_id")
+```
+
+Unlike the single-run reader, the cross-run reader is **lazy**: it keeps a DuckDB `read_parquet` scan over an explicit per-run file list (rebuilt on a TTL-gated refresh, default 5s) instead of materializing segments in memory, so nothing is pinned in RAM between queries. Segments that cannot be scanned in place are staged once into a local **segcache**:
+
+- Cloud stores (`gs://`, `s3://`): each segment is fetched once through `Storage` and cached (segments are immutable, so existence is validity).
+- v1-shaped segments are normalized to the v2 schema at cache fill (`upgraded/`); the original files are never rewritten.
+
+The segcache defaults to `~/.cache/tinker-cookbook/tokendb/segcache`; override it with the `segcache_dir` config knob (`python -m tinker_cookbook.tokendb.serve segcache_dir=/tmp/segcache`, or the `RegistryBackend(segcache_dir=...)` argument) or the `TINKER_TOKENDB_SEGCACHE` environment variable. There is no automatic eviction yet: the cache grows with the cloud/v1 segments you have actually queried, and it is always safe to delete (`rm -rf ~/.cache/tinker-cookbook/tokendb/segcache`); segments re-stage on the next refresh.
+
 ## Chat
 
 The viewer has a chat mode: ask questions about your training data in plain language and an LLM agent answers by querying the token DB for you. No SQL required. The agent can run read-only DuckDB queries (`sql`), search by regex or token-ID subsequence (`search`), pull whole trajectories (`get_rollout`), and publish self-contained HTML visuals (`publish_visual`) that render inline in the chat and in a gallery. In registry mode there is also a global cross-run chat (with `list_runs` and `dashboard` tools for comparing experiments) alongside the per-run chats.

--- a/tinker_cookbook/tokendb/__init__.py
+++ b/tinker_cookbook/tokendb/__init__.py
@@ -37,6 +37,7 @@ from tinker_cookbook.tokendb.registry import (
     resolve_registry_dir,
     run_status,
 )
+from tinker_cookbook.tokendb.registry_backend import RegistryBackend
 from tinker_cookbook.tokendb.schema import (
     SCHEMA_VERSION,
     TokenRow,
@@ -51,6 +52,7 @@ __all__ = [
     "CaptureContext",
     "ParquetSegmentBackend",
     "ParquetSegmentReader",
+    "RegistryBackend",
     "TokenDB",
     "TokenDbConfig",
     "TokenDbWriter",

--- a/tinker_cookbook/tokendb/agent.py
+++ b/tinker_cookbook/tokendb/agent.py
@@ -404,6 +404,23 @@ def _with_run_id(schema: dict[str, Any]) -> dict[str, Any]:
     return {"type": "object", "properties": properties, "required": required}
 
 
+def _with_optional_run_id(schema: dict[str, Any]) -> dict[str, Any]:
+    """Registry-mode variant of a tool schema: adds an optional run_id."""
+    properties = {
+        "run_id": {
+            "type": "string",
+            "description": "Optional: execute against one run's own store "
+            "(omit for cross-run SQL over every registered run).",
+        },
+        **schema.get("properties", {}),
+    }
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(schema.get("required", [])),
+    }
+
+
 @dataclass
 class ToolOutcome:
     """One executed tool call: model-facing content plus optional UI frames."""
@@ -517,7 +534,13 @@ class RunToolbox:
 
 
 class RegistryToolbox:
-    """Cross-run tools for the registry-level chat: per-run tools take run_id."""
+    """Cross-run tools for the registry-level chat.
+
+    ``sql`` runs against the cross-run *backend* (every registered run in
+    one database, ``run_id`` as a column) when no ``run_id`` argument is
+    given, and against that run's own store when one is. ``search`` and
+    ``get_rollout`` stay per-run (they require a ``run_id``).
+    """
 
     def __init__(
         self,
@@ -525,11 +548,13 @@ class RegistryToolbox:
         dashboard_fn: Callable[[], list[dict[str, Any]]],
         resolve_reader: Callable[[str], TokenStoreBackend],
         visual_store: VisualStore,
+        backend: TokenStoreBackend | None = None,
     ) -> None:
         self._list_runs_fn = list_runs_fn
         self._dashboard_fn = dashboard_fn
         self._resolve_reader = resolve_reader
         self._visual_store = visual_store
+        self._backend = backend
 
     def tool_defs(self) -> list[ToolDef]:
         empty = {"type": "object", "properties": {}}
@@ -542,10 +567,11 @@ class RegistryToolbox:
             ),
             ToolDef(
                 "sql",
-                "Run a read-only DuckDB SELECT over one run's token DB "
-                "(views: rollouts, rollouts_latest, trajectories, labels, runs, "
-                "correct, parse_errors, context_overflows).",
-                _with_run_id(_SQL_SCHEMA),
+                "Run a read-only DuckDB SELECT over the token DB spanning EVERY "
+                "registered run (views: rollouts, rollouts_latest, trajectories, "
+                "labels, runs, correct, parse_errors, context_overflows; run_id is "
+                "a normal column). Pass run_id to query one run's store instead.",
+                _with_optional_run_id(_SQL_SCHEMA),
             ),
             ToolDef(
                 "search",
@@ -572,13 +598,21 @@ class RegistryToolbox:
                 return ToolOutcome(_to_json({"runs": self._dashboard_fn()}))
             if call.name == "publish_visual":
                 return _publish_visual_outcome(self._visual_store, call.arguments)
-            if call.name in ("sql", "search", "get_rollout"):
+            if call.name == "sql":
+                run_id = call.arguments.get("run_id")
+                if run_id:
+                    reader = self._resolve_reader(str(run_id))
+                elif self._backend is not None:
+                    reader = self._backend
+                else:
+                    raise ToolExecutionError("sql needs a run_id (see list_runs)")
+                return ToolOutcome(_to_json(_execute_sql(reader, call.arguments)))
+            if call.name in ("search", "get_rollout"):
                 run_id = call.arguments.get("run_id")
                 if not run_id:
                     raise ToolExecutionError(f"{call.name} needs a run_id (see list_runs)")
                 reader = self._resolve_reader(str(run_id))
                 executor = {
-                    "sql": _execute_sql,
                     "search": _execute_search,
                     "get_rollout": _execute_get_rollout,
                 }[call.name]

--- a/tinker_cookbook/tokendb/agent_prompt.py
+++ b/tinker_cookbook/tokendb/agent_prompt.py
@@ -214,24 +214,67 @@ def _format_key_list(keys: list[str]) -> str:
     return ", ".join(f"`{key}`" for key in shown) + suffix
 
 
+def _format_key_list_with_runs(keys: list[str], field: str, runs: dict[str, dict[str, Any]]) -> str:
+    """Like :func:`_format_key_list`, with per-run attribution.
+
+    Keys present in only some of the contributing runs get an
+    ``(only: run_a, run_b)`` suffix so the model knows where map access
+    returns NULL.
+    """
+    if not keys:
+        return "(none)"
+    shown = keys[:_SCHEMA_CARD_MAX_KEYS]
+    parts = []
+    for key in shown:
+        present = [run_id for run_id, card in runs.items() if key in (card.get(field) or [])]
+        if 0 < len(present) < len(runs):
+            parts.append(f"`{key}` (only: {', '.join(sorted(present))})")
+        else:
+            parts.append(f"`{key}`")
+    suffix = f", ... ({len(keys) - len(shown)} more)" if len(keys) > len(shown) else ""
+    return ", ".join(parts) + suffix
+
+
 def format_schema_card(card: dict[str, Any]) -> str:
     """Render an observed-keys card (``reader.schema_card()``) as prompt text.
 
     Tells the model exactly which `metrics` / `attrs` / `token_metrics` keys
-    and tags exist in this run, plus the promoted views and `runs` columns,
-    so it writes correct map SQL on the first try instead of probing with
-    ``map_keys`` scans.
+    and tags exist, plus the promoted views and `runs` columns, so it writes
+    correct map SQL on the first try instead of probing with ``map_keys``
+    scans. A cross-run card (one with a ``runs`` mapping, from
+    ``RegistryBackend.schema_card()``) renders the union with per-run key
+    attribution.
     """
+    runs = card.get("runs")
+    if runs:
+        header = [
+            f"## Observed keys across runs ({len(runs)} runs)",
+            "",
+            "Union of the keys present across every registered run. A key marked",
+            "(only: ...) exists only in those runs; elsewhere map access returns",
+            "NULL. Do not guess other keys.",
+        ]
+
+        def render(field: str) -> str:
+            return _format_key_list_with_runs(card.get(field) or [], field, runs)
+    else:
+        header = [
+            "## This run's observed keys",
+            "",
+            "These are the keys actually present in this run's data. Do not guess",
+            "other keys; a key not listed here is absent (map access returns NULL).",
+        ]
+
+        def render(field: str) -> str:
+            return _format_key_list(card.get(field) or [])
+
     lines = [
-        "## This run's observed keys",
+        *header,
         "",
-        "These are the keys actually present in this run's data. Do not guess",
-        "other keys; a key not listed here is absent (map access returns NULL).",
-        "",
-        f"- `metrics` keys: {_format_key_list(card.get('metrics_keys') or [])}",
-        f"- `attrs` keys: {_format_key_list(card.get('attrs_keys') or [])}",
-        f"- `token_metrics` keys: {_format_key_list(card.get('token_metrics_keys') or [])}",
-        f"- tags: {_format_key_list(card.get('tags') or [])}",
+        f"- `metrics` keys: {render('metrics_keys')}",
+        f"- `attrs` keys: {render('attrs_keys')}",
+        f"- `token_metrics` keys: {render('token_metrics_keys')}",
+        f"- tags: {render('tags')}",
     ]
     if card.get("keys_truncated"):
         lines.append("- note: the key lists were truncated at capture time and may be incomplete.")
@@ -254,29 +297,38 @@ def build_system_prompt(
 
     Args:
         sql_url: Base path of the read-only SQL endpoint visuals should POST
-            to (e.g. ``/api/sql`` or ``/api/runs/{run_id}/sql``). In registry
-            mode this is a template: ``{run_id}`` must be substituted by the
-            visual's JS (the prompt tells the model so).
+            to (``/api/sql`` for single-run mode and for the registry's
+            cross-run endpoint, or ``/api/runs/{run_id}/sql`` for a per-run
+            chat mount).
         mode: ``"run"`` for a single-run chat, ``"registry"`` for the global
-            cross-run chat (extra tools: ``list_runs`` / ``dashboard``; data
-            tools take a ``run_id``).
+            cross-run chat (extra tools: ``list_runs`` / ``dashboard``; the
+            ``sql`` tool spans every run and takes an optional ``run_id``).
         run_info: Optional run metadata (``run.json`` content) shown to the
             model for a single-run chat.
-        schema_card: Optional observed-keys card
-            (:meth:`~tinker_cookbook.tokendb.reader.ParquetSegmentReader.schema_card`)
-            rendered via :func:`format_schema_card` for a single-run chat.
+        schema_card: Optional observed-keys card rendered via
+            :func:`format_schema_card` — the single-run reader's card, or the
+            registry backend's aggregated multi-run card.
     """
     parts = [_SCHEMA_AND_SEMANTICS, _VISUAL_GUIDE.format(sql_url=sql_url)]
     if mode == "registry":
         parts.append(
             "## Registry mode\n\n"
-            "This chat spans EVERY registered run. Start with `list_runs` or\n"
-            "`dashboard` to see what exists (run_id, model, recipe, liveness,\n"
-            "reward trends), then pass the relevant `run_id` to `sql`, `search`,\n"
-            "and `get_rollout`. In visual HTML, replace `{run_id}` in the SQL\n"
-            "endpoint template above with the actual run ID you are charting.\n"
-            "When comparing runs, query each run separately and align by\n"
-            "iteration."
+            "This chat spans EVERY registered run, and the `sql` tool queries ONE\n"
+            "database whose views (rollouts, rollouts_latest, trajectories, labels,\n"
+            "runs, and the promoted views) contain every run's rows. `run_id` is a\n"
+            "normal column: filter with `WHERE run_id = '...'`, compare runs with\n"
+            "`GROUP BY run_id`, and join `runs` USING (run_id, run_attempt) to\n"
+            "slice by config (temperature, learning_rate, model_name, ...). Note\n"
+            "that `rollouts` includes superseded rows from earlier run attempts;\n"
+            "prefer `rollouts_latest` for cross-run aggregates unless you are\n"
+            "explicitly comparing attempts.\n"
+            "Start with `list_runs` or `dashboard` for what exists (run_id, model,\n"
+            "recipe, liveness, reward trends). Pass the optional `run_id` argument\n"
+            "to `sql` only when you want one run's own store; `search` and\n"
+            "`get_rollout` always require a `run_id`.\n"
+            "In visual HTML, POST cross-run SQL to the endpoint above; a\n"
+            "single-run visual can instead use `/api/runs/{run_id}/sql` with the\n"
+            "actual run ID substituted."
         )
     if run_info:
         parts.append(

--- a/tinker_cookbook/tokendb/agent_test.py
+++ b/tinker_cookbook/tokendb/agent_test.py
@@ -849,9 +849,13 @@ def test_registry_toolbox_routes_by_run_id(tmp_path: Path):
     )
     names = [t.name for t in toolbox.tool_defs()]
     assert names == ["list_runs", "dashboard", "sql", "search", "get_rollout", "publish_visual"]
-    assert (
-        "run_id" in next(t for t in toolbox.tool_defs() if t.name == "sql").input_schema["required"]
-    )
+    # sql's run_id is optional (cross-run via the registry backend when
+    # omitted); search / get_rollout stay per-run.
+    sql_schema = next(t for t in toolbox.tool_defs() if t.name == "sql").input_schema
+    assert "run_id" in sql_schema["properties"]
+    assert "run_id" not in sql_schema["required"]
+    search_schema = next(t for t in toolbox.tool_defs() if t.name == "search").input_schema
+    assert "run_id" in search_schema["required"]
 
     outcome, payload = _run_tool(toolbox, "list_runs", {})
     assert payload["runs"][0]["run_id"] == run_id
@@ -861,6 +865,7 @@ def test_registry_toolbox_routes_by_run_id(tmp_path: Path):
         toolbox, "sql", {"run_id": run_id, "query": "SELECT count(*) AS n FROM rollouts"}
     )
     assert payload["rows"][0]["n"] == 1
+    # No cross-run backend was given, so run_id-less sql still errors.
     outcome, payload = _run_tool(toolbox, "sql", {"query": "SELECT 1"})
     assert outcome.is_error and "run_id" in payload["error"]
     outcome, payload = _run_tool(toolbox, "sql", {"run_id": "nope", "query": "SELECT 1"})

--- a/tinker_cookbook/tokendb/conftest.py
+++ b/tinker_cookbook/tokendb/conftest.py
@@ -5,10 +5,12 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _isolated_tokendb_registry(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point the run registry at a per-test directory.
+    """Point the run registry and segment cache at per-test directories.
 
     Writers register runs on construction (best-effort), so without this the
     test suite would pollute the developer's real registry under
-    ``~/.cache/tinker-cookbook/tokendb/runs``.
+    ``~/.cache/tinker-cookbook/tokendb/runs``; the cross-run reader would
+    similarly write into the real segcache.
     """
     monkeypatch.setenv("TINKER_TOKENDB_REGISTRY", str(tmp_path / "tokendb-registry"))
+    monkeypatch.setenv("TINKER_TOKENDB_SEGCACHE", str(tmp_path / "tokendb-segcache"))

--- a/tinker_cookbook/tokendb/interface.py
+++ b/tinker_cookbook/tokendb/interface.py
@@ -83,8 +83,14 @@ class TokenStoreBackend(Protocol):
         group_idx: int,
         traj_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> Any:
-        """Fetch all rows (turns) for one trajectory (latest attempt by default)."""
+        """Fetch all rows (turns) for one trajectory (latest attempt by default).
+
+        Rollout identity is only unique per run, so cross-run backends require
+        ``run_id`` when more than one run is registered; single-run backends
+        accept it as an extra filter.
+        """
         ...
 
     def search(self, **kwargs: Any) -> Any:
@@ -116,8 +122,13 @@ class TokenStoreBackend(Protocol):
         iteration: int,
         group_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> Any:
-        """The distinct ``traj_idx`` values of one group (sibling trajectories)."""
+        """The distinct ``traj_idx`` values of one group (sibling trajectories).
+
+        Like :meth:`get_rollout`, cross-run backends require ``run_id`` when
+        more than one run is registered.
+        """
         ...
 
     def subscribe(self, **filters: Any) -> AsyncIterator[Any]:

--- a/tinker_cookbook/tokendb/interface_test.py
+++ b/tinker_cookbook/tokendb/interface_test.py
@@ -113,6 +113,7 @@ class FakeBackend:
         group_idx: int,
         traj_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
         return [{"split": split, "iteration": iteration, "step_idx": 0}]
 
@@ -138,7 +139,12 @@ class FakeBackend:
         }
 
     def group_traj_idxs(
-        self, split: str, iteration: int, group_idx: int, run_attempt: int | None = None
+        self,
+        split: str,
+        iteration: int,
+        group_idx: int,
+        run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> list[int]:
         return [0]
 

--- a/tinker_cookbook/tokendb/reader.py
+++ b/tinker_cookbook/tokendb/reader.py
@@ -55,12 +55,39 @@ LABELS_PATH = f"{TOKENS_DIR}/labels.jsonl"
 DEFAULT_SUBSCRIBE_POLL_INTERVAL_S = 2.0
 
 _LABEL_KEY_FIELDS = ("run_id", "split", "iteration", "group_idx", "traj_idx", "step_idx")
+LABEL_FILTER_FIELDS = frozenset(_LABEL_KEY_FIELDS) | {"label_key", "author"}
 
 _LABEL_COLUMNS_SQL = (
     "{run_id: 'VARCHAR', split: 'VARCHAR', iteration: 'INTEGER', group_idx: 'INTEGER', "
     "traj_idx: 'INTEGER', step_idx: 'INTEGER', label_key: 'VARCHAR', label_value: 'JSON', "
     "author: 'VARCHAR', ts: 'TIMESTAMP', note: 'VARCHAR'}"
 )
+
+# Casts a raw (all-strings-and-ints) label relation to the typed label columns.
+LABELS_CAST_SELECT = (
+    "(SELECT run_id, split, iteration::INTEGER AS iteration,"
+    " group_idx::INTEGER AS group_idx, traj_idx::INTEGER AS traj_idx,"
+    " step_idx::INTEGER AS step_idx, label_key, label_value::JSON AS label_value,"
+    " author, ts::TIMESTAMP AS ts, note FROM {src})"
+)
+
+# Last write (by ts) wins per (identity, label_key); tombstones (null
+# label_value) win first, then drop out of the view.
+LABELS_DEDUP_VIEW_SQL = """
+    CREATE OR REPLACE VIEW labels AS
+    SELECT * EXCLUDE (_rank) FROM (
+        SELECT *,
+               row_number() OVER (
+                   PARTITION BY run_id, split, iteration, group_idx, traj_idx,
+                                step_idx, label_key
+                   ORDER BY ts DESC
+               ) AS _rank
+        FROM {source}
+    )
+    WHERE _rank = 1
+      AND label_value IS NOT NULL
+      AND CAST(label_value AS VARCHAR) <> 'null'
+"""
 
 # Trajectory-grain aggregation over the row-grain `rollouts` view (the
 # `trajectories()` backend method). Matches the `trajectories` view but keeps
@@ -308,6 +335,387 @@ def _contains_subsequence(haystack: Sequence[int], needle: Sequence[int]) -> boo
     return False
 
 
+# --- Shared query building (used by the single-run reader and the cross-run
+# --- registry backend; see registry_backend.py) ---
+
+
+def build_where(
+    *,
+    run_id: str | None = None,
+    run_attempt: int | None = None,
+    split: str | None = None,
+    iteration: int | None = None,
+    min_iteration: int | None = None,
+    max_iteration: int | None = None,
+    group_idx: int | None = None,
+    traj_idx: int | None = None,
+    min_reward: float | None = None,
+    max_reward: float | None = None,
+    stop_reason: str | None = None,
+    source: str | None = None,
+    filtered_reason: str | None = None,
+    tag: str | None = None,
+    env_row_id: str | None = None,
+    text_regex: str | None = None,
+    attr_eq: Mapping[str, str] | None = None,
+    metric_min: Mapping[str, float] | None = None,
+    metric_max: Mapping[str, float] | None = None,
+) -> tuple[str, list[Any]]:
+    """Build a parameterized ``WHERE`` clause from the structured row filters."""
+    clauses: list[str] = []
+    params: list[Any] = []
+    for column, value in [
+        ("run_id", run_id),
+        ("run_attempt", run_attempt),
+        ("split", split),
+        ("iteration", iteration),
+        ("group_idx", group_idx),
+        ("traj_idx", traj_idx),
+        ("stop_reason", stop_reason),
+        ("source", source),
+        ("filtered_reason", filtered_reason),
+        ("env_row_id", env_row_id),
+    ]:
+        if value is not None:
+            clauses.append(f"{column} = ?")
+            params.append(value)
+    if min_iteration is not None:
+        clauses.append("iteration >= ?")
+        params.append(min_iteration)
+    if max_iteration is not None:
+        clauses.append("iteration <= ?")
+        params.append(max_iteration)
+    if min_reward is not None:
+        clauses.append("total_reward >= ?")
+        params.append(min_reward)
+    if max_reward is not None:
+        clauses.append("total_reward <= ?")
+        params.append(max_reward)
+    if tag is not None:
+        clauses.append("list_contains(tags, ?)")
+        params.append(tag)
+    if text_regex is not None:
+        clauses.append(
+            "(regexp_matches(coalesce(ob_text, ''), ?) OR regexp_matches(coalesce(ac_text, ''), ?))"
+        )
+        params.extend([text_regex, text_regex])
+    # Structured map filters. Keys bind as parameters (map access on a
+    # missing key yields NULL, so these clauses also drop rows lacking
+    # the key). TRY_CAST guards the numeric comparison; note DuckDB
+    # orders NaN above every number, so a NaN metric passes metric_min.
+    for key, value in (attr_eq or {}).items():
+        clauses.append("attrs[?] = ?")
+        params.extend([str(key), str(value)])
+    for key, value in (metric_min or {}).items():
+        clauses.append("TRY_CAST(metrics[?] AS DOUBLE) >= ?")
+        params.extend([str(key), float(value)])
+    for key, value in (metric_max or {}).items():
+        clauses.append("TRY_CAST(metrics[?] AS DOUBLE) <= ?")
+        params.extend([str(key), float(value)])
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    return where, params
+
+
+def run_search(
+    fetch: Any,
+    *,
+    regex: str | None = None,
+    fields: Sequence[str] = ("ac_text", "ob_text"),
+    token_subsequence: Sequence[int] | None = None,
+    limit: int | None = None,
+    **filters: Any,
+) -> list[dict[str, Any]]:
+    """Shared :meth:`~ParquetSegmentReader.search` implementation.
+
+    *fetch* is a ``(sql, params) -> list[dict]`` callable bound to a
+    connection whose ``rollouts`` view is current (the caller refreshes).
+    """
+    string_fields = {"ac_text", "ob_text", "logs"}
+    map_fields = {"metrics", "attrs", "token_metrics"}
+    bad = set(fields) - string_fields - map_fields
+    if bad:
+        raise ValueError(f"Unsupported search fields: {sorted(bad)}")
+    where, params = build_where(**filters)
+    clauses = [where[len("WHERE ") :]] if where else []
+    if regex is not None:
+        field_matches = []
+        for f in fields:
+            if f in map_fields:
+                # regexp_matches on a MAP is a BinderException; match keys.
+                field_matches.append(
+                    "EXISTS (SELECT 1 FROM unnest(map_keys("
+                    f"{f})) AS _k(key) WHERE regexp_matches(_k.key, ?))"
+                )
+            else:
+                field_matches.append(f"regexp_matches(coalesce({f}, ''), ?)")
+        clauses.append(f"({' OR '.join(field_matches)})")
+        params.extend([regex] * len(fields))
+    if token_subsequence:
+        # Cheap SQL prefilter on the first token; the exact contiguous
+        # match runs in Python below (portable across backends).
+        clauses.append("list_contains(ac_tokens, ?)")
+        params.append(int(token_subsequence[0]))
+    sql = "SELECT * FROM rollouts"
+    if clauses:
+        sql += f" WHERE {' AND '.join(clauses)}"
+    sql += " ORDER BY iteration, ts, group_idx, traj_idx, step_idx"
+    rows = fetch(sql, params)
+    if token_subsequence:
+        needle = [int(t) for t in token_subsequence]
+        rows = [row for row in rows if _contains_subsequence(row["ac_tokens"], needle)]
+    if limit is not None:
+        rows = rows[: int(limit)]
+    return rows
+
+
+def get_rollout_query(
+    split: str,
+    iteration: int,
+    group_idx: int,
+    traj_idx: int,
+    run_attempt: int | None,
+    run_id: str | None,
+) -> tuple[str, list[Any]]:
+    """The (sql, params) fetching one trajectory's step rows from ``rollouts``.
+
+    ``run_attempt=None`` selects the latest attempt that produced rows for
+    this trajectory (within ``run_id``, when given).
+    """
+    ident = "split = ? AND iteration = ? AND group_idx = ? AND traj_idx = ?"
+    ident_params: list[Any] = [split, iteration, group_idx, traj_idx]
+    if run_id is not None:
+        ident += " AND run_id = ?"
+        ident_params.append(run_id)
+    sql = f"SELECT * FROM rollouts WHERE {ident}"
+    params = list(ident_params)
+    if run_attempt is None:
+        sql += f" AND run_attempt = (SELECT max(run_attempt) FROM rollouts WHERE {ident})"
+        params += ident_params
+    else:
+        sql += " AND run_attempt = ?"
+        params.append(run_attempt)
+    sql += " ORDER BY step_idx"
+    return sql, params
+
+
+def run_attempt_payloads(storage: Storage) -> list[dict[str, Any]]:
+    """All run-attempt payloads for one store, one per (run_id, run_attempt).
+
+    Reads ``run-attempts.jsonl`` (one line appended per attempt), falling
+    back to ``run.json`` (latest attempt only) for stores written before
+    the append-per-attempt record existed. Deduped by
+    ``(run_id, run_attempt)``, last line wins.
+    """
+    payloads: dict[tuple[Any, Any], dict[str, Any]] = {}
+    if storage.exists(RUN_ATTEMPTS_PATH):
+        for line in storage.read(RUN_ATTEMPTS_PATH).decode().splitlines():
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                payloads[(payload.get("run_id"), payload.get("run_attempt"))] = payload
+    if not payloads and storage.exists(RUN_JSON_PATH):
+        try:
+            payload = json.loads(storage.read(RUN_JSON_PATH).decode())
+            if isinstance(payload, dict):
+                payloads[(payload.get("run_id"), payload.get("run_attempt"))] = payload
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pass
+    return [payloads[key] for key in sorted(payloads, key=lambda k: (str(k[0]), str(k[1])))]
+
+
+def runs_arrow_schema() -> Any:
+    """Arrow schema of the ``runs`` view (typed config columns + config_json)."""
+    import pyarrow as pa
+
+    return pa.schema(
+        [
+            pa.field("run_id", pa.string()),
+            pa.field("run_attempt", pa.int32()),
+            pa.field("model_name", pa.string()),
+            pa.field("recipe_name", pa.string()),
+            pa.field("started_at", pa.string()),
+            pa.field("temperature", pa.float64()),
+            pa.field("max_tokens", pa.int64()),
+            pa.field("renderer_name", pa.string()),
+            pa.field("lora_rank", pa.int64()),
+            pa.field("seed", pa.int64()),
+            pa.field("group_size", pa.int64()),
+            pa.field("loss_fn", pa.string()),
+            pa.field("learning_rate", pa.float64()),
+            pa.field("config_json", pa.string()),
+        ]
+    )
+
+
+def load_schema_card(storage: Storage) -> dict[str, Any]:
+    """Aggregate one store's observed-keys manifest lines into a card.
+
+    Unions ``metrics_keys`` / ``attrs_keys`` / ``token_metrics_keys`` /
+    ``tags`` across every manifest line of every writer (cheap: manifest
+    lines only, no segment bytes). ``keys_truncated`` is true if any
+    contributing line hit the writer's per-line key cap, i.e. the lists
+    may be incomplete. Lines from writers that predate observed-keys
+    manifests contribute nothing.
+    """
+    union: dict[str, set[str]] = {
+        "metrics_keys": set(),
+        "attrs_keys": set(),
+        "token_metrics_keys": set(),
+        "tags": set(),
+    }
+    truncated = False
+    try:
+        names = [
+            name
+            for name in storage.list_dir(TOKENS_DIR)
+            if name.startswith("manifest-") and name.endswith(".jsonl")
+        ]
+    except FileNotFoundError:
+        names = []
+    for name in names:
+        try:
+            lines = storage.read(f"{TOKENS_DIR}/{name}").decode().splitlines()
+        except FileNotFoundError:
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            for field in union:
+                values = entry.get(field)
+                if isinstance(values, list):
+                    union[field].update(str(v) for v in values)
+            truncated = truncated or bool(entry.get("keys_truncated"))
+    return {
+        **{field: sorted(values) for field, values in union.items()},
+        "keys_truncated": truncated,
+    }
+
+
+def append_label(
+    storage: Storage,
+    key: Mapping[str, Any],
+    label_key: str,
+    label_value: Any,
+    *,
+    author: str,
+    note: str | None = None,
+) -> None:
+    """Append one annotation record to a store's ``labels.jsonl``.
+
+    See :meth:`ParquetSegmentReader.add_label` for the key/tombstone
+    semantics; this is the shared write path.
+    """
+    bad_keys = set(key) - set(_LABEL_KEY_FIELDS)
+    if bad_keys:
+        raise ValueError(f"Unsupported label key fields: {sorted(bad_keys)}")
+    record: dict[str, Any] = {field: key.get(field) for field in _LABEL_KEY_FIELDS}
+    record.update(
+        {
+            "label_key": label_key,
+            "label_value": label_value,
+            "author": author,
+            "ts": datetime.now(UTC).isoformat(),
+            "note": note,
+        }
+    )
+    storage.append(LABELS_PATH, (json.dumps(record, default=str) + "\n").encode())
+    # FsspecStorage stages append()s locally and only uploads on flush();
+    # nothing else ever flushes this storage, so without this a label
+    # written against a gs:///s3:// store would silently never reach the
+    # store. LocalStorage.flush() is a no-op, and FsspecStorage re-uploads
+    # only files with staged appends (here: labels.jsonl, which stays small).
+    storage.flush()
+
+
+def labels_arrow_table(records: Sequence[Mapping[str, Any]]) -> Any:
+    """Label records as an arrow table (``label_value`` JSON-encoded).
+
+    An explicit schema keeps the shape stable for empty record lists.
+    """
+    import pyarrow as pa
+
+    schema = pa.schema(
+        [
+            pa.field("run_id", pa.string()),
+            pa.field("split", pa.string()),
+            pa.field("iteration", pa.int64()),
+            pa.field("group_idx", pa.int64()),
+            pa.field("traj_idx", pa.int64()),
+            pa.field("step_idx", pa.int64()),
+            pa.field("label_key", pa.string()),
+            pa.field("label_value", pa.string()),
+            pa.field("author", pa.string()),
+            pa.field("ts", pa.string()),
+            pa.field("note", pa.string()),
+        ]
+    )
+    return pa.Table.from_pylist(
+        [
+            {
+                **{field: rec.get(field) for field in _LABEL_KEY_FIELDS},
+                "label_key": rec.get("label_key"),
+                "label_value": json.dumps(rec.get("label_value")),
+                "author": rec.get("author"),
+                "ts": rec.get("ts"),
+                "note": rec.get("note"),
+            }
+            for rec in records
+        ],
+        schema=schema,
+    )
+
+
+def create_derived_views(conn: duckdb.DuckDBPyConnection) -> None:
+    """Create the views derived from ``rollouts`` (shared across backends).
+
+    The caller creates ``rollouts`` (whose ``superseded`` window differs
+    between the single-run reader and the cross-run registry backend);
+    everything defined on top of it is identical.
+    """
+    # Dedup convenience: only the latest attempt per superseded partition.
+    conn.execute("CREATE VIEW rollouts_latest AS SELECT * FROM rollouts WHERE NOT superseded")
+    # Promoted views: thin CREATE VIEW sugar over `rollouts` for the
+    # hottest metrics keys, so common questions need no map syntax.
+    # Retroactive and reversible (zero write cost); the key choices match
+    # what the cookbook envs actually emit:
+    # - `correct`: ProblemEnv/code_rl/search_tool/eval benchmarks emit
+    #   metrics['correct']; group-level correctness lands as
+    #   metrics['group/correct'] (which wins when both are present).
+    conn.execute(
+        """
+        CREATE VIEW correct AS
+        SELECT *, coalesce(metrics['group/correct'], metrics['correct']) AS correct
+        FROM rollouts
+        WHERE metrics['correct'] IS NOT NULL OR metrics['group/correct'] IS NOT NULL
+        """
+    )
+    # - `parse_errors`: message-env turns whose response failed renderer
+    #   parsing (metrics['parse_error'] = 1.0 in rl/message_env.py).
+    conn.execute(
+        """
+        CREATE VIEW parse_errors AS
+        SELECT * FROM rollouts WHERE metrics['parse_error'] >= 1.0
+        """
+    )
+    # - `context_overflows`: turns that hit max_tokens — stop_reason
+    #   'length', or the message-env's metrics['max_tokens_reached'].
+    conn.execute(
+        """
+        CREATE VIEW context_overflows AS
+        SELECT * FROM rollouts
+        WHERE stop_reason = 'length' OR metrics['max_tokens_reached'] >= 1.0
+        """
+    )
+
+
 class ParquetSegmentReader:
     """DuckDB reader over a parquet segment token store.
 
@@ -355,8 +763,6 @@ class ParquetSegmentReader:
             FROM segment_rows
             """
         )
-        # Dedup convenience: only the latest attempt per (split, iteration).
-        conn.execute("CREATE VIEW rollouts_latest AS SELECT * FROM rollouts WHERE NOT superseded")
         # Trajectory grain.
         conn.execute(
             """
@@ -374,66 +780,7 @@ class ParquetSegmentReader:
             GROUP BY run_id, run_attempt, split, iteration, group_idx, traj_idx
             """
         )
-        # Promoted views: thin CREATE VIEW sugar over `rollouts` for the
-        # hottest metrics keys, so common questions need no map syntax.
-        # Retroactive and reversible (zero write cost); the key choices match
-        # what the cookbook envs actually emit:
-        # - `correct`: ProblemEnv/code_rl/search_tool/eval benchmarks emit
-        #   metrics['correct']; group-level correctness lands as
-        #   metrics['group/correct'] (which wins when both are present).
-        conn.execute(
-            """
-            CREATE VIEW correct AS
-            SELECT *, coalesce(metrics['group/correct'], metrics['correct']) AS correct
-            FROM rollouts
-            WHERE metrics['correct'] IS NOT NULL OR metrics['group/correct'] IS NOT NULL
-            """
-        )
-        # - `parse_errors`: message-env turns whose response failed renderer
-        #   parsing (metrics['parse_error'] = 1.0 in rl/message_env.py).
-        conn.execute(
-            """
-            CREATE VIEW parse_errors AS
-            SELECT * FROM rollouts WHERE metrics['parse_error'] >= 1.0
-            """
-        )
-        # - `context_overflows`: turns that hit max_tokens — stop_reason
-        #   'length', or the message-env's metrics['max_tokens_reached'].
-        conn.execute(
-            """
-            CREATE VIEW context_overflows AS
-            SELECT * FROM rollouts
-            WHERE stop_reason = 'length' OR metrics['max_tokens_reached'] >= 1.0
-            """
-        )
-
-    def _run_attempt_payloads(self) -> list[dict[str, Any]]:
-        """All run-attempt payloads for this store, one per (run_id, run_attempt).
-
-        Reads ``run-attempts.jsonl`` (one line appended per attempt), falling
-        back to ``run.json`` (latest attempt only) for stores written before
-        the append-per-attempt record existed. Deduped by
-        ``(run_id, run_attempt)``, last line wins.
-        """
-        payloads: dict[tuple[Any, Any], dict[str, Any]] = {}
-        if self._storage.exists(RUN_ATTEMPTS_PATH):
-            for line in self._storage.read(RUN_ATTEMPTS_PATH).decode().splitlines():
-                if not line.strip():
-                    continue
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(payload, dict):
-                    payloads[(payload.get("run_id"), payload.get("run_attempt"))] = payload
-        if not payloads and self._storage.exists(RUN_JSON_PATH):
-            try:
-                payload = json.loads(self._storage.read(RUN_JSON_PATH).decode())
-                if isinstance(payload, dict):
-                    payloads[(payload.get("run_id"), payload.get("run_attempt"))] = payload
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                pass
-        return [payloads[key] for key in sorted(payloads, key=lambda k: (str(k[0]), str(k[1])))]
+        create_derived_views(conn)
 
     def _refresh_runs_source(self, conn: duckdb.DuckDBPyConnection) -> None:
         """(Re)create the ``runs`` view: one row per (run_id, run_attempt).
@@ -446,26 +793,8 @@ class ParquetSegmentReader:
         """
         import pyarrow as pa
 
-        rows = [_run_row_from_payload(payload) for payload in self._run_attempt_payloads()]
-        schema = pa.schema(
-            [
-                pa.field("run_id", pa.string()),
-                pa.field("run_attempt", pa.int32()),
-                pa.field("model_name", pa.string()),
-                pa.field("recipe_name", pa.string()),
-                pa.field("started_at", pa.string()),
-                pa.field("temperature", pa.float64()),
-                pa.field("max_tokens", pa.int64()),
-                pa.field("renderer_name", pa.string()),
-                pa.field("lora_rank", pa.int64()),
-                pa.field("seed", pa.int64()),
-                pa.field("group_size", pa.int64()),
-                pa.field("loss_fn", pa.string()),
-                pa.field("learning_rate", pa.float64()),
-                pa.field("config_json", pa.string()),
-            ]
-        )
-        table = pa.Table.from_pylist(rows, schema=schema)
+        rows = [_run_row_from_payload(payload) for payload in run_attempt_payloads(self._storage)]
+        table = pa.Table.from_pylist(rows, schema=runs_arrow_schema())
         conn.execute("DROP VIEW IF EXISTS runs")
         conn.register("_runs_raw", table)
         conn.execute("CREATE VIEW runs AS SELECT * FROM _runs_raw")
@@ -479,49 +808,12 @@ class ParquetSegmentReader:
     def schema_card(self) -> dict[str, Any]:
         """Aggregate the observed-keys manifest lines into a per-run card.
 
-        Unions ``metrics_keys`` / ``attrs_keys`` / ``token_metrics_keys`` /
-        ``tags`` across every manifest line of every writer (cheap: manifest
-        lines only, no segment bytes). ``keys_truncated`` is true if any
-        contributing line hit the writer's per-line key cap, i.e. the lists
-        may be incomplete. Lines from writers that predate observed-keys
-        manifests contribute nothing.
+        See :func:`load_schema_card` (the shared implementation): unions
+        ``metrics_keys`` / ``attrs_keys`` / ``token_metrics_keys`` / ``tags``
+        across every manifest line of every writer, with ``keys_truncated``
+        set when any contributing line hit the writer's per-line key cap.
         """
-        union: dict[str, set[str]] = {
-            "metrics_keys": set(),
-            "attrs_keys": set(),
-            "token_metrics_keys": set(),
-            "tags": set(),
-        }
-        truncated = False
-        try:
-            names = [
-                name
-                for name in self._storage.list_dir(TOKENS_DIR)
-                if name.startswith("manifest-") and name.endswith(".jsonl")
-            ]
-        except FileNotFoundError:
-            names = []
-        for name in names:
-            try:
-                lines = self._storage.read(f"{TOKENS_DIR}/{name}").decode().splitlines()
-            except FileNotFoundError:
-                continue
-            for line in lines:
-                if not line.strip():
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                for field in union:
-                    values = entry.get(field)
-                    if isinstance(values, list):
-                        union[field].update(str(v) for v in values)
-                truncated = truncated or bool(entry.get("keys_truncated"))
-        return {
-            **{field: sorted(values) for field, values in union.items()},
-            "keys_truncated": truncated,
-        }
+        return load_schema_card(self._storage)
 
     def _list_segment_files(self) -> list[str]:
         return sorted(
@@ -555,83 +847,6 @@ class ParquetSegmentReader:
 
     # --- Structured query ---
 
-    def _build_where(
-        self,
-        *,
-        run_id: str | None = None,
-        run_attempt: int | None = None,
-        split: str | None = None,
-        iteration: int | None = None,
-        min_iteration: int | None = None,
-        max_iteration: int | None = None,
-        group_idx: int | None = None,
-        traj_idx: int | None = None,
-        min_reward: float | None = None,
-        max_reward: float | None = None,
-        stop_reason: str | None = None,
-        source: str | None = None,
-        filtered_reason: str | None = None,
-        tag: str | None = None,
-        env_row_id: str | None = None,
-        text_regex: str | None = None,
-        attr_eq: Mapping[str, str] | None = None,
-        metric_min: Mapping[str, float] | None = None,
-        metric_max: Mapping[str, float] | None = None,
-    ) -> tuple[str, list[Any]]:
-        clauses: list[str] = []
-        params: list[Any] = []
-        for column, value in [
-            ("run_id", run_id),
-            ("run_attempt", run_attempt),
-            ("split", split),
-            ("iteration", iteration),
-            ("group_idx", group_idx),
-            ("traj_idx", traj_idx),
-            ("stop_reason", stop_reason),
-            ("source", source),
-            ("filtered_reason", filtered_reason),
-            ("env_row_id", env_row_id),
-        ]:
-            if value is not None:
-                clauses.append(f"{column} = ?")
-                params.append(value)
-        if min_iteration is not None:
-            clauses.append("iteration >= ?")
-            params.append(min_iteration)
-        if max_iteration is not None:
-            clauses.append("iteration <= ?")
-            params.append(max_iteration)
-        if min_reward is not None:
-            clauses.append("total_reward >= ?")
-            params.append(min_reward)
-        if max_reward is not None:
-            clauses.append("total_reward <= ?")
-            params.append(max_reward)
-        if tag is not None:
-            clauses.append("list_contains(tags, ?)")
-            params.append(tag)
-        if text_regex is not None:
-            clauses.append(
-                "(regexp_matches(coalesce(ob_text, ''), ?)"
-                " OR regexp_matches(coalesce(ac_text, ''), ?))"
-            )
-            params.extend([text_regex, text_regex])
-        # Structured map filters. Keys bind as parameters (map access on a
-        # missing key yields NULL, so these clauses also drop rows lacking
-        # the key). TRY_CAST guards the numeric comparison; note DuckDB
-        # orders NaN above every number, so a NaN metric passes metric_min.
-        for key, value in (attr_eq or {}).items():
-            clauses.append("attrs[?] = ?")
-            params.extend([str(key), str(value)])
-        for key, value in (metric_min or {}).items():
-            clauses.append("TRY_CAST(metrics[?] AS DOUBLE) >= ?")
-            params.extend([str(key), float(value)])
-        for key, value in (metric_max or {}).items():
-            clauses.append("TRY_CAST(metrics[?] AS DOUBLE) <= ?")
-            params.extend([str(key), float(value)])
-        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-        return where, params
-
     def query(
         self,
         *,
@@ -655,7 +870,7 @@ class ParquetSegmentReader:
         ``(iteration, ts)`` and include the computed ``superseded`` flag.
         """
         self.refresh()
-        where, params = self._build_where(**filters)
+        where, params = build_where(**filters)
         view = "rollouts_latest" if latest_only else "rollouts"
         sql = f"SELECT * FROM {view} {where} ORDER BY iteration, ts, group_idx, traj_idx, step_idx"
         if limit is not None:
@@ -682,7 +897,7 @@ class ParquetSegmentReader:
         Ordered newest iteration first.
         """
         self.refresh()
-        where, params = self._build_where(**filters)
+        where, params = build_where(**filters)
         if latest_only:
             where = f"{where} AND NOT superseded" if where else "WHERE NOT superseded"
         sql = _TRAJECTORIES_SQL.format(where=where, limit=int(limit), offset=int(offset))
@@ -720,11 +935,14 @@ class ParquetSegmentReader:
         iteration: int,
         group_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> list[int]:
         """The distinct ``traj_idx`` values of one group, ascending.
 
         ``run_attempt=None`` spans every attempt (the viewer's sibling
         navigation shows all trajectories that ever existed for the group).
+        ``run_id`` is an optional extra filter (a single-run store holds one
+        run, so it is rarely needed here).
         """
         self.refresh()
         sql = (
@@ -735,6 +953,9 @@ class ParquetSegmentReader:
         if run_attempt is not None:
             sql += " AND run_attempt = ?"
             params.append(run_attempt)
+        if run_id is not None:
+            sql += " AND run_id = ?"
+            params.append(run_id)
         sql += " ORDER BY traj_idx"
         return [row["traj_idx"] for row in self._fetch(sql, params)]
 
@@ -749,31 +970,17 @@ class ParquetSegmentReader:
         group_idx: int,
         traj_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Fetch the full trajectory: all step rows ordered by ``step_idx``.
 
         ``run_attempt=None`` selects the latest attempt that produced rows for
-        this trajectory. Delta-encoded observations are returned as stored;
-        use :func:`reconstruct_full_ob` to expand them.
+        this trajectory. ``run_id`` is an optional extra filter (a single-run
+        store holds one run). Delta-encoded observations are returned as
+        stored; use :func:`reconstruct_full_ob` to expand them.
         """
         self.refresh()
-        params: list[Any] = [split, iteration, group_idx, traj_idx]
-        sql = """
-            SELECT * FROM rollouts
-            WHERE split = ? AND iteration = ? AND group_idx = ? AND traj_idx = ?
-        """
-        if run_attempt is None:
-            sql += """
-              AND run_attempt = (
-                  SELECT max(run_attempt) FROM rollouts
-                  WHERE split = ? AND iteration = ? AND group_idx = ? AND traj_idx = ?
-              )
-            """
-            params += [split, iteration, group_idx, traj_idx]
-        else:
-            sql += " AND run_attempt = ?"
-            params.append(run_attempt)
-        sql += " ORDER BY step_idx"
+        sql, params = get_rollout_query(split, iteration, group_idx, traj_idx, run_attempt, run_id)
         return self._fetch(sql, params)
 
     # --- Search ---
@@ -799,43 +1006,15 @@ class ParquetSegmentReader:
         Additional structured ``filters`` are the same as :meth:`query`.
         Results are ordered by ``(iteration, ts)``.
         """
-        string_fields = {"ac_text", "ob_text", "logs"}
-        map_fields = {"metrics", "attrs", "token_metrics"}
-        bad = set(fields) - string_fields - map_fields
-        if bad:
-            raise ValueError(f"Unsupported search fields: {sorted(bad)}")
         self.refresh()
-        where, params = self._build_where(**filters)
-        clauses = [where[len("WHERE ") :]] if where else []
-        if regex is not None:
-            field_matches = []
-            for f in fields:
-                if f in map_fields:
-                    # regexp_matches on a MAP is a BinderException; match keys.
-                    field_matches.append(
-                        "EXISTS (SELECT 1 FROM unnest(map_keys("
-                        f"{f})) AS _k(key) WHERE regexp_matches(_k.key, ?))"
-                    )
-                else:
-                    field_matches.append(f"regexp_matches(coalesce({f}, ''), ?)")
-            clauses.append(f"({' OR '.join(field_matches)})")
-            params.extend([regex] * len(fields))
-        if token_subsequence:
-            # Cheap SQL prefilter on the first token; the exact contiguous
-            # match runs in Python below (portable across backends).
-            clauses.append("list_contains(ac_tokens, ?)")
-            params.append(int(token_subsequence[0]))
-        sql = "SELECT * FROM rollouts"
-        if clauses:
-            sql += f" WHERE {' AND '.join(clauses)}"
-        sql += " ORDER BY iteration, ts, group_idx, traj_idx, step_idx"
-        rows = self._fetch(sql, params)
-        if token_subsequence:
-            needle = [int(t) for t in token_subsequence]
-            rows = [row for row in rows if _contains_subsequence(row["ac_tokens"], needle)]
-        if limit is not None:
-            rows = rows[: int(limit)]
-        return rows
+        return run_search(
+            self._fetch,
+            regex=regex,
+            fields=fields,
+            token_subsequence=token_subsequence,
+            limit=limit,
+            **filters,
+        )
 
     def search_hit_counts(self, **search_kwargs: Any) -> dict[int, int]:
         """Grouped-by-iteration hit counts for a :meth:`search` call."""
@@ -867,27 +1046,7 @@ class ParquetSegmentReader:
             author: Who wrote the label (user name, ``"agent"``, ...).
             note: Optional free-form note.
         """
-        bad_keys = set(key) - set(_LABEL_KEY_FIELDS)
-        if bad_keys:
-            raise ValueError(f"Unsupported label key fields: {sorted(bad_keys)}")
-        record: dict[str, Any] = {field: key.get(field) for field in _LABEL_KEY_FIELDS}
-        record.update(
-            {
-                "label_key": label_key,
-                "label_value": label_value,
-                "author": author,
-                "ts": datetime.now(UTC).isoformat(),
-                "note": note,
-            }
-        )
-        self._storage.append(LABELS_PATH, (json.dumps(record, default=str) + "\n").encode())
-        # FsspecStorage stages append()s locally and only uploads on flush();
-        # nothing else ever flushes this reader's storage, so without this a
-        # label written against a gs:///s3:// store would silently never
-        # reach the store. LocalStorage.flush() is a no-op, and FsspecStorage
-        # re-uploads only files with staged appends (here: labels.jsonl,
-        # which stays small).
-        self._storage.flush()
+        append_label(self._storage, key, label_key, label_value, author=author, note=note)
 
     def _refresh_labels_source(self, conn: duckdb.DuckDBPyConnection) -> None:
         """(Re)create the ``labels`` view over the current ``labels.jsonl``.
@@ -920,47 +1079,9 @@ class ParquetSegmentReader:
                 for line in self._storage.read(LABELS_PATH).decode().splitlines()
                 if line.strip()
             ]
-            import pyarrow as pa
-
-            table = pa.Table.from_pylist(
-                [
-                    {
-                        **{field: rec.get(field) for field in _LABEL_KEY_FIELDS},
-                        "label_key": rec.get("label_key"),
-                        "label_value": json.dumps(rec.get("label_value")),
-                        "author": rec.get("author"),
-                        "ts": rec.get("ts"),
-                        "note": rec.get("note"),
-                    }
-                    for rec in records
-                ]
-            )
-            conn.register("_labels_raw", table)
-            source = (
-                "(SELECT run_id, split, iteration::INTEGER AS iteration,"
-                " group_idx::INTEGER AS group_idx, traj_idx::INTEGER AS traj_idx,"
-                " step_idx::INTEGER AS step_idx, label_key, label_value::JSON AS label_value,"
-                " author, ts::TIMESTAMP AS ts, note FROM _labels_raw)"
-            )
-        # Last write (by ts) wins per (identity, label_key); tombstones
-        # (null label_value) win first, then drop out of the view.
-        conn.execute(
-            f"""
-            CREATE VIEW labels AS
-            SELECT * EXCLUDE (_rank) FROM (
-                SELECT *,
-                       row_number() OVER (
-                           PARTITION BY run_id, split, iteration, group_idx, traj_idx,
-                                        step_idx, label_key
-                           ORDER BY ts DESC
-                       ) AS _rank
-                FROM {source}
-            )
-            WHERE _rank = 1
-              AND label_value IS NOT NULL
-              AND CAST(label_value AS VARCHAR) <> 'null'
-            """
-        )
+            conn.register("_labels_raw", labels_arrow_table(records))
+            source = LABELS_CAST_SELECT.format(src="_labels_raw")
+        conn.execute(LABELS_DEDUP_VIEW_SQL.format(source=source))
 
     def labels(self, **filters: Any) -> list[dict[str, Any]]:
         """Fetch current labels (after last-write-wins and tombstone filtering).
@@ -969,8 +1090,7 @@ class ParquetSegmentReader:
         ``traj_idx``, ``step_idx``, ``label_key``, ``author``. Returned
         ``label_value`` is decoded back to a Python value.
         """
-        allowed = set(_LABEL_KEY_FIELDS) | {"label_key", "author"}
-        bad = set(filters) - allowed
+        bad = set(filters) - LABEL_FILTER_FIELDS
         if bad:
             raise ValueError(f"Unsupported label filters: {sorted(bad)}")
         conn = self._connection()
@@ -1008,7 +1128,7 @@ class ParquetSegmentReader:
         """
         # Baseline: everything already on disk is "old".
         await asyncio.to_thread(self.refresh)
-        where, params = self._build_where(**filters)
+        where, params = build_where(**filters)
         conn = self._connection()
         while True:
             await asyncio.sleep(poll_interval_s)
@@ -1086,9 +1206,10 @@ class TokenDB:
         group_idx: int,
         traj_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """See :meth:`ParquetSegmentReader.get_rollout`."""
-        return self._backend.get_rollout(split, iteration, group_idx, traj_idx, run_attempt)
+        return self._backend.get_rollout(split, iteration, group_idx, traj_idx, run_attempt, run_id)
 
     def search(self, **kwargs: Any) -> list[dict[str, Any]]:
         """See :meth:`ParquetSegmentReader.search`."""
@@ -1112,9 +1233,10 @@ class TokenDB:
         iteration: int,
         group_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> list[int]:
         """See :meth:`ParquetSegmentReader.group_traj_idxs`."""
-        return self._backend.group_traj_idxs(split, iteration, group_idx, run_attempt)
+        return self._backend.group_traj_idxs(split, iteration, group_idx, run_attempt, run_id)
 
     def add_label(
         self,

--- a/tinker_cookbook/tokendb/registry_backend.py
+++ b/tinker_cookbook/tokendb/registry_backend.py
@@ -1,0 +1,917 @@
+"""Cross-run DuckDB read path over every run in the token DB registry.
+
+:class:`RegistryBackend` is the read half of the ``TokenStoreBackend``
+protocol spanning *all* runs registered in the run registry
+(:mod:`tinker_cookbook.tokendb.registry`): one DuckDB connection whose
+``rollouts`` / ``rollouts_latest`` / ``trajectories`` / ``labels`` / ``runs``
+views (plus the promoted ``correct`` / ``parse_errors`` /
+``context_overflows``) contain every registered run's rows, with ``run_id``
+as an ordinary column. Writes still go through the per-run
+:class:`~tinker_cookbook.tokendb.writer.ParquetSegmentBackend`;
+``open_writer`` raises.
+
+Unlike the single-run :class:`~tinker_cookbook.tokendb.reader.ParquetSegmentReader`
+(which materializes every segment into an in-memory table), the cross-run
+reader is **lazy**: it maintains a ``segment_scan`` view over an explicit
+``read_parquet([...])`` file list rebuilt on :meth:`refresh` (TTL-gated), so
+DuckDB streams row groups per query and nothing is pinned in RAM between
+queries.
+
+Segments that cannot be scanned in place are staged once into a local
+**segcache**:
+
+- Cloud stores (``gs://``, ``s3://``): each segment is fetched once through
+  ``Storage`` and cached; segments are immutable, so cache validity is file
+  existence (no invalidation).
+- v1-shaped segments (``metrics`` as a JSON string) are normalized with the
+  same read path the single-run reader uses
+  (:func:`~tinker_cookbook.tokendb.reader._normalize_segment_table`) and the
+  v2 copy is cached under ``upgraded/``; the original file is never
+  rewritten.
+
+Default cache location: ``~/.cache/tinker-cookbook/tokendb/segcache``
+(override with the ``segcache_dir`` argument or the
+``TINKER_TOKENDB_SEGCACHE`` environment variable). The cache is unbounded in
+this version; it is safe to delete at any time (segments re-stage on the next
+refresh).
+
+Thread-safety: one shared DuckDB connection owns the view catalog; each
+executing thread queries through its own cursor, and view replacement during
+refresh is serialized with a lock. In-flight queries finish against the old
+scan list (segments are immutable, so an old list is merely stale, never
+wrong).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tinker_cookbook.stores.storage import LocalStorage, Storage, storage_from_uri
+from tinker_cookbook.tokendb.reader import (
+    _TRAJECTORIES_SQL,
+    DEFAULT_SUBSCRIBE_POLL_INTERVAL_S,
+    LABEL_FILTER_FIELDS,
+    LABELS_CAST_SELECT,
+    LABELS_DEDUP_VIEW_SQL,
+    LABELS_PATH,
+    _normalize_segment_table,
+    _require_duckdb,
+    _result_to_dicts,
+    _run_row_from_payload,
+    append_label,
+    build_where,
+    create_derived_views,
+    get_rollout_query,
+    labels_arrow_table,
+    load_schema_card,
+    run_attempt_payloads,
+    run_search,
+    runs_arrow_schema,
+)
+from tinker_cookbook.tokendb.registry import list_runs, resolve_registry_dir
+from tinker_cookbook.tokendb.writer import SEGMENTS_DIR
+
+if TYPE_CHECKING:
+    import duckdb
+
+    from tinker_cookbook.tokendb.interface import TokenWriter
+
+logger = logging.getLogger(__name__)
+
+SEGCACHE_ENV_VAR = "TINKER_TOKENDB_SEGCACHE"
+DEFAULT_SEGCACHE_DIR = "~/.cache/tinker-cookbook/tokendb/segcache"
+DEFAULT_REFRESH_TTL_S = 5.0
+
+# Per-run dashboard aggregates, one GROUP-BY-run_id pass each (replacing the
+# viewer's per-run reader loop).
+_TOTALS_BY_RUN_SQL = """
+    SELECT run_id,
+           count(*) AS n_rows,
+           count(*) FILTER (WHERE source = 'filtered') AS n_filtered_rows,
+           max(iteration) FILTER (WHERE iteration >= 0) AS latest_iteration
+    FROM rollouts
+    {where}
+    GROUP BY run_id
+"""
+# Per-iteration mean of per-trajectory total_reward, excluding filtered rows;
+# QUALIFY keeps the newest `series_len` iterations per run.
+_SERIES_BY_RUN_SQL = """
+    SELECT run_id, iteration, avg(total_reward) AS mean_total_reward
+    FROM (
+        SELECT run_id, iteration, any_value(total_reward) AS total_reward
+        FROM rollouts
+        WHERE iteration >= 0 AND source <> 'filtered' {extra}
+        GROUP BY run_id, run_attempt, split, iteration, group_idx, traj_idx
+    )
+    GROUP BY run_id, iteration
+    QUALIFY row_number() OVER (PARTITION BY run_id ORDER BY iteration DESC) <= {series_len}
+    ORDER BY run_id, iteration
+"""
+
+
+def resolve_segcache_dir(segcache_dir: str | Path | None = None) -> Path:
+    """Resolve the local segment-cache directory.
+
+    Precedence: explicit *segcache_dir*, then the ``TINKER_TOKENDB_SEGCACHE``
+    environment variable, then :data:`DEFAULT_SEGCACHE_DIR`.
+    """
+    if segcache_dir is None:
+        segcache_dir = os.environ.get(SEGCACHE_ENV_VAR) or DEFAULT_SEGCACHE_DIR
+    return Path(segcache_dir).expanduser()
+
+
+def _log_path_key(log_path: str) -> str:
+    """Stable per-store segcache subdirectory name."""
+    return hashlib.sha1(log_path.encode()).hexdigest()[:16]
+
+
+def _atomic_write_bytes(data: bytes, target: Path) -> None:
+    """Write *data* to *target* atomically (tmp file + rename)."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=target.parent, prefix=f".{target.name}.")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, target)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def _atomic_write_parquet(table: Any, target: Path) -> None:
+    import pyarrow.parquet as pq
+
+    sink = io.BytesIO()
+    pq.write_table(table, sink, compression="zstd")
+    _atomic_write_bytes(sink.getvalue(), target)
+
+
+def _is_v1_schema(schema: Any) -> bool:
+    """True when a segment's own arrow schema is v1-shaped.
+
+    Same sniff the single-run reader uses (``metrics`` as a JSON string
+    column); a file without a ``metrics`` column is not a token DB segment.
+    """
+    import pyarrow as pa
+
+    if "metrics" not in schema.names:
+        raise ValueError("not a token DB segment (no 'metrics' column)")
+    return pa.types.is_string(schema.field("metrics").type)
+
+
+@dataclass
+class _RunState:
+    """Everything the backend tracks for one registered run."""
+
+    run_id: str
+    log_path: str
+    storage: Storage | None
+    record: dict[str, Any] = field(default_factory=dict)
+    #: segment file name -> path the scan list references (in-place or cached)
+    segments: dict[str, str] = field(default_factory=dict)
+    #: unreadable segments, remembered so each is warned about once
+    skipped: set[str] = field(default_factory=set)
+    error: str | None = None
+    card: dict[str, Any] | None = None
+    card_key: Any = None
+
+
+class RegistryBackend:
+    """Lazy cross-run reader over every run in the token DB registry.
+
+    Implements the read half of ``TokenStoreBackend``; ``open_writer``
+    raises (writes stay per-run). ``sql()`` is the backend-specific escape
+    hatch, exactly as on the single-run reader, with identical view names
+    now spanning runs.
+
+    Args:
+        registry_dir: Registry directory override; ``None`` resolves via
+            ``TINKER_TOKENDB_REGISTRY`` then the default.
+        segcache_dir: Local cache directory for cloud-staged and v1-upgraded
+            segments; ``None`` resolves via ``TINKER_TOKENDB_SEGCACHE`` then
+            ``~/.cache/tinker-cookbook/tokendb/segcache``. Unbounded in this
+            version; safe to delete between runs of the viewer.
+        refresh_ttl_s: Minimum seconds between full registry rescans;
+            :meth:`refresh` calls inside the window are no-ops so agent tool
+            loops and dashboard polls stay cheap.
+        storage_factory: Override for constructing a run's ``Storage`` from
+            its ``log_path`` (tests inject counting stubs).
+    """
+
+    def __init__(
+        self,
+        registry_dir: str | None = None,
+        *,
+        segcache_dir: str | Path | None = None,
+        refresh_ttl_s: float = DEFAULT_REFRESH_TTL_S,
+        storage_factory: Callable[[str], Storage] | None = None,
+    ) -> None:
+        directory = resolve_registry_dir(registry_dir)
+        if directory is None:
+            raise ValueError(
+                "The run registry is disabled (empty registry_dir / "
+                "TINKER_TOKENDB_REGISTRY); the cross-run reader has nothing to scan."
+            )
+        self._registry_dir = directory
+        self._segcache_dir = resolve_segcache_dir(segcache_dir)
+        self._refresh_ttl_s = refresh_ttl_s
+        self._storage_factory: Callable[[str], Storage] = storage_factory or storage_from_uri
+        self._states: dict[str, _RunState] = {}
+        self._conn: duckdb.DuckDBPyConnection | None = None
+        self._tlocal = threading.local()
+        # Serializes refresh (registry rescan + catalog writes); per-thread
+        # cursors let queries run concurrently with each other.
+        self._lock = threading.Lock()
+        self._last_refresh: float | None = None
+        self._empty_segment_path: Path | None = None
+
+    # --- Connection / views ---
+
+    def _connection(self) -> duckdb.DuckDBPyConnection:
+        conn = self._conn
+        if conn is None:
+            duckdb = _require_duckdb()
+            conn = duckdb.connect(":memory:")
+            self._empty_segment_path = self._ensure_empty_segment()
+            self._replace_scan_view(conn, [])
+            self._create_views(conn)
+            self._rebuild_runs(conn, [])
+            self._rebuild_labels(conn, [])
+            self._conn = conn
+        return conn
+
+    def _cursor(self) -> duckdb.DuckDBPyConnection:
+        """This thread's cursor on the shared connection.
+
+        DuckDB cursors share the database instance (and therefore the view
+        catalog) while giving each thread its own execution state.
+        """
+        cursor = getattr(self._tlocal, "cursor", None)
+        if cursor is None:
+            conn = self._connection()
+            with self._lock:
+                cursor = conn.cursor()
+            self._tlocal.cursor = cursor
+        return cursor
+
+    def _fetch(self, sql: str, params: Sequence[Any] = ()) -> list[dict[str, Any]]:
+        return _result_to_dicts(self._cursor().execute(sql, list(params)))
+
+    def _ensure_empty_segment(self) -> Path:
+        """A zero-row v2 parquet file always included in the scan list.
+
+        Keeps ``read_parquet([...])`` valid (and the views' column types
+        anchored) when no run has segments yet.
+        """
+        import pyarrow as pa
+
+        from tinker_cookbook.tokendb.schema import arrow_schema
+
+        path = self._segcache_dir / "_empty-v2.parquet"
+        if not path.exists():
+            _atomic_write_parquet(pa.Table.from_pylist([], schema=arrow_schema()), path)
+        return path
+
+    def _replace_scan_view(self, conn: duckdb.DuckDBPyConnection, paths: Sequence[str]) -> None:
+        assert self._empty_segment_path is not None
+        all_paths = [str(self._empty_segment_path), *paths]
+        quoted = ", ".join("'" + p.replace("'", "''") + "'" for p in all_paths)
+        conn.execute(
+            "CREATE OR REPLACE VIEW segment_scan AS "
+            f"SELECT * FROM read_parquet([{quoted}], union_by_name = true)"
+        )
+
+    def _create_views(self, conn: duckdb.DuckDBPyConnection) -> None:
+        # All rows across runs, tagged: `superseded` is computed per run
+        # (same (split, iteration) in different runs never supersede each
+        # other), matching the single-run reader within one run.
+        conn.execute(
+            """
+            CREATE VIEW rollouts AS
+            SELECT *,
+                   run_attempt < max(run_attempt)
+                       OVER (PARTITION BY run_id, split, iteration) AS superseded
+            FROM segment_scan
+            """
+        )
+        conn.execute(
+            """
+            CREATE VIEW trajectories AS
+            SELECT run_id, run_attempt, split, iteration, group_idx, traj_idx,
+                   count(*) AS n_steps,
+                   sum(len(ac_tokens)) AS n_ac_tokens,
+                   any_value(total_reward) AS total_reward,
+                   any_value(final_reward) AS final_reward,
+                   arg_max(stop_reason, step_idx) AS stop_reason,
+                   any_value(filtered_reason) AS filtered_reason,
+                   any_value(env_row_id) AS env_row_id,
+                   min(ts) AS ts
+            FROM segment_scan
+            GROUP BY run_id, run_attempt, split, iteration, group_idx, traj_idx
+            """
+        )
+        create_derived_views(conn)
+
+    # --- Refresh: registry rescan + scan-list rebuild (TTL-gated) ---
+
+    def refresh(self, *, force: bool = False) -> list[tuple[str, str]]:
+        """Rescan the registry and pick up new runs/segments.
+
+        TTL-gated: calls within ``refresh_ttl_s`` of the last full rescan
+        are no-ops (pass ``force=True`` to override). A run whose store
+        errors is skipped with a warning and reported with an ``error``
+        field in :meth:`dashboard_stats`; one bad run or segment never
+        poisons the connection. Returns the newly seen
+        ``(run_id, segment_name)`` pairs.
+        """
+        with self._lock:
+            now = time.monotonic()
+            if (
+                not force
+                and self._last_refresh is not None
+                and now - self._last_refresh < self._refresh_ttl_s
+            ):
+                return []
+            conn = self._connection()
+            new_pairs: list[tuple[str, str]] = []
+            changed = False
+            seen: set[str] = set()
+            for record in list_runs(self._registry_dir):
+                run_id = str(record.get("run_id") or "")
+                log_path = record.get("log_path")
+                if not run_id or not log_path:
+                    continue
+                seen.add(run_id)
+                state = self._states.get(run_id)
+                if state is None:
+                    state = self._make_state(run_id, str(log_path))
+                    self._states[run_id] = state
+                    changed = True
+                state.record = record
+                if state.storage is None:
+                    continue
+                state.error = None
+                try:
+                    names = [
+                        n for n in state.storage.list_dir(SEGMENTS_DIR) if n.endswith(".parquet")
+                    ]
+                except FileNotFoundError:
+                    names = []
+                except Exception as e:
+                    state.error = str(e)
+                    logger.warning("Skipping run %s during registry refresh: %s", run_id, e)
+                    continue
+                for name in sorted(names):
+                    if name in state.segments or name in state.skipped:
+                        continue
+                    try:
+                        state.segments[name] = self._scan_path(state, name)
+                    except Exception as e:
+                        state.skipped.add(name)
+                        logger.warning(
+                            "Skipping unreadable segment %s of run %s: %s", name, run_id, e
+                        )
+                        continue
+                    new_pairs.append((run_id, name))
+                    changed = True
+            for run_id in set(self._states) - seen:
+                del self._states[run_id]
+                changed = True
+            if changed:
+                paths = sorted(
+                    path for state in self._states.values() for path in state.segments.values()
+                )
+                self._replace_scan_view(conn, paths)
+            states = list(self._states.values())
+            self._rebuild_runs(conn, states)
+            self._rebuild_labels(conn, states)
+            self._last_refresh = time.monotonic()
+            return new_pairs
+
+    def _make_state(self, run_id: str, log_path: str) -> _RunState:
+        try:
+            storage = self._storage_factory(log_path)
+        except Exception as e:
+            logger.warning("Could not open the store of run %s (%s): %s", run_id, log_path, e)
+            return _RunState(run_id=run_id, log_path=log_path, storage=None, error=str(e))
+        return _RunState(run_id=run_id, log_path=log_path, storage=storage)
+
+    def _scan_path(self, state: _RunState, name: str) -> str:
+        """Resolve one segment file to the path the scan list references.
+
+        Local v2 files are scanned in place (zero copy). Cloud and v1 files
+        are staged into the segcache exactly once (existence = validity;
+        segments are immutable), with v1 files normalized to v2 at cache
+        fill. Raises on unreadable files (the caller skips and warns).
+        """
+        import pyarrow.parquet as pq
+
+        assert state.storage is not None
+        cache_dir = self._segcache_dir / _log_path_key(state.log_path)
+        upgraded = cache_dir / "upgraded" / name
+        if upgraded.exists():
+            return str(upgraded)
+        staged = cache_dir / name
+        if staged.exists():
+            return str(staged)
+        if isinstance(state.storage, LocalStorage):
+            local = state.storage.root / SEGMENTS_DIR / name
+            # Footer-only sniff; also rejects corrupt files at refresh time
+            # instead of poisoning the shared scan.
+            if not _is_v1_schema(pq.read_schema(local)):
+                return str(local)
+            _atomic_write_parquet(_normalize_segment_table(pq.read_table(local)), upgraded)
+            return str(upgraded)
+        # Cloud (or otherwise non-local) store: one fetch through Storage.
+        data = state.storage.read(f"{SEGMENTS_DIR}/{name}")
+        table = pq.read_table(io.BytesIO(data))
+        if _is_v1_schema(table.schema):
+            _atomic_write_parquet(_normalize_segment_table(table), upgraded)
+            return str(upgraded)
+        _atomic_write_bytes(data, staged)
+        return str(staged)
+
+    def _rebuild_runs(self, conn: duckdb.DuckDBPyConnection, states: Sequence[_RunState]) -> None:
+        """(Re)build the ``runs`` relation: every store's run-attempt rows."""
+        import pyarrow as pa
+
+        rows: list[dict[str, Any]] = []
+        for state in states:
+            if state.storage is None or state.error is not None:
+                continue
+            try:
+                payloads = run_attempt_payloads(state.storage)
+            except Exception as e:
+                logger.warning("Could not read run attempts of run %s: %s", state.run_id, e)
+                continue
+            rows.extend(_run_row_from_payload(payload) for payload in payloads)
+        rows.sort(key=lambda r: (str(r.get("run_id")), str(r.get("run_attempt"))))
+        table = pa.Table.from_pylist(rows, schema=runs_arrow_schema())
+        conn.register("_registry_runs_src", table)
+        # A real table (not a view over the registration): cursors share the
+        # catalog but not the parent connection's registered objects.
+        conn.execute("CREATE OR REPLACE TABLE runs AS SELECT * FROM _registry_runs_src")
+        conn.unregister("_registry_runs_src")
+
+    def _rebuild_labels(self, conn: duckdb.DuckDBPyConnection, states: Sequence[_RunState]) -> None:
+        """(Re)build ``labels``: the union of every run's ``labels.jsonl``.
+
+        Records missing a ``run_id`` are backfilled with the owning run's,
+        so cross-run label queries always have run attribution.
+        """
+        records: list[dict[str, Any]] = []
+        for state in states:
+            if state.storage is None or state.error is not None:
+                continue
+            try:
+                if not state.storage.exists(LABELS_PATH):
+                    continue
+                raw = state.storage.read(LABELS_PATH).decode()
+            except Exception as e:
+                logger.warning("Could not read labels of run %s: %s", state.run_id, e)
+                continue
+            for line in raw.splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict):
+                    if record.get("run_id") is None:
+                        record["run_id"] = state.run_id
+                    records.append(record)
+        conn.register("_registry_labels_src", labels_arrow_table(records))
+        conn.execute(
+            "CREATE OR REPLACE TABLE _labels_union AS "
+            + LABELS_CAST_SELECT.format(src="_registry_labels_src")
+        )
+        conn.unregister("_registry_labels_src")
+        conn.execute(LABELS_DEDUP_VIEW_SQL.format(source="_labels_union"))
+
+    # --- TokenStoreBackend surface ---
+
+    def open_writer(self, run_context: Mapping[str, Any]) -> TokenWriter:
+        raise NotImplementedError(
+            "RegistryBackend is a read surface across runs; open a writer on the "
+            "run's own store (ParquetSegmentBackend) instead."
+        )
+
+    def query(
+        self,
+        *,
+        latest_only: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
+        **filters: Any,
+    ) -> list[dict[str, Any]]:
+        """Structured row query over the cross-run ``rollouts`` view.
+
+        Same filters as :meth:`ParquetSegmentReader.query`; ``run_id`` is an
+        ordinary optional filter, and omitting it spans every run.
+        """
+        self.refresh()
+        where, params = build_where(**filters)
+        view = "rollouts_latest" if latest_only else "rollouts"
+        sql = f"SELECT * FROM {view} {where} ORDER BY iteration, ts, group_idx, traj_idx, step_idx"
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        if offset:
+            sql += f" OFFSET {int(offset)}"
+        return self._fetch(sql, params)
+
+    def trajectories(
+        self,
+        *,
+        latest_only: bool = False,
+        limit: int = 500,
+        offset: int = 0,
+        **filters: Any,
+    ) -> list[dict[str, Any]]:
+        """Trajectory-grain aggregation of :meth:`query`, across runs."""
+        self.refresh()
+        where, params = build_where(**filters)
+        if latest_only:
+            where = f"{where} AND NOT superseded" if where else "WHERE NOT superseded"
+        sql = _TRAJECTORIES_SQL.format(where=where, limit=int(limit), offset=int(offset))
+        return self._fetch(sql, params)
+
+    def search(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Regex / token-subsequence search across every run's rows.
+
+        See :meth:`ParquetSegmentReader.search`; filter by ``run_id`` to
+        restrict to one run.
+        """
+        self.refresh()
+        return run_search(self._fetch, **kwargs)
+
+    def search_hit_counts(self, **search_kwargs: Any) -> dict[int, int]:
+        """Grouped-by-iteration hit counts for a :meth:`search` call."""
+        counts: dict[int, int] = {}
+        for row in self.search(**search_kwargs):
+            counts[row["iteration"]] = counts.get(row["iteration"], 0) + 1
+        return counts
+
+    def get_rollout(
+        self,
+        split: str,
+        iteration: int,
+        group_idx: int,
+        traj_idx: int,
+        run_attempt: int | None = None,
+        run_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch one trajectory's step rows; needs ``run_id`` beyond one run."""
+        self.refresh()
+        run_id = self._require_run_id(run_id, "get_rollout")
+        sql, params = get_rollout_query(split, iteration, group_idx, traj_idx, run_attempt, run_id)
+        return self._fetch(sql, params)
+
+    def group_traj_idxs(
+        self,
+        split: str,
+        iteration: int,
+        group_idx: int,
+        run_attempt: int | None = None,
+        run_id: str | None = None,
+    ) -> list[int]:
+        """One group's distinct ``traj_idx`` values; needs ``run_id`` beyond one run."""
+        self.refresh()
+        run_id = self._require_run_id(run_id, "group_traj_idxs")
+        sql = (
+            "SELECT DISTINCT traj_idx FROM rollouts"
+            " WHERE split = ? AND iteration = ? AND group_idx = ?"
+        )
+        params: list[Any] = [split, iteration, group_idx]
+        if run_attempt is not None:
+            sql += " AND run_attempt = ?"
+            params.append(run_attempt)
+        if run_id is not None:
+            sql += " AND run_id = ?"
+            params.append(run_id)
+        sql += " ORDER BY traj_idx"
+        return [row["traj_idx"] for row in self._fetch(sql, params)]
+
+    def _require_run_id(self, run_id: str | None, method: str) -> str | None:
+        """Rollout identity is only unique per run: with more than one run
+        registered, per-rollout methods must name the run."""
+        if run_id is None and len(self._states) > 1:
+            raise ValueError(
+                f"{method} needs a run_id: {len(self._states)} runs are registered "
+                "and rollout identity is only unique per run"
+            )
+        return run_id
+
+    def runs(self) -> list[dict[str, Any]]:
+        """The cross-run ``runs`` view: one row per (run_id, run_attempt)."""
+        self.refresh()
+        return self._fetch("SELECT * FROM runs ORDER BY run_id, run_attempt")
+
+    def dashboard_stats(
+        self, *, recent_k: int = 5, series_len: int = 50, run_id: str | None = None
+    ) -> dict[str, Any]:
+        """Dashboard aggregates in one GROUP-BY-run_id pass.
+
+        With ``run_id``, the shape matches the single-run reader's
+        ``dashboard_stats`` exactly. Without it, the same top-level
+        aggregates span every run and a ``per_run`` mapping adds the per-run
+        breakdown (runs whose store errored during refresh carry an
+        ``error`` field with null counts; runs with no rows yet report
+        zeros).
+        """
+        self.refresh()
+        per_run = self._per_run_stats(recent_k=recent_k, series_len=series_len, run_id=run_id)
+        if run_id is not None:
+            return per_run.get(run_id) or _zero_run_stats()
+        totals = self._fetch(_TOTALS_BY_RUN_SQL.format(where=""))
+        n_rows = sum(t["n_rows"] for t in totals)
+        n_filtered = sum(t["n_filtered_rows"] for t in totals)
+        latest = [t["latest_iteration"] for t in totals if t["latest_iteration"] is not None]
+        # Cross-run series: mean over every run's trajectories per iteration.
+        series = self._fetch(
+            f"""
+            SELECT iteration, avg(total_reward) AS mean_total_reward
+            FROM (
+                SELECT iteration, any_value(total_reward) AS total_reward
+                FROM rollouts
+                WHERE iteration >= 0 AND source <> 'filtered'
+                GROUP BY run_id, run_attempt, split, iteration, group_idx, traj_idx
+            )
+            GROUP BY iteration
+            ORDER BY iteration DESC
+            LIMIT {int(series_len)}
+            """
+        )
+        series.reverse()
+        return {
+            "n_rows": n_rows,
+            "n_filtered_rows": n_filtered,
+            "latest_iteration": max(latest) if latest else None,
+            "mean_recent_reward": _mean_recent(series, recent_k),
+            "reward_series": series,
+            "per_run": per_run,
+        }
+
+    def _per_run_stats(
+        self, *, recent_k: int, series_len: int, run_id: str | None
+    ) -> dict[str, dict[str, Any]]:
+        per_run: dict[str, dict[str, Any]] = {}
+        for state in self._states.values():
+            if run_id is not None and state.run_id != run_id:
+                continue
+            stats = _zero_run_stats()
+            if state.storage is None or state.error is not None:
+                stats.update(
+                    {
+                        "n_rows": None,
+                        "n_filtered_rows": None,
+                        "latest_iteration": None,
+                        "error": state.error or "store unavailable",
+                    }
+                )
+            per_run[state.run_id] = stats
+        where, params = ("WHERE run_id = ?", [run_id]) if run_id is not None else ("", [])
+        for totals in self._fetch(_TOTALS_BY_RUN_SQL.format(where=where), params):
+            stats = per_run.setdefault(str(totals["run_id"]), _zero_run_stats())
+            stats["n_rows"] = totals["n_rows"]
+            stats["n_filtered_rows"] = totals["n_filtered_rows"]
+            stats["latest_iteration"] = totals["latest_iteration"]
+        extra = "AND run_id = ?" if run_id is not None else ""
+        for point in self._fetch(
+            _SERIES_BY_RUN_SQL.format(extra=extra, series_len=int(series_len)), params
+        ):
+            stats = per_run.get(str(point["run_id"]))
+            if stats is not None:
+                stats["reward_series"].append(
+                    {
+                        "iteration": point["iteration"],
+                        "mean_total_reward": point["mean_total_reward"],
+                    }
+                )
+        for stats in per_run.values():
+            stats["mean_recent_reward"] = _mean_recent(stats["reward_series"], recent_k)
+        return per_run
+
+    def schema_card(self) -> dict[str, Any]:
+        """Aggregate every run's observed-keys card with per-run attribution.
+
+        Union shape matches the single-run card (``metrics_keys`` /
+        ``attrs_keys`` / ``token_metrics_keys`` / ``tags`` /
+        ``keys_truncated``), plus ``runs``: a per-``run_id`` mapping of the
+        contributing cards. Per-run cards are manifest-only and cached until
+        the run's manifest activity changes.
+        """
+        self.refresh()
+        union: dict[str, set[str]] = {
+            "metrics_keys": set(),
+            "attrs_keys": set(),
+            "token_metrics_keys": set(),
+            "tags": set(),
+        }
+        truncated = False
+        runs_cards: dict[str, dict[str, Any]] = {}
+        for state in self._states.values():
+            card = self._run_card(state)
+            if card is None:
+                continue
+            runs_cards[state.run_id] = card
+            for field_name in union:
+                union[field_name].update(card.get(field_name) or [])
+            truncated = truncated or bool(card.get("keys_truncated"))
+        return {
+            **{field_name: sorted(values) for field_name, values in union.items()},
+            "keys_truncated": truncated,
+            "runs": runs_cards,
+        }
+
+    def _run_card(self, state: _RunState) -> dict[str, Any] | None:
+        if state.storage is None:
+            return None
+        status = state.record.get("status") or {}
+        key = (status.get("last_activity_ts"), status.get("n_segments"))
+        if state.card is None or state.card_key != key:
+            try:
+                state.card = load_schema_card(state.storage)
+            except Exception as e:
+                logger.warning("Could not build the schema card of run %s: %s", state.run_id, e)
+                state.card = None
+            state.card_key = key
+        return state.card
+
+    # --- Labels ---
+
+    def labels(self, **filters: Any) -> list[dict[str, Any]]:
+        """Current labels across every run (last-write-wins, tombstones dropped).
+
+        Same filters as :meth:`ParquetSegmentReader.labels`; the label
+        sources are re-read on every call (labels are written out of band).
+        """
+        bad = set(filters) - LABEL_FILTER_FIELDS
+        if bad:
+            raise ValueError(f"Unsupported label filters: {sorted(bad)}")
+        self.refresh()
+        with self._lock:  # labels change out of band: re-resolve per read
+            self._rebuild_labels(self._connection(), list(self._states.values()))
+        clauses: list[str] = []
+        params: list[Any] = []
+        for column, value in filters.items():
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        sql = "SELECT * FROM labels"
+        if clauses:
+            sql += f" WHERE {' AND '.join(clauses)}"
+        sql += " ORDER BY ts"
+        rows = self._fetch(sql, params)
+        for row in rows:
+            row["label_value"] = json.loads(row["label_value"])
+        return rows
+
+    def add_label(
+        self,
+        key: Mapping[str, Any],
+        label_key: str,
+        label_value: Any,
+        *,
+        author: str,
+        note: str | None = None,
+    ) -> None:
+        """Append an annotation to the owning run's ``labels.jsonl``.
+
+        ``key`` must include ``run_id`` (labels are stored per run; the
+        cross-run reader only routes the write).
+        """
+        run_id = key.get("run_id")
+        if not run_id:
+            raise ValueError("add_label on the cross-run reader needs run_id in the key")
+        self.refresh()
+        state = self._states.get(str(run_id))
+        if state is None or state.storage is None:
+            raise ValueError(f"unknown run_id {run_id!r} (not in the registry)")
+        append_label(state.storage, key, label_key, label_value, author=author, note=note)
+
+    # --- Live tail (per-run only in this version) ---
+
+    def subscribe(
+        self,
+        *,
+        poll_interval_s: float = DEFAULT_SUBSCRIBE_POLL_INTERVAL_S,
+        **filters: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Tail one run's newly written rows; requires a ``run_id`` filter.
+
+        A multiplexed all-runs subscription is deliberately not offered yet;
+        the cross-run views pick new files up via :meth:`refresh` regardless.
+        """
+        run_id = filters.get("run_id")
+        if not run_id:
+            raise ValueError("RegistryBackend.subscribe requires a run_id filter")
+        self.refresh()
+        state = self._states.get(str(run_id))
+        if state is None:
+            self.refresh(force=True)
+            state = self._states.get(str(run_id))
+        if state is None or state.storage is None:
+            raise ValueError(f"unknown run_id {run_id!r} (not in the registry)")
+        return self._tail(state, filters, poll_interval_s)
+
+    async def _tail(
+        self, state: _RunState, filters: dict[str, Any], poll_interval_s: float
+    ) -> AsyncIterator[dict[str, Any]]:
+        # Baseline: everything already in the store is "old". New rows are
+        # matched on a scratch connection so the tail never contends with
+        # the shared catalog.
+        known = set(await asyncio.to_thread(self._segment_names, state))
+        where, params = build_where(**filters)
+        duckdb = _require_duckdb()
+        conn = duckdb.connect(":memory:")
+        while True:
+            await asyncio.sleep(poll_interval_s)
+            names = await asyncio.to_thread(self._segment_names, state)
+            for name in sorted(set(names) - known):
+                known.add(name)
+                table = await asyncio.to_thread(self._load_segment_table, state, name)
+                if table is None:
+                    continue
+                conn.register("_new_segment", table)
+                rows = _result_to_dicts(
+                    conn.execute(
+                        f"SELECT * FROM _new_segment {where}"
+                        " ORDER BY iteration, ts, group_idx, traj_idx, step_idx",
+                        params,
+                    )
+                )
+                conn.unregister("_new_segment")
+                for row in rows:
+                    yield row
+
+    def _segment_names(self, state: _RunState) -> list[str]:
+        assert state.storage is not None
+        try:
+            return [n for n in state.storage.list_dir(SEGMENTS_DIR) if n.endswith(".parquet")]
+        except FileNotFoundError:
+            return []
+
+    def _load_segment_table(self, state: _RunState, name: str) -> Any:
+        import pyarrow.parquet as pq
+
+        assert state.storage is not None
+        try:
+            data = state.storage.read(f"{SEGMENTS_DIR}/{name}")
+            return _normalize_segment_table(pq.read_table(io.BytesIO(data)))
+        except Exception as e:
+            logger.warning("Skipping unreadable segment %s of run %s: %s", name, state.run_id, e)
+            return None
+
+    # --- Backend-specific escape hatch (not part of TokenStoreBackend) ---
+
+    def sql(self, query: str, params: Sequence[Any] | None = None) -> list[dict[str, Any]]:
+        """Run a read-only DuckDB SQL query over the cross-run views.
+
+        Same contract and view names as the single-run reader's ``sql()``
+        (``rollouts``, ``rollouts_latest``, ``trajectories``, ``labels``,
+        ``runs``, ``correct``, ``parse_errors``, ``context_overflows``), now
+        spanning every registered run with ``run_id`` as a normal column.
+        Only a single ``SELECT`` (or ``WITH ... SELECT``) statement is
+        allowed.
+        """
+        duckdb = _require_duckdb()
+        self.refresh()
+        cursor = self._cursor()
+        statements = cursor.extract_statements(query)
+        if len(statements) != 1:
+            raise ValueError("sql() accepts exactly one statement")
+        if statements[0].type != duckdb.StatementType.SELECT:
+            raise ValueError(f"sql() only accepts SELECT statements, got {statements[0].type}")
+        return self._fetch(query, params or [])
+
+
+def _zero_run_stats() -> dict[str, Any]:
+    return {
+        "n_rows": 0,
+        "n_filtered_rows": 0,
+        "latest_iteration": None,
+        "mean_recent_reward": None,
+        "reward_series": [],
+    }
+
+
+def _mean_recent(series: list[dict[str, Any]], recent_k: int) -> float | None:
+    recent = [
+        p["mean_total_reward"]
+        for p in series[-int(recent_k) :]
+        if p["mean_total_reward"] is not None
+    ]
+    return (sum(recent) / len(recent)) if recent else None

--- a/tinker_cookbook/tokendb/registry_backend_test.py
+++ b/tinker_cookbook/tokendb/registry_backend_test.py
@@ -1,0 +1,425 @@
+"""Tests for the cross-run registry reader (RegistryBackend)."""
+
+import asyncio
+import json
+import math
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("pyarrow")
+pytest.importorskip("duckdb")
+
+from tinker_cookbook.stores.storage import LocalStorage, Storage
+from tinker_cookbook.tokendb.agent_prompt import format_schema_card
+from tinker_cookbook.tokendb.interface import TokenStoreBackend
+from tinker_cookbook.tokendb.reader import ParquetSegmentReader
+from tinker_cookbook.tokendb.reader_test import make_row, write_v1_segment
+from tinker_cookbook.tokendb.registry import register_run
+from tinker_cookbook.tokendb.registry_backend import RegistryBackend, resolve_segcache_dir
+from tinker_cookbook.tokendb.writer import RUN_JSON_PATH, TokenDbWriter
+
+V1_RUN_ID = "v1run"
+
+
+def make_v1_run(log_path: Path) -> None:
+    """A v1-shaped run written with raw pyarrow, as an old writer would.
+
+    One segment with dotted-key and NaN metrics (the payloads SQL-level
+    normalization cannot handle), plus a hand-written ``run.json`` and a
+    registry record.
+    """
+    write_v1_segment(
+        log_path,
+        [
+            {
+                "iteration": 2,
+                "metrics": json.dumps({"time/total.ms": 12.5, "acc": float("nan")}),
+                "ac_text": "v1 row",
+                "total_reward": 3.0,
+            },
+            {"iteration": 2, "traj_idx": 1, "metrics": "{}", "total_reward": 1.0},
+        ],
+    )
+    run_json = {
+        "schema_version": 1,
+        "run_id": V1_RUN_ID,
+        "run_attempt": 1,
+        "context": {"model_name": "old-model", "config": {"temperature": 0.2}},
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    path = log_path / RUN_JSON_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(run_json) + "\n")
+    register_run(log_path=str(log_path), run_id=V1_RUN_ID, run_attempt=1, model_name="old-model")
+
+
+@pytest.fixture
+def two_runs(tmp_path: Path) -> dict:
+    """Two registered runs: a v2 run (two attempts) and a raw-pyarrow v1 run."""
+    v2_path = tmp_path / "run-v2"
+    context = {"model_name": "new-model", "config": {"temperature": 0.7}}
+    with TokenDbWriter(v2_path, context=context) as writer:
+        writer.append_rows(
+            [
+                make_row(iteration=0, total_reward=1.0, ac_text="v2 first"),
+                make_row(iteration=2, total_reward=0.5, ac_text="attempt one answer"),
+            ]
+        )
+        v2_id = writer.run_id
+    # Resume: attempt 2 re-runs iteration 2 (superseding within this run only).
+    with TokenDbWriter(v2_path, context=context) as writer:
+        assert writer.run_attempt == 2
+        writer.append_rows([make_row(iteration=2, total_reward=2.0, ac_text="attempt two answer")])
+    v1_path = tmp_path / "run-v1"
+    make_v1_run(v1_path)
+    return {"v2_id": v2_id, "v2_path": v2_path, "v1_path": v1_path}
+
+
+def make_backend(**kwargs: Any) -> RegistryBackend:
+    kwargs.setdefault("refresh_ttl_s", 0.0)
+    return RegistryBackend(**kwargs)
+
+
+class TestCrossRunSql:
+    def test_rollouts_span_both_runs(self, two_runs: dict):
+        backend = make_backend()
+        rows = backend.query()
+        # Sum of the per-run readers' row counts.
+        n_v2 = len(ParquetSegmentReader(two_runs["v2_path"]).query())
+        n_v1 = len(ParquetSegmentReader(two_runs["v1_path"]).query())
+        assert len(rows) == n_v2 + n_v1 == 5
+        assert {row["run_id"] for row in rows} == {two_runs["v2_id"], V1_RUN_ID}
+
+    def test_join_trajectories_with_runs_config(self, two_runs: dict):
+        backend = make_backend()
+        rows = backend.sql(
+            """
+            SELECT r.temperature, avg(t.total_reward) AS mean_reward, count(*) AS n
+            FROM trajectories t JOIN runs r USING (run_id, run_attempt)
+            GROUP BY 1 ORDER BY 1
+            """
+        )
+        by_temp = {round(row["temperature"], 3): row for row in rows}
+        assert by_temp[0.2]["mean_reward"] == pytest.approx(2.0)  # (3 + 1) / 2
+        assert by_temp[0.7]["n"] == 3  # attempts 1 (2 trajs) + 2 (1 traj)
+
+    def test_group_by_run_id(self, two_runs: dict):
+        backend = make_backend()
+        rows = backend.sql(
+            "SELECT run_id, count(*) AS n FROM rollouts GROUP BY run_id ORDER BY run_id"
+        )
+        assert {row["run_id"]: row["n"] for row in rows} == {two_runs["v2_id"]: 3, V1_RUN_ID: 2}
+
+    def test_select_only_guard(self, two_runs: dict):
+        backend = make_backend()
+        with pytest.raises(ValueError, match="sql\\(\\)"):
+            backend.sql("DROP VIEW rollouts")
+        with pytest.raises(ValueError, match="exactly one"):
+            backend.sql("SELECT 1; SELECT 2")
+
+    def test_open_writer_raises(self, two_runs: dict):
+        with pytest.raises(NotImplementedError):
+            make_backend().open_writer({})
+
+
+class TestSuperseded:
+    def test_partitioned_by_run(self, two_runs: dict):
+        """Same (split, iteration) in different runs never supersede each other;
+        within one run the flag matches the single-run reader."""
+        backend = make_backend()
+        rows = backend.query(iteration=2)
+        flags = {(row["run_id"], row["run_attempt"]): row["superseded"] for row in rows}
+        # v2 run: attempt 1 superseded by attempt 2 (single-run semantics)...
+        assert flags[(two_runs["v2_id"], 1)] is True
+        assert flags[(two_runs["v2_id"], 2)] is False
+        single = ParquetSegmentReader(two_runs["v2_path"]).query(iteration=2)
+        assert {(r["run_attempt"], r["superseded"]) for r in single} == {(1, True), (2, False)}
+        # ...while the v1 run's attempt-1 rows at the same (split, iteration)
+        # stay live despite the other run's attempt 2.
+        assert flags[(V1_RUN_ID, 1)] is False
+        latest = backend.query(iteration=2, latest_only=True)
+        assert {row["run_id"] for row in latest} == {two_runs["v2_id"], V1_RUN_ID}
+
+
+class TestV1Upgrade:
+    def test_v1_metrics_survive_with_python_semantics(self, two_runs: dict):
+        backend = make_backend()
+        rows = backend.query(run_id=V1_RUN_ID, iteration=2, traj_idx=0)
+        (row,) = rows
+        assert row["metrics"]["time/total.ms"] == pytest.approx(12.5)  # dotted key intact
+        assert math.isnan(row["metrics"]["acc"])  # bare-NaN v1 JSON parsed leniently
+        assert row["attrs"] == {}
+        assert row["tool_calls"] is None
+
+    def test_original_file_untouched_and_upgrade_cached(self, two_runs: dict, tmp_path: Path):
+        segments_dir = two_runs["v1_path"] / "tokens" / "segments"
+        (original,) = segments_dir.iterdir()
+        before = original.read_bytes()
+        backend = make_backend()
+        backend.query()
+        assert original.read_bytes() == before  # store stays append-only
+        cache_root = resolve_segcache_dir(None)
+        upgraded = list(cache_root.rglob(f"upgraded/{original.name}"))
+        assert len(upgraded) == 1
+        # A second refresh does not re-upgrade the cached copy.
+        mtime = upgraded[0].stat().st_mtime_ns
+        backend.refresh(force=True)
+        backend.query()
+        assert upgraded[0].stat().st_mtime_ns == mtime
+
+    def test_local_v2_segments_are_scanned_in_place(self, two_runs: dict):
+        backend = make_backend()
+        backend.query()
+        cache_root = resolve_segcache_dir(None)
+        cached = [p.name for p in cache_root.rglob("seg-*.parquet")]
+        # Only the v1 segment was staged; v2 files stay in the store (no copy).
+        assert cached == ["seg-v1host-1-000000.parquet"]
+
+
+class TestCorruptSegment:
+    def test_bad_file_is_skipped_others_stay_queryable(self, two_runs: dict):
+        segments_dir = two_runs["v2_path"] / "tokens" / "segments"
+        (segments_dir / "seg-corrupt-000000.parquet").write_bytes(b"not a parquet file")
+        backend = make_backend()
+        rows = backend.query()
+        assert len(rows) == 5  # both runs' real segments, corrupt one skipped
+        # The skip is remembered: a forced refresh reports nothing new.
+        assert backend.refresh(force=True) == []
+
+
+class CountingStorage:
+    """Wraps a Storage and counts read() calls per path (delegates the rest)."""
+
+    def __init__(self, inner: Storage) -> None:
+        self._inner = inner
+        self.reads: dict[str, int] = {}
+
+    def read(self, path: str) -> bytes:
+        self.reads[path] = self.reads.get(path, 0) + 1
+        return self._inner.read(path)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+class TestSegcacheFillOnce:
+    def test_each_segment_fetched_exactly_once(self, two_runs: dict):
+        # A non-LocalStorage Storage exercises the cloud staging path: the
+        # backend must fetch each segment through Storage exactly once and
+        # answer every later query from the cache.
+        stores: list[CountingStorage] = []
+
+        def factory(log_path: str) -> Storage:
+            store = CountingStorage(LocalStorage(log_path))
+            stores.append(store)
+            return cast(Storage, store)
+
+        backend = make_backend(storage_factory=factory)
+        first = backend.sql("SELECT count(*) AS n FROM rollouts")[0]["n"]
+        for _ in range(5):
+            backend.refresh(force=True)
+            assert backend.sql("SELECT count(*) AS n FROM rollouts")[0]["n"] == first
+        segment_reads = {
+            path: count
+            for store in stores
+            for path, count in store.reads.items()
+            if path.startswith("tokens/segments/")
+        }
+        assert segment_reads  # the staging path was actually exercised
+        assert all(count == 1 for count in segment_reads.values()), segment_reads
+
+
+class TestRefreshTtl:
+    def test_new_run_discovered_after_ttl_not_before(self, two_runs: dict, tmp_path: Path):
+        gated = RegistryBackend(refresh_ttl_s=3600.0)
+        assert len({r["run_id"] for r in gated.runs()}) == 2
+        # Register a third run after backend construction.
+        with TokenDbWriter(tmp_path / "run-late", context={"model_name": "late"}) as writer:
+            writer.append_rows([make_row(iteration=0, ac_text="late row")])
+            late_id = writer.run_id
+        # Within the TTL window the rescan is a no-op: not visible yet.
+        assert late_id not in {r["run_id"] for r in gated.runs()}
+        # Once the gate opens (forced here instead of sleeping), it appears.
+        new_pairs = gated.refresh(force=True)
+        assert any(run_id == late_id for run_id, _ in new_pairs)
+        assert late_id in {r["run_id"] for r in gated.runs()}
+        # A TTL-0 backend sees it on the next call with no forcing.
+        assert late_id in {r["run_id"] for r in make_backend().runs()}
+
+
+class TestPerRolloutMethods:
+    def test_get_rollout_requires_run_id_with_multiple_runs(self, two_runs: dict):
+        backend = make_backend()
+        with pytest.raises(ValueError, match="run_id"):
+            backend.get_rollout("train", 2, 0, 0)
+        rows = backend.get_rollout("train", 2, 0, 0, run_id=two_runs["v2_id"])
+        assert [row["ac_text"] for row in rows] == ["attempt two answer"]  # latest attempt
+        rows = backend.get_rollout("train", 2, 0, 0, 1, two_runs["v2_id"])
+        assert [row["ac_text"] for row in rows] == ["attempt one answer"]
+        with pytest.raises(ValueError, match="run_id"):
+            backend.group_traj_idxs("train", 2, 0)
+        assert backend.group_traj_idxs("train", 2, 0, run_id=V1_RUN_ID) == [0, 1]
+
+    def test_single_run_registry_needs_no_run_id(self, tmp_path: Path):
+        with TokenDbWriter(tmp_path / "only-run", context={}) as writer:
+            writer.append_rows([make_row(iteration=1, ac_text="solo")])
+        backend = make_backend()
+        assert [r["ac_text"] for r in backend.get_rollout("train", 1, 0, 0)] == ["solo"]
+        assert backend.group_traj_idxs("train", 1, 0) == [0]
+
+
+class TestLabels:
+    def test_add_label_requires_and_routes_by_run_id(self, two_runs: dict):
+        backend = make_backend()
+        key = {"split": "train", "iteration": 2, "group_idx": 0, "traj_idx": 0}
+        with pytest.raises(ValueError, match="run_id"):
+            backend.add_label(key, "quality", "good", author="tester")
+        backend.add_label({**key, "run_id": V1_RUN_ID}, "quality", "good", author="tester")
+        # The append landed in the owning run's store.
+        assert (two_runs["v1_path"] / "tokens" / "labels.jsonl").exists()
+        assert not (two_runs["v2_path"] / "tokens" / "labels.jsonl").exists()
+        (label,) = backend.labels(label_key="quality")
+        assert label["run_id"] == V1_RUN_ID
+        assert label["label_value"] == "good"
+        with pytest.raises(ValueError, match="unknown run_id"):
+            backend.add_label({**key, "run_id": "nope"}, "k", 1, author="a")
+
+    def test_labels_union_backfills_run_id(self, two_runs: dict):
+        # A record written per-run without a run_id (older label files) gets
+        # the owning run's id in the cross-run view.
+        reader = ParquetSegmentReader(two_runs["v2_path"])
+        reader.add_label({"split": "train", "iteration": 0}, "flag", True, author="a")
+        backend = make_backend()
+        (label,) = backend.labels(label_key="flag")
+        assert label["run_id"] == two_runs["v2_id"]
+
+
+class TestSubscribe:
+    def test_requires_run_id(self, two_runs: dict):
+        backend = make_backend()
+        with pytest.raises(ValueError, match="run_id"):
+            backend.subscribe()
+        with pytest.raises(ValueError, match="unknown run_id"):
+            backend.subscribe(run_id="nope")
+
+    def test_yields_rows_written_after_subscription(self, two_runs: dict):
+        backend = make_backend()
+        run_id = two_runs["v2_id"]
+
+        async def main() -> list[dict]:
+            received: list[dict] = []
+
+            async def consume() -> None:
+                async for row in backend.subscribe(poll_interval_s=0.05, run_id=run_id):
+                    received.append(row)
+                    if len(received) >= 2:
+                        return
+
+            task = asyncio.create_task(consume())
+            await asyncio.sleep(0.15)  # let the subscriber take its baseline
+            with TokenDbWriter(two_runs["v2_path"], context={}) as writer:
+                writer.append_rows(
+                    [
+                        make_row(iteration=20, ac_text="live row 1"),
+                        make_row(iteration=21, ac_text="live row 2"),
+                    ]
+                )
+            await asyncio.wait_for(task, timeout=5.0)
+            return received
+
+        received = asyncio.run(main())
+        assert [row["ac_text"] for row in received] == ["live row 1", "live row 2"]
+        assert all(row["run_id"] == run_id for row in received)
+
+
+class TestDashboardStats:
+    def test_per_run_matches_single_run_readers(self, two_runs: dict):
+        backend = make_backend()
+        stats = backend.dashboard_stats()
+        per_run = stats["per_run"]
+        assert set(per_run) == {two_runs["v2_id"], V1_RUN_ID}
+        for run_id, path in [(two_runs["v2_id"], "v2_path"), (V1_RUN_ID, "v1_path")]:
+            single = ParquetSegmentReader(two_runs[path]).dashboard_stats()
+            cross = per_run[run_id]
+            assert cross["n_rows"] == single["n_rows"]
+            assert cross["n_filtered_rows"] == single["n_filtered_rows"]
+            assert cross["latest_iteration"] == single["latest_iteration"]
+            assert cross["mean_recent_reward"] == pytest.approx(single["mean_recent_reward"])
+            assert cross["reward_series"] == single["reward_series"]
+        # Top-level aggregates span both runs.
+        assert stats["n_rows"] == 5
+        assert stats["latest_iteration"] == 2
+        # With run_id: identical shape to the single-run reader's numbers.
+        one = backend.dashboard_stats(run_id=V1_RUN_ID)
+        assert "per_run" not in one
+        assert one["n_rows"] == 2
+
+    def test_unreadable_run_reports_error_row(self, two_runs: dict):
+        def factory(log_path: str) -> Storage:
+            if "run-v1" in log_path:
+                raise OSError("store unreachable")
+            return LocalStorage(log_path)
+
+        backend = make_backend(storage_factory=factory)
+        per_run = backend.dashboard_stats()["per_run"]
+        assert per_run[V1_RUN_ID]["n_rows"] is None
+        assert "unreachable" in per_run[V1_RUN_ID]["error"]
+        assert per_run[two_runs["v2_id"]]["n_rows"] == 3  # isolation: the other run is fine
+
+
+class TestSchemaCard:
+    @pytest.fixture
+    def keyed_runs(self, tmp_path: Path) -> dict:
+        with TokenDbWriter(tmp_path / "run-a", context={}) as writer:
+            writer.append_rows(
+                [make_row(metrics={"acc": 1.0, "shared": 0.5}, attrs={"dataset": "gsm8k"})]
+            )
+            id_a = writer.run_id
+        with TokenDbWriter(tmp_path / "run-b", context={}) as writer:
+            writer.append_rows([make_row(metrics={"shared": 0.1}, tags=["hard"])])
+            id_b = writer.run_id
+        return {"a": id_a, "b": id_b}
+
+    def test_union_with_per_run_attribution(self, keyed_runs: dict):
+        card = make_backend().schema_card()
+        assert card["metrics_keys"] == ["acc", "shared"]
+        assert card["attrs_keys"] == ["dataset"]
+        assert card["tags"] == ["hard"]
+        assert card["keys_truncated"] is False
+        assert set(card["runs"]) == {keyed_runs["a"], keyed_runs["b"]}
+        assert card["runs"][keyed_runs["a"]]["metrics_keys"] == ["acc", "shared"]
+        assert card["runs"][keyed_runs["b"]]["metrics_keys"] == ["shared"]
+
+    def test_prompt_rendering_attributes_partial_keys(self, keyed_runs: dict):
+        text = format_schema_card(make_backend().schema_card())
+        assert "Observed keys across runs (2 runs)" in text
+        # `acc` exists only in run a; `shared` everywhere (no suffix).
+        assert f"`acc` (only: {keyed_runs['a']})" in text
+        assert "`shared` (only:" not in text
+        assert "`shared`" in text
+
+
+class TestProtocolAndConcurrency:
+    def test_satisfies_token_store_backend(self, two_runs: dict):
+        # The typed assignment is the real check: pyright verifies that
+        # RegistryBackend structurally satisfies the enlarged protocol.
+        backend: TokenStoreBackend = make_backend()
+        assert isinstance(backend, TokenStoreBackend)
+
+    def test_concurrent_queries_on_per_thread_cursors(self, two_runs: dict):
+        backend = make_backend()
+        backend.refresh()
+
+        async def main() -> list[Any]:
+            def query(i: int) -> int:
+                # Interleave refreshes with queries across worker threads.
+                backend.refresh(force=(i % 3 == 0))
+                return backend.sql("SELECT count(*) AS n FROM rollouts")[0]["n"]
+
+            return await asyncio.gather(*[asyncio.to_thread(query, i) for i in range(8)])
+
+        results = asyncio.run(main())
+        assert results == [5] * 8

--- a/tinker_cookbook/tokendb/serve.py
+++ b/tinker_cookbook/tokendb/serve.py
@@ -94,6 +94,7 @@ from tinker_cookbook.tokendb.registry import (
     load_run_record,
     resolve_registry_dir,
 )
+from tinker_cookbook.tokendb.registry_backend import RegistryBackend
 from tinker_cookbook.tokendb.writer import RUN_JSON_PATH, ParquetSegmentBackend
 
 logger = logging.getLogger(__name__)
@@ -151,8 +152,14 @@ class RunContext:
 # Typed application-state keys (aiohttp's recommended alternative to str keys).
 SINGLE_CTX_KEY: web.AppKey[RunContext | None] = web.AppKey("single_ctx")
 REGISTRY_DIR_KEY: web.AppKey[str | None] = web.AppKey("registry_dir")
+# Registry mode: the one cross-run reader shared by the all-runs chat, the
+# dashboard aggregation, and the root /api/sql endpoint (thread-safe: shared
+# connection + per-thread cursors). Constructed lazily on first use, inside
+# a mutable holder (aiohttp forbids replacing app-state values post-startup).
+REGISTRY_BACKEND_KEY: web.AppKey[dict[str, RegistryBackend]] = web.AppKey("registry_backend")
+SEGCACHE_DIR_KEY: web.AppKey[str | None] = web.AppKey("segcache_dir")
 RUN_CACHE_KEY: web.AppKey[OrderedDict[str, RunContext]] = web.AppKey("run_cache")
-DASHBOARD_CACHE_KEY: web.AppKey[dict[str, tuple[float, dict[str, Any]]]] = web.AppKey(
+DASHBOARD_CACHE_KEY: web.AppKey[dict[str, tuple[float, list[dict[str, Any]]]]] = web.AppKey(
     "dashboard_cache"
 )
 DASHBOARD_TTL_KEY = web.AppKey("dashboard_ttl_s", float)
@@ -443,8 +450,7 @@ async def _handle_search(request: web.Request) -> web.Response:
     )
 
 
-async def _handle_sql(request: web.Request) -> web.Response:
-    reader = _request_ctx(request).reader
+async def _sql_response(reader: Any, request: web.Request) -> web.Response:
     # Raw SQL is a backend-specific escape hatch, deliberately not part of
     # the TokenStoreBackend protocol; 501 when the backend doesn't offer it.
     sql_fn = getattr(reader, "sql", None)
@@ -461,6 +467,19 @@ async def _handle_sql(request: web.Request) -> web.Response:
     except Exception as e:  # DuckDB parse/binder errors on user SQL
         return _error_response(str(e), 400)
     return _json_response({"rows": rows})
+
+
+async def _handle_sql(request: web.Request) -> web.Response:
+    return await _sql_response(_request_ctx(request).reader, request)
+
+
+async def _handle_registry_sql(request: web.Request) -> web.Response:
+    """Registry mode: read-only cross-run SQL over every registered run."""
+    try:
+        backend = _registry_backend(request.app)
+    except Exception as e:
+        return _error_response(str(e), 500)
+    return await _sql_response(backend, request)
 
 
 async def _handle_labels_get(request: web.Request) -> web.Response:
@@ -515,79 +534,81 @@ async def _handle_runs(request: web.Request) -> web.Response:
     return _json_response({"runs": runs})
 
 
-def _compute_dashboard_row(record: dict[str, Any], reader: TokenStoreBackend) -> dict[str, Any]:
-    """One dashboard row: registry record + status + backend aggregates."""
-    status = record.get("status") or {}
-    stats = reader.dashboard_stats(
-        recent_k=DASHBOARD_RECENT_ITERATIONS, series_len=REWARD_SERIES_ITERATIONS
-    )
-    latest_iteration = stats["latest_iteration"]
-    if latest_iteration is None:
-        latest_iteration = status.get("latest_iteration")
-    return {
-        "run_id": record.get("run_id"),
-        "run_attempt": record.get("run_attempt"),
-        "log_path": record.get("log_path"),
-        "model_name": record.get("model_name"),
-        "recipe_name": record.get("recipe_name"),
-        "started_at": record.get("started_at"),
-        "live": bool(status.get("live", False)),
-        "last_activity_ts": status.get("last_activity_ts"),
-        "latest_iteration": latest_iteration,
-        "n_rows": stats["n_rows"],
-        "n_filtered_rows": stats["n_filtered_rows"],
-        "mean_recent_reward": stats["mean_recent_reward"],
-        "reward_series": stats["reward_series"],
-    }
+def _registry_backend(app: web.Application) -> RegistryBackend:
+    """The lazily constructed cross-run reader for this registry-mode app."""
+    holder = app[REGISTRY_BACKEND_KEY]
+    backend = holder.get("backend")
+    if backend is None:
+        backend = RegistryBackend(app[REGISTRY_DIR_KEY], segcache_dir=app[SEGCACHE_DIR_KEY])
+        holder["backend"] = backend
+    return backend
 
 
 def _dashboard_rows(app: web.Application) -> list[dict[str, Any]]:
-    """Dashboard rows for every registered run, TTL-cached per run.
+    """Dashboard rows for every registered run, in one cross-run pass.
 
-    The TTL cache (default 10s) lets the dashboard poll without hammering
-    DuckDB; within the TTL a run's row is returned as-is, so repeated polls
-    are consistent and cheap.
+    One ``RegistryBackend.dashboard_stats()`` call (a GROUP-BY-run_id pass
+    over the shared cross-run views) joined with the registry's liveness
+    records, replacing the old per-run reader loop. The TTL cache (default
+    10s) lets the dashboard poll without hammering DuckDB; within the TTL
+    the whole payload is returned as-is, so repeated polls are consistent
+    and cheap. A run whose store errored is reported as a degraded row with
+    an ``error`` field (isolation now lives inside the backend's refresh).
     """
     cache = app[DASHBOARD_CACHE_KEY]
     ttl = app[DASHBOARD_TTL_KEY]
     now = time.monotonic()
+    cached = cache.get("__dashboard__")
+    if cached is not None and now - cached[0] <= ttl:
+        return cached[1]
+    records = list_runs(app[REGISTRY_DIR_KEY], live_window_s=app[LIVE_WINDOW_KEY])
+    per_run: dict[str, dict[str, Any]] = {}
+    try:
+        backend = _registry_backend(app)
+        # The dashboard has its own TTL cache, so a recompute forces a full
+        # rescan (matching the old per-run-reader refresh cadence).
+        backend.refresh(force=True)
+        stats = backend.dashboard_stats(
+            recent_k=DASHBOARD_RECENT_ITERATIONS, series_len=REWARD_SERIES_ITERATIONS
+        )
+        per_run = stats["per_run"]
+    except Exception as e:
+        logger.warning("Cross-run dashboard aggregation failed: %s", e)
     rows: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for record in list_runs(app[REGISTRY_DIR_KEY], live_window_s=app[LIVE_WINDOW_KEY]):
+    for record in records:
         run_id = str(record["run_id"])
-        seen.add(run_id)
-        cached = cache.get(run_id)
-        if cached is not None and now - cached[0] <= ttl:
-            rows.append(cached[1])
-            continue
-        try:
-            ctx = _get_or_create_ctx(app, run_id)
-            row = _compute_dashboard_row(record, ctx.reader)
-        except web.HTTPNotFound:
-            continue
-        except Exception as e:
-            logger.warning("Dashboard aggregation failed for run %s: %s", run_id, e)
-            row = {
-                "run_id": record.get("run_id"),
-                "run_attempt": record.get("run_attempt"),
-                "log_path": record.get("log_path"),
-                "model_name": record.get("model_name"),
-                "recipe_name": record.get("recipe_name"),
-                "started_at": record.get("started_at"),
-                "live": bool((record.get("status") or {}).get("live", False)),
-                "last_activity_ts": (record.get("status") or {}).get("last_activity_ts"),
-                "latest_iteration": (record.get("status") or {}).get("latest_iteration"),
-                "n_rows": None,
-                "n_filtered_rows": None,
-                "mean_recent_reward": None,
-                "reward_series": [],
-                "error": str(e),
-            }
-        cache[run_id] = (now, row)
+        status = record.get("status") or {}
+        run_stats = per_run.get(run_id) or {
+            "n_rows": None,
+            "n_filtered_rows": None,
+            "latest_iteration": None,
+            "mean_recent_reward": None,
+            "reward_series": [],
+            "error": "run not loaded",
+        }
+        latest_iteration = run_stats.get("latest_iteration")
+        if latest_iteration is None:
+            latest_iteration = status.get("latest_iteration")
+        row = {
+            "run_id": record.get("run_id"),
+            "run_attempt": record.get("run_attempt"),
+            "log_path": record.get("log_path"),
+            "model_name": record.get("model_name"),
+            "recipe_name": record.get("recipe_name"),
+            "started_at": record.get("started_at"),
+            "live": bool(status.get("live", False)),
+            "last_activity_ts": status.get("last_activity_ts"),
+            "latest_iteration": latest_iteration,
+            "n_rows": run_stats.get("n_rows"),
+            "n_filtered_rows": run_stats.get("n_filtered_rows"),
+            "mean_recent_reward": run_stats.get("mean_recent_reward"),
+            "reward_series": run_stats.get("reward_series") or [],
+        }
+        if run_stats.get("error"):
+            row["error"] = str(run_stats["error"])
         rows.append(row)
-    # Drop cache entries for unregistered runs.
-    for run_id in set(cache) - seen:
-        del cache[run_id]
+    cache.clear()
+    cache["__dashboard__"] = (now, rows)
     return rows
 
 
@@ -814,15 +835,34 @@ def _chat_scope(request: web.Request, *, include_prompt: bool = False) -> ChatSc
         except web.HTTPNotFound as e:
             raise ToolExecutionError(f"unknown run_id {rid!r} (see list_runs)") from e
 
+    backend: RegistryBackend | None = None
+    try:
+        backend = _registry_backend(app)
+    except Exception:
+        logger.warning(
+            "Could not construct the cross-run registry backend; the sql tool "
+            "will require a run_id",
+            exc_info=True,
+        )
     toolbox = RegistryToolbox(
         list_runs_fn=lambda: list_runs(app[REGISTRY_DIR_KEY], live_window_s=app[LIVE_WINDOW_KEY]),
         dashboard_fn=lambda: _dashboard_rows(app),
         resolve_reader=_resolve_reader,
         visual_store=visual_store,
+        backend=backend,
     )
     prompt = ""
     if include_prompt:
-        prompt = build_system_prompt(sql_url="/api/runs/{run_id}/sql", mode="registry")
+        card = None
+        if backend is not None:
+            try:
+                card = backend.schema_card()
+            except Exception:
+                logger.warning(
+                    "Could not build the cross-run schema card for the chat prompt",
+                    exc_info=True,
+                )
+        prompt = build_system_prompt(sql_url="/api/sql", mode="registry", schema_card=card)
     return ChatScope(
         toolbox=toolbox,
         chat_store=ChatStore(storage, prefix="chats"),
@@ -1287,6 +1327,7 @@ def build_app(
     log_path: str | Path | None = None,
     *,
     registry_dir: str | None = None,
+    segcache_dir: str | None = None,
     static_dir: Path | None = STATIC_DIR,
     load_tokenizer: bool = True,
     dashboard_ttl_s: float = DEFAULT_DASHBOARD_TTL_S,
@@ -1303,6 +1344,10 @@ def build_app(
         registry_dir: Registry directory override for registry mode;
             ``None`` resolves via ``TINKER_TOKENDB_REGISTRY`` then the
             default (``~/.cache/tinker-cookbook/tokendb/runs``).
+        segcache_dir: Local segment-cache directory for the cross-run
+            reader (cloud-staged and v1-upgraded segments); ``None``
+            resolves via ``TINKER_TOKENDB_SEGCACHE`` then the default
+            (``~/.cache/tinker-cookbook/tokendb/segcache``).
         static_dir: Directory with the built UI; a fallback page is served
             when it's missing (e.g. the frontend hasn't been built).
         load_tokenizer: Allow the best-effort tokenizer loads (single-run:
@@ -1325,6 +1370,8 @@ def build_app(
     app[DASHBOARD_TTL_KEY] = dashboard_ttl_s
     app[LIVE_WINDOW_KEY] = live_window_s
     app[REGISTRY_DIR_KEY] = registry_dir
+    app[REGISTRY_BACKEND_KEY] = {}
+    app[SEGCACHE_DIR_KEY] = segcache_dir
     # provider=None means "not explicitly chosen": the effective provider is
     # auto-detected from key availability until a POST pins one.
     app[AGENT_STATE_KEY] = {"provider": None, "model": None, "api_key": None}
@@ -1366,6 +1413,9 @@ def build_app(
         app[SINGLE_CTX_KEY] = None
         app.router.add_get("/api/runs", _handle_runs)
         app.router.add_get("/api/dashboard", _handle_dashboard)
+        # Cross-run SQL at the registry root (the per-run endpoint below
+        # stays valid for per-run visuals).
+        app.router.add_post("/api/sql", _handle_registry_sql)
         prefix = "/api/runs/{run_id}"
         app.router.add_get(f"{prefix}/run", _handle_run)
         app.router.add_get(f"{prefix}/rollouts", _handle_rollouts)
@@ -1415,13 +1465,19 @@ class Config:
 
     log_path: str | None = None
     registry_dir: str | None = None
+    # Local cache for the cross-run reader's cloud-staged / v1-upgraded
+    # segments (default ~/.cache/tinker-cookbook/tokendb/segcache; also via
+    # TINKER_TOKENDB_SEGCACHE). Unbounded; safe to delete between sessions.
+    segcache_dir: str | None = None
     port: int = DEFAULT_PORT
     host: str = "127.0.0.1"  # local viewer; not meant to be exposed
 
 
 def run(config: Config) -> None:
     logging.basicConfig(level=logging.INFO)
-    app = build_app(config.log_path, registry_dir=config.registry_dir)
+    app = build_app(
+        config.log_path, registry_dir=config.registry_dir, segcache_dir=config.segcache_dir
+    )
     if config.log_path is not None:
         logger.info(
             "Token DB viewer on http://%s:%d (log_path=%s)",

--- a/tinker_cookbook/tokendb/serve_test.py
+++ b/tinker_cookbook/tokendb/serve_test.py
@@ -649,6 +649,39 @@ def test_registry_websocket_dashboard(registry_stores: dict):
     run_registry_client(fn)
 
 
+def test_registry_root_sql_cross_run(registry_stores: dict):
+    """POST /api/sql at the registry root runs cross-run SQL over all runs."""
+
+    async def fn(client):
+        resp = await client.post("/api/sql", json={"query": "SELECT count(*) AS n FROM rollouts"})
+        assert resp.status == 200
+        assert (await resp.json())["rows"][0]["n"] == 4  # 3 live-run + 1 stale-run rows
+
+        resp = await client.post(
+            "/api/sql",
+            json={"query": "SELECT run_id, count(*) AS n FROM rollouts GROUP BY run_id"},
+        )
+        rows = (await resp.json())["rows"]
+        assert {r["run_id"]: r["n"] for r in rows} == {
+            registry_stores["live_id"]: 3,
+            registry_stores["stale_id"]: 1,
+        }
+
+        # runs is cross-run too: one row per (run_id, run_attempt).
+        resp = await client.post(
+            "/api/sql", json={"query": "SELECT run_id, model_name FROM runs ORDER BY model_name"}
+        )
+        rows = (await resp.json())["rows"]
+        assert [r["model_name"] for r in rows] == ["live-model", "stale-model"]
+
+        # The SELECT-only guard surfaces as a 400, same as the per-run endpoint.
+        resp = await client.post("/api/sql", json={"query": "DROP VIEW rollouts"})
+        assert resp.status == 400
+        assert "SELECT" in (await resp.json())["error"]
+
+    run_registry_client(fn)
+
+
 def test_registry_mode_requires_registry(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("TINKER_TOKENDB_REGISTRY", "")
     with pytest.raises(ValueError, match="registry is disabled"):
@@ -1363,6 +1396,63 @@ def test_registry_global_chat_lists_runs(registry_stores: dict):
             resp = await client.get(f"/api/runs/{live_id}/chats")
             assert resp.status == 200
             assert (await resp.json())["conversations"] == []
+
+    asyncio.run(main())
+
+
+def test_registry_chat_sql_tool_cross_run(registry_stores: dict):
+    """The registry chat's sql tool without a run_id spans every run."""
+    transport = ScriptedTransport(
+        [
+            anthropic_script(
+                text="Comparing runs.",
+                tool_calls=[
+                    (
+                        "t1",
+                        "sql",
+                        {
+                            "query": (
+                                "SELECT run_id, count(*) AS n FROM rollouts "
+                                "GROUP BY run_id ORDER BY n DESC"
+                            )
+                        },
+                    )
+                ],
+            ),
+            anthropic_script(text="One run has 3 rows, the other 1."),
+        ]
+    )
+
+    async def main():
+        app = build_app(None, static_dir=None, load_tokenizer=False, llm_transport=transport)
+        async with TestClient(TestServer(app)) as client:
+            await client.post("/api/agent/config", json={"api_key": "sk-test"})
+            async with client.ws_connect("/api/chat") as ws:
+                frames = await _chat_frames(ws, "compare the runs")
+            assert frames[-1]["type"] == "done"
+            sql_result = next(
+                f for f in frames if f.get("type") == "tool_result" and f["name"] == "sql"
+            )
+            assert not sql_result["is_error"]
+            # The model saw both runs' counts from ONE query with no run_id.
+            conversation_id = frames[0]["conversation_id"]
+            records = (await (await client.get(f"/api/chats/{conversation_id}")).json())["records"]
+            tool_record = next(
+                r for r in records if r["kind"] == "message" and r.get("role") == "tool"
+            )
+            content = json.loads(tool_record["content"])
+            assert {row["run_id"]: row["n"] for row in content["rows"]} == {
+                registry_stores["live_id"]: 3,
+                registry_stores["stale_id"]: 1,
+            }
+            # The registry prompt teaches cross-run SQL (root endpoint, run_id
+            # as a column) and carries the aggregated multi-run schema card.
+            system = transport.requests[0][2]["system"]
+            assert 'const SQL_URL = "/api/sql"' in system
+            assert "GROUP BY run_id" in system
+            assert "rollouts_latest` for cross-run aggregates" in system
+            assert "Observed keys across runs (2 runs)" in system
+            assert "/api/runs/{run_id}/sql" in system  # per-run template stays documented
 
     asyncio.run(main())
 

--- a/tinker_cookbook/tokendb/writer.py
+++ b/tinker_cookbook/tokendb/writer.py
@@ -458,9 +458,12 @@ class ParquetSegmentBackend:
         group_idx: int,
         traj_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> Any:
         """See :meth:`TokenStoreBackend.get_rollout`."""
-        return self._reader().get_rollout(split, iteration, group_idx, traj_idx, run_attempt)
+        return self._reader().get_rollout(
+            split, iteration, group_idx, traj_idx, run_attempt, run_id
+        )
 
     def search(self, **kwargs: Any) -> Any:
         """See :meth:`TokenStoreBackend.search` and
@@ -500,9 +503,10 @@ class ParquetSegmentBackend:
         iteration: int,
         group_idx: int,
         run_attempt: int | None = None,
+        run_id: str | None = None,
     ) -> Any:
         """See :meth:`TokenStoreBackend.group_traj_idxs`."""
-        return self._reader().group_traj_idxs(split, iteration, group_idx, run_attempt)
+        return self._reader().group_traj_idxs(split, iteration, group_idx, run_attempt, run_id)
 
     def runs(self) -> Any:
         """One row per (run_id, run_attempt); see


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #821
* __->__ #820
* #819
* #818
* #817
* #816
* #815
* #814
* #813
* #812
* #811
* #810
* #809
* #808
* #807
* #806
* #805
* #804

Add RegistryBackend (tokendb/registry_backend.py): one DuckDB connection
whose rollouts / rollouts_latest / trajectories / labels / runs views span
every run in the run registry, with run_id as an ordinary column. Instead
of materializing segments in memory, it binds a segment_scan view over an
explicit read_parquet file list rebuilt on a TTL-gated refresh, so nothing
is pinned in RAM between queries. Cloud and v1-shaped segments are staged
once into a local segcache (~/.cache/tinker-cookbook/tokendb/segcache,
segcache_dir / TINKER_TOKENDB_SEGCACHE to override; v1 files are upgraded
to v2 at cache fill via the existing normalization, originals untouched).
The superseded window is partitioned by run, so a resume in one run never
hides another run's rows.

- interface.py: get_rollout / group_traj_idxs gain an optional run_id
  (rollout identity is only unique per run); reader/backend/facade updated.
- reader.py: shared pieces (filter building, search, rollout query, runs
  payloads, schema card, label append/table, derived-view DDL) extracted
  to module-level functions reused by both readers; the single-run reader
  stays eager.
- serve.py: registry mode gets a shared RegistryBackend (per-thread
  cursors) powering the all-runs chat sql tool (run_id now optional), a
  root POST /api/sql, and the dashboard as one GROUP-BY-run_id pass.
- agent_prompt.py: registry chat teaches cross-run SQL (rollouts includes
  superseded rows; prefer rollouts_latest for cross-run aggregates) and
  renders an aggregated multi-run schema card with per-run key attribution.
- Tests: two-run fixture (raw-pyarrow v1 + v2) covering cross-run joins,
  superseded partitioning, segcache fill-once, TTL discovery, per-run-only
  subscribe, labels routing, dashboard parity, schema-card rendering,
  protocol conformance, and per-thread cursor concurrency.