### PR TITLE
Sync the research skills model lineup with the live Tinker lineup

### DIFF
--- a/skills/research/references/models.md
+++ b/skills/research/references/models.md
@@ -2,6 +2,12 @@
 
 Full listing of available models with types, architecture, and sizes.
 
+## Thinking Machines family
+
+| Model | Type | Arch | Size |
+|-------|------|------|------|
+| `thinkingmachines/Inkling` | Hybrid + Audio + Vision | MoE | Large |
+
 ## Qwen family
 
 | Model | Type | Arch | Size |
@@ -9,40 +15,19 @@ Full listing of available models with types, architecture, and sizes.
 | `Qwen/Qwen3.6-35B-A3B` | Hybrid + Vision | MoE | Medium |
 | `Qwen/Qwen3.6-27B` | Hybrid + Vision | Dense | Medium |
 | `Qwen/Qwen3.5-397B-A17B` | Hybrid + Vision | MoE | Large |
-| `Qwen/Qwen3.5-35B-A3B` | Hybrid + Vision | MoE | Medium |
 | `Qwen/Qwen3.5-35B-A3B-Base` | Base | MoE | Medium |
-| `Qwen/Qwen3.5-27B` | Hybrid + Vision | Dense | Medium |
 | `Qwen/Qwen3.5-9B` | Hybrid + Vision | Dense | Small |
 | `Qwen/Qwen3.5-9B-Base` | Base | Dense | Small |
 | `Qwen/Qwen3.5-4B` | Hybrid + Vision | Dense | Compact |
-| `Qwen/Qwen3-235B-A22B-Instruct-2507` | Instruction | MoE | Large |
-| `Qwen/Qwen3-30B-A3B-Instruct-2507` | Instruction | MoE | Medium |
-| `Qwen/Qwen3-30B-A3B` | Hybrid | MoE | Medium |
-| `Qwen/Qwen3-30B-A3B-Base` | Base | MoE | Medium |
-| `Qwen/Qwen3-32B` | Hybrid | Dense | Medium |
 | `Qwen/Qwen3-8B` | Hybrid | Dense | Small |
-| `Qwen/Qwen3-8B-Base` | Base | Dense | Small |
-| `Qwen/Qwen3-4B-Instruct-2507` | Instruction | Dense | Compact |
-| `Qwen/Qwen3-VL-235B-A22B-Instruct` | Vision | MoE | Large |
-| `Qwen/Qwen3-VL-30B-A3B-Instruct` | Vision | MoE | Medium |
 
 Use the `_disable_thinking` renderer variant when you want direct instruction-following behavior from a hybrid Qwen model.
-
-## Llama family
-
-| Model | Type | Arch | Size |
-|-------|------|------|------|
-| `meta-llama/Llama-3.3-70B-Instruct` | Instruction | Dense | Large |
-| `meta-llama/Llama-3.1-70B` | Base | Dense | Large |
-| `meta-llama/Llama-3.1-8B` | Base | Dense | Small |
-| `meta-llama/Llama-3.1-8B-Instruct` | Instruction | Dense | Small |
-| `meta-llama/Llama-3.2-3B` | Base | Dense | Compact |
-| `meta-llama/Llama-3.2-1B` | Base | Dense | Compact |
 
 ## Nemotron family
 
 | Model | Type | Arch | Size |
 |-------|------|------|------|
+| `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16` | Hybrid | MoE | Large |
 | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` | Hybrid | MoE | Large |
 | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` | Hybrid | MoE | Medium |
 
@@ -53,25 +38,22 @@ Use the `_disable_thinking` renderer variant when you want direct instruction-fo
 | `openai/gpt-oss-120b` | Reasoning | MoE | Medium |
 | `openai/gpt-oss-20b` | Reasoning | MoE | Small |
 | `deepseek-ai/DeepSeek-V3.1` | Hybrid | MoE | Large |
-| `deepseek-ai/DeepSeek-V3.1-Base` | Base | MoE | Large |
-| `moonshotai/Kimi-K2-Thinking` | Reasoning | MoE | Large |
-| `moonshotai/Kimi-K2.5` | Reasoning + Vision | MoE | Large |
-| `moonshotai/Kimi-K2.6` | Reasoning + Vision | MoE | Large |
+| `moonshotai/Kimi-K2.6` | Hybrid + Vision | MoE | Large |
 
 ## Model types explained
 
 - **Base**: Pre-trained on raw text. For research or full post-training pipelines.
-- **Instruction**: Fine-tuned for instruction following. Fast inference, no chain-of-thought.
 - **Reasoning**: Always uses chain-of-thought before visible output.
 - **Hybrid**: Can operate in both thinking and non-thinking modes.
 - **Vision**: Processes images alongside text.
+- **Audio**: Processes audio alongside text.
 
 ## Size categories
 
-- **Compact**: 1B-4B parameters
-- **Small**: 8B parameters
-- **Medium**: 27B-32B parameters
-- **Large**: 70B+ parameters
+Sizes are relative tiers (Compact < Small < Medium < Large) matching the
+[Models & Pricing](https://tinker-docs.thinkingmachines.ai/tinker/models/)
+table. For MoE models, compute cost tracks active parameters rather than
+total, so a large-total-parameter MoE model can sit in a smaller tier.
 
 ## Renderer matching
 
@@ -86,3 +68,12 @@ The mapping is maintained in `tinker_cookbook/model_info.py`. Never hardcode ren
 ## Reference
 
 - `tinker_cookbook/model_info.py` — Model metadata and renderer mapping
+
+## Retired models
+
+Models retired from the Tinker service can no longer be used for training or
+sampling, even though `model_info.py` retains their metadata (existing
+checkpoints can still be exported). See the Tinker docs
+([Models & Pricing](https://tinker-docs.thinkingmachines.ai/tinker/models/) and
+[Model Deprecations](https://tinker-docs.thinkingmachines.ai/tinker/model-deprecations/))
+for the retired list and recommended replacements.


### PR DESCRIPTION
The lineup still listed the models retired on June 12 (Qwen3/Qwen3.5 instruct variants, the Llama family, DeepSeek-V3.1-Base, Kimi-K2-Thinking) plus Kimi-K2.5, retired July 12. Remove all of them, add the missing Inkling and Nemotron-3-Ultra entries, and fix the Kimi type label (Hybrid + Vision, matching the docs).

Also drop the stale Instruction type (no such models remain), add Audio, describe size categories as relative tiers instead of parameter ranges the lineup no longer fits, and add a Retired Models pointer to the docs.