### PR TITLE
Filter method-only special tokens in BPB

### DIFF
--- a/tinker_cookbook/supervised/common.py
+++ b/tinker_cookbook/supervised/common.py
@@ -91,6 +91,22 @@ def _decoded_byte_length(token_ids: list[int], tokenizer: Tokenizer) -> int:
     return len(text.encode("utf-8"))
 
 
+def _special_token_ids(tokenizer: Tokenizer) -> frozenset[int]:
+    special_ids = getattr(tokenizer, "all_special_ids", None) or []
+    return frozenset(int(token_id) for token_id in special_ids if token_id is not None)
+
+
+def _is_special_token(
+    token_id: int,
+    tokenizer: Tokenizer,
+    special_ids: frozenset[int],
+) -> bool:
+    if token_id in special_ids:
+        return True
+    is_special_token = getattr(tokenizer, "is_special_token", None)
+    return callable(is_special_token) and bool(is_special_token(token_id))
+
+
 def compute_bpb(
     logprobs_list: list[tinker.TensorData],
     weights_list: list[tinker.TensorData],
@@ -109,8 +125,9 @@ def compute_bpb(
         bpb = -sum(logprob_i for i in counted) / (ln(2) * bytes(counted tokens))
 
     A token is *counted* iff it is trained (``weight > 0``) and is not a special
-    token (per ``tokenizer.all_special_ids``). The same mask drives both the
-    numerator and the byte denominator, so they always cover the identical span.
+    token (per ``tokenizer.all_special_ids`` or ``tokenizer.is_special_token``,
+    when available). The same mask drives both the numerator and the byte
+    denominator, so they always cover the identical span.
 
     Two properties matter:
 
@@ -127,8 +144,8 @@ def compute_bpb(
     The denominator counts the UTF-8 bytes of the decoded counted tokens, fixed
     by the raw text rather than by the tokenization; combined with the matched
     numerator this yields a proper compression rate comparable across
-    tokenizers. (If a tokenizer does not expose ``all_special_ids``, no tokens
-    are treated as special, but both sides still share the same mask and stay
+    tokenizers. (If a tokenizer exposes no special-token surface, no tokens are
+    treated as special, but both sides still share the same mask and stay
     consistent.)
 
     Args:
@@ -144,7 +161,7 @@ def compute_bpb(
     Returns:
         float: Bits per byte, or ``nan`` if the counted target has zero bytes.
     """
-    special_ids = frozenset(getattr(tokenizer, "all_special_ids", None) or [])
+    special_ids = _special_token_ids(tokenizer)
     total_nll_nats = 0.0
     total_bytes = 0
 
@@ -156,7 +173,7 @@ def compute_bpb(
         # This single mask is used for both the numerator and the byte
         # denominator, guaranteeing they cover the identical span.
         counted = [
-            weight > 0 and token_id not in special_ids
+            weight > 0 and not _is_special_token(token_id, tokenizer, special_ids)
             for weight, token_id in zip(weights.data, token_ids, strict=True)
         ]
         mask = torch.tensor(counted, dtype=torch.bool)

--- a/tinker_cookbook/supervised/common_test.py
+++ b/tinker_cookbook/supervised/common_test.py
@@ -156,6 +156,20 @@ class _FakeTokenizer:
         )
 
 
+class _MethodOnlySpecialTokenizer:
+    """Tokenizer that exposes special tokens by method, not ``all_special_ids``."""
+
+    def __init__(self, vocab: dict[int, str], special_ids: set[int]):
+        self.vocab = vocab
+        self._special_ids = special_ids
+
+    def decode(self, ids: list[int], skip_special_tokens: bool = False) -> str:
+        return "".join(self.vocab[i] for i in ids)
+
+    def is_special_token(self, token_id: int) -> bool:
+        return token_id in self._special_ids
+
+
 def _fake_tokenizer(vocab: dict[int, str], special_ids: set[int] | None = None) -> Tokenizer:
     """Build a `_FakeTokenizer` typed as `Tokenizer` for the BPB helpers."""
     return cast(Tokenizer, _FakeTokenizer(vocab, special_ids))
@@ -221,6 +235,17 @@ def test_compute_bpb_excludes_special_tokens_from_both_sides():
     bpb = compute_bpb([logprobs], [weights], [targets], tok)
     # Only token 1 ("hi") counts: 1 nat over 2 bytes. The special token's -5.0
     # nats are dropped along with its (zero) bytes.
+    expected = 1.0 / (math.log(2) * len("hi"))
+    assert math.isclose(bpb, expected, rel_tol=1e-6)
+
+
+def test_compute_bpb_excludes_method_only_special_tokens():
+    """Some tokenizers expose special/control IDs via an ``is_special_token`` method."""
+    tok = cast(Tokenizer, _MethodOnlySpecialTokenizer({1: "hi", 99: "<|end|>"}, {99}))
+    logprobs = _td([-1.0, -5.0], "float32")
+    weights = _td([1.0, 1.0], "float32")
+    targets = _td([1, 99], "int64")
+    bpb = compute_bpb([logprobs], [weights], [targets], tok)
     expected = 1.0 / (math.log(2) * len("hi"))
     assert math.isclose(bpb, expected, rel_tol=1e-6)
 


### PR DESCRIPTION
## Summary

- Make `compute_bpb` filter tokenizer special/control tokens exposed through `is_special_token(token_id)`, not only `all_special_ids`.
- Keep the BPB numerator and byte denominator on the same filtered target span.
- Add a regression test for tokenizers that expose special IDs by method only.

## Validation

- `uv run --with pytest python -m pytest tinker_cookbook/supervised/common_test.py`
- `uv run --with ruff ruff check tinker_cookbook/supervised/common.py tinker_cookbook/supervised/common_test.py`
- `uv run --with ruff ruff format --check tinker_cookbook/supervised/common.py tinker_cookbook/supervised/common_test.py`