### PR TITLE
Make deprecation deadlines visible in CI

### DIFF
--- a/.github/workflows/downstream-compat.yaml
+++ b/.github/workflows/downstream-compat.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history for version
 
       - name: install-uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history for version
 
       - name: install-uv
         uses: astral-sh/setup-uv@v6
@@ -58,6 +60,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history for version
 
       - name: install-uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history for version
 
       - name: install-uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history for version
 
       - name: install-uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/smoke-test-evals.yaml
+++ b/.github/workflows/smoke-test-evals.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history for version
 
       - name: install-uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/smoke-test-recipes.yaml
+++ b/.github/workflows/smoke-test-recipes.yaml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history for version
 
       - name: install-uv
         uses: astral-sh/setup-uv@v6

--- a/tinker_cookbook/rl/rollout_logging.py
+++ b/tinker_cookbook/rl/rollout_logging.py
@@ -1,6 +1,5 @@
 """Utilities for exporting per-rollout records to JSONL."""
 
-import json
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -8,7 +7,6 @@ from pathlib import Path
 from typing import Any
 
 from tinker_cookbook.rl.types import TrajectoryGroup
-from tinker_cookbook.utils.deprecation import deprecated
 from tinker_cookbook.utils.misc_utils import safezip
 
 logger = logging.getLogger(__name__)
@@ -80,7 +78,7 @@ def serialize_rollout_summaries(
     """Serialize trajectory groups into JSON-safe rollout summary records.
 
     Returns one record per trajectory, suitable for writing to JSONL via
-    ``TrainingRunStore.write_rollouts()`` or ``write_rollout_summaries_jsonl()``.
+    ``TrainingRunStore.write_rollouts()``.
 
     Each record contains::
 
@@ -146,46 +144,6 @@ def serialize_rollout_summaries(
     return records
 
 
-@deprecated(
-    message="Use serialize_rollout_summaries() + store.write_rollouts() instead.",
-    removal_version="0.4.0",
-)
-def write_rollout_summaries_jsonl(
-    path: str | Path,
-    *,
-    split: str,
-    iteration: int,
-    trajectory_groups_P: Sequence[TrajectoryGroup],
-    taglist_P: Sequence[list[str]],
-    sampling_client_steps_P: Sequence[int | None] | None = None,
-) -> None:
-    """Write one JSON record per rollout trajectory to a JSONL file.
-
-    .. deprecated::
-        Prefer ``serialize_rollout_summaries()`` + ``store.write_rollouts()``.
-
-    Args:
-        path (str | Path): Destination file path.
-        split (str): Dataset split identifier.
-        iteration (int): Training iteration / batch index.
-        trajectory_groups_P (Sequence[TrajectoryGroup]): One trajectory group per problem.
-        taglist_P (Sequence[list[str]]): Tags for each trajectory group.
-        sampling_client_steps_P (Sequence[int | None] | None): Per-group step counters.
-    """
-    records = serialize_rollout_summaries(
-        split=split,
-        iteration=iteration,
-        trajectory_groups_P=trajectory_groups_P,
-        taglist_P=taglist_P,
-        sampling_client_steps_P=sampling_client_steps_P,
-    )
-    path_obj = Path(path)
-    path_obj.parent.mkdir(parents=True, exist_ok=True)
-    with open(path_obj, "w") as f:
-        for record in records:
-            f.write(json.dumps(record) + "\n")
-
-
 def rollout_summaries_jsonl_path(iteration_dir: Path, base_name: str) -> Path:
     """Build the rollout-summary JSONL path inside an iteration subdirectory.
 
@@ -213,37 +171,6 @@ def serialize_rollout_summaries_from_groups(
     :class:`RolloutSummaryGroup` objects.
     """
     return serialize_rollout_summaries(
-        split=split,
-        iteration=iteration,
-        trajectory_groups_P=[group.trajectory_group for group in groups_P],
-        taglist_P=[group.tags for group in groups_P],
-        sampling_client_steps_P=[group.sampling_client_step for group in groups_P],
-    )
-
-
-def write_rollout_summaries_jsonl_from_groups(
-    path: Path,
-    *,
-    split: str,
-    iteration: int,
-    groups_P: Sequence[RolloutSummaryGroup],
-) -> None:
-    """Serialize rollout summaries from pre-grouped records to a JSONL file.
-
-    A convenience wrapper around :func:`write_rollout_summaries_jsonl` that
-    accepts a sequence of :class:`RolloutSummaryGroup` objects instead of
-    parallel sequences of trajectory groups, tags, and sampling steps.
-
-    Args:
-        path (Path): Destination file path.
-        split (str): Dataset split identifier (e.g. ``"train"``).
-        iteration (int): Training iteration / batch index.
-        groups_P (Sequence[RolloutSummaryGroup]): One summary group per
-            problem, each containing a trajectory group, tags, and an optional
-            sampling-client step.
-    """
-    write_rollout_summaries_jsonl(
-        path,
         split=split,
         iteration=iteration,
         trajectory_groups_P=[group.trajectory_group for group in groups_P],

--- a/tinker_cookbook/rl/rollout_logging_test.py
+++ b/tinker_cookbook/rl/rollout_logging_test.py
@@ -1,16 +1,15 @@
 import json
-from pathlib import Path
 from typing import cast
 
 import numpy as np
 import tinker
 
 from tinker_cookbook.completers import TokensWithLogprobs
-from tinker_cookbook.rl.rollout_logging import write_rollout_summaries_jsonl
+from tinker_cookbook.rl.rollout_logging import serialize_rollout_summaries
 from tinker_cookbook.rl.types import Logs, Metrics, Trajectory, TrajectoryGroup, Transition
 
 
-def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
+def test_serialize_rollout_summaries_handles_numpy_scalars():
     transition = Transition(
         ob=tinker.ModelInput.from_ints([101, 102, 103, 104, 105]),
         ac=TokensWithLogprobs(tokens=[1, 2, 3], maybe_logprobs=[-0.1, -0.2, -0.3]),
@@ -25,10 +24,7 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         final_rewards_G=[cast(float, np.float32(0.75))],
         metrics_G=[cast(Metrics, {"traj_metric": np.float32(3.0)})],
     )
-    output_path = tmp_path / "rollouts.jsonl"
-
-    write_rollout_summaries_jsonl(
-        output_path,
+    records = serialize_rollout_summaries(
         split="train",
         iteration=1,
         trajectory_groups_P=[trajectory_group],
@@ -36,7 +32,9 @@ def test_write_rollout_summaries_jsonl_handles_numpy_scalars(tmp_path: Path):
         sampling_client_steps_P=[7],
     )
 
-    record = json.loads(output_path.read_text().strip())
+    # Round-trip through JSON: a numpy scalar that escaped coercion serializes fine as a
+    # dict but raises here, which is the failure this test exists to catch.
+    record = json.loads(json.dumps(records[0]))
     assert record["iteration"] == 1
     assert record["sampling_client_step"] == 7
     assert record["total_reward"] == 1.0


### PR DESCRIPTION
CI uses shallow checkouts without tags, so `hatch-vcs` reports the package as `0.1.dev*`. Version-gated deprecations therefore never expire in CI. This hid rollout logging helpers scheduled for removal in v0.4.0 that still ship in v0.5.3.

The way I found this was:

* Installed tinker cookbook as an editable install (for me to use in a separate repo)
* Run the tests from there (which meant the version was 0.5.3)
* Tripwire from the deprecation lines actually trigger at this point

## Summary

- fetch full git history so CI tests against the real package version
- remove the expired rollout logging helpers and port their NumPy scalar coverage to the supported serializer