### PR TITLE
Add bits-per-byte (BPB) alongside NLL for tokenizer-independent comparison

### DIFF
--- a/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
+++ b/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
@@ -11,6 +11,8 @@ Use these as a reference when choosing learning rate and LoRA rank for your mode
 
 > **Note:** Wall times are approximate and depend on server load at the time of the run. They may fluctuate significantly between runs.
 
+> **Comparing across models:** `Test NLL` / `Train NLL` are *per-token* cross-entropy and are **not comparable across models with different tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` (bits per byte) normalize by the target text's UTF-8 byte count instead of the token count and *are* comparable across tokenizers. (These tables predate the BPB metric, so the columns are not yet shown; they will appear when the sweep is re-run and this doc is regenerated.)
+
 ## Key Findings
 
 **Optimal learning rate is model-size dependent.** Across all models, the best LR per model breaks down as:

--- a/tinker_cookbook/recipes/chat_sl/sweep/README.md
+++ b/tinker_cookbook/recipes/chat_sl/sweep/README.md
@@ -46,6 +46,21 @@ python -m tinker_cookbook.recipes.chat_sl.sweep \
     metric=test/nll
 ```
 
+**Comparing across tokenizers:** `train_mean_nll` / `test/nll` are *per-token*
+cross-entropy, which is not comparable across models with different tokenizers —
+a coarser tokenizer packs more text into each token (higher nats/token) while a
+finer one spreads it over more (lower nats/token). Training also logs
+`train_mean_bpb` / `test/bpb` (bits per byte), which divide the total log-loss by
+the number of UTF-8 bytes of the target text instead of by the token count, so
+they *are* comparable across tokenizers. Sweeping over models? Select on bits per
+byte:
+
+```bash
+python -m tinker_cookbook.recipes.chat_sl.sweep \
+    recipe=sft \
+    metric=test/bpb
+```
+
 ## Python API
 
 ```python

--- a/tinker_cookbook/recipes/chat_sl/sweep/analyze.py
+++ b/tinker_cookbook/recipes/chat_sl/sweep/analyze.py
@@ -39,6 +39,10 @@ class RunResult:
     run_name: str
     # step -> test_nll for NLL curves
     history: list[tuple[int, float]] = field(default_factory=list)
+    # Bits per byte (tokenizer-independent NLL). None for runs logged before it
+    # was added.
+    test_bpb: float | None = None
+    train_bpb: float | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +123,8 @@ def fetch_runs(wandb_project: str, fetch_history: bool = True) -> list[RunResult
         summary = dict(r.summary)
         test_nll = summary.get("test/nll")
         train_nll = summary.get("train_mean_nll")
+        test_bpb = summary.get("test/bpb")
+        train_bpb = summary.get("train_mean_bpb")
         runtime_s = summary.get("_runtime", 0)
 
         if test_nll is None or train_nll is None:
@@ -148,6 +154,8 @@ def fetch_runs(wandb_project: str, fetch_history: bool = True) -> list[RunResult
                 wall_time_min=float(runtime_s) / 60.0,
                 run_name=r.name,
                 history=history_points,
+                test_bpb=float(test_bpb) if test_bpb is not None else None,
+                train_bpb=float(train_bpb) if train_bpb is not None else None,
             )
         )
 
@@ -205,6 +213,8 @@ def fetch_runs_local(sweep_root: str) -> list[RunResult]:
 
             test_nll = last_row.get("test/nll")
             train_nll = last_row.get("train_mean_nll")
+            test_bpb = last_row.get("test/bpb")
+            train_bpb = last_row.get("train_mean_bpb")
             if test_nll is None or train_nll is None:
                 continue
 
@@ -225,6 +235,8 @@ def fetch_runs_local(sweep_root: str) -> list[RunResult]:
                     wall_time_min=wall_time_min,
                     run_name=run_name,
                     history=history_points,
+                    test_bpb=float(test_bpb) if test_bpb is not None else None,
+                    train_bpb=float(train_bpb) if train_bpb is not None else None,
                 )
             )
 
@@ -347,6 +359,11 @@ def _format_lr(lr: float) -> str:
     return f"{lr:.0e}"
 
 
+def _fmt_metric(value: float | None) -> str:
+    """Format an optional metric value, using an em dash when it is missing."""
+    return f"{value:.4f}" if value is not None else "—"
+
+
 def generate_model_section(
     model_slug: str,
     runs: list[RunResult],
@@ -377,7 +394,11 @@ def generate_model_section(
     lines.append("- Batch size: 128")
     lines.append(f"- Learning rates: [{lr_list_str}]")
     lines.append(f"- LoRA ranks: [{rank_list_str}]")
-    lines.append("- Metric: `test/nll` — negative log-likelihood on held-out test split")
+    lines.append(
+        "- Metric: `test/nll` — per-token negative log-likelihood on the held-out "
+        "test split (compare within a model; use `test/bpb` to compare across "
+        "tokenizers)"
+    )
     lines.append("")
     lines.append("<details>")
     lines.append("<summary>Reproduce</summary>")
@@ -401,15 +422,30 @@ def generate_model_section(
         lines.append("")
         return "\n".join(lines)
 
-    # Results table
+    # Results table. Include BPB columns only when at least one run has them, so
+    # legacy sweeps (logged before BPB existed) keep their original layout.
     lines.append("**Results:**")
     lines.append("")
-    lines.append("| LR | LoRA Rank | Test NLL | Train NLL | Wall Time (min) |")
-    lines.append("|---:|----------:|---------:|----------:|----------------:|")
-    for r in sorted(healthy, key=lambda r: (r.rank, r.lr)):
+    show_bpb = any(r.test_bpb is not None or r.train_bpb is not None for r in healthy)
+    if show_bpb:
         lines.append(
-            f"| {_format_lr(r.lr)} | {r.rank} | {r.test_nll:.4f} | {r.train_nll:.4f} | {r.wall_time_min:.0f} |"
+            "| LR | LoRA Rank | Test NLL | Test BPB | Train NLL | Train BPB | Wall Time (min) |"
         )
+        lines.append(
+            "|---:|----------:|---------:|---------:|----------:|----------:|----------------:|"
+        )
+        for r in sorted(healthy, key=lambda r: (r.rank, r.lr)):
+            lines.append(
+                f"| {_format_lr(r.lr)} | {r.rank} | {r.test_nll:.4f} | {_fmt_metric(r.test_bpb)} "
+                f"| {r.train_nll:.4f} | {_fmt_metric(r.train_bpb)} | {r.wall_time_min:.0f} |"
+            )
+    else:
+        lines.append("| LR | LoRA Rank | Test NLL | Train NLL | Wall Time (min) |")
+        lines.append("|---:|----------:|---------:|----------:|----------------:|")
+        for r in sorted(healthy, key=lambda r: (r.rank, r.lr)):
+            lines.append(
+                f"| {_format_lr(r.lr)} | {r.rank} | {r.test_nll:.4f} | {r.train_nll:.4f} | {r.wall_time_min:.0f} |"
+            )
     lines.append("")
 
     # Best config
@@ -532,6 +568,15 @@ def generate_sft_sweep_md(
     lines.append(
         "> **Note:** Wall times are approximate and depend on server load at the time of "
         "the run. They may fluctuate significantly between runs."
+    )
+    lines.append("")
+    lines.append(
+        "> **Comparing across models:** `Test NLL` / `Train NLL` are *per-token* "
+        "cross-entropy and are **not comparable across models with different "
+        "tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer "
+        "one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` "
+        "(bits per byte) normalize by the target text's UTF-8 byte count instead of "
+        "the token count and *are* comparable across tokenizers."
     )
     lines.append("")
 

--- a/tinker_cookbook/recipes/chat_sl/sweep/analyze_test.py
+++ b/tinker_cookbook/recipes/chat_sl/sweep/analyze_test.py
@@ -1,0 +1,41 @@
+"""Tests for the markdown generation in sweep/analyze.py (no W&B needed)."""
+
+from typing import Any
+
+from tinker_cookbook.recipes.chat_sl.sweep.analyze import RunResult, generate_model_section
+
+
+def _run(**overrides: Any) -> RunResult:
+    base: dict[str, Any] = {
+        "model": "Qwen-Qwen3-8B",
+        "rank": 32,
+        "lr": 3e-4,
+        "test_nll": 0.5,
+        "train_nll": 0.4,
+        "wall_time_min": 10.0,
+        "run_name": "tulu3-Qwen-Qwen3-8B-32rank-0.0003lr-128batch-local",
+    }
+    base.update(overrides)
+    return RunResult(**base)
+
+
+def test_model_section_includes_bpb_columns_when_present():
+    section = generate_model_section("Qwen-Qwen3-8B", [_run(test_bpb=0.8, train_bpb=0.7)], None)
+    assert "Test BPB" in section
+    assert "Train BPB" in section
+    assert "0.8000" in section  # test_bpb rendered
+    assert "0.7000" in section  # train_bpb rendered
+
+
+def test_model_section_omits_bpb_columns_for_legacy_runs():
+    section = generate_model_section("Qwen-Qwen3-8B", [_run()], None)
+    assert "BPB" not in section
+    assert "| LR | LoRA Rank | Test NLL | Train NLL | Wall Time (min) |" in section
+
+
+def test_model_section_shows_dash_for_missing_bpb_in_mixed_grid():
+    # One run has BPB, another doesn't -> columns shown, missing cell is an em dash.
+    runs = [_run(rank=32, test_bpb=0.8, train_bpb=0.7), _run(rank=64)]
+    section = generate_model_section("Qwen-Qwen3-8B", runs, None)
+    assert "Test BPB" in section
+    assert "—" in section  # the rank=64 run has no BPB

--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -11,7 +11,7 @@ import datasets
 import tinker
 
 from tinker_cookbook import checkpoint_utils, model_info, renderers
-from tinker_cookbook.supervised.common import compute_mean_nll
+from tinker_cookbook.supervised.common import compute_bpb, compute_mean_nll
 from tinker_cookbook.supervised.data import conversation_to_datum
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 from tinker_cookbook.utils import ml_log
@@ -142,7 +142,10 @@ def main(config: Config):
         # Compute train metrics
         train_logprobs = [x["logprobs"] for x in fwd_bwd_result.loss_fn_outputs]
         train_weights = [d.loss_fn_inputs["weights"] for d in batch]
+        train_target_tokens = [d.loss_fn_inputs["target_tokens"] for d in batch]
         train_nll = compute_mean_nll(train_logprobs, train_weights)
+        # Bits per byte: a tokenizer-independent counterpart to train_mean_nll.
+        train_bpb = compute_bpb(train_logprobs, train_weights, train_target_tokens, tokenizer)
 
         # Log metrics
         metrics.update(
@@ -150,6 +153,7 @@ def main(config: Config):
             num_tokens=sum(d.model_input.length for d in batch),
             learning_rate=current_lr,
             train_mean_nll=train_nll,
+            train_mean_bpb=train_bpb,
             progress=step / n_train_batches,
             time_total=time.time() - start_time,
         )

--- a/tinker_cookbook/supervised/__init__.py
+++ b/tinker_cookbook/supervised/__init__.py
@@ -1,6 +1,7 @@
 """Supervised learning: dataset builders, data utilities, and training loops."""
 
 from tinker_cookbook.supervised.common import (
+    compute_bpb,
     compute_mean_nll,
     datum_from_model_input_weights,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "SupervisedDatasetFromHFDataset",
     "conversation_to_datum",
     # Helpers (common.py)
+    "compute_bpb",
     "compute_mean_nll",
     "datum_from_model_input_weights",
 ]

--- a/tinker_cookbook/supervised/common.py
+++ b/tinker_cookbook/supervised/common.py
@@ -107,13 +107,16 @@ def compute_bpb(
     removes this dependence by dividing the *total* log-loss (converted to bits)
     by the number of UTF-8 bytes of the target text::
 
-        bpb = -sum(logprobs * weights) / (ln(2) * total_target_bytes)
+        bpb = -sum(logprob_i for i where weight_i > 0) / (ln(2) * total_target_bytes)
 
-    The numerator is the same weighted sum used by :func:`compute_mean_nll`
-    (only without the per-token averaging); the denominator counts the bytes of
-    the decoded loss-weighted tokens, which is fixed by the raw text rather than
-    by the tokenization. Both cover the same weighted span, so the ratio is a
-    proper compression rate that can be compared across tokenizers.
+    The numerator sums the raw per-token NLL over the loss-weighted tokens,
+    using the weights only as a ``> 0`` mask rather than as multipliers. This
+    keeps the total nats correct even when the weights are normalized per
+    example (``reduction="mean"``, the SFT default, where a datum's weights sum
+    to 1.0 instead of being 0/1). The denominator counts the UTF-8 bytes of
+    those same decoded tokens, which is fixed by the raw text rather than by the
+    tokenization. Because numerator and denominator cover the same span, the
+    ratio is a proper compression rate that can be compared across tokenizers.
 
     Args:
         logprobs_list (list[tinker.TensorData]): Per-token log-probabilities,
@@ -128,7 +131,7 @@ def compute_bpb(
     Returns:
         float: Bits per byte, or ``nan`` if the weighted target has zero bytes.
     """
-    total_weighted_logprobs = 0.0
+    total_nll_nats = 0.0
     total_bytes = 0
 
     for logprobs, weights, target_tokens in zip(
@@ -136,7 +139,11 @@ def compute_bpb(
     ):
         logprobs_torch = logprobs.to_torch()
         weights_torch = weights.to_torch()
-        total_weighted_logprobs += float(logprobs_torch.dot(weights_torch))
+        # Sum the raw NLL over trained tokens, using the weights only as a mask.
+        # This matches the tokens counted in the byte denominator and stays
+        # correct under per-example weight normalization (reduction="mean").
+        mask = weights_torch > 0
+        total_nll_nats += float(-logprobs_torch[mask].sum())
         total_bytes += _weighted_target_byte_count(
             list(target_tokens.data), list(weights.data), tokenizer
         )
@@ -145,7 +152,7 @@ def compute_bpb(
         logger.warning("No target bytes found for BPB computation")
         return float("nan")
 
-    return float(-total_weighted_logprobs / (math.log(2) * total_bytes))
+    return float(total_nll_nats / (math.log(2) * total_bytes))
 
 
 def create_rightshifted_model_input_and_leftshifted_targets(

--- a/tinker_cookbook/supervised/common.py
+++ b/tinker_cookbook/supervised/common.py
@@ -1,10 +1,13 @@
 import logging
+import math
+from collections.abc import Sequence
 from typing import Literal
 
 import tinker
 import torch
 
 from tinker_cookbook.exceptions import DataValidationError
+from tinker_cookbook.tokenizer_utils import Tokenizer
 
 _logged_reduction_modes: set[str] = set()
 
@@ -43,6 +46,106 @@ def compute_mean_nll(
         return float("nan")
 
     return float(-total_weighted_logprobs / total_weights)
+
+
+def _weighted_target_byte_count(
+    target_tokens: Sequence[float], weights: Sequence[float], tokenizer: Tokenizer
+) -> int:
+    """UTF-8 byte count of the text formed by the loss-weighted target tokens.
+
+    Each contiguous run of nonzero-weight tokens is decoded separately so that
+    weight-0 spans between trained regions (e.g. user turns in a multi-turn
+    conversation) do not get merged across the gap. Special tokens are skipped
+    so the count reflects natural-language bytes, which keeps the denominator
+    comparable across tokenizers with different control-token strings.
+
+    Args:
+        target_tokens (Sequence[float]): Target token IDs
+            (``loss_fn_inputs["target_tokens"].data``, stored as floats and cast
+            back to ``int`` here).
+        weights (Sequence[float]): Per-token loss weights aligned with
+            ``target_tokens``.
+        tokenizer (Tokenizer): Tokenizer used to decode tokens back to text.
+
+    Returns:
+        int: Total number of UTF-8 bytes across all weighted spans.
+    """
+    total_bytes = 0
+    run: list[int] = []
+    for token, weight in zip(target_tokens, weights, strict=True):
+        if weight > 0:
+            run.append(int(token))
+        elif run:
+            total_bytes += _decoded_byte_length(run, tokenizer)
+            run = []
+    if run:
+        total_bytes += _decoded_byte_length(run, tokenizer)
+    return total_bytes
+
+
+def _decoded_byte_length(token_ids: list[int], tokenizer: Tokenizer) -> int:
+    """UTF-8 byte length of ``token_ids`` decoded to natural-language text."""
+    text = tokenizer.decode(token_ids, skip_special_tokens=True)
+    if isinstance(text, list):
+        # Some tokenizers can return a list of piece strings; join them.
+        text = "".join(text)
+    return len(text.encode("utf-8"))
+
+
+def compute_bpb(
+    logprobs_list: list[tinker.TensorData],
+    weights_list: list[tinker.TensorData],
+    target_tokens_list: list[tinker.TensorData],
+    tokenizer: Tokenizer,
+) -> float:
+    """Compute bits-per-byte (BPB) across a batch: a tokenizer-independent NLL.
+
+    Per-token mean NLL (:func:`compute_mean_nll`) is not comparable across
+    models that use different tokenizers: a coarser tokenizer packs more text
+    into each token (higher nats/token) while a finer one spreads it over more
+    tokens (lower nats/token), even at equal modeling quality. Bits-per-byte
+    removes this dependence by dividing the *total* log-loss (converted to bits)
+    by the number of UTF-8 bytes of the target text::
+
+        bpb = -sum(logprobs * weights) / (ln(2) * total_target_bytes)
+
+    The numerator is the same weighted sum used by :func:`compute_mean_nll`
+    (only without the per-token averaging); the denominator counts the bytes of
+    the decoded loss-weighted tokens, which is fixed by the raw text rather than
+    by the tokenization. Both cover the same weighted span, so the ratio is a
+    proper compression rate that can be compared across tokenizers.
+
+    Args:
+        logprobs_list (list[tinker.TensorData]): Per-token log-probabilities,
+            one entry per datum in the batch.
+        weights_list (list[tinker.TensorData]): Per-token loss weights aligned
+            with ``logprobs_list``.
+        target_tokens_list (list[tinker.TensorData]): Per-token target IDs
+            (``loss_fn_inputs["target_tokens"]``) aligned with ``weights_list``,
+            used to recover the target text for the byte count.
+        tokenizer (Tokenizer): Tokenizer used to decode target tokens to bytes.
+
+    Returns:
+        float: Bits per byte, or ``nan`` if the weighted target has zero bytes.
+    """
+    total_weighted_logprobs = 0.0
+    total_bytes = 0
+
+    for logprobs, weights, target_tokens in zip(
+        logprobs_list, weights_list, target_tokens_list, strict=True
+    ):
+        logprobs_torch = logprobs.to_torch()
+        weights_torch = weights.to_torch()
+        total_weighted_logprobs += float(logprobs_torch.dot(weights_torch))
+        total_bytes += _weighted_target_byte_count(
+            list(target_tokens.data), list(weights.data), tokenizer
+        )
+
+    if total_bytes == 0:
+        logger.warning("No target bytes found for BPB computation")
+        return float("nan")
+
+    return float(-total_weighted_logprobs / (math.log(2) * total_bytes))
 
 
 def create_rightshifted_model_input_and_leftshifted_targets(

--- a/tinker_cookbook/supervised/common_test.py
+++ b/tinker_cookbook/supervised/common_test.py
@@ -1,12 +1,18 @@
 """Tests for supervised/common.py weight reduction in datum_from_model_input_weights."""
 
 import math
+from typing import Literal, cast
 
 import pytest
 import tinker
 import torch
 
-from tinker_cookbook.supervised.common import datum_from_model_input_weights
+from tinker_cookbook.supervised.common import (
+    _weighted_target_byte_count,
+    compute_bpb,
+    datum_from_model_input_weights,
+)
+from tinker_cookbook.tokenizer_utils import Tokenizer
 
 
 def _make_model_input(tokens: list[int]) -> tinker.ModelInput:
@@ -125,3 +131,104 @@ def test_invalid_reduction_raises():
     weights = torch.tensor([0.0, 1.0, 1.0])
     with pytest.raises(ValueError, match="Unknown reduction mode"):
         datum_from_model_input_weights(model_input, weights, reduction="invalid")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Bits-per-byte (compute_bpb)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer stand-in mapping each token id to a fixed string.
+
+    ``decode`` concatenates the per-token strings and, when
+    ``skip_special_tokens=True``, drops ids in ``special_ids``.
+    """
+
+    def __init__(self, vocab: dict[int, str], special_ids: set[int] | None = None):
+        self.vocab = vocab
+        self.special_ids = special_ids or set()
+
+    def decode(self, ids: list[int], skip_special_tokens: bool = False) -> str:
+        return "".join(
+            self.vocab[i] for i in ids if not (skip_special_tokens and i in self.special_ids)
+        )
+
+
+def _fake_tokenizer(vocab: dict[int, str], special_ids: set[int] | None = None) -> Tokenizer:
+    """Build a `_FakeTokenizer` typed as `Tokenizer` for the BPB helpers."""
+    return cast(Tokenizer, _FakeTokenizer(vocab, special_ids))
+
+
+def _td(data: list[float] | list[int], dtype: Literal["float32", "int64"]) -> tinker.TensorData:
+    return tinker.TensorData(data=list(data), dtype=dtype, shape=[len(data)])
+
+
+def test_compute_bpb_matches_hand_computation():
+    """bpb = -sum(logprobs * weights) / (ln(2) * target_bytes)."""
+    tok = _fake_tokenizer({1: "he", 2: "llo"})  # decodes to "hello" -> 5 bytes
+    logprobs = _td([-0.5, -1.5], "float32")
+    weights = _td([1.0, 1.0], "float32")
+    targets = _td([1, 2], "int64")
+    bpb = compute_bpb([logprobs], [weights], [targets], tok)
+    expected = 2.0 / (math.log(2) * 5)  # total nats = 0.5 + 1.5; bytes = 5
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_ignores_zero_weight_tokens():
+    """Weight-0 (prompt) tokens affect neither the numerator nor the byte count."""
+    tok = _fake_tokenizer({1: "AB", 2: "x", 3: "yz"})
+    logprobs = _td([-9.0, -1.0, -1.0], "float32")  # big loss on the prompt token
+    weights = _td([0.0, 1.0, 1.0], "float32")
+    targets = _td([1, 2, 3], "int64")  # weighted run [2, 3] -> "xyz" -> 3 bytes
+    bpb = compute_bpb([logprobs], [weights], [targets], tok)
+    expected = 2.0 / (math.log(2) * 3)
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_counts_utf8_bytes_not_chars():
+    """Multi-byte characters count as their UTF-8 byte length, not 1 char each."""
+    tok = _fake_tokenizer({1: "café", 2: "中"})  # "café" = 5 bytes, "中" = 3 bytes
+    logprobs = _td([-1.0, -1.0], "float32")
+    weights = _td([1.0, 1.0], "float32")
+    targets = _td([1, 2], "int64")
+    bpb = compute_bpb([logprobs], [weights], [targets], tok)
+    expected = 2.0 / (math.log(2) * 8)
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_skips_special_tokens_in_byte_count():
+    """A scored end-of-turn token contributes to nats but not to the byte count."""
+    tok = _fake_tokenizer({1: "hi", 99: "<|end|>"}, special_ids={99})
+    logprobs = _td([-1.0, -1.0], "float32")
+    weights = _td([1.0, 1.0], "float32")
+    targets = _td([1, 99], "int64")
+    bpb = compute_bpb([logprobs], [weights], [targets], tok)
+    expected = 2.0 / (math.log(2) * len("hi"))  # only "hi" counts toward bytes
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_aggregates_across_batch():
+    """Numerator and denominator sum over all datums in the batch."""
+    tok = _fake_tokenizer({1: "ab", 2: "cde"})
+    d1 = ([_td([-1.0], "float32")], [_td([1.0], "float32")], [_td([1], "int64")])  # "ab" = 2
+    d2 = ([_td([-3.0], "float32")], [_td([1.0], "float32")], [_td([2], "int64")])  # "cde" = 3
+    bpb = compute_bpb(d1[0] + d2[0], d1[1] + d2[1], d1[2] + d2[2], tok)
+    expected = 4.0 / (math.log(2) * 5)  # nats = 1 + 3; bytes = 2 + 3
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_zero_bytes_returns_nan():
+    """No weighted tokens -> zero bytes -> nan (no division by zero)."""
+    tok = _fake_tokenizer({1: "a"})
+    logprobs = _td([-1.0], "float32")
+    weights = _td([0.0], "float32")
+    targets = _td([1], "int64")
+    assert math.isnan(compute_bpb([logprobs], [weights], [targets], tok))
+
+
+def test_weighted_target_byte_count_splits_runs():
+    """Runs separated by a zero-weight gap are decoded independently."""
+    tok = _fake_tokenizer({1: "ab", 2: "GAP", 3: "cde"})
+    n = _weighted_target_byte_count([1, 2, 3], [1.0, 0.0, 1.0], tok)
+    assert n == len("ab") + len("cde")  # 2 + 3; the "GAP" token is excluded

--- a/tinker_cookbook/supervised/common_test.py
+++ b/tinker_cookbook/supervised/common_test.py
@@ -186,6 +186,19 @@ def test_compute_bpb_ignores_zero_weight_tokens():
     assert math.isclose(bpb, expected, rel_tol=1e-6)
 
 
+def test_compute_bpb_invariant_to_weight_magnitude():
+    """Weights are a mask, not a multiplier: per-example normalized weights
+    (reduction="mean") give the same BPB as 0/1 weights."""
+    tok = _fake_tokenizer({1: "ab", 2: "cd"})  # "abcd" -> 4 bytes
+    logprobs = _td([-1.0, -3.0], "float32")  # total nats = 1 + 3 = 4 in both cases
+    targets = _td([1, 2], "int64")
+    expected = 4.0 / (math.log(2) * 4)
+    bpb_binary = compute_bpb([logprobs], [_td([1.0, 1.0], "float32")], [targets], tok)
+    bpb_mean = compute_bpb([logprobs], [_td([0.5, 0.5], "float32")], [targets], tok)
+    assert math.isclose(bpb_binary, expected, rel_tol=1e-6)
+    assert math.isclose(bpb_mean, expected, rel_tol=1e-6)
+
+
 def test_compute_bpb_counts_utf8_bytes_not_chars():
     """Multi-byte characters count as their UTF-8 byte length, not 1 char each."""
     tok = _fake_tokenizer({1: "café", 2: "中"})  # "café" = 5 bytes, "中" = 3 bytes

--- a/tinker_cookbook/supervised/nll_evaluator.py
+++ b/tinker_cookbook/supervised/nll_evaluator.py
@@ -3,52 +3,80 @@ import itertools
 import tinker
 
 from tinker_cookbook.eval.evaluators import TrainingClientEvaluator
-from tinker_cookbook.supervised.common import compute_mean_nll
+from tinker_cookbook.supervised.common import compute_bpb, compute_mean_nll
 from tinker_cookbook.supervised.types import SupervisedDataset
+from tinker_cookbook.tokenizer_utils import Tokenizer
 
 
 class NLLEvaluator(TrainingClientEvaluator):
     """Evaluator that computes mean negative log-likelihood on held-out data.
 
     Uses the training client's ``forward_async`` to compute log-probabilities
-    on a fixed set of datums and returns the weighted mean NLL.
+    on a fixed set of datums and returns the weighted mean NLL.  When a
+    ``tokenizer`` is supplied it additionally reports bits-per-byte, a
+    tokenizer-independent NLL that is comparable across models.
 
     Attributes:
         name (str): Prefix for the returned metric key (default ``"test"``).
         data (list[tinker.Datum]): Evaluation datums.
+        tokenizer (Tokenizer | None): Tokenizer used to compute bits-per-byte.
+            When ``None``, only ``"{name}/nll"`` is reported.
     """
 
-    def __init__(self, data: list[tinker.Datum], name: str = "test"):
+    def __init__(
+        self,
+        data: list[tinker.Datum],
+        name: str = "test",
+        tokenizer: Tokenizer | None = None,
+    ):
         """Initialise the evaluator.
 
         Args:
             data (list[tinker.Datum]): Evaluation datums to score.
             name (str): Metric key prefix.  The returned dict will contain
                 ``"{name}/nll"``.  Default ``"test"``.
+            tokenizer (Tokenizer | None): If provided, also report
+                ``"{name}/bpb"`` (bits per byte), a tokenizer-normalized NLL.
+                Requires each datum to carry ``loss_fn_inputs["target_tokens"]``.
         """
         self.name = name
         self.data = data
+        self.tokenizer = tokenizer
 
     async def __call__(self, training_client: tinker.TrainingClient) -> dict[str, float]:
-        """Run a forward pass and return the mean NLL metric.
+        """Run a forward pass and return the NLL (and optionally BPB) metric.
 
         Args:
             training_client (tinker.TrainingClient): Client whose current
                 weights are evaluated.
 
         Returns:
-            dict[str, float]: Single-entry dict ``{"{name}/nll": <value>}``.
+            dict[str, float]: ``{"{name}/nll": <value>}``, plus
+            ``"{name}/bpb"`` when a tokenizer was provided.
         """
         future = await training_client.forward_async(self.data, loss_fn="cross_entropy")
         result = await future.result_async()
         logprobs = [x["logprobs"] for x in result.loss_fn_outputs]
         weights = [datum.loss_fn_inputs["weights"] for datum in self.data]
-        nll = compute_mean_nll(logprobs, weights)
-        key = f"{self.name}/nll"
-        return {key: nll}
+        metrics = {f"{self.name}/nll": compute_mean_nll(logprobs, weights)}
+        if (
+            self.tokenizer is not None
+            and self.data
+            and "target_tokens" in self.data[0].loss_fn_inputs
+        ):
+            target_tokens = [datum.loss_fn_inputs["target_tokens"] for datum in self.data]
+            metrics[f"{self.name}/bpb"] = compute_bpb(
+                logprobs, weights, target_tokens, self.tokenizer
+            )
+        return metrics
 
     @classmethod
-    def from_dataset(cls, dataset: SupervisedDataset, name: str = "test") -> "NLLEvaluator":
+    def from_dataset(
+        cls,
+        dataset: SupervisedDataset,
+        name: str = "test",
+        tokenizer: Tokenizer | None = None,
+    ) -> "NLLEvaluator":
         """Create an evaluator from all batches of a ``SupervisedDataset``.
 
         Materialises every batch into a flat list of datums so the evaluator
@@ -57,9 +85,11 @@ class NLLEvaluator(TrainingClientEvaluator):
         Args:
             dataset (SupervisedDataset): Dataset to draw evaluation data from.
             name (str): Metric key prefix. Default ``"test"``.
+            tokenizer (Tokenizer | None): If provided, also report
+                ``"{name}/bpb"`` (bits per byte).
 
         Returns:
             NLLEvaluator: A new evaluator instance.
         """
         all_data = list(itertools.chain(*[dataset.get_batch(i) for i in range(len(dataset))]))
-        return cls(all_data, name=name)
+        return cls(all_data, name=name, tokenizer=tokenizer)

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -27,7 +27,7 @@ from tinker_cookbook.eval.evaluators import (
     TrainingClientEvaluator,
 )
 from tinker_cookbook.exceptions import ConfigurationError
-from tinker_cookbook.supervised.common import compute_mean_nll
+from tinker_cookbook.supervised.common import compute_bpb, compute_mean_nll
 from tinker_cookbook.supervised.nll_evaluator import NLLEvaluator
 from tinker_cookbook.supervised.types import SupervisedDatasetBuilder
 from tinker_cookbook.tokenizer_utils import get_tokenizer
@@ -382,7 +382,9 @@ async def main(config: Config):
 
     evaluators = [evaluator() for evaluator in config.evaluator_builders]
     if maybe_test_dataset is not None:
-        evaluators.append(NLLEvaluator.from_dataset(maybe_test_dataset))
+        # Pass the tokenizer so the evaluator also reports test/bpb (bits per
+        # byte), a tokenizer-independent NLL that is comparable across models.
+        evaluators.append(NLLEvaluator.from_dataset(maybe_test_dataset, tokenizer=tokenizer))
 
     infrequent_evaluators = [evaluator() for evaluator in config.infrequent_evaluator_builders]
     logger.info(
@@ -487,6 +489,11 @@ async def main(config: Config):
             ),
             train_mean_nll=train_nll,
         )
+        # Bits per byte: a tokenizer-independent counterpart to train_mean_nll,
+        # letting NLL be compared across models with different tokenizers.
+        if submitted.data and "target_tokens" in submitted.data[0].loss_fn_inputs:
+            target_tokens = [datum.loss_fn_inputs["target_tokens"] for datum in submitted.data]
+            metrics["train_mean_bpb"] = compute_bpb(logprobs, weights, target_tokens, tokenizer)
         # Merge evaluation metrics gathered before the training step was submitted
         if submitted.eval_metrics is not None:
             metrics.update(submitted.eval_metrics)


### PR DESCRIPTION
## Summary

The chat_sl sweep optimizes `train_mean_nll` (and `test/nll`), which are **per-token** cross-entropy. Per-token NLL is **not comparable across tokenizers**: a coarser tokenizer packs more text into each token (higher nats/token), while a finer one spreads the same text over more tokens (lower nats/token) — even at equal modeling quality. This makes any cross-model comparison in `results/sft_sweep.md` apples-to-oranges.

This PR adds **bits-per-byte (BPB)** as a tokenizer-independent counterpart, logged alongside NLL. BPB divides the total log-loss (in bits) over the trained tokens by the number of UTF-8 bytes of the target text:

```
bpb = -sum(logprob_i for i where weight_i > 0) / (ln(2) * total_target_bytes)
```

The numerator sums the raw per-token NLL over the loss-weighted tokens (weights used only as a `> 0` **mask**, so it stays correct under the SFT default `reduction="mean"`, where per-example weights sum to 1.0 rather than being 0/1). The denominator counts the UTF-8 bytes of those same decoded tokens — fixed by the raw text, not the tokenization. Same span in numerator and denominator ⟹ a proper compression rate that's comparable across tokenizers.

Within a single model, BPB and NLL differ only by a constant, so `argmin` over LR / LoRA rank is unchanged — this only affects cross-tokenizer comparisons.

## Details

- **`supervised/common.py`** — new `compute_bpb(logprobs, weights, target_tokens, tokenizer)` + `_weighted_target_byte_count` (decodes each contiguous run of loss-weighted target tokens, skipping special tokens, and sums UTF-8 bytes). Uses `loss_fn_inputs["target_tokens"]`, already on every SFT datum. Weights are treated as a mask, so BPB is correct regardless of `reduction`.
- **`supervised/nll_evaluator.py`** — `NLLEvaluator` gains an optional `tokenizer`; when supplied it also reports `{name}/bpb`. Backward compatible (defaults to `None`; the DPO caller is unaffected).
- **`supervised/train.py`** — passes the tokenizer to the eval (adds `test/bpb`) and logs `train_mean_bpb` next to `train_mean_nll`.
- **`recipes/sl_loop.py`** — logs `train_mean_bpb` too.
- **`recipes/chat_sl/sweep/analyze.py`** — `RunResult` carries optional `test_bpb`/`train_bpb` (read from W&B + local `metrics.jsonl`); the per-model tables gain `Test BPB`/`Train BPB` columns when present (legacy runs keep the old layout; missing cells render as an em dash), and the doc header explains the NLL-vs-BPB distinction for cross-model reading.
- **`recipes/chat_sl/sweep/README.md`** + **`results/sft_sweep.md`** — document selecting `metric=test/bpb` when comparing across tokenizers, and the cross-model caveat.

Sweeping across models is then just:

```bash
python -m tinker_cookbook.recipes.chat_sl.sweep recipe=sft metric=test/bpb
```

## Test

- `supervised/common_test.py` — `compute_bpb`: hand-computed value, zero-weight (prompt) masking, **weight-magnitude invariance (0/1 vs mean-reduction)**, UTF-8 byte counting, special-token handling, batch aggregation, zero-byte → `nan`, contiguous-run splitting.
- `recipes/chat_sl/sweep/analyze_test.py` — table generation with/without BPB and the mixed-grid em-dash case.
- Verified end-to-end against a real `gpt2` tokenizer: `_weighted_target_byte_count` reconstructs the exact raw-text byte length, and BPB is invariant to mean-reduction weights.
- `uv run --extra dev pytest tinker_cookbook/supervised/common_test.py tinker_cookbook/recipes/chat_sl/sweep/analyze_test.py` → **21 passed**; `ruff check` / `ruff format --check` clean; `pyright` **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019F6rpcmF91w8f8LUnVBcRk