### PR TITLE
Make sl_basic and rl_basic derive renderer from CLI model_name override

### DIFF
--- a/tinker_cookbook/cli_utils.py
+++ b/tinker_cookbook/cli_utils.py
@@ -10,6 +10,20 @@ logger = logging.getLogger(__name__)
 LogdirBehavior = Literal["delete", "resume", "ask", "raise"]
 
 
+def model_name_from_argv(argv: list[str], default: str) -> str:
+    """Extract a model_name=... override from argv before building a blueprint.
+
+    Recipes that derive settings from the model name (renderer name, dataset
+    tokenizer) must resolve those values before applying the rest of argv;
+    otherwise a model_name override trains with the default model's renderer
+    and tokenizer.
+    """
+    for arg in argv:
+        if arg.startswith("model_name="):
+            return arg.removeprefix("model_name=")
+    return default
+
+
 def check_log_dir(log_dir: str, behavior_if_exists: LogdirBehavior):
     """
     Call this at the beginning of CLI entrypoint to training scripts. This handles

--- a/tinker_cookbook/cli_utils.py
+++ b/tinker_cookbook/cli_utils.py
@@ -18,10 +18,12 @@ def model_name_from_argv(argv: list[str], default: str) -> str:
     otherwise a model_name override trains with the default model's renderer
     and tokenizer.
     """
+    model_name = default
+    # Last occurrence wins, matching chz's argv precedence.
     for arg in argv:
         if arg.startswith("model_name="):
-            return arg.removeprefix("model_name=")
-    return default
+            model_name = arg.removeprefix("model_name=")
+    return model_name
 
 
 def check_log_dir(log_dir: str, behavior_if_exists: LogdirBehavior):

--- a/tinker_cookbook/recipes/rl_basic.py
+++ b/tinker_cookbook/recipes/rl_basic.py
@@ -7,9 +7,10 @@ from tinker_cookbook import cli_utils, model_info
 from tinker_cookbook.recipes.math_rl.math_env import Gsm8kDatasetBuilder
 from tinker_cookbook.rl import train
 
+DEFAULT_MODEL_NAME = "Qwen/Qwen3.5-9B-Base"
 
-def build_config_blueprint() -> chz.Blueprint[train.Config]:
-    model_name = "Qwen/Qwen3.5-9B-Base"
+
+def build_config_blueprint(model_name: str = DEFAULT_MODEL_NAME) -> chz.Blueprint[train.Config]:
     renderer_name = model_info.get_recommended_renderer_name(model_name)
     builder = Gsm8kDatasetBuilder(
         batch_size=128,
@@ -39,6 +40,8 @@ def main(config: train.Config):
 
 
 if __name__ == "__main__":
-    blueprint = build_config_blueprint()
+    # Resolve model_name first so the renderer and dataset tokenizer follow it.
+    model_name = cli_utils.model_name_from_argv(sys.argv[1:], default=DEFAULT_MODEL_NAME)
+    blueprint = build_config_blueprint(model_name)
     blueprint.make_from_argv(sys.argv[1:])
     main(blueprint.make())

--- a/tinker_cookbook/recipes/sl_basic.py
+++ b/tinker_cookbook/recipes/sl_basic.py
@@ -10,9 +10,10 @@ from tinker_cookbook.supervised import train
 from tinker_cookbook.supervised.data import FromConversationFileBuilder
 from tinker_cookbook.supervised.types import ChatDatasetBuilderCommonConfig
 
+DEFAULT_MODEL_NAME = "Qwen/Qwen3.5-9B-Base"
 
-def build_config_blueprint() -> chz.Blueprint[train.Config]:
-    model_name = "Qwen/Qwen3.5-9B-Base"
+
+def build_config_blueprint(model_name: str = DEFAULT_MODEL_NAME) -> chz.Blueprint[train.Config]:
     renderer_name = model_info.get_recommended_renderer_name(model_name)
     common_config = ChatDatasetBuilderCommonConfig(
         model_name_for_tokenizer=model_name,
@@ -50,6 +51,8 @@ def main(config: train.Config):
 
 
 if __name__ == "__main__":
-    blueprint = build_config_blueprint()
+    # Resolve model_name first so the renderer and dataset tokenizer follow it.
+    model_name = cli_utils.model_name_from_argv(sys.argv[1:], default=DEFAULT_MODEL_NAME)
+    blueprint = build_config_blueprint(model_name)
     blueprint.make_from_argv(sys.argv[1:])
     main(blueprint.make())


### PR DESCRIPTION
`sl_basic.py` and `rl_basic.py` resolve `renderer_name` and the dataset builder's tokenizer from a hardcoded default model at blueprint-build time. Passing `model_name=...` on the command line therefore overrides only `train.Config.model_name`, and the run silently trains with the default model's renderer and tokenizer. For example, `python -m tinker_cookbook.recipes.sl_basic model_name=thinkingmachines/Inkling` renders NoRobots with the default renderer instead of `tml_v0`.

This resolves the `model_name` override from argv before building the blueprint (via a new `cli_utils.model_name_from_argv` helper shared by both recipes), so the recommended renderer and dataset tokenizer follow the requested model. Defaults are unchanged.

Verified: with `model_name=thinkingmachines/Inkling` both recipes now produce `renderer_name=tml_v0` and `model_name_for_tokenizer=thinkingmachines/Inkling` on both `train.Config` and the dataset builder, other CLI overrides still apply, and the no-override path is byte-identical to before.