### PR TITLE
Add Lean Workbook tactics dataset

### DIFF
--- a/tinker_cookbook/recipes/chat_sl/chat_datasets.py
+++ b/tinker_cookbook/recipes/chat_sl/chat_datasets.py
@@ -76,3 +76,39 @@ class NoRobotsBuilder(ChatDatasetBuilder):
         ), SupervisedDatasetFromHFDataset(
             test_dataset, batch_size=self.common_config.batch_size, map_fn=map_fn
         )
+
+
+@chz.chz
+class LeanWorkbookTacticsBuilder(ChatDatasetBuilder):
+    """Lean-Workbook proof states as next-tactic SFT examples."""
+
+    def __call__(self) -> tuple[SupervisedDataset, SupervisedDataset]:
+        dataset = datasets.load_dataset("internlm/Lean-Workbook")
+        dataset = cast(datasets.DatasetDict, dataset)
+        dataset = dataset["train"]
+        dataset = dataset.filter(lambda row: bool(row["tactic"]) and row["status"] == "proved")
+        dataset = dataset.shuffle(seed=0)
+        test_ds = dataset.take(512)
+        train_ds = dataset.skip(512)
+
+        train_on_what = (
+            TrainOnWhat(self.common_config.train_on_what)
+            if self.common_config.train_on_what
+            else TrainOnWhat.LAST_ASSISTANT_MESSAGE
+        )
+
+        def map_fn(row: dict) -> tinker.Datum:
+            prompt = f"[THEOREM]{row['formal_statement']}[GOAL]{row['state_before']}[PROOFSTEP]"
+            messages = [
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": row["tactic"]},
+            ]
+            return conversation_to_datum(
+                messages, self.renderer, self.common_config.max_length, train_on_what
+            )
+
+        return SupervisedDatasetFromHFDataset(
+            train_ds, batch_size=self.common_config.batch_size, map_fn=map_fn
+        ), SupervisedDatasetFromHFDataset(
+            test_ds, batch_size=self.common_config.batch_size, map_fn=map_fn
+        )

--- a/tinker_cookbook/recipes/chat_sl/chat_datasets_test.py
+++ b/tinker_cookbook/recipes/chat_sl/chat_datasets_test.py
@@ -1,0 +1,84 @@
+import datasets
+
+from tinker_cookbook.recipes.chat_sl import chat_datasets
+from tinker_cookbook.renderers import TrainOnWhat
+from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
+
+
+def test_lean_workbook_tactics_builder_filters_and_formats(monkeypatch):
+    rows = [
+        {
+            "formal_statement": f"theorem proved_{i} : True := by",
+            "state_before": "|- True",
+            "tactic": f"tactic_{i}",
+            "status": "proved",
+        }
+        for i in range(514)
+    ]
+    rows.extend(
+        [
+            {
+                "formal_statement": "theorem empty : True := by",
+                "state_before": "|- True",
+                "tactic": "",
+                "status": "proved",
+            },
+            {
+                "formal_statement": "theorem failed : True := by",
+                "state_before": "|- True",
+                "tactic": "sorry",
+                "status": "failed",
+            },
+        ]
+    )
+    hf_dataset = datasets.DatasetDict({"train": datasets.Dataset.from_list(rows)})
+
+    def fake_load_dataset(name: str) -> datasets.DatasetDict:
+        assert name == "internlm/Lean-Workbook"
+        return hf_dataset
+
+    monkeypatch.setattr(chat_datasets.datasets, "load_dataset", fake_load_dataset)
+    monkeypatch.setattr(
+        chat_datasets.LeanWorkbookTacticsBuilder,
+        "renderer",
+        property(lambda self: object()),
+    )
+
+    examples: list[list[dict[str, str]]] = []
+
+    def fake_conversation_to_datum(
+        messages: list[dict[str, str]],
+        renderer: object,
+        max_length: int | None,
+        train_on_what: TrainOnWhat,
+    ) -> object:
+        examples.append(messages)
+        assert max_length == 1024
+        assert train_on_what == TrainOnWhat.LAST_ASSISTANT_MESSAGE
+        return messages
+
+    monkeypatch.setattr(chat_datasets, "conversation_to_datum", fake_conversation_to_datum)
+
+    builder = chat_datasets.LeanWorkbookTacticsBuilder(
+        common_config=ChatDatasetBuilderCommonConfig(
+            model_name_for_tokenizer="Qwen/Qwen3-8B",
+            renderer_name="qwen3",
+            max_length=1024,
+            batch_size=1,
+            train_on_what=None,
+        ),
+    )
+    train_dataset, test_dataset = builder()
+
+    assert len(train_dataset) == 2
+    assert len(test_dataset) == 512
+    train_dataset.get_batch(0)
+    test_dataset.get_batch(0)
+
+    assert len(examples) == 2
+    assert all(example[0]["role"] == "user" for example in examples)
+    assert all(example[1]["role"] == "assistant" for example in examples)
+    assert all(example[1]["content"].startswith("tactic_") for example in examples)
+    assert all("[THEOREM]" in example[0]["content"] for example in examples)
+    assert all("[GOAL]" in example[0]["content"] for example in examples)
+    assert all(example[0]["content"].endswith("[PROOFSTEP]") for example in examples)

--- a/tinker_cookbook/recipes/chat_sl/train.py
+++ b/tinker_cookbook/recipes/chat_sl/train.py
@@ -82,6 +82,8 @@ def get_dataset_builder(
         return chat_datasets.Tulu3Builder(common_config=common_config)
     elif dataset == "no_robots":
         return chat_datasets.NoRobotsBuilder(common_config=common_config)
+    elif dataset == "lean_workbook_tactics":
+        return chat_datasets.LeanWorkbookTacticsBuilder(common_config=common_config)
     elif dataset.endswith(".jsonl"):
         # Load conversations from a JSONL file
         return FromConversationFileBuilder(


### PR DESCRIPTION
## Summary

- Add a `LeanWorkbookTacticsBuilder` for `internlm/Lean-Workbook` proof-state next-tactic SFT examples.
- Expose it through the chat SL CLI as `base.dataset=lean_workbook_tactics`.
- Filter to proved rows with nonempty tactics and use a deterministic held-out split.

## Validation

- `uv run --with pytest python -m pytest tinker_cookbook/recipes/chat_sl/chat_datasets_test.py`
- `uv run --with ruff ruff check tinker_cookbook/recipes/chat_sl/chat_datasets.py tinker_cookbook/recipes/chat_sl/train.py tinker_cookbook/recipes/chat_sl/chat_datasets_test.py`
- `uv run --with ruff ruff format --check tinker_cookbook/recipes/chat_sl/chat_datasets.py tinker_cookbook/recipes/chat_sl/train.py tinker_cookbook/recipes/chat_sl/chat_datasets_test.py`