### PR TITLE
Handle single-token completions when building RL datums

### DIFF
--- a/tinker_cookbook/recipes/rl_loop.py
+++ b/tinker_cookbook/recipes/rl_loop.py
@@ -215,7 +215,11 @@ def main(config: Config):
                 sampled_tokens_G_T, logprobs_G_T, advantages_G
             ):
                 ob_len = prompt.length - 1
-                model_input = prompt.append(types.EncodedTextChunk(tokens=sampled_tokens[:-1]))
+                # A one-token completion has an empty shift; keep it as a target and
+                # skip the empty input chunk (the server rejects empty chunks).
+                model_input = prompt
+                if len(sampled_tokens) > 1:
+                    model_input = prompt.append(types.EncodedTextChunk(tokens=sampled_tokens[:-1]))
                 target_tokens = [0] * ob_len + sampled_tokens
                 padded_logprobs = [0.0] * ob_len + logprobs
                 padded_advantages = [0.0] * ob_len + [advantage] * (model_input.length - ob_len)

--- a/tutorials/104_first_rl.py
+++ b/tutorials/104_first_rl.py
@@ -284,7 +284,11 @@ async def _(
             # Build a Datum for each completion
             ob_len = prompt.length - 1
             for tokens, logprobs, advantage in zip(tokens_G_T, logprobs_G_T, advantages_G):
-                model_input = prompt.append(tinker.EncodedTextChunk(tokens=tokens[:-1]))
+                # A one-token completion has an empty shift; keep it as a target and
+                # skip the empty input chunk (the server rejects empty chunks).
+                model_input = prompt
+                if len(tokens) > 1:
+                    model_input = prompt.append(tinker.EncodedTextChunk(tokens=tokens[:-1]))
                 target_tokens = [0] * ob_len + tokens
                 padded_logprobs = [0.0] * ob_len + logprobs
                 padded_advantages = [0.0] * ob_len + [advantage] * (model_input.length - ob_len)


### PR DESCRIPTION
A completion can be a single token: the model emits `<|endoftext|>` as its first token. `tokens[:-1]` is then empty, and the server rejects the empty chunk:

```
Empty tokens list in input for field input_sequence[28][7]
```

`forward_backward` takes the whole batch in one call, so one such datum fails the step after it was fully sampled. On base weights this hits roughly 22% of full tutorial runs (math in the comments below).

Fix: append the shifted input chunk only when the completion has more than one token. The lone token still trains via `target_tokens`. Skipping these completions (this PR's first version) was wrong: a lone EOS scores 0 in a non-degenerate group, and its negative advantage is the signal that discourages stopping immediately. Mirrors `create_rightshifted_model_input_and_leftshifted_targets`.

Applied in `tutorials/104_first_rl.py` and `recipes/rl_loop.py`, which had the same construction.
