### PR TITLE
Add tml_v0_disable_thinking renderer (Inkling reasoning-effort as a renderer default)

### DIFF
--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -154,6 +154,8 @@ def get_renderer(
             - ``"gpt_oss_low_reasoning"``: GPT-OSS with low reasoning
             - ``"gpt_oss_medium_reasoning"``: GPT-OSS with medium reasoning
             - ``"gpt_oss_high_reasoning"``: GPT-OSS with high reasoning
+            - ``"tml_v0"``: TML v0 (Inkling) with default thinking effort (0.9)
+            - ``"tml_v0_disable_thinking"``: TML v0 (Inkling) with thinking disabled (effort 0.0)
             - Custom renderers registered via ``register_renderer()``
         tokenizer (Tokenizer): The tokenizer to use.
         image_processor (ImageProcessor | None): Required for VL renderers.
@@ -282,6 +284,8 @@ def get_renderer(
         renderer = GptOssRenderer(tokenizer, use_system_prompt=True, reasoning_effort="high")
     elif name == "tml_v0":
         renderer = TmlV0Renderer(tokenizer)
+    elif name == "tml_v0_disable_thinking":
+        renderer = TmlV0Renderer(tokenizer, effort=0.0)
     else:
         raise RendererError(
             f"Unknown renderer: {name}. If this is a custom renderer, please register it via register_renderer()."

--- a/tinker_cookbook/renderers/tml_v0.py
+++ b/tinker_cookbook/renderers/tml_v0.py
@@ -409,10 +409,16 @@ class TmlV0Renderer(Renderer):
 
     supports_streaming = False
 
-    def __init__(self, tokenizer: Tokenizer):
+    def __init__(self, tokenizer: Tokenizer, effort: float = DEFAULT_EFFORT):
         super().__init__(tokenizer)
         _validate_torch_version()
         ensure_tml_renderers_importable()
+        _validate_effort(effort)
+        # Instance-level default reasoning effort, used by build_generation_prompt /
+        # build_supervised_example(s) when the caller does not pass an explicit `effort`.
+        # This lets a fixed-effort renderer (e.g. `tml_v0_disable_thinking`, effort=0.0)
+        # flow through generic builders that never forward a per-call effort.
+        self._default_effort = effort
         self._tml_tokenizer = _unwrap_tml_tokenizer(tokenizer)
         self._tml_renderer: tml_v0.Renderer = import_module("tml_renderers.v0").Renderer(
             self._tml_tokenizer
@@ -449,15 +455,18 @@ class TmlV0Renderer(Renderer):
         messages: list[Message] | TmlRenderInput,
         role: Role = "assistant",
         prefill: str | None = None,
-        effort: float = DEFAULT_EFFORT,
+        effort: float | None = None,
     ) -> tinker.ModelInput:
         """Build a generation prompt with reasoning-effort conditioning.
 
-        ``effort`` must be a finite value in ``[0.0, 1.0)`` and defaults to
-        high. Insertion of the system-level effort directive is delegated to
+        ``effort`` must be a finite value in ``[0.0, 1.0)``. When ``None`` (the
+        default) the renderer's instance-level default effort is used (``0.9``
+        unless the renderer was constructed with a different ``effort``).
+        Insertion of the system-level effort directive is delegated to
         ``tml-renderers``.
         """
         self._validate_generation_options(role, prefill)
+        effort = self._default_effort if effort is None else effort
         _validate_effort(effort)
         render_input = _messages_to_render_input(messages)
         spans, _parser = self._tml_renderer.render_for_completion_with_effort(render_input, effort)
@@ -480,18 +489,21 @@ class TmlV0Renderer(Renderer):
         self,
         messages: list[Message] | TmlRenderInput,
         train_on_what: TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
-        effort: float = DEFAULT_EFFORT,
+        effort: float | None = None,
     ) -> list[tuple[tinker.ModelInput, torch.Tensor]]:
         """Build SFT examples with the same effort conditioning used for generation.
 
         The inserted effort message is token-identical to the one
         ``build_generation_prompt`` renders, so supervised data matches sampling.
 
-        Generic supervised dataset builders currently use the default effort
-        (``0.9``). We plan to expose per-example effort through those builders;
-        until then, call this method directly to render a conversation at a
-        specific effort level.
+        When ``effort`` is ``None`` (the default) the renderer's instance-level
+        default effort is used. Generic supervised dataset builders call this
+        without an ``effort`` argument, so to render a whole dataset at a fixed
+        effort, construct the renderer with that ``effort`` (e.g. the
+        ``tml_v0_disable_thinking`` renderer uses ``effort=0.0``) or pass an
+        explicit ``effort`` here.
         """
+        effort = self._default_effort if effort is None else effort
         render_input = _cookbook_messages_to_sft_input(messages, train_on_what)
         return self._render_sft_examples(_prepare_sft_input(render_input, effort))
 
@@ -499,7 +511,7 @@ class TmlV0Renderer(Renderer):
         self,
         messages: list[Message] | TmlRenderInput,
         train_on_what: TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
-        effort: float = DEFAULT_EFFORT,
+        effort: float | None = None,
     ) -> tuple[tinker.ModelInput, torch.Tensor]:
         examples = self.build_supervised_examples(messages, train_on_what, effort=effort)
         return self._single_example(examples)

--- a/tinker_cookbook/renderers/tml_v0_test.py
+++ b/tinker_cookbook/renderers/tml_v0_test.py
@@ -334,6 +334,45 @@ def test_build_generation_prompt_defaults_to_high_effort() -> None:
     assert "Thinking effort level: 0.9" in renderer.tokenizer.decode(default_prompt.to_ints())
 
 
+def _disable_thinking_renderer() -> tml_v0.TmlV0Renderer:
+    _require_tml_renderers()
+    tokenizer = get_tokenizer("thinkingmachines/Inkling")
+    return cast(tml_v0.TmlV0Renderer, get_renderer("tml_v0_disable_thinking", tokenizer))
+
+
+def test_disable_thinking_renderer_generation_prompt_uses_zero_effort() -> None:
+    renderer = _disable_thinking_renderer()
+
+    decoded = renderer.tokenizer.decode(renderer.build_generation_prompt(_messages()).to_ints())
+
+    assert "Thinking effort level: 0<|end_message|>" in decoded
+    assert "Thinking effort level: 0.9" not in decoded
+
+
+def test_disable_thinking_renderer_sft_example_uses_zero_effort_and_plain_target() -> None:
+    renderer = _disable_thinking_renderer()
+
+    model_input, weights = renderer.build_supervised_example(_messages())
+    ints = model_input.to_ints()
+    decoded = renderer.tokenizer.decode(ints)
+    trained = renderer.tokenizer.decode([t for t, w in zip(ints, weights.tolist()) if w > 0])
+
+    assert "Thinking effort level: 0<|end_message|>" in decoded
+    # The no-thinking demos train on a plain assistant answer — no <think> scaffold.
+    assert "<think>" not in decoded
+    assert "Hello." in trained
+
+
+def test_explicit_effort_overrides_disable_thinking_default() -> None:
+    renderer = _disable_thinking_renderer()
+
+    decoded = renderer.tokenizer.decode(
+        renderer.build_generation_prompt(_messages(), effort=0.9).to_ints()
+    )
+
+    assert "Thinking effort level: 0.9" in decoded
+
+
 def test_build_generation_prompt_effort_validates_range() -> None:
     renderer = _renderer()
 


### PR DESCRIPTION
## What

Adds a `tml_v0_disable_thinking` renderer for Inkling, and makes the reasoning **effort** a first-class instance default on `TmlV0Renderer`.

## Why

Inkling's `tml_v0` renderer conditions on a scalar reasoning effort in `[0.0, 1.0)`, injected as a `Thinking effort level: <e>` system message (default `0.9`). The effort was a **per-call** default on `build_generation_prompt` / `build_supervised_example(s)` — not renderer state. But the generic supervised path (`FromConversationFileBuilder` → `conversation_to_datum`) calls `renderer.build_supervised_example(conversation, train_on_what=...)` and never forwards an `effort`, so **every** cookbook-driven SFT dataset renders at `0.9`, with no seam to change it. `build_supervised_examples`' own docstring flagged this ("Generic supervised dataset builders currently use the default effort (`0.9`). We plan to expose per-example effort…").

Concretely this bit us fine-tuning Inkling on **no-thinking** demonstrations (SFT targets are a direct assistant answer, no `<think>` block). To keep the effort conditioning honest and consistent between training and sampling, we want the whole dataset rendered at effort `0`, but there was no way to do it through the standard builder without subclassing the renderer downstream.

## What changed

- `TmlV0Renderer.__init__(tokenizer, effort=DEFAULT_EFFORT)` — validates and stores `self._default_effort`.
- The three effort-bearing methods (`build_generation_prompt`, `build_supervised_examples`, `build_supervised_example`) now take `effort: float | None = None` and fall back to the instance default when the caller passes nothing. **An explicit per-call `effort` still wins**, so existing callers are unaffected (`effort=DEFAULT_EFFORT` on a default-constructed renderer is byte-identical to before).
- `get_renderer("tml_v0_disable_thinking")` → `TmlV0Renderer(tokenizer, effort=0.0)`, so the standard name-based plumbing (dataset builder, evaluators, `train.Config.renderer_name`) can select a thinking-disabled renderer that flows through builders which never forward an effort.

## Naming

`tml_v0_disable_thinking`, matching the existing family-scoped convention (`deepseekv3_disable_thinking`, `qwen3_disable_thinking`, `nemotron3_disable_thinking`) rather than a model-scoped `inkling_disable_thinking`.

## Base

Branched off current `main` (has `tml_v0`); the diff is the single renderer commit.

## Tests

Added to `tinker_cookbook/renderers/tml_v0_test.py` (skip-guarded on the optional `tml_renderers` package, like the sibling tests): the disable-thinking renderer renders `Thinking effort level: 0` for both a generation prompt and an SFT example, the SFT assistant target stays plain text (no `<think>` scaffold), and an explicit `effort=0.9` still overrides the instance default. `tml_v0_test.py` passes locally (41 passed, 1 skipped); `ruff check` / `ruff format` clean.

---
🤖 Authored with [Claude Code](https://claude.ai/code) — implementation by Claude, reviewed by Clément Dumas.
Co-Authored-By: Claude <noreply@anthropic.com>
https://claude.ai/code/session_01A7gbnx18vrcUxJKzeVscQi
