### PR TITLE
Simplify redundant except clause in modal_sandbox drain loop

### DIFF
--- a/tinker_cookbook/sandbox/modal_sandbox.py
+++ b/tinker_cookbook/sandbox/modal_sandbox.py
@@ -55,7 +55,8 @@ async def _read_stream_capped(stream: object, max_bytes: int) -> str:
     try:
         async for _ in stream:  # type: ignore[union-attr]
             pass
-    except (UnicodeDecodeError, Exception):
+    except Exception:
+        # Best-effort drain; ignore any error (including Modal's internal decoding errors).
         pass
 
     return b"".join(chunks).decode("utf-8", errors="replace")


### PR DESCRIPTION
In the stream drain loop in `sandbox/modal_sandbox.py`, the handler `except (UnicodeDecodeError, Exception)` is redundant — `Exception` already subsumes `UnicodeDecodeError`, so listing both only makes the broad catch look narrower than it actually is.

Replaced with `except Exception` plus a comment noting the drain is best-effort. No behavior change (the same set of exceptions was already being caught).
