### PR TITLE
BPB: exclude special tokens from both numerator and denominator

### DIFF
--- a/tinker_cookbook/supervised/common.py
+++ b/tinker_cookbook/supervised/common.py
@@ -1,6 +1,5 @@
 import logging
 import math
-from collections.abc import Sequence
 from typing import Literal
 
 import tinker
@@ -48,33 +47,28 @@ def compute_mean_nll(
     return float(-total_weighted_logprobs / total_weights)
 
 
-def _weighted_target_byte_count(
-    target_tokens: Sequence[float], weights: Sequence[float], tokenizer: Tokenizer
-) -> int:
-    """UTF-8 byte count of the text formed by the loss-weighted target tokens.
+def _counted_byte_count(token_ids: list[int], counted: list[bool], tokenizer: Tokenizer) -> int:
+    """UTF-8 byte count of the ``counted`` tokens, decoded per contiguous run.
 
-    Each contiguous run of nonzero-weight tokens is decoded separately so that
-    weight-0 spans between trained regions (e.g. user turns in a multi-turn
-    conversation) do not get merged across the gap. Special tokens are skipped
-    so the count reflects natural-language bytes, which keeps the denominator
-    comparable across tokenizers with different control-token strings.
+    ``counted[i]`` marks whether ``token_ids[i]`` contributes to BPB (i.e. it is
+    trained and not a special token). Contiguous runs of counted tokens are
+    decoded separately so that gaps (untrained or special tokens) don't merge
+    unrelated spans across the hole.
 
     Args:
-        target_tokens (Sequence[float]): Target token IDs
-            (``loss_fn_inputs["target_tokens"].data``, stored as floats and cast
-            back to ``int`` here).
-        weights (Sequence[float]): Per-token loss weights aligned with
-            ``target_tokens``.
+        token_ids (list[int]): Target token IDs.
+        counted (list[bool]): Per-token inclusion mask, aligned with
+            ``token_ids``.
         tokenizer (Tokenizer): Tokenizer used to decode tokens back to text.
 
     Returns:
-        int: Total number of UTF-8 bytes across all weighted spans.
+        int: Total number of UTF-8 bytes across all counted spans.
     """
     total_bytes = 0
     run: list[int] = []
-    for token, weight in zip(target_tokens, weights, strict=True):
-        if weight > 0:
-            run.append(int(token))
+    for token_id, is_counted in zip(token_ids, counted, strict=True):
+        if is_counted:
+            run.append(token_id)
         elif run:
             total_bytes += _decoded_byte_length(run, tokenizer)
             run = []
@@ -84,8 +78,13 @@ def _weighted_target_byte_count(
 
 
 def _decoded_byte_length(token_ids: list[int], tokenizer: Tokenizer) -> int:
-    """UTF-8 byte length of ``token_ids`` decoded to natural-language text."""
-    text = tokenizer.decode(token_ids, skip_special_tokens=True)
+    """UTF-8 byte length of ``token_ids`` decoded to text.
+
+    Decodes with ``skip_special_tokens=False``; the caller is responsible for
+    excluding special tokens beforehand so the numerator and denominator cover
+    the same span.
+    """
+    text = tokenizer.decode(token_ids, skip_special_tokens=False)
     if isinstance(text, list):
         # Some tokenizers can return a list of piece strings; join them.
         text = "".join(text)
@@ -107,16 +106,30 @@ def compute_bpb(
     removes this dependence by dividing the *total* log-loss (converted to bits)
     by the number of UTF-8 bytes of the target text::
 
-        bpb = -sum(logprob_i for i where weight_i > 0) / (ln(2) * total_target_bytes)
+        bpb = -sum(logprob_i for i in counted) / (ln(2) * bytes(counted tokens))
 
-    The numerator sums the raw per-token NLL over the loss-weighted tokens,
-    using the weights only as a ``> 0`` mask rather than as multipliers. This
-    keeps the total nats correct even when the weights are normalized per
-    example (``reduction="mean"``, the SFT default, where a datum's weights sum
-    to 1.0 instead of being 0/1). The denominator counts the UTF-8 bytes of
-    those same decoded tokens, which is fixed by the raw text rather than by the
-    tokenization. Because numerator and denominator cover the same span, the
-    ratio is a proper compression rate that can be compared across tokenizers.
+    A token is *counted* iff it is trained (``weight > 0``) and is not a special
+    token (per ``tokenizer.all_special_ids``). The same mask drives both the
+    numerator and the byte denominator, so they always cover the identical span.
+
+    Two properties matter:
+
+    * Weights are used only as a ``> 0`` mask, not as multipliers, so the total
+      nats stay correct even when weights are normalized per example
+      (``reduction="mean"``, the SFT default, where a datum's weights sum to 1.0
+      instead of being 0/1).
+    * Special / structural tokens (e.g. end-of-turn markers like ``<|im_end|>``
+      or ``<|eot_id|>``) are excluded from *both* sides. They carry no
+      natural-language bytes and their number varies by chat template, so
+      counting their NLL while dropping their bytes would bias BPB — worst for
+      short completions — and break comparability across templates.
+
+    The denominator counts the UTF-8 bytes of the decoded counted tokens, fixed
+    by the raw text rather than by the tokenization; combined with the matched
+    numerator this yields a proper compression rate comparable across
+    tokenizers. (If a tokenizer does not expose ``all_special_ids``, no tokens
+    are treated as special, but both sides still share the same mask and stay
+    consistent.)
 
     Args:
         logprobs_list (list[tinker.TensorData]): Per-token log-probabilities,
@@ -129,24 +142,26 @@ def compute_bpb(
         tokenizer (Tokenizer): Tokenizer used to decode target tokens to bytes.
 
     Returns:
-        float: Bits per byte, or ``nan`` if the weighted target has zero bytes.
+        float: Bits per byte, or ``nan`` if the counted target has zero bytes.
     """
+    special_ids = frozenset(getattr(tokenizer, "all_special_ids", None) or [])
     total_nll_nats = 0.0
     total_bytes = 0
 
     for logprobs, weights, target_tokens in zip(
         logprobs_list, weights_list, target_tokens_list, strict=True
     ):
-        logprobs_torch = logprobs.to_torch()
-        weights_torch = weights.to_torch()
-        # Sum the raw NLL over trained tokens, using the weights only as a mask.
-        # This matches the tokens counted in the byte denominator and stays
-        # correct under per-example weight normalization (reduction="mean").
-        mask = weights_torch > 0
-        total_nll_nats += float(-logprobs_torch[mask].sum())
-        total_bytes += _weighted_target_byte_count(
-            list(target_tokens.data), list(weights.data), tokenizer
-        )
+        token_ids = [int(t) for t in target_tokens.data]
+        # A token contributes iff it is trained (weight > 0) and not special.
+        # This single mask is used for both the numerator and the byte
+        # denominator, guaranteeing they cover the identical span.
+        counted = [
+            weight > 0 and token_id not in special_ids
+            for weight, token_id in zip(weights.data, token_ids, strict=True)
+        ]
+        mask = torch.tensor(counted, dtype=torch.bool)
+        total_nll_nats += float(-logprobs.to_torch()[mask].sum())
+        total_bytes += _counted_byte_count(token_ids, counted, tokenizer)
 
     if total_bytes == 0:
         logger.warning("No target bytes found for BPB computation")

--- a/tinker_cookbook/supervised/common_test.py
+++ b/tinker_cookbook/supervised/common_test.py
@@ -238,6 +238,20 @@ def test_compute_bpb_excludes_special_tokens_under_mean_reduction():
     assert math.isclose(bpb, expected, rel_tol=1e-6)
 
 
+def test_compute_bpb_multi_turn_excludes_specials_and_splits_runs():
+    """Special tokens between trained content runs (multi-turn) are excluded from
+    both sides, and each content run is byte-counted independently."""
+    tok = _fake_tokenizer({1: "ab", 2: "cd", 3: "ef", 99: "<|end|>"}, special_ids={99})
+    # layout: run1=[1,2]  <|end|>  run2=[3]  <|end|>   (all trained)
+    logprobs = _td([-1.0, -2.0, -8.0, -3.0, -8.0], "float32")  # big loss on both specials
+    weights = _td([1.0, 1.0, 1.0, 1.0, 1.0], "float32")
+    targets = _td([1, 2, 99, 3, 99], "int64")
+    bpb = compute_bpb([logprobs], [weights], [targets], tok)
+    # counted = tokens 1,2,3: nats = 1 + 2 + 3 = 6; bytes = "ab" + "cd" + "ef" = 6.
+    expected = 6.0 / (math.log(2) * 6)
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
 def test_compute_bpb_aggregates_across_batch():
     """Numerator and denominator sum over all datums in the batch."""
     tok = _fake_tokenizer({1: "ab", 2: "cde"})

--- a/tinker_cookbook/supervised/common_test.py
+++ b/tinker_cookbook/supervised/common_test.py
@@ -8,7 +8,7 @@ import tinker
 import torch
 
 from tinker_cookbook.supervised.common import (
-    _weighted_target_byte_count,
+    _counted_byte_count,
     compute_bpb,
     datum_from_model_input_weights,
 )
@@ -141,17 +141,18 @@ def test_invalid_reduction_raises():
 class _FakeTokenizer:
     """Minimal tokenizer stand-in mapping each token id to a fixed string.
 
-    ``decode`` concatenates the per-token strings and, when
-    ``skip_special_tokens=True``, drops ids in ``special_ids``.
+    Exposes ``all_special_ids`` (used by ``compute_bpb`` to exclude special
+    tokens from both numerator and denominator) and a ``decode`` that renders
+    the given ids to their strings.
     """
 
     def __init__(self, vocab: dict[int, str], special_ids: set[int] | None = None):
         self.vocab = vocab
-        self.special_ids = special_ids or set()
+        self.all_special_ids = list(special_ids or [])
 
     def decode(self, ids: list[int], skip_special_tokens: bool = False) -> str:
         return "".join(
-            self.vocab[i] for i in ids if not (skip_special_tokens and i in self.special_ids)
+            self.vocab[i] for i in ids if not (skip_special_tokens and i in self.all_special_ids)
         )
 
 
@@ -210,14 +211,30 @@ def test_compute_bpb_counts_utf8_bytes_not_chars():
     assert math.isclose(bpb, expected, rel_tol=1e-6)
 
 
-def test_compute_bpb_skips_special_tokens_in_byte_count():
-    """A scored end-of-turn token contributes to nats but not to the byte count."""
+def test_compute_bpb_excludes_special_tokens_from_both_sides():
+    """A trained end-of-turn special token is excluded from BOTH the numerator
+    and the byte denominator, so it does not bias BPB."""
     tok = _fake_tokenizer({1: "hi", 99: "<|end|>"}, special_ids={99})
-    logprobs = _td([-1.0, -1.0], "float32")
+    logprobs = _td([-1.0, -5.0], "float32")  # large loss on the special token
     weights = _td([1.0, 1.0], "float32")
     targets = _td([1, 99], "int64")
     bpb = compute_bpb([logprobs], [weights], [targets], tok)
-    expected = 2.0 / (math.log(2) * len("hi"))  # only "hi" counts toward bytes
+    # Only token 1 ("hi") counts: 1 nat over 2 bytes. The special token's -5.0
+    # nats are dropped along with its (zero) bytes.
+    expected = 1.0 / (math.log(2) * len("hi"))
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_excludes_special_tokens_under_mean_reduction():
+    """Both fixes together: special tokens excluded from both sides, and weights
+    treated as a mask (mean-reduction normalized weights)."""
+    tok = _fake_tokenizer({1: "ab", 2: "cd", 99: "<|end|>"}, special_ids={99})
+    logprobs = _td([-1.0, -3.0, -9.0], "float32")  # special token has huge loss
+    weights = _td([1 / 3, 1 / 3, 1 / 3], "float32")  # normalized over 3 trained tokens
+    targets = _td([1, 2, 99], "int64")
+    bpb = compute_bpb([logprobs], [weights], [targets], tok)
+    # Counted = tokens 1, 2 ("abcd"): nats = 1 + 3 = 4, bytes = 4.
+    expected = 4.0 / (math.log(2) * 4)
     assert math.isclose(bpb, expected, rel_tol=1e-6)
 
 
@@ -240,8 +257,8 @@ def test_compute_bpb_zero_bytes_returns_nan():
     assert math.isnan(compute_bpb([logprobs], [weights], [targets], tok))
 
 
-def test_weighted_target_byte_count_splits_runs():
-    """Runs separated by a zero-weight gap are decoded independently."""
+def test_counted_byte_count_splits_runs():
+    """Counted tokens separated by an uncounted gap are decoded independently."""
     tok = _fake_tokenizer({1: "ab", 2: "GAP", 3: "cde"})
-    n = _weighted_target_byte_count([1, 2, 3], [1.0, 0.0, 1.0], tok)
-    assert n == len("ab") + len("cde")  # 2 + 3; the "GAP" token is excluded
+    n = _counted_byte_count([1, 2, 3], [True, False, True], tok)
+    assert n == len("ab") + len("cde")  # 2 + 3; the middle token is excluded


### PR DESCRIPTION
Follow-up to #823 (review feedback from @-team's bot).

## Problem

`compute_bpb`'s numerator summed NLL over *every* trained token, including end-of-turn markers like `<|im_end|>` / `<|eot_id|>` that renderers put in the trainable output. But the byte denominator decoded with `skip_special_tokens=True`, so those tokens' bytes were **excluded**.

Confirmed with a real `Qwen2.5` tokenizer: `<|im_end|>` is in `all_special_ids`, and `decode([im_end], skip_special_tokens=True)` → `''` (0 bytes). So a trained end-of-turn token contributed its NLL to the numerator but 0 bytes to the denominator — biasing BPB upward, worst for short completions, and by an amount that varies with the chat template (Qwen `<|im_end|>` vs Llama `<|eot_id|>` vs …), which defeats the cross-tokenizer comparability BPB exists to provide.

## Fix

Compute one per-token **`counted` mask** — trained (`weight > 0`) **and** not in `tokenizer.all_special_ids` — and use the *same* mask for both the numerator sum and the byte count, so they always cover the identical span. `_decoded_byte_length` now decodes with `skip_special_tokens=False` since the caller pre-filters. If a tokenizer doesn't expose `all_special_ids`, nothing is excluded but both sides still share the mask and stay consistent.

```
bpb = -sum(logprob_i for i in counted) / (ln(2) * bytes(counted tokens))
```

## Verification

Real Qwen2.5 tokenizer, a short `"Hello!"` + trained `<|im_end|>` completion (mean-reduction weights):
- **Fixed:** BPB = `0.3366` (im_end excluded from both sides).
- Previously-biased code would have returned `1.7793` — a >5× inflation, driven entirely by the special token.

## Test

- `_weighted_target_byte_count` → `_counted_byte_count` (mask-based).
- The special-token test now asserts exclusion from **both** numerator and denominator (with a large loss on the special token to make the difference explicit).
- Added a combined special-token **+** mean-reduction test.
- `pytest tinker_cookbook/supervised/common_test.py` → **19 passed**; `ruff` clean; `pyright` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019F6rpcmF91w8f8LUnVBcRk