### PR TITLE
Add preserve-thinking Nemotron-3 renderers (HF truncate_history_thinking=False)

### DIFF
--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -27,12 +27,13 @@ _GPT_OSS = ("gpt_oss_no_sysprompt", "gpt_oss_medium_reasoning")
 _KIMI_K2 = ("kimi_k2",)
 _KIMI_K25 = ("kimi_k25", "kimi_k25_disable_thinking")
 _KIMI_K26 = ("kimi_k26", "kimi_k26_disable_thinking", "kimi_k26_preserve_thinking")
-_NEMOTRON3 = ("nemotron3", "nemotron3_disable_thinking")
+_NEMOTRON3 = ("nemotron3", "nemotron3_disable_thinking", "nemotron3_preserve_thinking")
 _NEMOTRON3_SUPER = _NEMOTRON3 + ("nemotron3_low_thinking",)
 _NEMOTRON3_ULTRA = (
     "nemotron3_ultra",
     "nemotron3_ultra_disable_thinking",
     "nemotron3_ultra_medium_thinking",
+    "nemotron3_ultra_preserve_thinking",
 )
 _TML_V0 = ("tml_v0",)
 

--- a/tinker_cookbook/model_info_test.py
+++ b/tinker_cookbook/model_info_test.py
@@ -56,6 +56,7 @@ class TestNemotron3:
             "nemotron3_ultra",
             "nemotron3_ultra_disable_thinking",
             "nemotron3_ultra_medium_thinking",
+            "nemotron3_ultra_preserve_thinking",
         ]
 
 

--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -147,9 +147,11 @@ def get_renderer(
             - ``"nemotron3"``: Nemotron-3 with full reasoning
             - ``"nemotron3_low_thinking"``: Nemotron-3 with low-effort reasoning (Super only)
             - ``"nemotron3_disable_thinking"``: Nemotron-3 with reasoning off
+            - ``"nemotron3_preserve_thinking"``: Nemotron-3 (Nano/Super) with full reasoning and historical ``<think>...</think>`` blocks preserved (HF ``truncate_history_thinking=false``); use for multi-turn RL / long-horizon agents
             - ``"nemotron3_ultra"``: Nemotron-3 Ultra with full reasoning
             - ``"nemotron3_ultra_disable_thinking"``: Nemotron-3 Ultra with reasoning off
             - ``"nemotron3_ultra_medium_thinking"``: Nemotron-3 Ultra with medium-effort reasoning
+            - ``"nemotron3_ultra_preserve_thinking"``: Nemotron-3 Ultra with full reasoning and historical ``<think>...</think>`` blocks preserved (HF ``truncate_history_thinking=false``)
             - ``"gpt_oss_no_sysprompt"``: GPT-OSS without system prompt
             - ``"gpt_oss_low_reasoning"``: GPT-OSS with low reasoning
             - ``"gpt_oss_medium_reasoning"``: GPT-OSS with medium reasoning
@@ -205,9 +207,11 @@ def get_renderer(
     from tinker_cookbook.renderers.nemotron3 import (
         Nemotron3DisableThinkingRenderer,
         Nemotron3LowThinkingRenderer,
+        Nemotron3PreserveThinkingRenderer,
         Nemotron3Renderer,
         Nemotron3UltraDisableThinkingRenderer,
         Nemotron3UltraMediumThinkingRenderer,
+        Nemotron3UltraPreserveThinkingRenderer,
         Nemotron3UltraRenderer,
     )
     from tinker_cookbook.renderers.qwen3 import (
@@ -266,12 +270,16 @@ def get_renderer(
         renderer = Nemotron3LowThinkingRenderer(tokenizer)
     elif name == "nemotron3_disable_thinking":
         renderer = Nemotron3DisableThinkingRenderer(tokenizer)
+    elif name == "nemotron3_preserve_thinking":
+        renderer = Nemotron3PreserveThinkingRenderer(tokenizer)
     elif name == "nemotron3_ultra":
         renderer = Nemotron3UltraRenderer(tokenizer)
     elif name == "nemotron3_ultra_disable_thinking":
         renderer = Nemotron3UltraDisableThinkingRenderer(tokenizer)
     elif name == "nemotron3_ultra_medium_thinking":
         renderer = Nemotron3UltraMediumThinkingRenderer(tokenizer)
+    elif name == "nemotron3_ultra_preserve_thinking":
+        renderer = Nemotron3UltraPreserveThinkingRenderer(tokenizer)
     elif name == "gpt_oss_no_sysprompt":
         renderer = GptOssRenderer(tokenizer, use_system_prompt=False)
     elif name == "gpt_oss_low_reasoning":

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -73,6 +73,7 @@ from tinker_cookbook.renderers.base import (
     ToolSpec,
 )
 from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
+from tinker_cookbook.tokenizer_utils import Tokenizer
 
 
 def _render_extra_keys(obj: Mapping[str, object], handled_keys: set[str]) -> list[str]:
@@ -191,14 +192,19 @@ class Nemotron3Renderer(Qwen3_5Renderer):
 
         Nemotron-3's HF template prepends <think></think> to assistant message
         content when there are no <think> tags in the output:
-        - Historical messages (idx < last_user_index): thinking is stripped,
-          so <think></think> is always prepended regardless of original content.
+        - Historical messages (idx < last_user_index): with the default
+          ``truncate_history_thinking=True`` (``strip_thinking_from_history=True``)
+          the thinking is stripped, so <think></think> is prepended regardless of
+          original content. With ``strip_thinking_from_history=False`` (HF
+          ``truncate_history_thinking=False``) the thinking stays in the output,
+          so historical messages are treated like non-historical ones.
         - Non-historical messages: prepend only if the message has no thinking.
 
-        When a historical message has non-empty text content, the HF template
-        produces "<think></think>\\ntext" (with a newline separator). This comes
-        from c.split('</think>')[-1] preserving the \\n in _format_thinking_text's
-        output. We add the \\n to the header suffix in that case.
+        When a historical message with stripped thinking has non-empty text
+        content, the HF template produces "<think></think>\\ntext" (with a
+        newline separator). This comes from c.split('</think>')[-1] preserving
+        the \\n in _format_thinking_text's output. We add the \\n to the header
+        suffix in that case.
         """
         is_historical = ctx.idx < ctx.last_user_index
         content = message.get("content", "")
@@ -207,8 +213,9 @@ class Nemotron3Renderer(Qwen3_5Renderer):
             has_think = any(p["type"] == "thinking" for p in content)
         elif isinstance(content, str):
             has_think = "<think>" in content
-        # Non-historical with thinking: thinking will be in output, no prefix needed.
-        if has_think and not is_historical:
+        # No empty prefix when the thinking itself will be rendered in the output:
+        # always for the current turn, and for history when it is preserved.
+        if has_think and (not is_historical or not self.strip_thinking_from_history):
             return ""
         # For historical messages with stripped thinking and non-empty text:
         # add \n separator to match HF template's c.split('</think>')[-1] behavior.
@@ -364,6 +371,28 @@ class Nemotron3Renderer(Qwen3_5Renderer):
         return [Message(role="system", content=content)]
 
 
+class Nemotron3PreserveThinkingRenderer(Nemotron3Renderer):
+    """Nemotron-3 (Nano/Super) that keeps <think> blocks from previous turns.
+
+    Matches the Nemotron-3 HF chat template rendered with
+    ``truncate_history_thinking=False``: every historical assistant turn keeps
+    its full ``<think>\\n...\\n</think>`` reasoning block instead of the default
+    behavior that collapses prior reasoning to ``<think></think>``.
+
+    Use this variant when reasoning traces on prior turns are load-bearing at
+    inference or training time — most commonly multi-turn RL, where preserving
+    history thinking gives the renderer the extension property (a shorter prefix
+    of a conversation tokenizes to a prefix of the full conversation).
+
+    Under the hood this forwards ``strip_thinking_from_history=False`` to
+    :class:`Nemotron3Renderer`. HF's ``truncate_history_thinking=False`` is
+    byte-equivalent to the cookbook's ``strip_thinking_from_history=False``.
+    """
+
+    def __init__(self, tokenizer: Tokenizer):
+        super().__init__(tokenizer, strip_thinking_from_history=False)
+
+
 class Nemotron3LowThinkingRenderer(Nemotron3Renderer):
     """Renderer for Nemotron-3 models with low-effort reasoning.
 
@@ -408,7 +437,13 @@ class Nemotron3UltraRenderer(Nemotron3Renderer):
     """
 
     def _assistant_header_suffix(self, message: Message, ctx: RenderContext) -> str:
-        """Prepend <think></think> when Ultra's template omits thinking content."""
+        """Prepend <think></think> when Ultra's template omits thinking content.
+
+        As with :class:`Nemotron3Renderer`, historical thinking is only
+        replaced by an empty block when it is stripped from the output
+        (``strip_thinking_from_history=True``); when it is preserved, historical
+        messages are treated like non-historical ones.
+        """
         is_historical = ctx.idx < ctx.last_user_index
         content = message.get("content", "")
         has_think = False
@@ -416,7 +451,7 @@ class Nemotron3UltraRenderer(Nemotron3Renderer):
             has_think = any(p["type"] == "thinking" for p in content)
         elif isinstance(content, str):
             has_think = "<think>" in content
-        if has_think and not is_historical:
+        if has_think and (not is_historical or not self.strip_thinking_from_history):
             return ""
         return "<think></think>"
 
@@ -433,6 +468,19 @@ class Nemotron3UltraRenderer(Nemotron3Renderer):
     def _postprocess_parsed_message(self, message: Message) -> None:
         """Ultra has no separator newline after ``</think>`` to strip."""
         Qwen3_5Renderer._postprocess_parsed_message(self, message)
+
+
+class Nemotron3UltraPreserveThinkingRenderer(Nemotron3UltraRenderer):
+    """Nemotron-3 Ultra that keeps <think> blocks from previous turns.
+
+    Ultra counterpart of :class:`Nemotron3PreserveThinkingRenderer`: matches
+    Ultra's HF chat template with ``truncate_history_thinking=False``, keeping
+    each historical assistant turn's ``<think>\\n...</think>`` block instead of
+    collapsing it to ``<think></think>``. See that class for when to use it.
+    """
+
+    def __init__(self, tokenizer: Tokenizer):
+        super().__init__(tokenizer, strip_thinking_from_history=False)
 
 
 class Nemotron3UltraMediumThinkingRenderer(Nemotron3UltraRenderer):

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -1287,9 +1287,72 @@ def test_preserve_thinking_registered_in_model_info():
         "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
     ]:
         assert "nemotron3_preserve_thinking" in model_info.get_recommended_renderer_names(model)
-    assert (
-        "nemotron3_ultra_preserve_thinking"
-        in model_info.get_recommended_renderer_names(
-            "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
-        )
+    assert "nemotron3_ultra_preserve_thinking" in model_info.get_recommended_renderer_names(
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
     )
+
+
+# The preserve-thinking behavior isn't limited to the two named variants above:
+# any Nemotron-3 mode renderer keeps history thinking when constructed with
+# strip_thinking_from_history=False. These check that opt-in matches HF for the
+# disable / low-effort / medium-effort modes, which have no named preserve variant.
+
+
+def _assert_mode_preserve_matches_hf(tokenizer, renderer, **hf_kwargs):
+    """Renderer (built with strip_thinking_from_history=False) matches HF with
+    truncate_history_thinking=False plus the mode flags in ``hf_kwargs``."""
+    sup_msgs = get_multiturn_thinking_conversation()
+    cookbook_sup = renderer.build_supervised_example(sup_msgs)[0].to_ints()
+    hf_sup = _hf_supervised_tokens(
+        tokenizer,
+        [renderer.to_openai_message(m) for m in sup_msgs],
+        truncate_history_thinking=False,
+        **hf_kwargs,
+    )
+    assert cookbook_sup == hf_sup, (
+        f"supervised: {tokenizer.decode(cookbook_sup)}\nHF: {tokenizer.decode(hf_sup)}"
+    )
+
+    gen_msgs = get_multiturn_thinking_conversation()[:4]
+    cookbook_gen = renderer.build_generation_prompt(gen_msgs).to_ints()
+    hf_gen = _hf_generation_tokens(
+        tokenizer,
+        [renderer.to_openai_message(m) for m in gen_msgs],
+        truncate_history_thinking=False,
+        **hf_kwargs,
+    )
+    assert cookbook_gen == hf_gen, (
+        f"generation: {tokenizer.decode(cookbook_gen)}\nHF: {tokenizer.decode(hf_gen)}"
+    )
+
+
+def test_disable_thinking_preserve_matches_hf(nemotron_tokenizer):
+    """Reasoning-off + strip_thinking_from_history=False keeps history, matches HF."""
+    renderer = Nemotron3DisableThinkingRenderer(
+        nemotron_tokenizer, strip_thinking_from_history=False
+    )
+    _assert_mode_preserve_matches_hf(nemotron_tokenizer, renderer, enable_thinking=False)
+
+
+def test_low_thinking_preserve_matches_hf(nemotron_super_tokenizer):
+    """Low-effort + strip_thinking_from_history=False keeps history, matches HF (Super)."""
+    renderer = Nemotron3LowThinkingRenderer(
+        nemotron_super_tokenizer, strip_thinking_from_history=False
+    )
+    _assert_mode_preserve_matches_hf(nemotron_super_tokenizer, renderer, low_effort=True)
+
+
+def test_ultra_medium_thinking_preserve_matches_hf(nemotron_ultra_tokenizer):
+    """Ultra medium-effort + strip_thinking_from_history=False keeps history, matches HF."""
+    renderer = Nemotron3UltraMediumThinkingRenderer(
+        nemotron_ultra_tokenizer, strip_thinking_from_history=False
+    )
+    _assert_mode_preserve_matches_hf(nemotron_ultra_tokenizer, renderer, medium_effort=True)
+
+
+def test_ultra_disable_thinking_preserve_matches_hf(nemotron_ultra_tokenizer):
+    """Ultra reasoning-off + strip_thinking_from_history=False keeps history, matches HF."""
+    renderer = Nemotron3UltraDisableThinkingRenderer(
+        nemotron_ultra_tokenizer, strip_thinking_from_history=False
+    )
+    _assert_mode_preserve_matches_hf(nemotron_ultra_tokenizer, renderer, enable_thinking=False)

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -19,9 +19,11 @@ from tinker_cookbook.renderers import Message, ToolCall, ToolSpec, get_renderer
 from tinker_cookbook.renderers.nemotron3 import (
     Nemotron3DisableThinkingRenderer,
     Nemotron3LowThinkingRenderer,
+    Nemotron3PreserveThinkingRenderer,
     Nemotron3Renderer,
     Nemotron3UltraDisableThinkingRenderer,
     Nemotron3UltraMediumThinkingRenderer,
+    Nemotron3UltraPreserveThinkingRenderer,
     Nemotron3UltraRenderer,
     _format_nemotron3_tool_declaration,
 )
@@ -60,9 +62,15 @@ def _hf_generation_tokens(
     enable_thinking: bool = True,
     low_effort: bool = False,
     medium_effort: bool = False,
+    truncate_history_thinking: bool = True,
 ):
     """Run HF apply_chat_template with generation prompt and return token list."""
-    kwargs = {"add_generation_prompt": True, "tokenize": True, "enable_thinking": enable_thinking}
+    kwargs = {
+        "add_generation_prompt": True,
+        "tokenize": True,
+        "enable_thinking": enable_thinking,
+        "truncate_history_thinking": truncate_history_thinking,
+    }
     if tools is not None:
         kwargs["tools"] = tools
     if low_effort:
@@ -83,9 +91,15 @@ def _hf_supervised_tokens(
     enable_thinking: bool = True,
     low_effort: bool = False,
     medium_effort: bool = False,
+    truncate_history_thinking: bool = True,
 ):
     """Run HF apply_chat_template without generation prompt, strip trailing newline, re-encode."""
-    kwargs = {"add_generation_prompt": False, "tokenize": False, "enable_thinking": enable_thinking}
+    kwargs = {
+        "add_generation_prompt": False,
+        "tokenize": False,
+        "enable_thinking": enable_thinking,
+        "truncate_history_thinking": truncate_history_thinking,
+    }
     if tools is not None:
         kwargs["tools"] = tools
     if low_effort:
@@ -1104,4 +1118,178 @@ def test_ultra_medium_thinking_multiturn_supervised_matches_hf(
     assert cookbook == hf, (
         f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
         f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+# =============================================================================
+# Preserve-Thinking Renderer Tests (HF truncate_history_thinking=False)
+# =============================================================================
+
+# The default Nemotron-3 renderers strip <think> blocks from historical assistant
+# turns, matching the HF template default truncate_history_thinking=True. The
+# preserve-thinking variants keep them, matching truncate_history_thinking=False.
+
+
+@pytest.fixture(scope="module")
+def nemotron_preserve_thinking_renderer(nemotron_tokenizer):
+    return get_renderer("nemotron3_preserve_thinking", nemotron_tokenizer)
+
+
+@pytest.fixture(scope="module")
+def nemotron_ultra_preserve_thinking_renderer(nemotron_ultra_tokenizer):
+    return get_renderer("nemotron3_ultra_preserve_thinking", nemotron_ultra_tokenizer)
+
+
+def test_preserve_thinking_renderer_types(
+    nemotron_preserve_thinking_renderer, nemotron_ultra_preserve_thinking_renderer
+):
+    assert isinstance(nemotron_preserve_thinking_renderer, Nemotron3PreserveThinkingRenderer)
+    assert isinstance(nemotron_preserve_thinking_renderer, Nemotron3Renderer)
+    assert isinstance(
+        nemotron_ultra_preserve_thinking_renderer, Nemotron3UltraPreserveThinkingRenderer
+    )
+    assert isinstance(nemotron_ultra_preserve_thinking_renderer, Nemotron3UltraRenderer)
+
+
+def test_preserve_thinking_has_extension_property(
+    nemotron_preserve_thinking_renderer,
+    nemotron_ultra_preserve_thinking_renderer,
+    nemotron_renderer,
+):
+    """Preserving history thinking gives the extension property; the default does not."""
+    assert nemotron_preserve_thinking_renderer.has_extension_property is True
+    assert nemotron_ultra_preserve_thinking_renderer.has_extension_property is True
+    assert nemotron_renderer.has_extension_property is False
+
+
+def test_default_strips_history_thinking(nemotron_tokenizer, nemotron_renderer):
+    """Sanity contrast: the default renderer collapses historical thinking."""
+    messages = get_multiturn_thinking_conversation()
+    decoded = nemotron_tokenizer.decode(
+        nemotron_renderer.build_supervised_example(messages)[0].to_ints()
+    )
+    assert "First turn reasoning." not in decoded  # historical thinking dropped
+    assert "<think></think>" in decoded
+    assert "Second turn reasoning." in decoded  # last turn's thinking always kept
+
+
+def test_preserve_thinking_keeps_history_thinking(
+    nemotron_tokenizer, nemotron_preserve_thinking_renderer
+):
+    """Preserve variant keeps the historical <think>...</think> block verbatim."""
+    messages = get_multiturn_thinking_conversation()
+    decoded = nemotron_tokenizer.decode(
+        nemotron_preserve_thinking_renderer.build_supervised_example(messages)[0].to_ints()
+    )
+    assert "<think>\nFirst turn reasoning.\n</think>" in decoded
+    assert "Second turn reasoning." in decoded
+
+
+def test_preserve_thinking_multiturn_supervised_matches_hf(
+    nemotron_tokenizer, nemotron_preserve_thinking_renderer
+):
+    """Preserve variant supervised example matches HF truncate_history_thinking=False."""
+    messages = get_multiturn_thinking_conversation()
+    r = nemotron_preserve_thinking_renderer
+    cookbook = r.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        truncate_history_thinking=False,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_preserve_thinking_multiturn_generation_matches_hf(
+    nemotron_tokenizer, nemotron_preserve_thinking_renderer
+):
+    """Preserve variant generation prompt matches HF truncate_history_thinking=False."""
+    messages = get_multiturn_thinking_conversation()[:4]
+    r = nemotron_preserve_thinking_renderer
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        truncate_history_thinking=False,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_preserve_thinking_historical_tool_call_supervised_matches_hf(
+    nemotron_tokenizer, nemotron_preserve_thinking_renderer
+):
+    """Historical assistant turn with thinking + text + tool_calls, preserved, matches HF."""
+    messages, tools = get_historical_tool_call_with_nonempty_text_conversation()
+    openai_tools = [{"type": "function", "function": tool} for tool in tools]
+    system_prompt = "You are a helpful assistant."
+    r = nemotron_preserve_thinking_renderer
+
+    prefix = r.create_conversation_prefix_with_tools(tools, system_prompt=system_prompt)
+    cookbook = r.build_supervised_example(prefix + messages)[0].to_ints()
+
+    hf_messages = [
+        {"role": "system", "content": system_prompt},
+        *[r.to_openai_message(m) for m in messages],
+    ]
+    hf = _hf_supervised_tokens(
+        nemotron_tokenizer, hf_messages, tools=openai_tools, truncate_history_thinking=False
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_tokenizer.decode(cookbook)}\nHF: {nemotron_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_preserve_thinking_multiturn_supervised_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_preserve_thinking_renderer
+):
+    """Ultra preserve variant supervised example matches HF truncate_history_thinking=False."""
+    messages = get_multiturn_thinking_conversation()
+    r = nemotron_ultra_preserve_thinking_renderer
+    cookbook = r.build_supervised_example(messages)[0].to_ints()
+    hf = _hf_supervised_tokens(
+        nemotron_ultra_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        truncate_history_thinking=False,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_ultra_preserve_thinking_multiturn_generation_matches_hf(
+    nemotron_ultra_tokenizer, nemotron_ultra_preserve_thinking_renderer
+):
+    """Ultra preserve variant generation prompt matches HF truncate_history_thinking=False."""
+    messages = get_multiturn_thinking_conversation()[:4]
+    r = nemotron_ultra_preserve_thinking_renderer
+    cookbook = r.build_generation_prompt(messages).to_ints()
+    hf = _hf_generation_tokens(
+        nemotron_ultra_tokenizer,
+        [r.to_openai_message(m) for m in messages],
+        truncate_history_thinking=False,
+    )
+    assert cookbook == hf, (
+        f"Cookbook: {nemotron_ultra_tokenizer.decode(cookbook)}\n"
+        f"HF: {nemotron_ultra_tokenizer.decode(hf)}"
+    )
+
+
+def test_preserve_thinking_registered_in_model_info():
+    from tinker_cookbook import model_info
+
+    for model in [
+        "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+    ]:
+        assert "nemotron3_preserve_thinking" in model_info.get_recommended_renderer_names(model)
+    assert (
+        "nemotron3_ultra_preserve_thinking"
+        in model_info.get_recommended_renderer_names(
+            "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+        )
     )


### PR DESCRIPTION
Fixes #837.

## Problem

The Nemotron-3 HF chat template allow to NOT truncate the thinking from previous turns behind the `truncate_history_thinking` flag, but the cookbook renderers hardcoded `truncate_history_thinking=True`, so there was no way to keep previous-turn reasoning.

From the HF chat template:
```jinja
{%- set truncate_history_thinking = truncate_history_thinking if truncate_history_thinking is defined else True %}
...
{%- if not (truncate_history_thinking and loop.index0 < ns.last_user_idx) %}
    {{- '<|im_start|>assistant\n' ~ (content | ... | trim) ~ '<|im_end|>\n' }}   {# keep thinking #}
{%- else %}
    ... {%- set c = "<think></think>" ~ c.split('</think>')[-1] %} ...            {# collapse thinking #}
```

With the default `truncate_history_thinking=True`, each historical assistant turn's `<think>…</think>` block collapses to `<think></think>`. Setting it `False` keeps the full block. All three Nemotron-3 templates (Nano, Super, Ultra) declare this flag identically.
(small note: Qwen3.5's template has no equivalent knob (its history thinking is unconditionally dropped), so no Qwen change is needed.)

## Change

- Added **`nemotron3_preserve_thinking`** (Nano/Super) and **`nemotron3_ultra_preserve_thinking`** (Ultra): thin renderer variants that forward `strip_thinking_from_history=False`. This mirrors the existing `kimi_k26_preserve_thinking` precedent; HF's `truncate_history_thinking=False` is byte-equivalent to the cookbook's `strip_thinking_from_history=False`.
- The base machinery already skips stripping when `strip_thinking_from_history=False`, but Nemotron's `_assistant_header_suffix` injected `<think></think>` for historical messages **unconditionally**, which would double-render preserved thinking (`<think></think>\n<think>real reasoning</think>`). Gated that injection on the flag — a one-condition change (`not is_historical` → `not is_historical or not self.strip_thinking_from_history`) on both `Nemotron3Renderer` and `Nemotron3UltraRenderer`. The default (strip) path is untouched.
- Registered both names in the renderer factory and in `model_info` recommended-renderer lists.
- These variants report `has_extension_property = True` (inherited), unlike the default renderers.

## Tests

`nemotron3_test.py` compares the preserve renderers against `apply_chat_template(..., truncate_history_thinking=False)` and asserts **token-id equality** (Nano + Ultra, generation + supervised, plus a historical thinking+text+tool_calls turn). The `_hf_*_tokens` helpers now thread `truncate_history_thinking` through, defaulting to `True` so every pre-existing test is unchanged. Added sanity-contrast tests (default collapses historical thinking, preserve keeps it verbatim), renderer-type, extension-property, and `model_info` registration tests. Full `nemotron3_test.py` + `model_info_test.py` pass (70).

## Notes for review

- Only added preserve variants for the full-thinking modes (base + Ultra), where preserving reasoning is meaningful; the disable/low/medium renderers can still opt in via the constructor kwarg:
  ```python
  # reasoning-off mode that still keeps previous-turn <think> blocks
  renderer = Nemotron3DisableThinkingRenderer(tokenizer, strip_thinking_from_history=False)
  ```
  (verified byte-identical to `apply_chat_template(..., enable_thinking=False, truncate_history_thinking=False)`; same holds for `Nemotron3LowThinkingRenderer` / `Nemotron3UltraMediumThinkingRenderer` with their mode flags.)

🤖 Drafted by Claude (Opus 4.8) in Claude Code, reviewed and edited by @Butanium.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01HTuq4hYbEseWwRa38npcjg
