### PR TITLE
BPB: use renderer-reported content bytes as the denominator

### DIFF
--- a/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
+++ b/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
@@ -11,7 +11,7 @@ Use these as a reference when choosing learning rate and LoRA rank for your mode
 
 > **Note:** Wall times are approximate and depend on server load at the time of the run. They may fluctuate significantly between runs.
 
-> **Comparing across models:** `Test NLL` / `Train NLL` are *per-token* cross-entropy and are **not comparable across models with different tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` (bits per byte) normalize by the target text's UTF-8 byte count instead of the token count and *are* comparable across tokenizers. (These tables predate the BPB metric, so the columns are not yet shown; they will appear when the sweep is re-run and this doc is regenerated.)
+> **Comparing across models:** `Test NLL` / `Train NLL` are *per-token* cross-entropy and are **not comparable across models with different tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` (bits per byte) normalize by the UTF-8 byte count of the trained message content instead of the token count — chat-template scaffolding is never counted as bytes — and *are* comparable across tokenizers and chat templates. (These tables predate the BPB metric, so the columns are not yet shown; they will appear when the sweep is re-run and this doc is regenerated.)
 
 ## Key Findings
 

--- a/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
+++ b/tinker_cookbook/recipes/chat_sl/results/sft_sweep.md
@@ -11,7 +11,7 @@ Use these as a reference when choosing learning rate and LoRA rank for your mode
 
 > **Note:** Wall times are approximate and depend on server load at the time of the run. They may fluctuate significantly between runs.
 
-> **Comparing across models:** `Test NLL` / `Train NLL` are *per-token* cross-entropy and are **not comparable across models with different tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` (bits per byte) normalize by the UTF-8 byte count of the trained message content instead of the token count — chat-template scaffolding is never counted as bytes — and *are* comparable across tokenizers and chat templates. (These tables predate the BPB metric, so the columns are not yet shown; they will appear when the sweep is re-run and this doc is regenerated.)
+> **Comparing across models:** `Test NLL` / `Train NLL` are *per-token* cross-entropy and are **not comparable across models with different tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` (bits per byte) normalize by the UTF-8 byte count of the trained message content instead of the token count, making them comparable across tokenizers and chat templates (chat-template scaffolding is not counted; see the sweep README for caveats on thinking-in-history and truncated or custom-renderer datums). (These tables predate the BPB metric, so the columns are not yet shown; they will appear when the sweep is re-run and this doc is regenerated.)
 
 ## Key Findings
 

--- a/tinker_cookbook/recipes/chat_sl/sweep/README.md
+++ b/tinker_cookbook/recipes/chat_sl/sweep/README.md
@@ -52,11 +52,18 @@ a coarser tokenizer packs more text into each token (higher nats/token) while a
 finer one spreads it over more (lower nats/token). Training also logs
 `train_mean_bpb` / `test/bpb` (bits per byte), which divide the total log-loss by
 the number of UTF-8 bytes of the *semantic content* of the trained messages
-(message text, preserved thinking, tool-call names/arguments) instead of by the
+(message text, rendered thinking, tool-call names/arguments) instead of by the
 token count. Chat-template scaffolding — think tags, role markers, end-of-turn
-tokens — is never counted as bytes, so a verbose template gains no artificial
-BPB advantage, and the denominator is identical across renderers for the same
-data. That makes BPB comparable across tokenizers *and* chat templates.
+tokens — is not counted as bytes, so a verbose template gains no artificial BPB
+advantage: the denominator depends on *what* content a renderer trains on, not
+on how its template formats it. That makes BPB comparable across tokenizers and
+chat templates, with two caveats. Renderers that legitimately train on
+different content count different bytes — e.g. gpt-oss preserves (and counts)
+thinking in historical assistant turns that Qwen3/Kimi renderers strip — so
+cross-model comparisons are cleanest on data without thinking in historical
+turns. And datums without renderer-reported content bytes (custom renderers
+that override only `build_supervised_example`, or examples whose trained span
+was cut by `max_length`) fall back to the previous token-byte computation.
 Sweeping over models? Select on bits per byte:
 
 ```bash

--- a/tinker_cookbook/recipes/chat_sl/sweep/README.md
+++ b/tinker_cookbook/recipes/chat_sl/sweep/README.md
@@ -51,9 +51,13 @@ cross-entropy, which is not comparable across models with different tokenizers �
 a coarser tokenizer packs more text into each token (higher nats/token) while a
 finer one spreads it over more (lower nats/token). Training also logs
 `train_mean_bpb` / `test/bpb` (bits per byte), which divide the total log-loss by
-the number of UTF-8 bytes of the target text instead of by the token count, so
-they *are* comparable across tokenizers. Sweeping over models? Select on bits per
-byte:
+the number of UTF-8 bytes of the *semantic content* of the trained messages
+(message text, preserved thinking, tool-call names/arguments) instead of by the
+token count. Chat-template scaffolding — think tags, role markers, end-of-turn
+tokens — is never counted as bytes, so a verbose template gains no artificial
+BPB advantage, and the denominator is identical across renderers for the same
+data. That makes BPB comparable across tokenizers *and* chat templates.
+Sweeping over models? Select on bits per byte:
 
 ```bash
 python -m tinker_cookbook.recipes.chat_sl.sweep \

--- a/tinker_cookbook/recipes/chat_sl/sweep/analyze.py
+++ b/tinker_cookbook/recipes/chat_sl/sweep/analyze.py
@@ -575,8 +575,10 @@ def generate_sft_sweep_md(
         "cross-entropy and are **not comparable across models with different "
         "tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer "
         "one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` "
-        "(bits per byte) normalize by the target text's UTF-8 byte count instead of "
-        "the token count and *are* comparable across tokenizers."
+        "(bits per byte) normalize by the UTF-8 byte count of the trained message "
+        "content instead of the token count — chat-template scaffolding is never "
+        "counted as bytes — and *are* comparable across tokenizers and chat "
+        "templates."
     )
     lines.append("")
 

--- a/tinker_cookbook/recipes/chat_sl/sweep/analyze.py
+++ b/tinker_cookbook/recipes/chat_sl/sweep/analyze.py
@@ -576,9 +576,10 @@ def generate_sft_sweep_md(
         "tokenizers** (a coarser tokenizer has fewer, higher-loss tokens; a finer "
         "one has more, lower-loss tokens). Where present, `Test BPB` / `Train BPB` "
         "(bits per byte) normalize by the UTF-8 byte count of the trained message "
-        "content instead of the token count — chat-template scaffolding is never "
-        "counted as bytes — and *are* comparable across tokenizers and chat "
-        "templates."
+        "content instead of the token count, making them comparable across "
+        "tokenizers and chat templates (chat-template scaffolding is not counted; "
+        "see the sweep README for caveats on thinking-in-history and truncated or "
+        "custom-renderer datums)."
     )
     lines.append("")
 

--- a/tinker_cookbook/recipes/sl_loop.py
+++ b/tinker_cookbook/recipes/sl_loop.py
@@ -145,7 +145,14 @@ def main(config: Config):
         train_target_tokens = [d.loss_fn_inputs["target_tokens"] for d in batch]
         train_nll = compute_mean_nll(train_logprobs, train_weights)
         # Bits per byte: a tokenizer-independent counterpart to train_mean_nll.
-        train_bpb = compute_bpb(train_logprobs, train_weights, train_target_tokens, tokenizer)
+        train_content_bytes = [getattr(d, "trained_content_bytes", None) for d in batch]
+        train_bpb = compute_bpb(
+            train_logprobs,
+            train_weights,
+            train_target_tokens,
+            tokenizer,
+            content_bytes_list=train_content_bytes,
+        )
 
         # Log metrics
         metrics.update(

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -27,6 +27,7 @@ from tinker_cookbook.renderers.base import (
     StreamingMessageHeader,
     StreamingTextDelta,
     StreamingThinkingDelta,
+    SupervisedExample,
     TextPart,
     ThinkingPart,
     ToolCall,
@@ -37,6 +38,7 @@ from tinker_cookbook.renderers.base import (
     ensure_text,
     format_content_as_string,
     get_text_content,
+    message_content_byte_count,
     parse_content_blocks,
 )
 from tinker_cookbook.tokenizer_utils import Tokenizer
@@ -303,11 +305,13 @@ __all__ = [
     # Renderer base
     "RenderContext",
     "Renderer",
+    "SupervisedExample",
     "TrainOnWhat",
     # Utility functions
     "ensure_text",
     "format_content_as_string",
     "get_text_content",
+    "message_content_byte_count",
     "parse_content_blocks",
     # Registry
     "register_renderer",

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -22,6 +22,7 @@ from typing import (
     Protocol,
     TypedDict,
     Union,
+    final,
 )
 
 import pydantic
@@ -1222,6 +1223,19 @@ class TrainOnWhat(StrEnum):
     CUSTOMIZED = "customized"
 
 
+def _mro_definer_index(cls: type, method_name: str) -> int:
+    """Index in ``cls.__mro__`` of the class that provides ``method_name``.
+
+    Used to decide, per class, whether a legacy ``build_supervised_example``
+    override or a ``_build_supervised_example_impl`` override is more derived
+    (a smaller index wins the dispatch).
+    """
+    for index, klass in enumerate(cls.__mro__):
+        if method_name in vars(klass):
+            return index
+    raise AttributeError(f"{cls.__name__} has no method {method_name!r}")
+
+
 def _unpickle_renderer(
     renderer_name: str, model_name: str, has_image_processor: bool
 ) -> "Renderer":
@@ -1650,9 +1664,9 @@ class Renderer(ABC):
         Build tokens and per-token weights for supervised fine-tuning.
 
         This default implementation concatenates rendered messages in order. Override
-        :meth:`build_supervised_example_with_metadata` if your build_generation_prompt
-        does anything that breaks the simple concatenation assumption—for example, if
-        it strips thinking blocks from history (like Qwen3Renderer), injects default
+        :meth:`_build_supervised_example_impl` if your build_generation_prompt does
+        anything that breaks the simple concatenation assumption—for example, if it
+        strips thinking blocks from history (like Qwen3Renderer), injects default
         system prompts (like KimiK2Renderer), or otherwise modifies the token sequence.
         (Overriding this method still works and is supported for backward
         compatibility, but such renderers won't report content bytes for the
@@ -1678,17 +1692,13 @@ class Renderer(ABC):
                 tuple where weights is a 1-D float tensor with the same length
                 as the total number of tokens.
         """
-        if (
-            type(self).build_supervised_example_with_metadata
-            is not Renderer.build_supervised_example_with_metadata
-        ):
-            example = self.build_supervised_example_with_metadata(
-                messages, train_on_what=train_on_what
-            )
-            return example.model_input, example.weights
+        # Calling the impl chain directly (rather than the metadata dispatcher)
+        # makes super().build_supervised_example() from a legacy override run
+        # the parent's implementation, exactly as before this method existed.
         example = self._build_supervised_example_impl(messages, train_on_what)
         return example.model_input, example.weights
 
+    @final
     def build_supervised_example_with_metadata(
         self,
         messages: list[Message],
@@ -1700,8 +1710,15 @@ class Renderer(ABC):
         Same tokens and weights as :meth:`build_supervised_example`, plus
         ``trained_content_bytes``: the UTF-8 byte count of the semantic content
         of the loss-weighted messages, used as the bits-per-byte denominator.
-        Renderers that customize supervised-example construction should
-        override this method rather than :meth:`build_supervised_example`.
+
+        This method is a final dispatcher; renderers customize supervised
+        example construction by overriding :meth:`_build_supervised_example_impl`
+        (or, for pre-existing code, :meth:`build_supervised_example`). When a
+        subclass overrides ``build_supervised_example`` at a point in the MRO
+        more derived than any ``_build_supervised_example_impl`` override, that
+        legacy override is honored -- its tokens and weights are returned with
+        ``trained_content_bytes=None`` -- so this method always agrees with
+        :meth:`build_supervised_example` about the tokens.
 
         Args:
             messages (list[Message]): A list of messages to render.
@@ -1710,12 +1727,16 @@ class Renderer(ABC):
 
         Returns:
             SupervisedExample: The tokenized example with per-token weights and
-                ``trained_content_bytes`` (``None`` if this renderer does not
-                report content bytes).
+                ``trained_content_bytes`` (``None`` if the resolved
+                implementation does not report content bytes).
         """
-        if type(self).build_supervised_example is not Renderer.build_supervised_example:
-            # Subclass predates this method and overrides build_supervised_example
-            # only: use its tokens/weights and skip content-byte accounting.
+        cls = type(self)
+        legacy_index = _mro_definer_index(cls, "build_supervised_example")
+        impl_index = _mro_definer_index(cls, "_build_supervised_example_impl")
+        if cls.__mro__[legacy_index] is not Renderer and legacy_index < impl_index:
+            # A legacy build_supervised_example override is more derived than
+            # any impl override: honor it so both entry points return the same
+            # tokens. Content bytes are unavailable on that path.
             model_input, weights = self.build_supervised_example(
                 messages, train_on_what=train_on_what
             )
@@ -1727,7 +1748,15 @@ class Renderer(ABC):
         messages: list[Message],
         train_on_what: TrainOnWhat,
     ) -> SupervisedExample:
-        """Default supervised-example construction shared by the two public entry points."""
+        """Supervised-example construction shared by the two public entry points.
+
+        This is the single override point for renderers that customize
+        supervised example construction (like the protected rendering hooks,
+        e.g. ``_render_tool_calls``): both :meth:`build_supervised_example`
+        and :meth:`build_supervised_example_with_metadata` route here, so an
+        override automatically keeps the two public entry points consistent
+        and reports content bytes for the bits-per-byte metric.
+        """
         # Warn if training on multiple assistant messages with a renderer that doesn't
         # satisfy the extension property. In that case, each assistant message sees a
         # different context prefix, so they should be trained as separate examples.

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1069,6 +1069,56 @@ def _tool_call_payload(tool_call: ToolCall) -> dict[str, object]:
     }
 
 
+def message_content_byte_count(
+    message: Message,
+    *,
+    include_thinking: bool = True,
+    include_tool_calls: bool = True,
+) -> int:
+    """UTF-8 byte count of the semantic content of a message.
+
+    Counts the payload that survives round-tripping through ``parse_response``:
+    text parts, thinking parts (when ``include_thinking`` is True), and
+    tool-call function names and arguments (when ``include_tool_calls`` is
+    True). Everything a renderer injects *around* that payload -- role headers,
+    think tags, tool-call framing, end-of-turn markers -- is excluded, so the
+    count is identical no matter which renderer formats the message. Image
+    parts contribute zero bytes.
+
+    Renderers use this to report ``RenderedMessage.content_byte_count``, which
+    feeds the bits-per-byte (BPB) denominator. Callers must pass flags that
+    match what the renderer actually rendered (e.g. ``include_thinking=False``
+    for a historical message whose thinking was stripped), so the count covers
+    exactly the content present in the output tokens.
+
+    Args:
+        message (Message): The message to measure.
+        include_thinking (bool): Count ThinkingPart payloads. Set False when
+            the renderer strips thinking from this message.
+        include_tool_calls (bool): Count tool-call function names and argument
+            strings. Set False for renderers that do not render tool calls.
+
+    Returns:
+        int: Total UTF-8 bytes of the counted content.
+    """
+    total = 0
+    content = message["content"]
+    if isinstance(content, str):
+        total += len(content.encode("utf-8"))
+    else:
+        for part in content:
+            if part["type"] == "text":
+                total += len(part["text"].encode("utf-8"))
+            elif part["type"] == "thinking" and include_thinking:
+                total += len(part["thinking"].encode("utf-8"))
+            # Image parts contribute zero bytes.
+    if include_tool_calls:
+        for tool_call in message.get("tool_calls") or []:
+            total += len(tool_call.function.name.encode("utf-8"))
+            total += len(tool_call.function.arguments.encode("utf-8"))
+    return total
+
+
 @dataclass(frozen=True)
 class RenderedMessage:
     """
@@ -1112,6 +1162,41 @@ class RenderedMessage:
 
     stop_overlap: tinker.EncodedTextChunk | None = None
     """Tokens that overlap between stop sequence and next message's header."""
+
+    content_byte_count: int | None = None
+    """UTF-8 bytes of the semantic content rendered into ``output``.
+
+    Counts only the message payload (text, rendered thinking, tool-call names
+    and arguments) -- not renderer-injected scaffolding such as think tags,
+    tool-call framing, or end-of-turn markers. Computed with
+    :func:`message_content_byte_count` using flags that match what was actually
+    rendered. ``None`` means the renderer does not report content bytes; the
+    bits-per-byte metric then falls back to token-based byte counting.
+    """
+
+
+@dataclass(frozen=True)
+class SupervisedExample:
+    """A supervised training example plus rendering metadata.
+
+    Returned by :meth:`Renderer.build_supervised_example_with_metadata`. The
+    ``model_input``/``weights`` pair is identical to what
+    :meth:`Renderer.build_supervised_example` returns.
+
+    Attributes:
+        model_input: Full token sequence for the conversation.
+        weights: Per-token loss weights aligned with ``model_input``.
+        trained_content_bytes: Total UTF-8 bytes of the semantic content of the
+            messages that received loss weight (see
+            :func:`message_content_byte_count`). Excludes renderer scaffolding,
+            so it is comparable across renderers/tokenizers and serves as the
+            bits-per-byte denominator. ``None`` when the renderer does not
+            report content bytes.
+    """
+
+    model_input: tinker.ModelInput
+    weights: torch.Tensor
+    trained_content_bytes: int | None = None
 
 
 class TrainOnWhat(StrEnum):
@@ -1565,10 +1650,13 @@ class Renderer(ABC):
         Build tokens and per-token weights for supervised fine-tuning.
 
         This default implementation concatenates rendered messages in order. Override
-        this method if your build_generation_prompt does anything that breaks the simple
-        concatenation assumption—for example, if it strips thinking blocks from history
-        (like Qwen3Renderer), injects default system prompts (like KimiK2Renderer), or
-        otherwise modifies the token sequence.
+        :meth:`build_supervised_example_with_metadata` if your build_generation_prompt
+        does anything that breaks the simple concatenation assumption—for example, if
+        it strips thinking blocks from history (like Qwen3Renderer), injects default
+        system prompts (like KimiK2Renderer), or otherwise modifies the token sequence.
+        (Overriding this method still works and is supported for backward
+        compatibility, but such renderers won't report content bytes for the
+        bits-per-byte metric.)
 
         The supervised example tokens should match what build_generation_prompt would
         produce for the same conversation prefix, so the model trains on the same
@@ -1590,6 +1678,56 @@ class Renderer(ABC):
                 tuple where weights is a 1-D float tensor with the same length
                 as the total number of tokens.
         """
+        if (
+            type(self).build_supervised_example_with_metadata
+            is not Renderer.build_supervised_example_with_metadata
+        ):
+            example = self.build_supervised_example_with_metadata(
+                messages, train_on_what=train_on_what
+            )
+            return example.model_input, example.weights
+        example = self._build_supervised_example_impl(messages, train_on_what)
+        return example.model_input, example.weights
+
+    def build_supervised_example_with_metadata(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ) -> SupervisedExample:
+        """
+        Build a supervised example plus rendering metadata.
+
+        Same tokens and weights as :meth:`build_supervised_example`, plus
+        ``trained_content_bytes``: the UTF-8 byte count of the semantic content
+        of the loss-weighted messages, used as the bits-per-byte denominator.
+        Renderers that customize supervised-example construction should
+        override this method rather than :meth:`build_supervised_example`.
+
+        Args:
+            messages (list[Message]): A list of messages to render.
+            train_on_what (TrainOnWhat): Controls which tokens receive non-zero
+                training weight. See :meth:`build_supervised_example`.
+
+        Returns:
+            SupervisedExample: The tokenized example with per-token weights and
+                ``trained_content_bytes`` (``None`` if this renderer does not
+                report content bytes).
+        """
+        if type(self).build_supervised_example is not Renderer.build_supervised_example:
+            # Subclass predates this method and overrides build_supervised_example
+            # only: use its tokens/weights and skip content-byte accounting.
+            model_input, weights = self.build_supervised_example(
+                messages, train_on_what=train_on_what
+            )
+            return SupervisedExample(model_input, weights, None)
+        return self._build_supervised_example_impl(messages, train_on_what)
+
+    def _build_supervised_example_impl(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat,
+    ) -> SupervisedExample:
+        """Default supervised-example construction shared by the two public entry points."""
         # Warn if training on multiple assistant messages with a renderer that doesn't
         # satisfy the extension property. In that case, each assistant message sees a
         # different context prefix, so they should be trained as separate examples.
@@ -1608,6 +1746,7 @@ class Renderer(ABC):
             )
 
         model_input_chunks_weights: list[tuple[tinker.types.ModelInputChunk, float]] = []
+        trained_content_bytes: int | None = 0
         if self._bos_tokens:
             model_input_chunks_weights.append(
                 (tinker.types.EncodedTextChunk(tokens=self._bos_tokens), 0.0)
@@ -1667,6 +1806,14 @@ class Renderer(ABC):
                 case _:
                     raise RendererError(f"Unknown train_on_what: {train_on_what}")
 
+            if output_has_weight:
+                if rendered_message.content_byte_count is None:
+                    # A trained message without content accounting invalidates
+                    # the total for the whole example.
+                    trained_content_bytes = None
+                elif trained_content_bytes is not None:
+                    trained_content_bytes += rendered_message.content_byte_count
+
             model_input_chunks_weights += [
                 (output_part, int(output_has_weight)) for output_part in output_parts if output_part
             ]
@@ -1680,7 +1827,9 @@ class Renderer(ABC):
         weights_tensor = torch.tensor(weights_data)
 
         model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        return SupervisedExample(
+            tinker.ModelInput(chunks=model_input_chunks), weights_tensor, trained_content_bytes
+        )
 
 
 def tokens_weights_from_strings_weights(

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1082,9 +1082,11 @@ def message_content_byte_count(
     text parts, thinking parts (when ``include_thinking`` is True), and
     tool-call function names and arguments (when ``include_tool_calls`` is
     True). Everything a renderer injects *around* that payload -- role headers,
-    think tags, tool-call framing, end-of-turn markers -- is excluded, so the
-    count is identical no matter which renderer formats the message. Image
-    parts contribute zero bytes.
+    think tags, tool-call framing, end-of-turn markers -- is excluded, so for
+    the same flags the count does not depend on how a renderer formats the
+    message. (Renderers may still legitimately differ in *what* they render --
+    e.g. whether thinking is preserved in historical turns -- and pass
+    different flags accordingly.) Image parts contribute zero bytes.
 
     Renderers use this to report ``RenderedMessage.content_byte_count``, which
     feeds the bits-per-byte (BPB) denominator. Callers must pass flags that
@@ -1189,10 +1191,11 @@ class SupervisedExample:
         weights: Per-token loss weights aligned with ``model_input``.
         trained_content_bytes: Total UTF-8 bytes of the semantic content of the
             messages that received loss weight (see
-            :func:`message_content_byte_count`). Excludes renderer scaffolding,
-            so it is comparable across renderers/tokenizers and serves as the
-            bits-per-byte denominator. ``None`` when the renderer does not
-            report content bytes.
+            :func:`message_content_byte_count`). Excludes renderer scaffolding:
+            it reflects what content the renderer trains on, independent of how
+            the template formats it, and serves as the bits-per-byte
+            denominator. ``None`` when the renderer does not report content
+            bytes.
     """
 
     model_input: tinker.ModelInput
@@ -1221,19 +1224,6 @@ class TrainOnWhat(StrEnum):
     ALL_TOKENS = "all_tokens"
     ALL_USER_AND_SYSTEM_MESSAGES = "all_user_and_system_messages"
     CUSTOMIZED = "customized"
-
-
-def _mro_definer_index(cls: type, method_name: str) -> int:
-    """Index in ``cls.__mro__`` of the class that provides ``method_name``.
-
-    Used to decide, per class, whether a legacy ``build_supervised_example``
-    override or a ``_build_supervised_example_impl`` override is more derived
-    (a smaller index wins the dispatch).
-    """
-    for index, klass in enumerate(cls.__mro__):
-        if method_name in vars(klass):
-            return index
-    raise AttributeError(f"{cls.__name__} has no method {method_name!r}")
 
 
 def _unpickle_renderer(
@@ -1713,12 +1703,16 @@ class Renderer(ABC):
 
         This method is a final dispatcher; renderers customize supervised
         example construction by overriding :meth:`_build_supervised_example_impl`
-        (or, for pre-existing code, :meth:`build_supervised_example`). When a
-        subclass overrides ``build_supervised_example`` at a point in the MRO
-        more derived than any ``_build_supervised_example_impl`` override, that
-        legacy override is honored -- its tokens and weights are returned with
-        ``trained_content_bytes=None`` -- so this method always agrees with
-        :meth:`build_supervised_example` about the tokens.
+        (or, for pre-existing code, :meth:`build_supervised_example`). Whenever
+        *any* class in the MRO overrides ``build_supervised_example``, that
+        override is what a direct call to :meth:`build_supervised_example`
+        resolves to, so it is honored here too -- its tokens and weights are
+        returned with ``trained_content_bytes=None`` (the override may transform
+        messages in ways the content accounting cannot see). This guarantees the
+        two entry points always agree about the tokens: legacy overrides that
+        call ``super().build_supervised_example()`` still reach the most-derived
+        ``_build_supervised_example_impl`` through :meth:`build_supervised_example`,
+        so impl overrides participate on both paths.
 
         Args:
             messages (list[Message]): A list of messages to render.
@@ -1730,13 +1724,11 @@ class Renderer(ABC):
                 ``trained_content_bytes`` (``None`` if the resolved
                 implementation does not report content bytes).
         """
-        cls = type(self)
-        legacy_index = _mro_definer_index(cls, "build_supervised_example")
-        impl_index = _mro_definer_index(cls, "_build_supervised_example_impl")
-        if cls.__mro__[legacy_index] is not Renderer and legacy_index < impl_index:
-            # A legacy build_supervised_example override is more derived than
-            # any impl override: honor it so both entry points return the same
-            # tokens. Content bytes are unavailable on that path.
+        if type(self).build_supervised_example is not Renderer.build_supervised_example:
+            # Some class overrides the legacy method, so a direct
+            # build_supervised_example() call would run that override. Route
+            # through it so both entry points return identical tokens. Content
+            # bytes are unavailable on that path.
             model_input, weights = self.build_supervised_example(
                 messages, train_on_what=train_on_what
             )

--- a/tinker_cookbook/renderers/content_bytes_test.py
+++ b/tinker_cookbook/renderers/content_bytes_test.py
@@ -1,0 +1,189 @@
+"""Tests for renderer content-byte reporting (bits-per-byte denominator).
+
+``build_supervised_example_with_metadata`` reports the UTF-8 byte count of the
+semantic content of loss-weighted messages. The count must exclude everything
+the renderer injects (think tags, role headers, tool framing, end-of-turn
+markers) and must be identical across renderers for the same messages -- that
+is what makes the BPB metric comparable across models.
+"""
+
+import functools
+
+import pytest
+import tinker
+import torch
+
+from tinker_cookbook.renderers import (
+    Message,
+    Renderer,
+    TextPart,
+    ThinkingPart,
+    TrainOnWhat,
+    get_renderer,
+)
+from tinker_cookbook.renderers.base import message_content_byte_count
+from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+
+@functools.cache
+def _qwen3_tokenizer():
+    return get_tokenizer("Qwen/Qwen3-8B")
+
+
+@functools.cache
+def _kimi_tokenizer():
+    return get_tokenizer("moonshotai/Kimi-K2-Instruct")
+
+
+USER_TEXT = "What is 2+2?"
+RESPONSE_TEXT = "2+2 equals 4."
+RESPONSE_BYTES = len(RESPONSE_TEXT.encode("utf-8"))
+
+
+def _simple_convo() -> list[Message]:
+    return [
+        Message(role="user", content=USER_TEXT),
+        Message(role="assistant", content=RESPONSE_TEXT),
+    ]
+
+
+def test_message_content_byte_count_text_and_thinking():
+    message = Message(
+        role="assistant",
+        content=[
+            ThinkingPart(type="thinking", thinking="chain"),
+            TextPart(type="text", text="répond"),
+        ],
+    )
+    assert message_content_byte_count(message) == len(b"chain") + len("répond".encode())
+    assert message_content_byte_count(message, include_thinking=False) == len("répond".encode())
+
+
+def test_qwen3_simple_conversation_counts_response_bytes():
+    renderer = get_renderer("qwen3", _qwen3_tokenizer())
+    example = renderer.build_supervised_example_with_metadata(
+        _simple_convo(), train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN
+    )
+    assert example.trained_content_bytes == RESPONSE_BYTES
+
+
+def test_kimi_k2_excludes_think_scaffolding_but_trains_on_it():
+    """Kimi injects <think></think> into the trained assistant body. Those
+    tokens carry loss weight, yet they must not count as content bytes."""
+    tokenizer = _kimi_tokenizer()
+    renderer = get_renderer("kimi_k2", tokenizer)
+    example = renderer.build_supervised_example_with_metadata(
+        _simple_convo(), train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN
+    )
+    tokens = example.model_input.to_ints()
+    trained = [t for t, w in zip(tokens, example.weights.tolist()) if w > 0]
+    trained_text = tokenizer.decode(trained, skip_special_tokens=False)
+    assert "<think></think>" in trained_text  # scaffolding IS trained...
+    assert example.trained_content_bytes == RESPONSE_BYTES  # ...but not counted
+
+
+def test_kimi_k2_and_qwen3_agree_on_content_bytes():
+    """The whole point: the denominator is renderer-independent."""
+    kimi = get_renderer("kimi_k2", _kimi_tokenizer())
+    qwen = get_renderer("qwen3", _qwen3_tokenizer())
+    convo = _simple_convo()
+    kimi_bytes = kimi.build_supervised_example_with_metadata(convo).trained_content_bytes
+    qwen_bytes = qwen.build_supervised_example_with_metadata(convo).trained_content_bytes
+    assert kimi_bytes == qwen_bytes == RESPONSE_BYTES
+
+
+@pytest.mark.parametrize("renderer_name", ["qwen3", "kimi_k2"])
+def test_thinking_counted_only_where_rendered(renderer_name: str):
+    """Thinking bytes count for the last assistant message (where thinking is
+    preserved) but not for historical ones (where it is stripped)."""
+    tokenizer = _kimi_tokenizer() if renderer_name == "kimi_k2" else _qwen3_tokenizer()
+    renderer = get_renderer(renderer_name, tokenizer)
+    thinking = "Let me think about this carefully."
+    convo_with_thinking = [
+        Message(role="user", content=USER_TEXT),
+        Message(
+            role="assistant",
+            content=[
+                ThinkingPart(type="thinking", thinking=thinking),
+                TextPart(type="text", text=RESPONSE_TEXT),
+            ],
+        ),
+    ]
+    # Last assistant message: thinking preserved and counted.
+    example = renderer.build_supervised_example_with_metadata(
+        convo_with_thinking, train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN
+    )
+    assert example.trained_content_bytes == len(thinking.encode()) + RESPONSE_BYTES
+
+    # Same assistant message in history: thinking stripped, only text counted.
+    # (The final assistant message contributes its own RESPONSE_BYTES.)
+    convo_multi = convo_with_thinking + [
+        Message(role="user", content="And 3+3?"),
+        Message(role="assistant", content=RESPONSE_TEXT),
+    ]
+    example_multi = renderer.build_supervised_example_with_metadata(
+        convo_multi, train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES
+    )
+    assert example_multi.trained_content_bytes == 2 * RESPONSE_BYTES
+
+
+def test_untrained_messages_contribute_no_content_bytes():
+    renderer = get_renderer("qwen3", _qwen3_tokenizer())
+    convo = [
+        Message(role="user", content="A" * 1000),
+        Message(role="assistant", content=RESPONSE_TEXT),
+    ]
+    example = renderer.build_supervised_example_with_metadata(
+        convo, train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN
+    )
+    assert example.trained_content_bytes == RESPONSE_BYTES
+
+
+def test_role_colon_counts_content_without_separators():
+    renderer = get_renderer("role_colon", _qwen3_tokenizer())
+    example = renderer.build_supervised_example_with_metadata(
+        _simple_convo(), train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN
+    )
+    # The " " prefix, "\n\n" suffix, and "User:" stop-overlap are scaffolding.
+    assert example.trained_content_bytes == RESPONSE_BYTES
+
+
+class _LegacyOnlyRenderer(Qwen3Renderer):
+    """Simulates a pre-existing custom renderer overriding only the legacy API."""
+
+    def build_supervised_example(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        return super().build_supervised_example(messages, train_on_what=train_on_what)
+
+
+def test_legacy_only_override_falls_back_to_none():
+    """A renderer overriding only build_supervised_example keeps working; the
+    metadata entry point delegates to it and reports no content bytes."""
+    renderer = _LegacyOnlyRenderer(_qwen3_tokenizer())
+    baseline = get_renderer("qwen3", _qwen3_tokenizer())
+    convo = _simple_convo()
+
+    model_input, weights = renderer.build_supervised_example(convo)
+    base_model_input, base_weights = baseline.build_supervised_example(convo)
+    assert model_input.to_ints() == base_model_input.to_ints()
+    assert torch.equal(weights, base_weights)
+
+    example = renderer.build_supervised_example_with_metadata(convo)
+    assert example.model_input.to_ints() == base_model_input.to_ints()
+    assert example.trained_content_bytes is None
+
+
+def test_both_entry_points_agree_for_builtin_renderers():
+    """The legacy tuple API and the metadata API must return identical
+    tokens/weights for renderers that override the metadata method."""
+    for name, tokenizer in [("qwen3", _qwen3_tokenizer()), ("kimi_k2", _kimi_tokenizer())]:
+        renderer: Renderer = get_renderer(name, tokenizer)
+        convo = _simple_convo()
+        model_input, weights = renderer.build_supervised_example(convo)
+        example = renderer.build_supervised_example_with_metadata(convo)
+        assert model_input.to_ints() == example.model_input.to_ints(), name
+        assert torch.equal(weights, example.weights), name

--- a/tinker_cookbook/renderers/content_bytes_test.py
+++ b/tinker_cookbook/renderers/content_bytes_test.py
@@ -22,6 +22,7 @@ from tinker_cookbook.renderers import (
     get_renderer,
 )
 from tinker_cookbook.renderers.base import message_content_byte_count
+from tinker_cookbook.renderers.kimi_k2 import KimiK2Renderer
 from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
@@ -179,7 +180,7 @@ def test_legacy_only_override_falls_back_to_none():
 
 def test_both_entry_points_agree_for_builtin_renderers():
     """The legacy tuple API and the metadata API must return identical
-    tokens/weights for renderers that override the metadata method."""
+    tokens/weights for renderers that override the impl hook."""
     for name, tokenizer in [("qwen3", _qwen3_tokenizer()), ("kimi_k2", _kimi_tokenizer())]:
         renderer: Renderer = get_renderer(name, tokenizer)
         convo = _simple_convo()
@@ -187,3 +188,50 @@ def test_both_entry_points_agree_for_builtin_renderers():
         example = renderer.build_supervised_example_with_metadata(convo)
         assert model_input.to_ints() == example.model_input.to_ints(), name
         assert torch.equal(weights, example.weights), name
+
+
+class _LegacyKimiSubclass(KimiK2Renderer):
+    """Legacy override layered on a renderer that itself overrides the impl
+    hook -- the metadata dispatcher must honor the MORE DERIVED legacy
+    override, not silently route around it to KimiK2's impl."""
+
+    def build_supervised_example(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        messages = [Message(role="system", content="CUSTOM PREFIX")] + list(messages)
+        return super().build_supervised_example(messages, train_on_what=train_on_what)
+
+
+def test_legacy_override_of_impl_overriding_renderer_is_honored():
+    """Both entry points must return the customized tokens (with the injected
+    system message), and the metadata path reports no content bytes."""
+    tokenizer = _kimi_tokenizer()
+    renderer = _LegacyKimiSubclass(tokenizer)
+    convo = _simple_convo()
+
+    model_input, weights = renderer.build_supervised_example(convo)
+    example = renderer.build_supervised_example_with_metadata(convo)
+    assert "CUSTOM PREFIX" in tokenizer.decode(model_input.to_ints())
+    assert example.model_input.to_ints() == model_input.to_ints()
+    assert torch.equal(example.weights, weights)
+    assert example.trained_content_bytes is None
+
+
+class _ImplOverridingRenderer(Qwen3Renderer):
+    """The going-forward pattern: customize via the impl hook and keep
+    content-byte reporting on both entry points."""
+
+    def _build_supervised_example_impl(self, messages, train_on_what):  # type: ignore[override]
+        messages = [Message(role="system", content="sys")] + list(messages)
+        return super()._build_supervised_example_impl(messages, train_on_what)
+
+
+def test_impl_override_reports_content_bytes_on_both_entry_points():
+    renderer = _ImplOverridingRenderer(_qwen3_tokenizer())
+    convo = _simple_convo()
+    example = renderer.build_supervised_example_with_metadata(convo)
+    model_input, _ = renderer.build_supervised_example(convo)
+    assert example.model_input.to_ints() == model_input.to_ints()
+    assert example.trained_content_bytes == RESPONSE_BYTES

--- a/tinker_cookbook/renderers/content_bytes_test.py
+++ b/tinker_cookbook/renderers/content_bytes_test.py
@@ -3,8 +3,8 @@
 ``build_supervised_example_with_metadata`` reports the UTF-8 byte count of the
 semantic content of loss-weighted messages. The count must exclude everything
 the renderer injects (think tags, role headers, tool framing, end-of-turn
-markers) and must be identical across renderers for the same messages -- that
-is what makes the BPB metric comparable across models.
+markers), so renderers that render the same content report identical counts --
+that is what makes the BPB metric comparable across models.
 """
 
 import functools
@@ -235,3 +235,38 @@ def test_impl_override_reports_content_bytes_on_both_entry_points():
     model_input, _ = renderer.build_supervised_example(convo)
     assert example.model_input.to_ints() == model_input.to_ints()
     assert example.trained_content_bytes == RESPONSE_BYTES
+
+
+class _LegacyBaseRenderer(Qwen3Renderer):
+    """A legacy override in a BASE class of an impl-overriding subclass."""
+
+    def build_supervised_example(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        messages = [Message(role="system", content="LEGACY WRAPPER")] + list(messages)
+        return super().build_supervised_example(messages, train_on_what=train_on_what)
+
+
+class _ImplChildOfLegacyBase(_LegacyBaseRenderer):
+    def _build_supervised_example_impl(self, messages, train_on_what):  # type: ignore[override]
+        return super()._build_supervised_example_impl(messages, train_on_what)
+
+
+def test_impl_override_layered_above_legacy_override_still_agrees():
+    """Reverse layering: a legacy override in a parent class with an impl-hook
+    override in the child. A direct build_supervised_example call resolves to
+    the parent's legacy override, so the metadata dispatcher must honor it too
+    -- the two entry points must return identical tokens (with the legacy
+    transformation applied) and no content bytes."""
+    tokenizer = _qwen3_tokenizer()
+    renderer = _ImplChildOfLegacyBase(tokenizer)
+    convo = _simple_convo()
+
+    model_input, weights = renderer.build_supervised_example(convo)
+    example = renderer.build_supervised_example_with_metadata(convo)
+    assert "LEGACY WRAPPER" in tokenizer.decode(model_input.to_ints())
+    assert example.model_input.to_ints() == model_input.to_ints()
+    assert torch.equal(example.weights, weights)
+    assert example.trained_content_bytes is None

--- a/tinker_cookbook/renderers/deepseek_v3.py
+++ b/tinker_cookbook/renderers/deepseek_v3.py
@@ -6,6 +6,7 @@ Includes:
 - DeepSeekV3DisableThinkingRenderer: V3 models with thinking disabled
 """
 
+import dataclasses
 import json
 import re
 import warnings
@@ -24,6 +25,7 @@ from tinker_cookbook.renderers.base import (
     ToolSpec,
     UnparsedToolCall,
     ensure_text,
+    message_content_byte_count,
     parse_response_for_stop_token,
     parse_think_blocks,
 )
@@ -103,6 +105,7 @@ class _DeepSeekV3BaseRenderer(Renderer):
         follows_tool = ctx.prev_message is not None and ctx.prev_message["role"] == "tool"
 
         content = message["content"]
+        thinking_rendered = True
 
         if message["role"] == "system":
             # HF template collects all system messages at the start without role tokens
@@ -132,6 +135,7 @@ class _DeepSeekV3BaseRenderer(Renderer):
             should_strip_thinking = (
                 self.strip_thinking_from_history and not has_tool_calls and not ctx.is_last
             )
+            thinking_rendered = not should_strip_thinking
 
             if isinstance(content, list):
                 # Structured content - handle with list operations
@@ -193,14 +197,17 @@ class _DeepSeekV3BaseRenderer(Renderer):
             output_tokens.append(self._end_message_token)
 
         output: list[tinker.ModelInputChunk] = [tinker.types.EncodedTextChunk(tokens=output_tokens)]
+        content_byte_count = message_content_byte_count(message, include_thinking=thinking_rendered)
         # Only include header if non-empty; tinker rejects empty token chunks with
         # "Chunk N has empty tokens list". This happens for system messages at idx=0.
         if header_tokens:
             return RenderedMessage(
-                header=tinker.types.EncodedTextChunk(tokens=header_tokens), output=output
+                header=tinker.types.EncodedTextChunk(tokens=header_tokens),
+                output=output,
+                content_byte_count=content_byte_count,
             )
         else:
-            return RenderedMessage(output=output)
+            return RenderedMessage(output=output, content_byte_count=content_byte_count)
 
     def _get_special_token(self, name: str) -> int:
         sep = chr(65372)
@@ -473,7 +480,7 @@ class DeepSeekV3ThinkingRenderer(_DeepSeekV3BaseRenderer):
             think_close_tokens = self.tokenizer.encode("</think>", add_special_tokens=False)
             old_header_tokens = list(rendered.header.tokens) if rendered.header else []
             new_header = tinker.EncodedTextChunk(tokens=old_header_tokens + think_close_tokens)
-            rendered = RenderedMessage(header=new_header, output=rendered.output)
+            rendered = dataclasses.replace(rendered, header=new_header)
 
         return rendered
 
@@ -563,6 +570,6 @@ class DeepSeekV3DisableThinkingRenderer(_DeepSeekV3BaseRenderer):
             think_close_tokens = self.tokenizer.encode("</think>", add_special_tokens=False)
             old_header_tokens = list(rendered.header.tokens) if rendered.header else []
             new_header = tinker.EncodedTextChunk(tokens=old_header_tokens + think_close_tokens)
-            rendered = RenderedMessage(header=new_header, output=rendered.output)
+            rendered = dataclasses.replace(rendered, header=new_header)
 
         return rendered

--- a/tinker_cookbook/renderers/gpt_oss.py
+++ b/tinker_cookbook/renderers/gpt_oss.py
@@ -437,7 +437,7 @@ class GptOssRenderer(Renderer):
             messages = [system_msg] + list(messages)
         return super().build_generation_prompt(messages, role, prefill)
 
-    def build_supervised_example_with_metadata(
+    def _build_supervised_example_impl(
         self,
         messages: list[Message],
         train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
@@ -456,7 +456,7 @@ class GptOssRenderer(Renderer):
         system_msg = self._get_system_message()
         if system_msg:
             messages = [system_msg] + list(messages)
-        return super().build_supervised_example_with_metadata(messages, train_on_what)
+        return super()._build_supervised_example_impl(messages, train_on_what)
 
     @property
     def _return_token(self) -> int:

--- a/tinker_cookbook/renderers/gpt_oss.py
+++ b/tinker_cookbook/renderers/gpt_oss.py
@@ -6,7 +6,6 @@ import warnings
 from datetime import datetime
 
 import tinker
-import torch
 
 from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers.base import (
@@ -17,6 +16,7 @@ from tinker_cookbook.renderers.base import (
     RenderedMessage,
     Renderer,
     Role,
+    SupervisedExample,
     TextPart,
     ThinkingPart,
     ToolCall,
@@ -25,6 +25,7 @@ from tinker_cookbook.renderers.base import (
     UnparsedToolCall,
     ensure_list,
     ensure_text,
+    message_content_byte_count,
 )
 from tinker_cookbook.tokenizer_utils import Tokenizer
 
@@ -308,7 +309,10 @@ class GptOssRenderer(Renderer):
                 tokens=self.tokenizer.encode(output_str, add_special_tokens=False)
             )
         ]
-        return RenderedMessage(header=header, output=output)
+        # Harmony renders thinking (analysis channel) whenever it is present.
+        return RenderedMessage(
+            header=header, output=output, content_byte_count=message_content_byte_count(message)
+        )
 
     def _render_tool_calls(self, tool_calls: list[ToolCall]) -> str:
         """Render tool calls in Harmony commentary channel format.
@@ -374,7 +378,11 @@ class GptOssRenderer(Renderer):
                 tokens=self.tokenizer.encode(output_str, add_special_tokens=False)
             )
         ]
-        return RenderedMessage(header=header, output=output)
+        return RenderedMessage(
+            header=header,
+            output=output,
+            content_byte_count=len(content.encode("utf-8")),
+        )
 
     def _get_system_message(self) -> Message | None:
         """Return system message if configured, else None.
@@ -429,11 +437,11 @@ class GptOssRenderer(Renderer):
             messages = [system_msg] + list(messages)
         return super().build_generation_prompt(messages, role, prefill)
 
-    def build_supervised_example(
+    def build_supervised_example_with_metadata(
         self,
         messages: list[Message],
         train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
-    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+    ) -> SupervisedExample:
         """Build supervised example, prepending system message if configured.
 
         Args:
@@ -441,14 +449,14 @@ class GptOssRenderer(Renderer):
             train_on_what (TrainOnWhat): Which message tokens to assign training weight.
 
         Returns:
-            tuple[tinker.ModelInput, torch.Tensor]: The tokenized model input and
-                per-token weight tensor.
+            SupervisedExample: The tokenized model input, per-token weight tensor,
+                and content byte count of the loss-weighted messages.
         """
         self._warn_if_user_system_message(messages)
         system_msg = self._get_system_message()
         if system_msg:
             messages = [system_msg] + list(messages)
-        return super().build_supervised_example(messages, train_on_what)
+        return super().build_supervised_example_with_metadata(messages, train_on_what)
 
     @property
     def _return_token(self) -> int:

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -16,6 +16,7 @@ from tinker_cookbook.renderers.base import (
     RenderedMessage,
     Renderer,
     Role,
+    SupervisedExample,
     TextPart,
     ToolCall,
     ToolSpec,
@@ -23,6 +24,7 @@ from tinker_cookbook.renderers.base import (
     UnparsedToolCall,
     ensure_list,
     ensure_text,
+    message_content_byte_count,
     parse_response_for_stop_token,
     parse_think_blocks,
 )
@@ -272,7 +274,17 @@ class KimiK2Renderer(Renderer):
 
         header = tinker.types.EncodedTextChunk(tokens=self.tokenizer.encode(header_str))
 
-        return RenderedMessage(header=header, output=output)
+        # Thinking survives rendering only for the last assistant message (or
+        # always when strip_thinking_from_history is False); the injected empty
+        # <think></think> block is scaffolding and not counted as content.
+        thinking_rendered = ctx.is_last or not self.strip_thinking_from_history
+        return RenderedMessage(
+            header=header,
+            output=output,
+            content_byte_count=message_content_byte_count(
+                message, include_thinking=thinking_rendered
+            ),
+        )
 
     def _encode_multipart_content(self, content: list[ContentPart]) -> list[tinker.ModelInputChunk]:
         raise NotImplementedError(
@@ -394,11 +406,11 @@ class KimiK2Renderer(Renderer):
 
         return supervised_examples
 
-    def build_supervised_example(
+    def build_supervised_example_with_metadata(
         self,
         messages: list[Message],
         train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
-    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+    ) -> SupervisedExample:
         """Build a single supervised training example with proper thinking preservation.
 
         Ensures a default system message is present and preserves thinking content
@@ -410,8 +422,8 @@ class KimiK2Renderer(Renderer):
             train_on_what (TrainOnWhat): Which message tokens to assign training weight.
 
         Returns:
-            tuple[tinker.ModelInput, torch.Tensor]: The tokenized model input and
-                per-token weight tensor.
+            SupervisedExample: The tokenized model input, per-token weight tensor,
+                and content byte count of the loss-weighted messages.
         """
         messages = self._ensure_system_message(messages)
 
@@ -426,6 +438,7 @@ class KimiK2Renderer(Renderer):
                 break
 
         model_input_chunks_weights: list[tuple[tinker.types.ModelInputChunk, float]] = []
+        trained_content_bytes: int | None = 0
 
         for idx, message in enumerate(messages):
             if train_on_what == TrainOnWhat.CUSTOMIZED:
@@ -482,6 +495,12 @@ class KimiK2Renderer(Renderer):
                 case _:
                     raise RendererError(f"Unknown train_on_what: {train_on_what}")
 
+            if output_has_weight:
+                if rendered_message.content_byte_count is None:
+                    trained_content_bytes = None
+                elif trained_content_bytes is not None:
+                    trained_content_bytes += rendered_message.content_byte_count
+
             model_input_chunks_weights += [
                 (output_part, int(output_has_weight)) for output_part in output_parts if output_part
             ]
@@ -490,7 +509,9 @@ class KimiK2Renderer(Renderer):
         weights_tensor = torch.tensor(weights_data)
 
         model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        return SupervisedExample(
+            tinker.ModelInput(chunks=model_input_chunks), weights_tensor, trained_content_bytes
+        )
 
     @property
     def _end_message_token(self) -> int:

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -406,7 +406,7 @@ class KimiK2Renderer(Renderer):
 
         return supervised_examples
 
-    def build_supervised_example_with_metadata(
+    def _build_supervised_example_impl(
         self,
         messages: list[Message],
         train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,

--- a/tinker_cookbook/renderers/llama3.py
+++ b/tinker_cookbook/renderers/llama3.py
@@ -54,7 +54,8 @@ class Llama3Renderer(Renderer):
         """
         role = message["role"]
         header_str = f"<|start_header_id|>{role}<|end_header_id|>\n\n"
-        output_str = ensure_text(message["content"]) + "<|eot_id|>"
+        content_str = ensure_text(message["content"])
+        output_str = content_str + "<|eot_id|>"
 
         header = tinker.types.EncodedTextChunk(
             tokens=self.tokenizer.encode(header_str, add_special_tokens=False)
@@ -64,7 +65,9 @@ class Llama3Renderer(Renderer):
                 tokens=self.tokenizer.encode(output_str, add_special_tokens=False)
             )
         ]
-        return RenderedMessage(header=header, output=output)
+        return RenderedMessage(
+            header=header, output=output, content_byte_count=len(content_str.encode("utf-8"))
+        )
 
     @property
     def _bos_tokens(self) -> list[int]:

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -172,7 +172,7 @@ class Nemotron3Renderer(Qwen3_5Renderer):
         """
         return super().build_generation_prompt(self._normalize_messages(messages), *args, **kwargs)  # type: ignore[arg-type]
 
-    def build_supervised_example_with_metadata(
+    def _build_supervised_example_impl(
         self,
         messages: list[Message],
         *args: object,
@@ -189,7 +189,7 @@ class Nemotron3Renderer(Qwen3_5Renderer):
             SupervisedExample: The tokenized model input, per-token weight tensor,
                 and content byte count of the loss-weighted messages.
         """
-        return super().build_supervised_example_with_metadata(
+        return super()._build_supervised_example_impl(
             self._normalize_messages(messages),
             *args,  # type: ignore[arg-type]
             **kwargs,  # type: ignore[arg-type]

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -74,6 +74,25 @@ from tinker_cookbook.renderers.base import (
 )
 from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
 
+_LOW_EFFORT_SUFFIX = "\n\n{reasoning effort: low}"
+_MEDIUM_EFFORT_SUFFIX = "\n\n{reasoning effort: efficient}"
+
+
+def _discount_injected_suffix(rendered: RenderedMessage, suffix: str) -> RenderedMessage:
+    """Remove a renderer-injected suffix's bytes from the content byte count.
+
+    The reasoning-effort suffix is baked into the message content before
+    rendering (so it tokenizes exactly like the HF template), but it is
+    renderer-injected scaffolding, not semantic content -- it must not count
+    toward the bits-per-byte denominator.
+    """
+    if rendered.content_byte_count is None:
+        return rendered
+    return dataclasses.replace(
+        rendered,
+        content_byte_count=rendered.content_byte_count - len(suffix.encode("utf-8")),
+    )
+
 
 def _render_extra_keys(obj: Mapping[str, object], handled_keys: set[str]) -> list[str]:
     """Render extra dict keys as XML, mirroring the HF template's render_extra_keys macro.
@@ -399,7 +418,10 @@ class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
                 "Nemotron-3 low-thinking mode is text-only; list content not supported"
             )
             message = message.copy()
-            message["content"] = content + "\n\n{reasoning effort: low}"
+            message["content"] = content + _LOW_EFFORT_SUFFIX
+            return _discount_injected_suffix(
+                super().render_message(message, ctx), _LOW_EFFORT_SUFFIX
+            )
         return super().render_message(message, ctx)
 
 
@@ -460,7 +482,10 @@ class Nemotron3UltraMediumThinkingRenderer(Nemotron3UltraRenderer):
                 "Nemotron-3 Ultra medium-thinking mode is text-only; list content not supported"
             )
             message = message.copy()
-            message["content"] = content + "\n\n{reasoning effort: efficient}"
+            message["content"] = content + _MEDIUM_EFFORT_SUFFIX
+            return _discount_injected_suffix(
+                super().render_message(message, ctx), _MEDIUM_EFFORT_SUFFIX
+            )
         return super().render_message(message, ctx)
 
 

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -172,7 +172,12 @@ class Nemotron3Renderer(Qwen3_5Renderer):
         """
         return super().build_generation_prompt(self._normalize_messages(messages), *args, **kwargs)  # type: ignore[arg-type]
 
-    def build_supervised_example(self, messages: list[Message], *args: object, **kwargs: object):  # type: ignore[override]
+    def build_supervised_example_with_metadata(
+        self,
+        messages: list[Message],
+        *args: object,
+        **kwargs: object,
+    ):  # type: ignore[override]
         """Build supervised example, prepending an empty system message if none exists.
 
         Args:
@@ -181,10 +186,14 @@ class Nemotron3Renderer(Qwen3_5Renderer):
             **kwargs: Additional keyword arguments passed to the parent.
 
         Returns:
-            tuple[tinker.ModelInput, torch.Tensor]: The tokenized model input and
-                per-token weight tensor.
+            SupervisedExample: The tokenized model input, per-token weight tensor,
+                and content byte count of the loss-weighted messages.
         """
-        return super().build_supervised_example(self._normalize_messages(messages), *args, **kwargs)  # type: ignore[arg-type]
+        return super().build_supervised_example_with_metadata(
+            self._normalize_messages(messages),
+            *args,  # type: ignore[arg-type]
+            **kwargs,  # type: ignore[arg-type]
+        )
 
     def _assistant_header_suffix(self, message: Message, ctx: RenderContext) -> str:
         """Prepend <think></think> when thinking will not appear in the output.

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from tinker_cookbook.renderers import Message, ToolCall, ToolSpec, get_renderer
+from tinker_cookbook.renderers import Message, ToolCall, ToolSpec, TrainOnWhat, get_renderer
 from tinker_cookbook.renderers.nemotron3 import (
     Nemotron3DisableThinkingRenderer,
     Nemotron3LowThinkingRenderer,
@@ -909,6 +909,28 @@ def test_low_thinking_multiturn_supervised_matches_hf(
         f"Cookbook: {nemotron_super_tokenizer.decode(cookbook)}\n"
         f"HF: {nemotron_super_tokenizer.decode(hf)}"
     )
+
+
+def test_low_thinking_effort_suffix_not_counted_as_content_bytes(
+    nemotron_super_tokenizer, nemotron_low_thinking_renderer
+):
+    """The injected '{reasoning effort: low}' suffix is rendered (and trained
+    under ALL_MESSAGES) but is renderer scaffolding, so it must not count
+    toward trained_content_bytes."""
+    user_text = "What is 2+2?"
+    response_text = "2+2 equals 4."
+    messages = [
+        Message(role="user", content=user_text),
+        Message(role="assistant", content=response_text),
+    ]
+    example = nemotron_low_thinking_renderer.build_supervised_example_with_metadata(
+        messages, train_on_what=TrainOnWhat.ALL_MESSAGES
+    )
+    rendered_text = nemotron_super_tokenizer.decode(example.model_input.to_ints())
+    assert "{reasoning effort: low}" in rendered_text  # suffix IS rendered...
+    # ...but only the raw user + assistant content counts (plus the injected
+    # empty system message, which contributes zero bytes).
+    assert example.trained_content_bytes == len(user_text.encode()) + len(response_text.encode())
 
 
 # =============================================================================

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -9,6 +9,7 @@ Includes:
 - Qwen3VLInstructRenderer: Vision-language instruct models
 """
 
+import dataclasses
 import json
 from typing import cast
 
@@ -29,6 +30,7 @@ from tinker_cookbook.renderers.base import (
     UnparsedToolCall,
     _tool_call_payload,
     image_to_chunk,
+    message_content_byte_count,
     parse_content_blocks,
     parse_response_for_stop_token,
     remove_thinking,
@@ -198,7 +200,16 @@ class Qwen3Renderer(Renderer):
                 tokens=self.tokenizer.encode(output_content, add_special_tokens=False)
             )
         ]
-        return RenderedMessage(header=header, output=output)
+        thinking_rendered = not (
+            self.strip_thinking_from_history and message["role"] == "assistant" and not ctx.is_last
+        )
+        return RenderedMessage(
+            header=header,
+            output=output,
+            content_byte_count=message_content_byte_count(
+                message, include_thinking=thinking_rendered
+            ),
+        )
 
     @property
     def _end_message_token(self) -> int:
@@ -449,9 +460,7 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
                 )
                 old_header_tokens = list(rendered.header.tokens) if rendered.header else []
                 new_header = tinker.EncodedTextChunk(tokens=old_header_tokens + empty_think_tokens)
-                rendered = RenderedMessage(
-                    header=new_header, output=rendered.output, stop_overlap=rendered.stop_overlap
-                )
+                rendered = dataclasses.replace(rendered, header=new_header)
 
         return rendered
 
@@ -651,7 +660,13 @@ class Qwen3VLRenderer(Qwen3Renderer):
         header = tinker.types.EncodedTextChunk(
             tokens=self.tokenizer.encode(header_str, add_special_tokens=False)
         )
-        return RenderedMessage(header=header, output=output_chunks_encoded)
+        return RenderedMessage(
+            header=header,
+            output=output_chunks_encoded,
+            content_byte_count=message_content_byte_count(
+                message, include_thinking=not strip_thinking
+            ),
+        )
 
 
 class Qwen3VLInstructRenderer(Qwen3VLRenderer):

--- a/tinker_cookbook/renderers/role_colon.py
+++ b/tinker_cookbook/renderers/role_colon.py
@@ -49,7 +49,8 @@ class RoleColonRenderer(Renderer):
             RenderedMessage: Header, output, and stop_overlap token chunks.
         """
         header_str = message["role"].capitalize() + ":"
-        output_str = " " + ensure_text(message["content"]) + "\n\n"
+        content_str = ensure_text(message["content"])
+        output_str = " " + content_str + "\n\n"
         # stop_overlap completes the stop sequence "\n\nUser:" for assistant messages.
         # For non-assistant messages, we use a placeholder that's never actually concatenated.
         stop_overlap_str = "User:" if message["role"] == "assistant" else "<UNUSED>"
@@ -64,7 +65,12 @@ class RoleColonRenderer(Renderer):
         stop_overlap = tinker.types.EncodedTextChunk(
             tokens=self.tokenizer.encode(stop_overlap_str, add_special_tokens=False)
         )
-        return RenderedMessage(header=header, output=output, stop_overlap=stop_overlap)
+        return RenderedMessage(
+            header=header,
+            output=output,
+            stop_overlap=stop_overlap,
+            content_byte_count=len(content_str.encode("utf-8")),
+        )
 
     def get_stop_sequences(self) -> list[str]:
         """Return stop sequences for RoleColon generation.

--- a/tinker_cookbook/supervised/__init__.py
+++ b/tinker_cookbook/supervised/__init__.py
@@ -1,6 +1,7 @@
 """Supervised learning: dataset builders, data utilities, and training loops."""
 
 from tinker_cookbook.supervised.common import (
+    DatumWithContentBytes,
     compute_bpb,
     compute_mean_nll,
     datum_from_model_input_weights,
@@ -34,6 +35,7 @@ __all__ = [
     "SupervisedDatasetFromHFDataset",
     "conversation_to_datum",
     # Helpers (common.py)
+    "DatumWithContentBytes",
     "compute_bpb",
     "compute_mean_nll",
     "datum_from_model_input_weights",

--- a/tinker_cookbook/supervised/common.py
+++ b/tinker_cookbook/supervised/common.py
@@ -1,5 +1,7 @@
 import logging
 import math
+from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Literal
 
 import tinker
@@ -96,6 +98,7 @@ def compute_bpb(
     weights_list: list[tinker.TensorData],
     target_tokens_list: list[tinker.TensorData],
     tokenizer: Tokenizer,
+    content_bytes_list: Sequence[int | None] | None = None,
 ) -> float:
     """Compute bits-per-byte (BPB) across a batch: a tokenizer-independent NLL.
 
@@ -103,33 +106,43 @@ def compute_bpb(
     models that use different tokenizers: a coarser tokenizer packs more text
     into each token (higher nats/token) while a finer one spreads it over more
     tokens (lower nats/token), even at equal modeling quality. Bits-per-byte
-    removes this dependence by dividing the *total* log-loss (converted to bits)
-    by the number of UTF-8 bytes of the target text::
+    removes this dependence by dividing the *total* log-loss (converted to
+    bits) by a byte count of the target text.
+
+    A datum is scored in one of two modes:
+
+    **Content-byte mode** (used when its ``content_bytes_list`` entry is not
+    ``None``, as reported by the renderer via
+    ``Renderer.build_supervised_example_with_metadata``)::
+
+        bpb = -sum(logprob_i for i where weight_i > 0) / (ln(2) * content_bytes)
+
+    The numerator is the model's *entire* trained code length, including
+    chat-template scaffolding (think tags, tool-call framing, end-of-turn
+    markers). The denominator counts only the UTF-8 bytes of the semantic
+    message content, which is identical across renderers and tokenizers (see
+    ``message_content_byte_count``). Scaffolding therefore never pads the
+    denominator: a template whose markup costs real bits pays for them in the
+    numerator (a cost that vanishes as the template is learned), and a verbose
+    template gains no artificial BPB advantage from its extra markup bytes.
+    This is the preferred mode for cross-model comparison.
+
+    **Token-byte fallback** (entry is ``None``: renderer without content-byte
+    support, or the trained region was truncated by ``max_length``)::
 
         bpb = -sum(logprob_i for i in counted) / (ln(2) * bytes(counted tokens))
 
-    A token is *counted* iff it is trained (``weight > 0``) and is not a special
-    token (per ``tokenizer.all_special_ids``). The same mask drives both the
-    numerator and the byte denominator, so they always cover the identical span.
+    where a token is *counted* iff it is trained (``weight > 0``) and not a
+    special token (per ``tokenizer.all_special_ids``). The same mask drives
+    both sides, so they cover the identical span. Caveat: non-special
+    scaffolding that renderers inject as plain text (e.g. ``<think></think>``)
+    is counted as target bytes here, which slightly deflates BPB by an amount
+    that varies with the chat template.
 
-    Two properties matter:
-
-    * Weights are used only as a ``> 0`` mask, not as multipliers, so the total
-      nats stay correct even when weights are normalized per example
-      (``reduction="mean"``, the SFT default, where a datum's weights sum to 1.0
-      instead of being 0/1).
-    * Special / structural tokens (e.g. end-of-turn markers like ``<|im_end|>``
-      or ``<|eot_id|>``) are excluded from *both* sides. They carry no
-      natural-language bytes and their number varies by chat template, so
-      counting their NLL while dropping their bytes would bias BPB — worst for
-      short completions — and break comparability across templates.
-
-    The denominator counts the UTF-8 bytes of the decoded counted tokens, fixed
-    by the raw text rather than by the tokenization; combined with the matched
-    numerator this yields a proper compression rate comparable across
-    tokenizers. (If a tokenizer does not expose ``all_special_ids``, no tokens
-    are treated as special, but both sides still share the same mask and stay
-    consistent.)
+    In both modes weights are used only as a ``> 0`` mask, not as multipliers,
+    so the total nats stay correct even when weights are normalized per example
+    (``reduction="mean"``, the SFT default, where a datum's weights sum to 1.0
+    instead of being 0/1).
 
     Args:
         logprobs_list (list[tinker.TensorData]): Per-token log-probabilities,
@@ -138,23 +151,42 @@ def compute_bpb(
             with ``logprobs_list``.
         target_tokens_list (list[tinker.TensorData]): Per-token target IDs
             (``loss_fn_inputs["target_tokens"]``) aligned with ``weights_list``,
-            used to recover the target text for the byte count.
-        tokenizer (Tokenizer): Tokenizer used to decode target tokens to bytes.
+            used to recover the target text for the byte count in fallback mode.
+        tokenizer (Tokenizer): Tokenizer used to decode target tokens to bytes
+            in fallback mode.
+        content_bytes_list (Sequence[int | None] | None): Per-datum semantic
+            content byte counts (``DatumWithContentBytes.trained_content_bytes``),
+            aligned with ``logprobs_list``. ``None`` (or a ``None`` entry)
+            selects the token-byte fallback for the batch (or that datum).
 
     Returns:
         float: Bits per byte, or ``nan`` if the counted target has zero bytes.
     """
+    if content_bytes_list is not None and len(content_bytes_list) != len(logprobs_list):
+        raise ValueError(
+            f"content_bytes_list has length {len(content_bytes_list)}, "
+            f"expected {len(logprobs_list)}"
+        )
     special_ids = frozenset(getattr(tokenizer, "all_special_ids", None) or [])
     total_nll_nats = 0.0
     total_bytes = 0
 
-    for logprobs, weights, target_tokens in zip(
-        logprobs_list, weights_list, target_tokens_list, strict=True
+    for i, (logprobs, weights, target_tokens) in enumerate(
+        zip(logprobs_list, weights_list, target_tokens_list, strict=True)
     ):
+        content_bytes = content_bytes_list[i] if content_bytes_list is not None else None
+        if content_bytes is not None:
+            # Content-byte mode: full trained NLL over renderer-reported
+            # content bytes.
+            trained_mask = weights.to_torch() > 0
+            total_nll_nats += float(-logprobs.to_torch()[trained_mask].sum())
+            total_bytes += content_bytes
+            continue
         token_ids = [int(t) for t in target_tokens.data]
-        # A token contributes iff it is trained (weight > 0) and not special.
-        # This single mask is used for both the numerator and the byte
-        # denominator, guaranteeing they cover the identical span.
+        # Token-byte fallback: a token contributes iff it is trained
+        # (weight > 0) and not special. This single mask is used for both the
+        # numerator and the byte denominator, guaranteeing they cover the
+        # identical span.
         counted = [
             weight > 0 and token_id not in special_ids
             for weight, token_id in zip(weights.data, token_ids, strict=True)
@@ -226,11 +258,34 @@ def create_rightshifted_model_input_and_leftshifted_targets(
     return tinker.ModelInput(chunks=input_chunks), target_tokens
 
 
+@dataclass(frozen=True)
+class DatumWithContentBytes(tinker.Datum):
+    """A ``tinker.Datum`` carrying client-side metadata for metric computation.
+
+    ``trained_content_bytes`` is a plain Python attribute, deliberately *not*
+    a ``loss_fn_inputs`` entry: the Tinker SDK serializes datums from
+    ``model_input`` and ``loss_fn_inputs`` only, so this field never reaches
+    the service (which restricts ``loss_fn_inputs`` keys), and the datum can
+    be passed to ``forward_backward`` / ``forward_backward_custom`` unchanged.
+    Read it with ``getattr(datum, "trained_content_bytes", None)`` so plain
+    datums keep working.
+
+    Attributes:
+        trained_content_bytes: UTF-8 bytes of the semantic content of the
+            loss-weighted messages (see
+            ``tinker_cookbook.renderers.message_content_byte_count``). Used as
+            the bits-per-byte denominator by :func:`compute_bpb`.
+    """
+
+    trained_content_bytes: int | None = None
+
+
 def datum_from_model_input_weights(
     model_input: tinker.ModelInput,
     weights: torch.Tensor,
     max_length: int | None = None,
     reduction: Literal["none", "mean"] = "none",
+    trained_content_bytes: int | None = None,
 ) -> tinker.Datum:
     """Create a training Datum from a ModelInput and per-token weights tensor.
 
@@ -252,6 +307,14 @@ def datum_from_model_input_weights(
             per example (token-mean loss), making gradient magnitudes
             consistent across variable-length sequences.
             Defaults to ``"none"``.
+        trained_content_bytes (int | None): Semantic content byte count of the
+            loss-weighted messages, as reported by
+            ``Renderer.build_supervised_example_with_metadata``. When provided
+            and no loss-weighted token is lost to truncation, the returned
+            datum is a :class:`DatumWithContentBytes` carrying the count for
+            the bits-per-byte metric. If truncation removes any trained token,
+            the count no longer matches the surviving tokens and is dropped
+            (the metric then falls back to token-based byte counting).
 
     Returns:
         tinker.Datum: A datum whose ``model_input`` holds the right-shifted
@@ -311,7 +374,15 @@ def datum_from_model_input_weights(
     input_model_input, target_tokens = create_rightshifted_model_input_and_leftshifted_targets(
         model_input_chunks
     )
+    # Trained-token count over the full (untruncated) sequence, post-shift.
+    n_trained_full = int((weights[1:] > 0).sum())
     weights = weights[1 : len(target_tokens) + 1]
+
+    if trained_content_bytes is not None and int((weights > 0).sum()) != n_trained_full:
+        # Truncation removed loss-weighted tokens, so the content byte count no
+        # longer describes the surviving trained span. Drop it; BPB falls back
+        # to token-based byte counting for this datum.
+        trained_content_bytes = None
 
     # Apply weight reduction
     if reduction == "mean":
@@ -324,18 +395,22 @@ def datum_from_model_input_weights(
     elif reduction != "none":
         raise ValueError(f"Unknown reduction mode: {reduction!r}")
 
-    return tinker.Datum(
-        model_input=input_model_input,
-        loss_fn_inputs={
-            "weights": tinker.TensorData(
-                data=weights.tolist(),
-                dtype="float32",
-                shape=list(weights.shape),
-            ),
-            "target_tokens": tinker.TensorData(
-                data=target_tokens,
-                dtype="int64",
-                shape=[len(target_tokens)],
-            ),
-        },
-    )
+    loss_fn_inputs = {
+        "weights": tinker.TensorData(
+            data=weights.tolist(),
+            dtype="float32",
+            shape=list(weights.shape),
+        ),
+        "target_tokens": tinker.TensorData(
+            data=target_tokens,
+            dtype="int64",
+            shape=[len(target_tokens)],
+        ),
+    }
+    if trained_content_bytes is not None:
+        return DatumWithContentBytes(
+            model_input=input_model_input,
+            loss_fn_inputs=loss_fn_inputs,
+            trained_content_bytes=trained_content_bytes,
+        )
+    return tinker.Datum(model_input=input_model_input, loss_fn_inputs=loss_fn_inputs)

--- a/tinker_cookbook/supervised/common.py
+++ b/tinker_cookbook/supervised/common.py
@@ -120,12 +120,15 @@ def compute_bpb(
     The numerator is the model's *entire* trained code length, including
     chat-template scaffolding (think tags, tool-call framing, end-of-turn
     markers). The denominator counts only the UTF-8 bytes of the semantic
-    message content, which is identical across renderers and tokenizers (see
-    ``message_content_byte_count``). Scaffolding therefore never pads the
-    denominator: a template whose markup costs real bits pays for them in the
-    numerator (a cost that vanishes as the template is learned), and a verbose
-    template gains no artificial BPB advantage from its extra markup bytes.
-    This is the preferred mode for cross-model comparison.
+    message content, which depends on *what* content the renderer trains on
+    but not on how its template formats it (see
+    ``message_content_byte_count``; renderers that render more content -- e.g.
+    preserved thinking in historical turns -- count those bytes and also train
+    on them). Scaffolding therefore never pads the denominator: a template
+    whose markup costs real bits pays for them in the numerator (a cost that
+    vanishes as the template is learned), and a verbose template gains no
+    artificial BPB advantage from its extra markup bytes. This is the
+    preferred mode for cross-model comparison.
 
     **Token-byte fallback** (entry is ``None``: renderer without content-byte
     support, or the trained region was truncated by ``max_length``)::

--- a/tinker_cookbook/supervised/common_test.py
+++ b/tinker_cookbook/supervised/common_test.py
@@ -8,6 +8,7 @@ import tinker
 import torch
 
 from tinker_cookbook.supervised.common import (
+    DatumWithContentBytes,
     _counted_byte_count,
     compute_bpb,
     datum_from_model_input_weights,
@@ -276,3 +277,136 @@ def test_counted_byte_count_splits_runs():
     tok = _fake_tokenizer({1: "ab", 2: "GAP", 3: "cde"})
     n = _counted_byte_count([1, 2, 3], [True, False, True], tok)
     assert n == len("ab") + len("cde")  # 2 + 3; the middle token is excluded
+
+
+def test_compute_bpb_content_bytes_mode_hand_computation():
+    """With renderer-reported content bytes, the numerator is the FULL trained
+    NLL (including special/scaffolding tokens) and the denominator is the
+    provided byte count."""
+    tok = _fake_tokenizer({1: "hi", 99: "<|end|>"}, special_ids={99})
+    logprobs = _td([-1.0, -0.25], "float32")  # trained content + trained special
+    weights = _td([1.0, 1.0], "float32")
+    targets = _td([1, 99], "int64")
+    bpb = compute_bpb([logprobs], [weights], [targets], tok, content_bytes_list=[2])
+    # Numerator = 1.0 + 0.25 (the special token's nats ARE charged);
+    # denominator = 2 content bytes (the special token adds no bytes).
+    expected = 1.25 / (math.log(2) * 2)
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_content_bytes_mode_invariant_to_weight_magnitude():
+    """Content-byte mode also treats weights as a mask (mean-reduction safe)."""
+    tok = _fake_tokenizer({1: "ab", 2: "cd"})
+    logprobs = _td([-1.0, -3.0], "float32")
+    targets = _td([1, 2], "int64")
+    expected = 4.0 / (math.log(2) * 4)
+    bpb_binary = compute_bpb(
+        [logprobs], [_td([1.0, 1.0], "float32")], [targets], tok, content_bytes_list=[4]
+    )
+    bpb_mean = compute_bpb(
+        [logprobs], [_td([0.5, 0.5], "float32")], [targets], tok, content_bytes_list=[4]
+    )
+    assert math.isclose(bpb_binary, expected, rel_tol=1e-6)
+    assert math.isclose(bpb_mean, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_content_bytes_denominator_excludes_scaffolding():
+    """Non-special scaffolding (e.g. <think></think> rendered as plain tokens)
+    pads the token-byte fallback denominator but not the content-byte one."""
+    tok = _fake_tokenizer({1: "<think></think>", 2: "hi"})
+    logprobs = _td([-0.0, -1.0], "float32")  # scaffolding fully learned
+    weights = _td([1.0, 1.0], "float32")
+    targets = _td([1, 2], "int64")
+    fallback = compute_bpb([logprobs], [weights], [targets], tok)
+    content = compute_bpb([logprobs], [weights], [targets], tok, content_bytes_list=[len("hi")])
+    # Fallback counts 15 scaffolding bytes in the denominator, deflating BPB.
+    assert math.isclose(fallback, 1.0 / (math.log(2) * 17), rel_tol=1e-6)
+    assert math.isclose(content, 1.0 / (math.log(2) * 2), rel_tol=1e-6)
+
+
+def test_compute_bpb_mixed_batch_uses_fallback_per_datum():
+    """A None entry falls back to token-byte counting for that datum only."""
+    tok = _fake_tokenizer({1: "ab", 2: "cde"})
+    logprobs = [_td([-1.0], "float32"), _td([-3.0], "float32")]
+    weights = [_td([1.0], "float32"), _td([1.0], "float32")]
+    targets = [_td([1], "int64"), _td([2], "int64")]
+    bpb = compute_bpb(logprobs, weights, targets, tok, content_bytes_list=[2, None])
+    # Datum 1: content mode (2 bytes). Datum 2: fallback decodes "cde" (3 bytes).
+    expected = 4.0 / (math.log(2) * 5)
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_content_bytes_list_length_mismatch_raises():
+    tok = _fake_tokenizer({1: "ab"})
+    logprobs = _td([-1.0], "float32")
+    weights = _td([1.0], "float32")
+    targets = _td([1], "int64")
+    with pytest.raises(ValueError, match="content_bytes_list"):
+        compute_bpb([logprobs], [weights], [targets], tok, content_bytes_list=[2, 3])
+
+
+def test_datum_carries_trained_content_bytes():
+    """datum_from_model_input_weights returns a DatumWithContentBytes carrying
+    the count, without touching loss_fn_inputs (which the service validates)."""
+    model_input = _make_model_input([10, 20, 30, 40, 50])
+    weights = torch.tensor([0.0, 0.0, 1.0, 1.0, 1.0])
+    datum = datum_from_model_input_weights(model_input, weights, trained_content_bytes=42)
+    assert isinstance(datum, tinker.Datum)
+    assert isinstance(datum, DatumWithContentBytes)
+    assert datum.trained_content_bytes == 42
+    assert set(datum.loss_fn_inputs.keys()) == {"weights", "target_tokens"}
+
+
+def test_datum_without_content_bytes_is_plain_datum():
+    model_input = _make_model_input([10, 20, 30])
+    weights = torch.tensor([0.0, 1.0, 1.0])
+    datum = datum_from_model_input_weights(model_input, weights)
+    assert type(datum) is tinker.Datum
+    assert getattr(datum, "trained_content_bytes", None) is None
+
+
+def test_datum_with_content_bytes_pickles():
+    """Datasets may cross process boundaries; the metadata must survive pickling."""
+    import pickle
+
+    model_input = _make_model_input([10, 20, 30])
+    weights = torch.tensor([0.0, 1.0, 1.0])
+    datum = datum_from_model_input_weights(model_input, weights, trained_content_bytes=7)
+    restored = pickle.loads(pickle.dumps(datum))
+    assert isinstance(restored, DatumWithContentBytes)
+    assert restored.trained_content_bytes == 7
+
+
+def test_truncation_of_trained_tokens_drops_content_bytes():
+    """If max_length cuts into the loss-weighted region, the byte count no
+    longer matches the surviving tokens and must be dropped."""
+    model_input = _make_model_input([10, 20, 30, 40, 50])
+    weights = torch.tensor([0.0, 0.0, 1.0, 1.0, 1.0])
+    datum = datum_from_model_input_weights(
+        model_input, weights, max_length=4, trained_content_bytes=42
+    )
+    assert type(datum) is tinker.Datum
+    assert getattr(datum, "trained_content_bytes", None) is None
+
+
+def test_truncation_of_untrained_tokens_keeps_content_bytes():
+    """Truncation that only removes weight-0 tokens leaves the count valid."""
+    model_input = _make_model_input([10, 20, 30, 40, 50])
+    weights = torch.tensor([0.0, 1.0, 1.0, 0.0, 0.0])
+    datum = datum_from_model_input_weights(
+        model_input, weights, max_length=4, trained_content_bytes=42
+    )
+    assert isinstance(datum, DatumWithContentBytes)
+    assert datum.trained_content_bytes == 42
+
+
+def test_content_bytes_preserved_under_mean_reduction():
+    """Mean reduction rescales weights but must not affect the byte count."""
+    model_input = _make_model_input([10, 20, 30, 40, 50])
+    weights = torch.tensor([0.0, 0.0, 1.0, 1.0, 1.0])
+    datum = datum_from_model_input_weights(
+        model_input, weights, reduction="mean", trained_content_bytes=42
+    )
+    assert isinstance(datum, DatumWithContentBytes)
+    assert datum.trained_content_bytes == 42
+    assert math.isclose(sum(_extract_weights(datum)), 1.0, rel_tol=1e-6)

--- a/tinker_cookbook/supervised/data.py
+++ b/tinker_cookbook/supervised/data.py
@@ -50,7 +50,10 @@ def conversation_to_datum(
 
     Returns:
         tinker.Datum: A training datum with model input, target tokens,
-        and per-token loss weights.
+        and per-token loss weights. When the renderer reports content bytes
+        (and no trained token is lost to truncation), this is a
+        ``DatumWithContentBytes`` whose ``trained_content_bytes`` feeds the
+        bits-per-byte metric.
 
     Example::
 
@@ -65,10 +68,16 @@ def conversation_to_datum(
         ]
         datum = conversation_to_datum(messages, renderer, max_length=2048)
     """
-    model_input, weights = renderer.build_supervised_example(
+    example = renderer.build_supervised_example_with_metadata(
         conversation, train_on_what=train_on_what
     )
-    return datum_from_model_input_weights(model_input, weights, max_length, reduction=reduction)
+    return datum_from_model_input_weights(
+        example.model_input,
+        example.weights,
+        max_length,
+        reduction=reduction,
+        trained_content_bytes=example.trained_content_bytes,
+    )
 
 
 def _one_of(a: Any, b: Any) -> bool:

--- a/tinker_cookbook/supervised/nll_evaluator.py
+++ b/tinker_cookbook/supervised/nll_evaluator.py
@@ -65,8 +65,9 @@ class NLLEvaluator(TrainingClientEvaluator):
             and "target_tokens" in self.data[0].loss_fn_inputs
         ):
             target_tokens = [datum.loss_fn_inputs["target_tokens"] for datum in self.data]
+            content_bytes = [getattr(datum, "trained_content_bytes", None) for datum in self.data]
             metrics[f"{self.name}/bpb"] = compute_bpb(
-                logprobs, weights, target_tokens, self.tokenizer
+                logprobs, weights, target_tokens, self.tokenizer, content_bytes_list=content_bytes
             )
         return metrics
 

--- a/tinker_cookbook/supervised/train.py
+++ b/tinker_cookbook/supervised/train.py
@@ -493,7 +493,12 @@ async def main(config: Config):
         # letting NLL be compared across models with different tokenizers.
         if submitted.data and "target_tokens" in submitted.data[0].loss_fn_inputs:
             target_tokens = [datum.loss_fn_inputs["target_tokens"] for datum in submitted.data]
-            metrics["train_mean_bpb"] = compute_bpb(logprobs, weights, target_tokens, tokenizer)
+            content_bytes = [
+                getattr(datum, "trained_content_bytes", None) for datum in submitted.data
+            ]
+            metrics["train_mean_bpb"] = compute_bpb(
+                logprobs, weights, target_tokens, tokenizer, content_bytes_list=content_bytes
+            )
         # Merge evaluation metrics gathered before the training step was submitted
         if submitted.eval_metrics is not None:
             metrics.update(submitted.eval_metrics)


### PR DESCRIPTION
Follow-up to #823 / #824.

## Problem

The BPB denominator counts the UTF-8 bytes of the decoded trained tokens. #824 excluded registered special tokens from both sides, but scaffolding that renderers inject as **ordinary text** still counts as target bytes. The clearest case: Kimi renderers put a `<think></think>` block in every trained assistant message, and `<think>`/`</think>` are not in `all_special_ids` for the Kimi K2 tokenizer (where `<think>` is even three regular tokens: `<`, `think`, `>`) nor for Qwen3.

Scaffolding is near-zero-loss once the template is learned, so its bytes act as free denominator padding: measured BPB ≈ true BPB × B/(B+C) for B content bytes and C scaffolding bytes per turn. On a short turn (`"2+2 equals 4."` = 13 bytes), Kimi's trained span decodes to `<think></think>2+2 equals 4.` — **15 of 28 denominator bytes (54%) are scaffolding**. The deflation varies with the chat template, biasing exactly the cross-model comparisons BPB exists for; templates with more markup look artificially better.

Token-level filtering can't fix this: renderers deliberately encode scaffolding + content as one concatenated string so tokenization matches the HF chat template, so no exact per-token content mask exists (and BPE can merge across the boundary). The message level is where content bytes are exact.

## Fix

**Renderers report content bytes.** New helper `message_content_byte_count(message, include_thinking=..., include_tool_calls=...)` counts the payload that survives round-tripping through `parse_response`: text parts, thinking parts (when actually rendered), and tool-call function names/arguments. Each built-in renderer sets `RenderedMessage.content_byte_count` using flags that match what it actually rendered (e.g. thinking stripped from history → not counted; Nemotron's injected `{reasoning effort: ...}` suffix → discounted). For the same rendered content the count is independent of how the template formats it — which is what makes the denominator comparable. (Renderers that legitimately train on *different* content count different bytes: gpt-oss preserves historical thinking that Qwen3/Kimi strip, so cross-model comparisons are cleanest on data without thinking in historical turns; documented in the sweep README.)

**A new entry point carries the total; dispatch matches Python attribute lookup.** `Renderer.build_supervised_example_with_metadata` returns a `SupervisedExample(model_input, weights, trained_content_bytes)` where the count sums over loss-weighted messages. It is a `@final` dispatcher over a single overridable implementation chain, `_build_supervised_example_impl` (same protected-hook style as `_render_tool_calls`); `kimi_k2` / `gpt_oss` / `nemotron3` override the hook. The legacy `build_supervised_example` keeps its tuple signature and routes into the same chain. If **any** class in the MRO overrides the legacy method — the pre-existing extension point, at any layer, including overrides that call `super().build_supervised_example()` — the dispatcher routes through it exactly as a direct call would (reporting `None` for content bytes), so the two public entry points return identical tokens in every hierarchy, and no existing subclass silently changes its training tokens.

**The count rides on the datum without touching the wire.** `DatumWithContentBytes` is a `tinker.Datum` subclass with a plain attribute — deliberately *not* a `loss_fn_inputs` entry: the SDK serializes datums from `model_input` + `loss_fn_inputs` only (and `forward_backward_custom` rejects unknown `loss_fn_inputs` keys), so the field never reaches the service and datums pass through `forward_backward` unchanged. `datum_from_model_input_weights` drops the count if `max_length` truncation removes any loss-weighted token, since it would no longer describe the surviving span.

**`compute_bpb` prefers content bytes.** For datums carrying a count:

```
bpb = -sum(logprob_i for i where weight_i > 0) / (ln(2) * content_bytes)
```

The numerator is the model's entire trained code length — scaffolding pays its real bits, which vanish as the template is learned and are charged symmetrically to every model (no dependence on which tokens happen to be registered as special). The denominator is fixed by the trained content, not the template. Datums without a count (custom renderers overriding only the legacy method, or trained spans cut by `max_length`) fall back per-datum to the previous token-byte computation, so everything keeps working and `train_mean_bpb` / `test/bpb` keep their names; the sweep README documents the fallback.

With this, the same conversation scored under Kimi K2 and Qwen3 renderers yields the identical denominator (asserted in tests), and think-tag scaffolding remains trained but contributes no bytes.

## Review

Beyond unit tests, the change went through an independent multi-lens review (metric math, dispatch/backward-compat, per-renderer accounting, SDK integration, test quality, docs accuracy, whole-diff pass) with two adversarial verifiers per finding. Confirmed findings — a dispatch edge where an impl-hook override layered above a legacy override diverged from direct-call behavior, the Nemotron effort-suffix bytes, and two over-broad doc claims — are all fixed in the last commit; the dispatcher now defers to any legacy override exactly as Python attribute lookup does.

## Test

- `renderers/content_bytes_test.py` (new): kimi/qwen3 agree on content bytes for the same conversation; Kimi's `<think></think>` is trained but not counted; thinking counted only where rendered (last message vs. stripped history, both renderers); untrained messages contribute nothing; role_colon separators excluded; both entry points return identical tokens/weights. Dispatch regression tests: legacy-only overrides fall back to `None` with identical tokens; a legacy override layered on `KimiK2Renderer` is honored on both entry points; an impl-hook override layered **above** a legacy override still agrees; `super().build_supervised_example()` from a legacy override is recursion-free; impl-hook overrides report content bytes on both paths.
- `renderers/nemotron3_test.py`: the rendered `{reasoning effort: low}` suffix is excluded from content bytes.
- `supervised/common_test.py`: content-byte mode hand computation (numerator includes trained special tokens); weight-magnitude invariance (mean reduction); scaffolding pads the fallback denominator but not the content one; mixed batches fall back per-datum; length-mismatch raises; `DatumWithContentBytes` keeps `loss_fn_inputs` to exactly `{weights, target_tokens}`, pickles, and survives mean reduction; truncation into the trained region drops the count while truncation of untrained tokens keeps it.
- Verified the metadata attribute never reaches the wire: the SDK's pydantic and proto conversions rebuild datums from `model_input` + `loss_fn_inputs` only.
- `uv run --extra dev pytest tinker_cookbook/renderers/ tinker_cookbook/supervised/ tinker_cookbook/recipes/chat_sl/` → **557 passed, 46 skipped** (skips pre-existing, HF-gated); `tests/downstream_compat/` → **499 passed**; `ruff check` / `ruff format --check` clean; `pyright` 0 errors on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LC4d9VwvhNY3DX7EbmpMmv