### PR TITLE
Add offline evaluation run comparison

### DIFF
--- a/tinker_cookbook/eval/README.md
+++ b/tinker_cookbook/eval/README.md
@@ -234,7 +234,16 @@ print(f"GSM8K: {result.score:.1%}")
 # List all runs
 for run in store.list_runs():
     print(f"{run.run_id}: {run.scores}")
+
+# Compare two stored runs without calling the model or any external service
+comparison = store.compare_runs("sft_step500_...", "sft_step1000_...")
+print(comparison.to_markdown())
 ```
+
+Run comparisons match trajectories by stable, non-empty `example_id` values, not
+by positional index. Benchmark implementations should provide deterministic IDs
+(for example, with `make_example_id`) so examples remain comparable when dataset
+ordering changes. Missing IDs are reported as unmatched.
 
 ### Storage layout
 

--- a/tinker_cookbook/eval/__init__.py
+++ b/tinker_cookbook/eval/__init__.py
@@ -61,6 +61,12 @@ from tinker_cookbook.eval.evaluators import (
     SamplingClientEvaluatorBuilder,
     TrainingClientEvaluator,
 )
+from tinker_cookbook.stores.eval_comparison import (
+    BenchmarkComparison,
+    ExampleClassification,
+    ExampleComparison,
+    RunComparison,
+)
 from tinker_cookbook.stores.eval_store import EvalStore, RunMetadata
 
 __all__ = [
@@ -83,6 +89,10 @@ __all__ = [
     # Benchmark-to-evaluator bridge
     "BenchmarkEvaluator",
     # Eval store — persistent storage and querying
+    "BenchmarkComparison",
     "EvalStore",
+    "ExampleClassification",
+    "ExampleComparison",
+    "RunComparison",
     "RunMetadata",
 ]

--- a/tinker_cookbook/stores/eval_comparison.py
+++ b/tinker_cookbook/stores/eval_comparison.py
@@ -1,0 +1,428 @@
+"""Typed, offline comparison of two :class:`EvalStore` runs."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+from tinker_cookbook.stores.storage import storage_join
+
+if TYPE_CHECKING:
+    from tinker_cookbook.eval.benchmarks._types import StoredTrajectory
+    from tinker_cookbook.stores.eval_store import EvalStore
+
+
+ExampleClassification = Literal[
+    "regression",
+    "improvement",
+    "unchanged_correct",
+    "unchanged_incorrect",
+    "persistent_error",
+    "new_error",
+    "resolved_error",
+    "baseline_only",
+    "candidate_only",
+]
+"""Classification assigned to an example while comparing two evaluation runs."""
+
+
+@dataclass
+class ExampleComparison:
+    """Comparison of one matched or unmatched evaluation example."""
+
+    benchmark: str
+    example_id: str
+    classification: ExampleClassification
+    baseline_reward: float | None
+    candidate_reward: float | None
+    baseline_error: str | None
+    candidate_error: str | None
+    baseline_logs: dict[str, Any] | None
+    candidate_logs: dict[str, Any] | None
+    baseline_trajectory_index: int | None
+    candidate_trajectory_index: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return asdict(self)
+
+
+@dataclass
+class BenchmarkComparison:
+    """Score and per-example changes for one benchmark shared by two runs."""
+
+    name: str
+    baseline_score: float
+    candidate_score: float
+    score_delta: float
+    baseline_num_examples: int
+    candidate_num_examples: int
+    baseline_trajectories_available: bool
+    candidate_trajectories_available: bool
+    num_regressions: int
+    num_improvements: int
+    num_unchanged: int
+    num_unchanged_correct: int
+    num_unchanged_incorrect: int
+    num_persistent_errors: int
+    num_new_errors: int
+    num_resolved_errors: int
+    num_baseline_only: int
+    num_candidate_only: int
+    examples: list[ExampleComparison] = field(default_factory=list)
+
+    @property
+    def num_unmatched(self) -> int:
+        return self.num_baseline_only + self.num_candidate_only
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        data = asdict(self)
+        data["num_unmatched"] = self.num_unmatched
+        return data
+
+
+@dataclass
+class RunComparison:
+    """Offline comparison of two stored evaluation runs."""
+
+    baseline_run_id: str
+    candidate_run_id: str
+    baseline_model_name: str
+    candidate_model_name: str
+    baseline_checkpoint_path: str | None
+    candidate_checkpoint_path: str | None
+    baseline_checkpoint_name: str | None
+    candidate_checkpoint_name: str | None
+    shared_benchmarks: list[str]
+    baseline_only_benchmarks: list[str]
+    candidate_only_benchmarks: list[str]
+    benchmarks: dict[str, BenchmarkComparison]
+    num_regressions: int
+    num_improvements: int
+    num_unchanged: int
+    num_persistent_errors: int
+    num_new_errors: int
+    num_resolved_errors: int
+    num_baseline_only: int
+    num_candidate_only: int
+
+    @property
+    def num_unmatched(self) -> int:
+        return self.num_baseline_only + self.num_candidate_only
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        data = asdict(self)
+        data["num_unmatched"] = self.num_unmatched
+        for name, benchmark in self.benchmarks.items():
+            data["benchmarks"][name]["num_unmatched"] = benchmark.num_unmatched
+        return data
+
+    def to_markdown(self, max_examples_per_section: int = 20) -> str:
+        """Render a concise Markdown regression report."""
+        if max_examples_per_section < 0:
+            raise ValueError("max_examples_per_section must be non-negative")
+
+        lines = [
+            "# Evaluation Comparison",
+            "",
+            _run_line(
+                "Baseline",
+                self.baseline_run_id,
+                self.baseline_model_name,
+                self.baseline_checkpoint_name or self.baseline_checkpoint_path,
+            ),
+            _run_line(
+                "Candidate",
+                self.candidate_run_id,
+                self.candidate_model_name,
+                self.candidate_checkpoint_name or self.candidate_checkpoint_path,
+            ),
+            "",
+            (
+                f"Regressions: **{self.num_regressions}** · "
+                f"Improvements: **{self.num_improvements}** · "
+                f"Unchanged: **{self.num_unchanged}** · "
+                f"Errors: **{self.num_new_errors} new, "
+                f"{self.num_resolved_errors} resolved, "
+                f"{self.num_persistent_errors} persistent** · "
+                f"Unmatched: **{self.num_unmatched}**"
+            ),
+            "",
+            "## Benchmark summary",
+            "",
+        ]
+        if self.shared_benchmarks:
+            lines.extend(
+                [
+                    (
+                        "| Benchmark | Baseline | Candidate | Delta | "
+                        "Regressions | Improvements | Errors | Unmatched |"
+                    ),
+                    "|---|---:|---:|---:|---:|---:|---:|---:|",
+                ]
+            )
+            for name in self.shared_benchmarks:
+                benchmark = self.benchmarks[name]
+                num_errors = (
+                    benchmark.num_new_errors
+                    + benchmark.num_resolved_errors
+                    + benchmark.num_persistent_errors
+                )
+                lines.append(
+                    f"| {name.replace('|', '/')} | {benchmark.baseline_score:.4f} "
+                    f"| {benchmark.candidate_score:.4f} | {benchmark.score_delta:+.4f} "
+                    f"| {benchmark.num_regressions} | {benchmark.num_improvements} "
+                    f"| {num_errors} | {benchmark.num_unmatched} |"
+                )
+        else:
+            lines.append("_No shared benchmarks._")
+
+        missing = []
+        for name in self.shared_benchmarks:
+            benchmark = self.benchmarks[name]
+            sides = []
+            if not benchmark.baseline_trajectories_available:
+                sides.append("baseline")
+            if not benchmark.candidate_trajectories_available:
+                sides.append("candidate")
+            if sides:
+                missing.append(f"`{_inline(name)}` ({' and '.join(sides)})")
+        if missing:
+            lines.extend(["", "**Trajectory data unavailable:** " + "; ".join(missing)])
+        for label, names in (
+            ("Baseline-only benchmarks", self.baseline_only_benchmarks),
+            ("Candidate-only benchmarks", self.candidate_only_benchmarks),
+        ):
+            if names:
+                lines.extend(["", f"{label}: " + ", ".join(f"`{_inline(n)}`" for n in names)])
+
+        sections: list[tuple[str, tuple[ExampleClassification, ...]]] = [
+            ("Regressions", ("regression",)),
+            ("Improvements", ("improvement",)),
+            ("Persistent failures", ("unchanged_incorrect",)),
+            ("Errors", ("new_error", "resolved_error", "persistent_error")),
+            ("Unmatched examples", ("baseline_only", "candidate_only")),
+        ]
+        all_examples = [
+            example for name in self.shared_benchmarks for example in self.benchmarks[name].examples
+        ]
+        for title, classifications in sections:
+            examples = [
+                example for example in all_examples if example.classification in classifications
+            ]
+            if not examples:
+                continue
+            shown = examples[:max_examples_per_section]
+            lines.extend(["", f"## {title}", ""])
+            if len(shown) < len(examples):
+                lines.extend([f"_Showing {len(shown)} of {len(examples)} examples._", ""])
+            for example in shown:
+                lines.extend(_example_lines(example))
+        return "\n".join(lines).rstrip() + "\n"
+
+
+def _inline(value: str) -> str:
+    return value.replace("`", "'").replace("\n", " ")
+
+
+def _run_line(label: str, run_id: str, model: str, checkpoint: str | None) -> str:
+    return (
+        f"**{label}:** `{_inline(run_id)}` "
+        f"(model: `{_inline(model)}`, checkpoint: `{_inline(checkpoint or 'base')}`)"
+    )
+
+
+def _example_lines(example: ExampleComparison) -> list[str]:
+    lines = [
+        f"- **{example.benchmark}** / `{_inline(example.example_id or '<missing example_id>')}`",
+        f"  - Status: `{example.classification}`",
+    ]
+    for label, value in (
+        ("Baseline reward", example.baseline_reward),
+        ("Candidate reward", example.candidate_reward),
+        ("Baseline error", example.baseline_error),
+        ("Candidate error", example.candidate_error),
+    ):
+        if value is not None:
+            lines.append(f"  - {label}: {value}")
+    for label, logs in (
+        ("Baseline logs", example.baseline_logs),
+        ("Candidate logs", example.candidate_logs),
+    ):
+        if logs:
+            value = json.dumps(logs, ensure_ascii=False, sort_keys=True, default=str)
+            lines.append(f"  - {label}: `{_inline(value[:300])}`")
+    return lines
+
+
+def _classify(
+    baseline: StoredTrajectory,
+    candidate: StoredTrajectory,
+) -> ExampleClassification:
+    if baseline.error is not None and candidate.error is not None:
+        return "persistent_error"
+    if candidate.error is not None:
+        return "new_error"
+    if baseline.error is not None:
+        return "resolved_error"
+    if baseline.reward > 0 and candidate.reward <= 0:
+        return "regression"
+    if baseline.reward <= 0 and candidate.reward > 0:
+        return "improvement"
+    return "unchanged_correct" if baseline.reward > 0 else "unchanged_incorrect"
+
+
+def _comparison(
+    benchmark: str,
+    baseline: StoredTrajectory | None,
+    candidate: StoredTrajectory | None,
+) -> ExampleComparison:
+    trajectory = baseline or candidate
+    if trajectory is None:
+        raise ValueError("An example comparison requires at least one trajectory")
+    if baseline is None:
+        classification: ExampleClassification = "candidate_only"
+    elif candidate is None:
+        classification = "baseline_only"
+    else:
+        classification = _classify(baseline, candidate)
+    return ExampleComparison(
+        benchmark=benchmark,
+        example_id=trajectory.example_id,
+        classification=classification,
+        baseline_reward=baseline.reward if baseline is not None else None,
+        candidate_reward=candidate.reward if candidate is not None else None,
+        baseline_error=baseline.error if baseline is not None else None,
+        candidate_error=candidate.error if candidate is not None else None,
+        baseline_logs=baseline.logs if baseline is not None else None,
+        candidate_logs=candidate.logs if candidate is not None else None,
+        baseline_trajectory_index=baseline.idx if baseline is not None else None,
+        candidate_trajectory_index=candidate.idx if candidate is not None else None,
+    )
+
+
+def _index(
+    trajectories: list[StoredTrajectory],
+    *,
+    run_id: str,
+    benchmark: str,
+) -> tuple[dict[str, StoredTrajectory], list[StoredTrajectory]]:
+    by_id: dict[str, StoredTrajectory] = {}
+    missing_id: list[StoredTrajectory] = []
+    for trajectory in trajectories:
+        if not trajectory.example_id:
+            missing_id.append(trajectory)
+        elif trajectory.example_id in by_id:
+            raise ValueError(
+                f"Duplicate example_id {trajectory.example_id!r} in benchmark "
+                f"{benchmark!r} for run {run_id!r}"
+            )
+        else:
+            by_id[trajectory.example_id] = trajectory
+    return by_id, sorted(missing_id, key=lambda trajectory: trajectory.idx)
+
+
+def _compare_examples(
+    baseline: list[StoredTrajectory],
+    candidate: list[StoredTrajectory],
+    *,
+    baseline_run_id: str,
+    candidate_run_id: str,
+    benchmark: str,
+) -> list[ExampleComparison]:
+    baseline_by_id, baseline_missing_id = _index(
+        baseline, run_id=baseline_run_id, benchmark=benchmark
+    )
+    candidate_by_id, candidate_missing_id = _index(
+        candidate, run_id=candidate_run_id, benchmark=benchmark
+    )
+    examples = [
+        _comparison(benchmark, baseline_by_id.get(example_id), candidate_by_id.get(example_id))
+        for example_id in sorted(baseline_by_id.keys() | candidate_by_id.keys())
+    ]
+    examples.extend(_comparison(benchmark, trajectory, None) for trajectory in baseline_missing_id)
+    examples.extend(_comparison(benchmark, None, trajectory) for trajectory in candidate_missing_id)
+    return examples
+
+
+def compare_eval_runs(
+    store: EvalStore,
+    baseline_run_id: str,
+    candidate_run_id: str,
+) -> RunComparison:
+    """Build an offline comparison from two runs in ``store``."""
+    baseline_metadata = store.read_run(baseline_run_id)
+    candidate_metadata = store.read_run(candidate_run_id)
+    baseline_benchmarks = set(store.list_benchmarks(baseline_run_id))
+    candidate_benchmarks = set(store.list_benchmarks(candidate_run_id))
+    shared = sorted(baseline_benchmarks & candidate_benchmarks)
+    benchmarks: dict[str, BenchmarkComparison] = {}
+
+    for name in shared:
+        baseline_result = store.read_result(baseline_run_id, name)
+        candidate_result = store.read_result(candidate_run_id, name)
+        if baseline_result is None or candidate_result is None:
+            run_id = baseline_run_id if baseline_result is None else candidate_run_id
+            raise ValueError(f"Benchmark result {name!r} for run {run_id!r} could not be read")
+        baseline_path = storage_join(
+            store.prefix, "runs", baseline_run_id, name, "trajectories.jsonl"
+        )
+        candidate_path = storage_join(
+            store.prefix, "runs", candidate_run_id, name, "trajectories.jsonl"
+        )
+        examples = _compare_examples(
+            store.read_trajectories(baseline_run_id, name),
+            store.read_trajectories(candidate_run_id, name),
+            baseline_run_id=baseline_run_id,
+            candidate_run_id=candidate_run_id,
+            benchmark=name,
+        )
+        counts = Counter(example.classification for example in examples)
+        benchmarks[name] = BenchmarkComparison(
+            name=name,
+            baseline_score=baseline_result.score,
+            candidate_score=candidate_result.score,
+            score_delta=candidate_result.score - baseline_result.score,
+            baseline_num_examples=baseline_result.num_examples,
+            candidate_num_examples=candidate_result.num_examples,
+            baseline_trajectories_available=store.storage.exists(baseline_path),
+            candidate_trajectories_available=store.storage.exists(candidate_path),
+            num_regressions=counts["regression"],
+            num_improvements=counts["improvement"],
+            num_unchanged=counts["unchanged_correct"] + counts["unchanged_incorrect"],
+            num_unchanged_correct=counts["unchanged_correct"],
+            num_unchanged_incorrect=counts["unchanged_incorrect"],
+            num_persistent_errors=counts["persistent_error"],
+            num_new_errors=counts["new_error"],
+            num_resolved_errors=counts["resolved_error"],
+            num_baseline_only=counts["baseline_only"],
+            num_candidate_only=counts["candidate_only"],
+            examples=examples,
+        )
+
+    return RunComparison(
+        baseline_run_id=baseline_run_id,
+        candidate_run_id=candidate_run_id,
+        baseline_model_name=baseline_metadata.model_name,
+        candidate_model_name=candidate_metadata.model_name,
+        baseline_checkpoint_path=baseline_metadata.checkpoint_path,
+        candidate_checkpoint_path=candidate_metadata.checkpoint_path,
+        baseline_checkpoint_name=baseline_metadata.checkpoint_name,
+        candidate_checkpoint_name=candidate_metadata.checkpoint_name,
+        shared_benchmarks=shared,
+        baseline_only_benchmarks=sorted(baseline_benchmarks - candidate_benchmarks),
+        candidate_only_benchmarks=sorted(candidate_benchmarks - baseline_benchmarks),
+        benchmarks=benchmarks,
+        num_regressions=sum(value.num_regressions for value in benchmarks.values()),
+        num_improvements=sum(value.num_improvements for value in benchmarks.values()),
+        num_unchanged=sum(value.num_unchanged for value in benchmarks.values()),
+        num_persistent_errors=sum(value.num_persistent_errors for value in benchmarks.values()),
+        num_new_errors=sum(value.num_new_errors for value in benchmarks.values()),
+        num_resolved_errors=sum(value.num_resolved_errors for value in benchmarks.values()),
+        num_baseline_only=sum(value.num_baseline_only for value in benchmarks.values()),
+        num_candidate_only=sum(value.num_candidate_only for value in benchmarks.values()),
+    )

--- a/tinker_cookbook/stores/eval_comparison_test.py
+++ b/tinker_cookbook/stores/eval_comparison_test.py
@@ -1,0 +1,282 @@
+"""Offline tests for EvalStore run comparison."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tinker_cookbook.eval.benchmarks._types import BenchmarkResult, StoredTrajectory
+from tinker_cookbook.stores.eval_store import EvalStore
+from tinker_cookbook.stores.storage import LocalStorage
+
+
+def _store(
+    tmp_path: Path,
+    baseline_benchmarks: tuple[str, ...] = ("bench",),
+    candidate_benchmarks: tuple[str, ...] = ("bench",),
+) -> EvalStore:
+    store = EvalStore(LocalStorage(tmp_path), "eval")
+    store.create_run(
+        "baseline-model",
+        list(baseline_benchmarks),
+        checkpoint_path="tinker://baseline",
+        checkpoint_name="step-100",
+        run_id="baseline",
+    )
+    store.create_run(
+        "candidate-model",
+        list(candidate_benchmarks),
+        checkpoint_path="tinker://candidate",
+        checkpoint_name="step-200",
+        run_id="candidate",
+    )
+    return store
+
+
+def _trajectory(
+    example_id: str,
+    reward: float,
+    idx: int,
+    *,
+    benchmark: str = "bench",
+    error: str | None = None,
+    logs: dict | None = None,
+) -> StoredTrajectory:
+    return StoredTrajectory(
+        idx=idx,
+        benchmark=benchmark,
+        example_id=example_id,
+        reward=reward,
+        error=error,
+        logs=logs or {},
+    )
+
+
+def _write(
+    store: EvalStore,
+    run_id: str,
+    trajectories: list[StoredTrajectory],
+    *,
+    benchmark: str = "bench",
+    score: float = 0.0,
+    num_examples: int | None = None,
+) -> None:
+    store.write_result(
+        run_id,
+        BenchmarkResult(
+            name=benchmark,
+            score=score,
+            num_examples=len(trajectories) if num_examples is None else num_examples,
+            num_correct=sum(trajectory.reward > 0 for trajectory in trajectories),
+            num_errors=sum(trajectory.error is not None for trajectory in trajectories),
+        ),
+    )
+    for trajectory in trajectories:
+        store.write_trajectory(run_id, benchmark, trajectory)
+
+
+def test_scores_metadata_benchmark_sets_and_reordered_matching(tmp_path: Path) -> None:
+    store = _store(
+        tmp_path,
+        baseline_benchmarks=("bench", "baseline_only"),
+        candidate_benchmarks=("bench", "candidate_only"),
+    )
+    _write(
+        store,
+        "baseline",
+        [_trajectory("a", 0.25, 10), _trajectory("b", 0.0, 20)],
+        score=0.5,
+        num_examples=8,
+    )
+    _write(
+        store,
+        "candidate",
+        [_trajectory("b", 0.4, 200), _trajectory("a", 0.0, 100)],
+        score=0.625,
+        num_examples=12,
+    )
+    _write(store, "baseline", [], benchmark="baseline_only", score=0.5)
+    _write(store, "candidate", [], benchmark="candidate_only", score=0.9)
+
+    comparison = store.compare_runs("baseline", "candidate")
+    benchmark = comparison.benchmarks["bench"]
+    examples = {example.example_id: example for example in benchmark.examples}
+
+    assert comparison.baseline_model_name == "baseline-model"
+    assert comparison.candidate_checkpoint_name == "step-200"
+    assert comparison.shared_benchmarks == ["bench"]
+    assert comparison.baseline_only_benchmarks == ["baseline_only"]
+    assert comparison.candidate_only_benchmarks == ["candidate_only"]
+    assert benchmark.score_delta == pytest.approx(0.125)
+    assert (benchmark.baseline_num_examples, benchmark.candidate_num_examples) == (8, 12)
+    assert examples["a"].classification == "regression"
+    assert examples["a"].baseline_trajectory_index == 10
+    assert examples["a"].candidate_trajectory_index == 100
+    assert examples["b"].classification == "improvement"
+
+
+def test_all_matched_classifications_and_debug_data(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    baseline = [
+        _trajectory("regression", 0.1, 0, logs={"expected": "yes"}),
+        _trajectory("improvement", 0.0, 1),
+        _trajectory("unchanged_correct", 0.2, 2),
+        _trajectory("unchanged_incorrect", 0.0, 3),
+        _trajectory("persistent_error", 0.0, 4, error="old timeout"),
+        _trajectory("new_error", 0.3, 5),
+        _trajectory("resolved_error", 0.0, 6, error="old crash"),
+    ]
+    candidate = [
+        _trajectory("regression", 0.0, 10, logs={"output": "no"}),
+        _trajectory("improvement", 0.2, 11),
+        _trajectory("unchanged_correct", 0.4, 12),
+        _trajectory("unchanged_incorrect", -0.5, 13),
+        _trajectory("persistent_error", 0.0, 14, error="new timeout"),
+        _trajectory("new_error", 0.0, 15, error="new crash"),
+        _trajectory("resolved_error", 0.6, 16),
+    ]
+    _write(store, "baseline", baseline)
+    _write(store, "candidate", candidate)
+
+    comparison = store.compare_runs("baseline", "candidate")
+    benchmark = comparison.benchmarks["bench"]
+    examples = {example.example_id: example for example in benchmark.examples}
+
+    assert {example_id: example.classification for example_id, example in examples.items()} == {
+        name: name
+        for name in (
+            "regression",
+            "improvement",
+            "unchanged_correct",
+            "unchanged_incorrect",
+            "persistent_error",
+            "new_error",
+            "resolved_error",
+        )
+    }
+    assert (benchmark.num_regressions, benchmark.num_improvements, benchmark.num_unchanged) == (
+        1,
+        1,
+        2,
+    )
+    assert (
+        benchmark.num_persistent_errors,
+        benchmark.num_new_errors,
+        benchmark.num_resolved_errors,
+    ) == (1, 1, 1)
+    assert examples["regression"].baseline_logs == {"expected": "yes"}
+    assert examples["regression"].candidate_logs == {"output": "no"}
+    assert examples["persistent_error"].baseline_error == "old timeout"
+    assert examples["persistent_error"].candidate_error == "new timeout"
+
+
+def test_unmatched_and_empty_ids_are_never_matched_by_index(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _write(
+        store,
+        "baseline",
+        [_trajectory("baseline-only", 1.0, 1), _trajectory("", 0.0, 7)],
+    )
+    _write(
+        store,
+        "candidate",
+        [_trajectory("candidate-only", 1.0, 2), _trajectory("", 0.0, 7)],
+    )
+
+    comparison = store.compare_runs("baseline", "candidate")
+    benchmark = comparison.benchmarks["bench"]
+
+    assert (benchmark.num_baseline_only, benchmark.num_candidate_only) == (2, 2)
+    assert comparison.num_unmatched == 4
+    assert sum(example.example_id == "" for example in benchmark.examples) == 2
+
+
+def test_no_shared_benchmarks_and_missing_runs(tmp_path: Path) -> None:
+    store = _store(tmp_path, ("old",), ("new",))
+    _write(store, "baseline", [], benchmark="old")
+    _write(store, "candidate", [], benchmark="new")
+
+    comparison = store.compare_runs("baseline", "candidate")
+    assert comparison.shared_benchmarks == []
+    assert comparison.baseline_only_benchmarks == ["old"]
+    assert comparison.candidate_only_benchmarks == ["new"]
+    assert "_No shared benchmarks._" in comparison.to_markdown()
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        store.compare_runs("missing", "candidate")
+    with pytest.raises(FileNotFoundError, match="missing"):
+        store.compare_runs("baseline", "missing")
+
+
+def test_missing_empty_and_corrupted_trajectory_files(tmp_path: Path) -> None:
+    store = _store(tmp_path, ("missing", "empty"), ("missing", "empty"))
+    available = _trajectory("available", 1.0, 0, benchmark="missing")
+    _write(store, "baseline", [available], benchmark="missing", score=1.0)
+    _write(store, "candidate", [], benchmark="missing", num_examples=1)
+    _write(store, "baseline", [], benchmark="empty", num_examples=1)
+    _write(store, "candidate", [], benchmark="empty", num_examples=1)
+    store.storage.write("eval/runs/baseline/empty/trajectories.jsonl", b"")
+    store.storage.write("eval/runs/candidate/empty/trajectories.jsonl", b"")
+    store.storage.append(
+        "eval/runs/baseline/missing/trajectories.jsonl",
+        b"{not-json}\n" + json.dumps({"benchmark": "missing"}).encode() + b"\n",
+    )
+
+    comparison = store.compare_runs("baseline", "candidate")
+    missing = comparison.benchmarks["missing"]
+    empty = comparison.benchmarks["empty"]
+
+    assert missing.baseline_trajectories_available
+    assert not missing.candidate_trajectories_available
+    assert missing.num_baseline_only == 1
+    assert empty.baseline_trajectories_available and empty.candidate_trajectories_available
+    assert empty.examples == []
+    assert "`missing` (candidate)" in comparison.to_markdown()
+
+
+def test_duplicate_non_empty_id_raises(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    duplicate = [_trajectory("duplicate", 1.0, 0), _trajectory("duplicate", 0.0, 1)]
+    _write(store, "baseline", duplicate)
+    _write(store, "candidate", [_trajectory("duplicate", 1.0, 0)])
+
+    with pytest.raises(ValueError, match=r"Duplicate example_id 'duplicate'.*run 'baseline'"):
+        store.compare_runs("baseline", "candidate")
+
+
+def test_identical_run_ids(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _write(store, "baseline", [_trajectory("same", 0.01, 0)], score=1.0)
+
+    comparison = store.compare_runs("baseline", "baseline")
+
+    assert comparison.num_unchanged == 1
+    assert comparison.num_regressions == comparison.num_unmatched == 0
+
+
+def test_markdown_bound_and_serialization(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    baseline = [
+        _trajectory("regression-a", 1.0, 0, logs={"expected": "A"}),
+        _trajectory("regression-b", 1.0, 1, logs={"expected": "B"}),
+    ]
+    candidate = [
+        _trajectory("regression-a", 0.0, 10, logs={"output": "wrong A"}),
+        _trajectory("regression-b", 0.0, 11, logs={"output": "wrong B"}),
+    ]
+    _write(store, "baseline", baseline, score=1.0)
+    _write(store, "candidate", candidate, score=0.0)
+
+    comparison = store.compare_runs("baseline", "candidate")
+    serialized = comparison.to_dict()
+    json.dumps(serialized)
+    markdown = comparison.to_markdown(max_examples_per_section=1)
+
+    assert serialized["benchmarks"]["bench"]["score_delta"] == -1.0
+    assert serialized["benchmarks"]["bench"]["num_unmatched"] == 0
+    assert "| bench | 1.0000 | 0.0000 | -1.0000 |" in markdown
+    assert "_Showing 1 of 2 examples._" in markdown
+    assert "`regression-a`" in markdown and "`regression-b`" not in markdown
+    assert '"output": "wrong A"' in markdown
+    with pytest.raises(ValueError, match="non-negative"):
+        comparison.to_markdown(max_examples_per_section=-1)

--- a/tinker_cookbook/stores/eval_store.py
+++ b/tinker_cookbook/stores/eval_store.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from tinker_cookbook.stores.eval_comparison import RunComparison, compare_eval_runs
 from tinker_cookbook.stores.storage import Storage, storage_join
 
 if TYPE_CHECKING:
@@ -285,6 +286,15 @@ class EvalStore:
     def read_summary(self, run_id: str) -> dict[str, Any] | None:
         """Read the combined summary for a run, or ``None`` if missing."""
         return self._read_json("runs", run_id, "summary.json")
+
+    def compare_runs(self, baseline_run_id: str, candidate_run_id: str) -> RunComparison:
+        """Compare two stored runs using stable, non-empty ``example_id`` values.
+
+        The comparison is entirely offline. Examples without an ID are reported
+        as unmatched and duplicate non-empty IDs raise ``ValueError``. Error
+        classifications take precedence over reward-based classifications.
+        """
+        return compare_eval_runs(self, baseline_run_id, candidate_run_id)
 
     # ── Writes (for eval runner) ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- add `EvalStore.compare_runs()` for offline checkpoint comparisons
- match trajectories by stable `example_id` and classify regressions, improvements, persistent failures, error transitions, and unmatched examples
- expose typed, JSON-serializable comparison results with a bounded Markdown report
- document stable-ID requirements and cover storage edge cases with synthetic LocalStorage tests

## Validation

- `uv sync --all-extras`
- `uvx --from pre-commit pre-commit run --all-files`
- `uv run pyright tinker_cookbook`
- `uv run pytest tinker_cookbook/stores/ tinker_cookbook/eval/benchmarks/benchmark_test.py -q` (175 passed, 4 skipped)

The full local unit suite reached 1776 passed / 52 skipped; one unrelated existing deprecation-version assertion fails only in the tagged editable checkout. Recent main-branch pytest CI is green.