### PR TITLE
Add FystashSandbox backend for Harbor RL

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,12 +17,24 @@ import pytest
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip smoke tests locally when TINKER_API_KEY is not set. Fail on CI."""
+    """Skip smoke tests locally when TINKER_API_KEY is not set. Fail on CI.
+
+    Sandbox-backend smokes (Modal / Fystash) gate on their own credentials and
+    do not need a Tinker API key.
+    """
     if os.environ.get("TINKER_API_KEY"):
         return
 
+    sandbox_only = {"test_modal_sandbox.py", "test_fystash_sandbox.py"}
+
     # Separate smoke tests from downstream_compat tests (which don't need API keys)
-    smoke_items = [item for item in items if "downstream_compat" not in str(item.fspath)]
+    # and from sandbox-only tests that use their own auth skip markers.
+    smoke_items = [
+        item
+        for item in items
+        if "downstream_compat" not in str(item.fspath)
+        and os.path.basename(str(item.fspath)) not in sandbox_only
+    ]
     if not smoke_items:
         return
 

--- a/tests/test_fystash_sandbox.py
+++ b/tests/test_fystash_sandbox.py
@@ -1,0 +1,99 @@
+"""Smoke tests for FystashSandbox.
+
+Require FYSTASH_API_KEY and network access; skipped when the key is unset.
+Mirrors tests/test_modal_sandbox.py for local/partner evidence (not PR CI).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+import pytest_asyncio
+
+from tinker_cookbook.sandbox.fystash_sandbox import FystashSandbox
+
+_has_fystash_auth = bool(os.environ.get("FYSTASH_API_KEY"))
+
+requires_fystash = pytest.mark.skipif(
+    not _has_fystash_auth, reason="FYSTASH_API_KEY not set"
+)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def sandbox():
+    """Shared Fystash sandbox for all tests in this module."""
+    sb = await FystashSandbox.create(timeout=120)
+    yield sb
+    await sb.cleanup()
+
+
+async def _timed(coro):
+    """Await a coroutine and return (result, elapsed_seconds)."""
+    start = time.monotonic()
+    result = await coro
+    return result, time.monotonic() - start
+
+
+@requires_fystash
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+async def test_write_file_latency(sandbox):
+    """write_file should complete in seconds and round-trip via run_command."""
+    content = "#!/bin/bash\necho hello world\n"
+
+    result, elapsed = await _timed(
+        sandbox.write_file("/tmp/test.sh", content, executable=True, timeout=30)
+    )
+    assert result.exit_code == 0, f"write_file failed: {result.stderr}"
+    assert elapsed < 30, f"write_file took {elapsed:.1f}s (expected <30s)"
+
+    read_result = await sandbox.run_command("cat /tmp/test.sh")
+    assert read_result.exit_code == 0
+    assert read_result.stdout == content
+
+    stat_result = await sandbox.run_command("test -x /tmp/test.sh && echo yes")
+    assert stat_result.stdout.strip() == "yes"
+
+    print(f"\nwrite_file latency: {elapsed:.2f}s")
+
+
+@requires_fystash
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+async def test_write_file_binary(sandbox):
+    """write_file should handle binary content correctly."""
+    content = bytes(range(256))
+
+    result, elapsed = await _timed(sandbox.write_file("/tmp/binary.bin", content, timeout=30))
+    assert result.exit_code == 0, f"write_file failed: {result.stderr}"
+    assert elapsed < 30, f"write_file took {elapsed:.1f}s (expected <30s)"
+
+    size_result = await sandbox.run_command("wc -c < /tmp/binary.bin")
+    assert size_result.exit_code == 0
+    assert int(size_result.stdout.strip()) == 256
+
+    print(f"\nwrite_file (binary) latency: {elapsed:.2f}s")
+
+
+@requires_fystash
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+async def test_cleanup_idempotent():
+    """cleanup() should not raise if called twice."""
+    sb = await FystashSandbox.create(timeout=120)
+    await sb.cleanup()
+    await sb.cleanup()
+
+
+@requires_fystash
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+async def test_cleanup_after_command():
+    """cleanup() should work after a successful run_command."""
+    sb = await FystashSandbox.create(timeout=120)
+    result = await sb.run_command("echo ok", timeout=30)
+    assert result.exit_code == 0
+    assert "ok" in result.stdout
+    await sb.cleanup()

--- a/tinker_cookbook/recipes/code_rl/code_grading.py
+++ b/tinker_cookbook/recipes/code_rl/code_grading.py
@@ -1,9 +1,10 @@
 """
 Code grading utilities for RL training.
 
-Supports two execution backends:
+Supports three execution backends:
 - sandboxfusion: Local Docker-based sandbox (default)
 - modal: Cloud-based Modal sandbox
+- fystash: Warm Firecracker rooms via Fystash (capacity pool)
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from tinker_cookbook.sandbox import SandboxBackend, SandboxFusionClient
 # Global sandbox backend clients (lazily initialized)
 _sandboxfusion_client: SandboxFusionClient | None = None
 _modal_pool: Any = None  # ModalSandboxPool, but avoid import at module level
+_fystash_pool: Any = None
 
 
 def _get_sandboxfusion_client() -> SandboxFusionClient:
@@ -40,6 +42,17 @@ def _get_modal_pool():
         _modal_pool = ModalSandboxPool(image=image)
     return _modal_pool
 
+
+
+
+def _get_fystash_pool():
+    """Get or create the Fystash capacity-backed sandbox pool."""
+    global _fystash_pool
+    if _fystash_pool is None:
+        from tinker_cookbook.sandbox.fystash_pool import FystashSandboxPool
+
+        _fystash_pool = FystashSandboxPool()
+    return _fystash_pool
 
 def extract_code_from_model(model_response: str) -> str | None:
     """Extract the last fenced code block from a model response."""
@@ -116,6 +129,34 @@ async def _check_with_modal(
     }
 
 
+
+
+async def _check_with_fystash(
+    test_cases: dict[str, str],
+    generation: str,
+    timeout: int,
+    total_timeout: int,
+) -> tuple[bool, dict[str, Any]]:
+    """Execute tests using Fystash capacity-backed pool."""
+    pool = _get_fystash_pool()
+    if not pool._started:
+        await pool.start()
+    result = await pool.run_in_workdir(
+        files={
+            "test_cases.txt": json.dumps(test_cases),
+            "code.py": generation,
+            "testing_util.py": TEST_UTIL,
+            "run.py": TEST_CODE % {"timeout": timeout},
+        },
+        command=["python", "run.py"],
+        timeout=total_timeout,
+    )
+    return result.exit_code == 0, {
+        "exit_code": result.exit_code,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
 async def sandbox_check_correctness(
     sample: list[dict[str, Any]],
     generation: str,
@@ -146,6 +187,8 @@ async def sandbox_check_correctness(
 
         if use_backend == SandboxBackend.MODAL:
             return await _check_with_modal(test_cases, generation, timeout, total_timeout)
+        elif use_backend == SandboxBackend.FYSTASH:
+            return await _check_with_fystash(test_cases, generation, timeout, total_timeout)
         elif use_backend == SandboxBackend.SANDBOXFUSION:
             return await _check_with_sandboxfusion(test_cases, generation, timeout, total_timeout)
         else:

--- a/tinker_cookbook/recipes/harbor_rl/README.md
+++ b/tinker_cookbook/recipes/harbor_rl/README.md
@@ -110,6 +110,18 @@ TINKER_SANDBOX_BACKEND=fystash uv run python …
 
 **Honesty:** Modal's default factory builds `environment/Dockerfile`. Fystash does **not** — it uses a warmed template (or pulls a prebuilt image when `FYSTASH_DOCKER_IMAGE` is set). See https://docs.fystash.ai
 
+### Fystash capacity pool (optional)
+
+For denser Harbor RL / code_rl fan-out, set a pool size so creates happen under a capacity reservation:
+
+```bash
+export FYSTASH_POOL_SIZE=8
+export FYSTASH_POOL_CREATE_RATE=4
+export FYSTASH_CAPACITY_TTL_S=3600
+```
+
+When `FYSTASH_POOL_SIZE>0`, `fystash_sandbox_factory` acquires from `FystashSandboxPool` (reserve → episode-batch replenish → acquire). Paid Fystash quota max is 64 slots.
+
 ## Running
 
 First, download the Terminal-Bench tasks:

--- a/tinker_cookbook/recipes/harbor_rl/README.md
+++ b/tinker_cookbook/recipes/harbor_rl/README.md
@@ -83,7 +83,32 @@ async def default_sandbox_factory(env_dir: Path, timeout: int) -> SandboxInterfa
 
 The first argument is the task's `environment/` directory (containing a Dockerfile and build context). Each backend converts this to its own image format internally (e.g. Modal builds a `modal.Image`).
 
-`cli_main()` accepts an optional `sandbox_factory` parameter. When `None`, it falls back to `default_sandbox_factory` (Modal). The factory flows through: `cli_main` -> `HarborDatasetBuilder` -> `HarborEnvGroupBuilder.make_envs()`.
+`cli_main()` / `run_eval()` accept an optional `sandbox_factory` parameter. When `None`, the factory is resolved from `sandbox_backend` / `TINKER_SANDBOX_BACKEND` (default Modal). The factory flows through: `cli_main` -> `HarborDatasetBuilder` -> `HarborEnvGroupBuilder.make_envs()`.
+
+### Fystash backend
+
+[Fystash](https://fystash.ai) provides warm Firecracker rooms as a `SandboxInterface` backend (`SandboxBackend.FYSTASH`). No optional extra is required (stdlib HTTP).
+
+```bash
+export FYSTASH_API_KEY=key-…          # https://fystash.ai/signup
+export FYSTASH_API=https://api.fystash.ai   # optional
+export FYSTASH_TEMPLATE_ID=default          # optional; ignored when FYSTASH_DOCKER_IMAGE is set
+# optional DinD (pull only — does not build task Dockerfiles):
+# export FYSTASH_DOCKER_IMAGE=ghcr.io/example/task:latest
+```
+
+Train / eval with:
+
+```bash
+uv run python tinker_cookbook/recipes/harbor_rl/scripts/train_terminal_bench.py \
+    sandbox_backend=fystash \
+    …
+
+# or
+TINKER_SANDBOX_BACKEND=fystash uv run python …
+```
+
+**Honesty:** Modal's default factory builds `environment/Dockerfile`. Fystash does **not** — it uses a warmed template (or pulls a prebuilt image when `FYSTASH_DOCKER_IMAGE` is set). See https://docs.fystash.ai
 
 ## Running
 

--- a/tinker_cookbook/recipes/harbor_rl/eval.py
+++ b/tinker_cookbook/recipes/harbor_rl/eval.py
@@ -27,7 +27,7 @@ from tinker_cookbook.recipes.harbor_rl.harbor_env import (
     HarborTask,
     SandboxFactory,
     _initial_messages,
-    default_sandbox_factory,
+    resolve_sandbox_factory,
 )
 from tinker_cookbook.recipes.harbor_rl.harbor_tools import HarborBashTool, HarborReward
 from tinker_cookbook.renderers import get_renderer
@@ -56,6 +56,8 @@ class EvalConfig:
     checkpoint_url: str | None = None
     base_url: str | None = None
     renderer_name: str | None = None
+    # Sandbox backend: "modal" (default) or "fystash". Also TINKER_SANDBOX_BACKEND.
+    sandbox_backend: str | None = None
 
 
 @dataclass
@@ -172,7 +174,7 @@ async def evaluate_task(
 async def run_eval(
     config: EvalConfig,
     tasks: list[HarborTask],
-    sandbox_factory: SandboxFactory = default_sandbox_factory,
+    sandbox_factory: SandboxFactory | None = None,
 ) -> list[TaskResult]:
     """Run evaluation on a list of Harbor tasks.
 
@@ -181,11 +183,16 @@ async def run_eval(
     Args:
         config: Evaluation configuration.
         tasks: List of HarborTask to evaluate.
-        sandbox_factory: Factory for creating sandboxes (defaults to Modal).
+        sandbox_factory: Factory for creating sandboxes. When None, resolved from
+            ``config.sandbox_backend`` / ``TINKER_SANDBOX_BACKEND`` (default Modal).
 
     Returns:
         List of per-task results.
     """
+    factory = resolve_sandbox_factory(
+        sandbox_backend=config.sandbox_backend,
+        sandbox_factory=sandbox_factory,
+    )
     results_dir = Path(config.output_path) / datetime.now().strftime("%Y%m%d_%H%M%S")
     results_dir.mkdir(parents=True, exist_ok=True)
     print(f"Results dir: {results_dir}")
@@ -231,7 +238,7 @@ async def run_eval(
                     task,
                     policy,
                     renderer,
-                    sandbox_factory,
+                    factory,
                     config,
                     results_dir,
                     lock,

--- a/tinker_cookbook/recipes/harbor_rl/harbor_env.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import tomllib
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
@@ -16,7 +17,8 @@ from tinker_cookbook.recipes.harbor_rl.harbor_tools import HarborBashTool, Harbo
 from tinker_cookbook.renderers import get_renderer
 from tinker_cookbook.renderers.base import Message, Renderer
 from tinker_cookbook.rl.types import Env, EnvGroupBuilder, RLDataset, RLDatasetBuilder
-from tinker_cookbook.sandbox import SandboxInterface
+from tinker_cookbook.sandbox import SandboxBackend, SandboxInterface
+from tinker_cookbook.sandbox.fystash_sandbox import fystash_sandbox_factory
 from tinker_cookbook.sandbox.modal_sandbox import ModalSandbox
 from tinker_cookbook.tool_use import build_agent_tool_env
 from tinker_cookbook.tool_use.agent_tool_message_env import RewardFn
@@ -45,6 +47,30 @@ async def default_sandbox_factory(env_dir: Path, timeout: int) -> SandboxInterfa
     dockerfile_path = env_dir / "Dockerfile"
     image = modal.Image.from_dockerfile(path=str(dockerfile_path), context_dir=str(env_dir))
     return await ModalSandbox.create(image=image, timeout=timeout)
+
+
+def resolve_sandbox_factory(
+    sandbox_backend: str | None = None,
+    sandbox_factory: SandboxFactory | None = None,
+) -> SandboxFactory:
+    """Resolve a SandboxFactory from an explicit factory, CLI backend, or env.
+
+    Priority: explicit ``sandbox_factory`` > ``sandbox_backend`` /
+    ``TINKER_SANDBOX_BACKEND`` > Modal default.
+
+    Backends: ``modal`` (default), ``fystash``.
+    """
+    if sandbox_factory is not None:
+        return sandbox_factory
+    backend = (sandbox_backend or os.environ.get("TINKER_SANDBOX_BACKEND") or "modal").strip().lower()
+    if backend in ("", SandboxBackend.MODAL, "modal"):
+        return default_sandbox_factory
+    if backend in (SandboxBackend.FYSTASH, "fystash"):
+        return fystash_sandbox_factory
+    raise ValueError(
+        f"Unknown sandbox_backend={backend!r}. Supported: modal, fystash "
+        "(or pass sandbox_factory explicitly)."
+    )
 
 
 @dataclass(frozen=True)

--- a/tinker_cookbook/recipes/harbor_rl/scripts/eval_harbor_rl.py
+++ b/tinker_cookbook/recipes/harbor_rl/scripts/eval_harbor_rl.py
@@ -4,10 +4,7 @@ from pathlib import Path
 import chz
 
 from tinker_cookbook.recipes.harbor_rl.eval import EvalConfig, TaskResult, run_eval
-from tinker_cookbook.recipes.harbor_rl.harbor_env import (
-    default_sandbox_factory,
-    load_harbor_tasks,
-)
+from tinker_cookbook.recipes.harbor_rl.harbor_env import load_harbor_tasks
 
 DATASETS: dict[str, str] = {
     "terminal_bench": "terminal-bench-2.0/terminal-bench",
@@ -29,6 +26,8 @@ class CLIConfig:
     command_timeout: int = 120
     grader_timeout: int = 60
     max_tasks: int | None = None
+    # Sandbox backend: "modal" (default) or "fystash". Also TINKER_SANDBOX_BACKEND.
+    sandbox_backend: str | None = None
 
     base_url: str | None = None
     renderer_name: str | None = None
@@ -71,10 +70,11 @@ async def run_benchmark(cli_config: CLIConfig, benchmark: str) -> list[TaskResul
         checkpoint_url=cli_config.checkpoint_url,
         base_url=cli_config.base_url,
         renderer_name=cli_config.renderer_name,
+        sandbox_backend=cli_config.sandbox_backend,
     )
     tasks = load_harbor_tasks(DATASETS[benchmark])
     print(f"Running {benchmark} on {len(tasks)} tasks")
-    results = await run_eval(eval_config, tasks, sandbox_factory=default_sandbox_factory)
+    results = await run_eval(eval_config, tasks)
     print_summary(benchmark, results)
     return results
 

--- a/tinker_cookbook/recipes/harbor_rl/scripts/train_terminal_bench.py
+++ b/tinker_cookbook/recipes/harbor_rl/scripts/train_terminal_bench.py
@@ -6,7 +6,7 @@ import asyncio
 
 import chz
 
-from tinker_cookbook.recipes.harbor_rl.harbor_env import default_sandbox_factory, load_harbor_tasks
+from tinker_cookbook.recipes.harbor_rl.harbor_env import load_harbor_tasks
 from tinker_cookbook.recipes.harbor_rl.train import CLIConfig, cli_main
 
 TERMINAL_BENCH_DATASET = "terminal-bench-2.0/terminal-bench"
@@ -15,4 +15,5 @@ TERMINAL_BENCH_DATASET = "terminal-bench-2.0/terminal-bench"
 if __name__ == "__main__":
     cli_config = chz.entrypoint(CLIConfig)
     tasks = load_harbor_tasks(TERMINAL_BENCH_DATASET)
-    asyncio.run(cli_main(cli_config, tasks, sandbox_factory=default_sandbox_factory))
+    # Factory resolved inside cli_main from sandbox_backend / TINKER_SANDBOX_BACKEND.
+    asyncio.run(cli_main(cli_config, tasks))

--- a/tinker_cookbook/recipes/harbor_rl/train.py
+++ b/tinker_cookbook/recipes/harbor_rl/train.py
@@ -10,6 +10,7 @@ from tinker_cookbook.recipes.harbor_rl.harbor_env import (
     HarborDatasetBuilder,
     HarborTask,
     SandboxFactory,
+    resolve_sandbox_factory,
 )
 from tinker_cookbook.rl.train import AsyncConfig, Config, main
 
@@ -36,6 +37,8 @@ class CLIConfig:
     max_trajectory_tokens: int = 32 * 1024
     max_generation_tokens: int | None = None
     context_overflow_reward: float = -0.1
+    # Sandbox backend: "modal" (default) or "fystash". Also TINKER_SANDBOX_BACKEND.
+    sandbox_backend: str | None = None
 
     # Training hyperparameters
     group_size: int = 4
@@ -86,6 +89,11 @@ async def cli_main(
         else cli_config.max_tokens
     )
 
+    factory = resolve_sandbox_factory(
+        sandbox_backend=cli_config.sandbox_backend,
+        sandbox_factory=sandbox_factory,
+    )
+
     dataset_builder = HarborDatasetBuilder(
         tasks=tasks,
         batch_size=cli_config.groups_per_batch,
@@ -99,7 +107,7 @@ async def cli_main(
         max_trajectory_tokens=cli_config.max_trajectory_tokens,
         max_generation_tokens=max_generation_tokens,
         context_overflow_reward=cli_config.context_overflow_reward,
-        sandbox_factory=sandbox_factory,
+        sandbox_factory=factory,
     )
 
     config = Config(

--- a/tinker_cookbook/sandbox/README.md
+++ b/tinker_cookbook/sandbox/README.md
@@ -2,7 +2,7 @@
 
 This directory contains code execution backends for sandboxed evaluation (e.g., grading code in RL environments).
 
-There are currently two available backends: SandboxFusion for local execution and Modal for cloud execution.
+There are currently three available backends: SandboxFusion for local execution, Modal for cloud execution, and Fystash for warm Firecracker rooms.
 
 ## Backends
 
@@ -65,3 +65,46 @@ print(result.stdout)
 Environment variables:
 
 - `MODAL_POOL_SIZE`: Number of sandboxes in the pool (default: 32)
+
+### Fystash (cloud Firecracker rooms)
+
+[Fystash](https://fystash.ai) provides warm Firecracker rooms as a `SandboxInterface` backend (`SandboxBackend.FYSTASH`). No optional extra is required (stdlib HTTP).
+
+```python
+from tinker_cookbook.sandbox import FystashSandbox, FystashSandboxPool
+
+sandbox = await FystashSandbox.create(timeout=600)
+await sandbox.write_file("/tmp/hi.py", "print('hello')")
+result = await sandbox.run_command("python /tmp/hi.py")
+print(result.stdout)
+await sandbox.cleanup()
+
+# Optional capacity-backed pool (harbor_rl / code_rl)
+pool = FystashSandboxPool(pool_size=8)
+await pool.start()
+result = await pool.run_in_workdir(
+    files={"code.py": "print('hello')"},
+    command=["python", "code.py"],
+)
+await pool.terminate()
+```
+
+Harbor RL selection:
+
+```bash
+export FYSTASH_API_KEY=key-…          # https://fystash.ai/signup
+# sandbox_backend=fystash on train/eval, or:
+export TINKER_SANDBOX_BACKEND=fystash
+```
+
+Environment variables:
+
+- `FYSTASH_API_KEY`: Required
+- `FYSTASH_API`: API base (default `https://api.fystash.ai`)
+- `FYSTASH_TEMPLATE_ID`: Template id (default `default`; ignored when `FYSTASH_DOCKER_IMAGE` is set)
+- `FYSTASH_DOCKER_IMAGE`: Optional DinD pull only — does **not** build Harbor task Dockerfiles
+- `FYSTASH_POOL_SIZE`: When `>0`, harbor_rl factory acquires from `FystashSandboxPool` (default cold create when unset/`0`)
+- `FYSTASH_POOL_CREATE_RATE`: Concurrent replenish (default `4`)
+- `FYSTASH_CAPACITY_TTL_S`: Capacity reservation TTL (default `3600`)
+
+**Honesty:** Modal's harbor factory builds `environment/Dockerfile`. Fystash does not — template or prebuilt image pull only. See [`recipes/harbor_rl/README.md`](../recipes/harbor_rl/README.md) for the full Fystash subsection.

--- a/tinker_cookbook/sandbox/__init__.py
+++ b/tinker_cookbook/sandbox/__init__.py
@@ -4,10 +4,12 @@ Code execution backends for sandboxed code evaluation.
 The sandbox/ directory provides thin wrappers around different sandbox backends:
 - SandboxFusionClient: HTTP-based sandbox using SandboxFusion Docker container
 - ModalSandbox: Cloud sandbox using Modal's infrastructure
+- FystashSandbox: Warm Firecracker rooms via Fystash (template / optional DinD pull)
 """
 
 from enum import StrEnum
 
+from tinker_cookbook.sandbox.fystash_sandbox import FystashSandbox, fystash_sandbox_factory
 from tinker_cookbook.sandbox.sandbox_interface import (
     SandboxInterface,
     SandboxResult,
@@ -19,12 +21,15 @@ from tinker_cookbook.sandbox.sandboxfusion import SandboxFusionClient
 class SandboxBackend(StrEnum):
     SANDBOXFUSION = "sandboxfusion"
     MODAL = "modal"
+    FYSTASH = "fystash"
 
 
 __all__ = [
+    "FystashSandbox",
     "SandboxBackend",
     "SandboxFusionClient",
     "SandboxInterface",
     "SandboxResult",
     "SandboxTerminatedError",
+    "fystash_sandbox_factory",
 ]

--- a/tinker_cookbook/sandbox/__init__.py
+++ b/tinker_cookbook/sandbox/__init__.py
@@ -4,11 +4,12 @@ Code execution backends for sandboxed code evaluation.
 The sandbox/ directory provides thin wrappers around different sandbox backends:
 - SandboxFusionClient: HTTP-based sandbox using SandboxFusion Docker container
 - ModalSandbox: Cloud sandbox using Modal's infrastructure
-- FystashSandbox: Warm Firecracker rooms via Fystash (template / optional DinD pull)
+- FystashSandbox / FystashSandboxPool: Warm Firecracker rooms via Fystash
 """
 
 from enum import StrEnum
 
+from tinker_cookbook.sandbox.fystash_pool import FystashSandboxPool
 from tinker_cookbook.sandbox.fystash_sandbox import FystashSandbox, fystash_sandbox_factory
 from tinker_cookbook.sandbox.sandbox_interface import (
     SandboxInterface,
@@ -26,6 +27,7 @@ class SandboxBackend(StrEnum):
 
 __all__ = [
     "FystashSandbox",
+    "FystashSandboxPool",
     "SandboxBackend",
     "SandboxFusionClient",
     "SandboxInterface",

--- a/tinker_cookbook/sandbox/fystash_pool.py
+++ b/tinker_cookbook/sandbox/fystash_pool.py
@@ -15,6 +15,7 @@ Env:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import shlex
@@ -24,8 +25,8 @@ from typing import Any
 
 from tinker_cookbook.sandbox.fystash_sandbox import (
     FystashSandbox,
+    _memory_for_template,
     _RoomApi,
-    __memory_for_template,
 )
 from tinker_cookbook.sandbox.sandbox_interface import SandboxResult
 
@@ -154,7 +155,7 @@ class FystashSandboxPool:
                 attach_fabric=True,
                 labels=labels,
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.error("episode batch replenish failed: %s", exc)
             return
         batch_id = str(batch.get("batch_id") or "")
@@ -184,12 +185,10 @@ class FystashSandboxPool:
             if self._dind and self._docker_image:
                 try:
                     await sb._prepare_dind(self._docker_image)
-                except Exception as exc:  # noqa: BLE001
+                except Exception as exc:
                     logger.error("DinD prepare failed for %s: %s", room_id, exc)
-                    try:
+                    with contextlib.suppress(Exception):
                         await sb.cleanup()
-                    except Exception:  # noqa: BLE001
-                        pass
                     continue
             await self._warm_pool.put(sb)
 
@@ -197,7 +196,7 @@ class FystashSandboxPool:
         while not self._terminated:
             try:
                 await self._maintain_pool_step()
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logger.error("Error maintaining FystashSandboxPool: %s", exc)
             await asyncio.sleep(1.0)
 
@@ -263,10 +262,8 @@ class FystashSandboxPool:
         self._terminated = True
         if self._maintain_task is not None:
             self._maintain_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self._maintain_task
-            except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                pass
             self._maintain_task = None
 
         while self._active_count > 0:
@@ -284,19 +281,15 @@ class FystashSandboxPool:
         )
 
         for batch_id in list(self._batch_ids):
-            try:
+            with contextlib.suppress(Exception):
                 await asyncio.to_thread(self._api.destroy_episode_batch, batch_id)
-            except Exception:  # noqa: BLE001
-                pass
         self._batch_ids.clear()
 
         if self._reservation_id:
-            try:
+            with contextlib.suppress(Exception):
                 await asyncio.to_thread(
                     self._api.release_capacity, self._reservation_id
                 )
-            except Exception:  # noqa: BLE001
-                pass
             self._reservation_id = None
 
         self._api.close()

--- a/tinker_cookbook/sandbox/fystash_pool.py
+++ b/tinker_cookbook/sandbox/fystash_pool.py
@@ -1,0 +1,338 @@
+"""FystashSandboxPool — capacity-backed warm pool for Tinker (Layer 3).
+
+Peer of tinker_cookbook ModalSandboxPool:
+
+  reserve capacity → episode-batch replenish → acquire SandboxInterface →
+  cleanup destroys room → replenish under the same reservation.
+
+Env:
+  FYSTASH_POOL_SIZE          (default 8; 0 disables pooling at factory layer)
+  FYSTASH_POOL_CREATE_RATE   (default 4 concurrent replenish)
+  FYSTASH_CAPACITY_TTL_S     (default 3600)
+  FYSTASH_TEMPLATE_ID / FYSTASH_DOCKER_IMAGE / FYSTASH_API_KEY / FYSTASH_API
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shlex
+import time
+import uuid
+from typing import Any
+
+from tinker_cookbook.sandbox.fystash_sandbox import (
+    FystashSandbox,
+    _RoomApi,
+    __memory_for_template,
+)
+from tinker_cookbook.sandbox.sandbox_interface import SandboxResult
+
+logger = logging.getLogger(__name__)
+
+
+class FystashSandboxPool:
+    """Warm pool of Fystash rooms for concurrent Harbor RL / code_rl rollouts."""
+
+    def __init__(
+        self,
+        *,
+        pool_size: int | None = None,
+        create_rate: int | None = None,
+        capacity_ttl_s: int | None = None,
+        sandbox_timeout_secs: int = 1200,
+        api_url: str | None = None,
+        api_key: str | None = None,
+        template_id: str | None = None,
+        docker_image: str | None = None,
+        agent_id: str | None = None,
+    ) -> None:
+        key = api_key or os.environ.get("FYSTASH_API_KEY") or ""
+        if not key:
+            raise RuntimeError(
+                "FYSTASH_API_KEY is required for FystashSandboxPool. "
+                "Signup: https://fystash.ai/signup"
+            )
+        self._pool_size = (
+            pool_size
+            if pool_size is not None
+            else int(os.environ.get("FYSTASH_POOL_SIZE", "8"))
+        )
+        self._create_rate = (
+            create_rate
+            if create_rate is not None
+            else int(os.environ.get("FYSTASH_POOL_CREATE_RATE", "4"))
+        )
+        self._capacity_ttl_s = (
+            capacity_ttl_s
+            if capacity_ttl_s is not None
+            else int(os.environ.get("FYSTASH_CAPACITY_TTL_S", "3600"))
+        )
+        self._sandbox_timeout_secs = sandbox_timeout_secs
+        image = docker_image if docker_image is not None else (
+            os.environ.get("FYSTASH_DOCKER_IMAGE") or None
+        )
+        if image:
+            self._template_id = "docker"
+            self._docker_image = image
+            self._dind = True
+        else:
+            self._template_id = (
+                template_id or os.environ.get("FYSTASH_TEMPLATE_ID") or "default"
+            )
+            self._docker_image = None
+            self._dind = False
+        self._agent_id = agent_id or os.environ.get("FYSTASH_AGENT_ID") or "tinker"
+        base = (
+            api_url or os.environ.get("FYSTASH_API") or "https://api.fystash.ai"
+        ).rstrip("/")
+        self._api = _RoomApi(base, key)
+        self._warm_pool: asyncio.Queue[FystashSandbox] = asyncio.Queue()
+        self._active_count = 0
+        self._terminated = False
+        self._maintain_task: asyncio.Task[None] | None = None
+        self._reservation_id: str | None = None
+        self._batch_ids: list[str] = []
+        self._lock = asyncio.Lock()
+        self._started = False
+        self.start_wall_ms: float | None = None
+
+    @property
+    def reservation_id(self) -> str | None:
+        return self._reservation_id
+
+    @property
+    def pool_size(self) -> int:
+        return self._pool_size
+
+    async def start(self) -> None:
+        """Reserve capacity and kick the replenish loop."""
+        if self._started:
+            return
+        if self._pool_size <= 0:
+            raise RuntimeError("FYSTASH_POOL_SIZE must be > 0 to start a pool")
+        t0 = time.perf_counter()
+        labels = {"purpose": "tinker-pool", "agent": self._agent_id}
+        reserved = await asyncio.to_thread(
+            self._api.reserve_capacity,
+            count=self._pool_size,
+            template_id=self._template_id,
+            ttl_s=self._capacity_ttl_s,
+            kind="hard_l1_fence",
+            labels=labels,
+        )
+        self._reservation_id = str(
+            reserved.get("reservation_id")
+            or reserved.get("id")
+            or reserved.get("reservationId")
+            or ""
+        ) or None
+        self._started = True
+        self.start_wall_ms = (time.perf_counter() - t0) * 1000.0
+        self._maintain_task = asyncio.create_task(self._maintain_pool())
+        # Seed immediately so first acquire isn't starved.
+        await self._maintain_pool_step()
+
+    async def _notify_spent(self, _sb: FystashSandbox) -> None:
+        self._active_count = max(0, self._active_count - 1)
+
+    async def _replenish(self, need: int) -> None:
+        if need <= 0 or self._terminated:
+            return
+        memory = _memory_for_template(self._template_id)
+        labels = {"purpose": "tinker-pool-replenish"}
+        try:
+            batch = await asyncio.to_thread(
+                self._api.create_episode_batch,
+                count=need,
+                template_id=self._template_id,
+                agent_id=self._agent_id,
+                room_id_prefix="tkp",
+                memory_mib=memory,
+                strategy="wave",
+                attach_fabric=True,
+                labels=labels,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("episode batch replenish failed: %s", exc)
+            return
+        batch_id = str(batch.get("batch_id") or "")
+        if batch_id:
+            self._batch_ids.append(batch_id)
+        episodes = batch.get("episodes") or []
+        for ep in episodes:
+            room_id = str(ep.get("room_id") or "")
+            if not room_id:
+                continue
+            agent_id = str(ep.get("agent_id") or self._agent_id)
+            sb = FystashSandbox.from_existing(
+                self._api,
+                room_id=room_id,
+                agent_id=agent_id,
+                timeout=self._sandbox_timeout_secs,
+                template_id=self._template_id,
+                docker_image=self._docker_image,
+                create_wall_ms=(
+                    float(ep["create_wall_ms"])
+                    if ep.get("create_wall_ms") is not None
+                    else None
+                ),
+                dind=self._dind,
+                on_cleanup=self._notify_spent,
+            )
+            if self._dind and self._docker_image:
+                try:
+                    await sb._prepare_dind(self._docker_image)
+                except Exception as exc:  # noqa: BLE001
+                    logger.error("DinD prepare failed for %s: %s", room_id, exc)
+                    try:
+                        await sb.cleanup()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    continue
+            await self._warm_pool.put(sb)
+
+    async def _maintain_pool(self) -> None:
+        while not self._terminated:
+            try:
+                await self._maintain_pool_step()
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Error maintaining FystashSandboxPool: %s", exc)
+            await asyncio.sleep(1.0)
+
+    async def _maintain_pool_step(self) -> None:
+        async with self._lock:
+            if self._terminated:
+                return
+            total = self._warm_pool.qsize() + self._active_count
+            need = min(self._create_rate, self._pool_size - total)
+            if need > 0:
+                await self._replenish(need)
+
+    async def acquire(self, *, timeout: int | None = None) -> FystashSandbox:
+        """Borrow one warm sandbox. Blocks until available."""
+        if self._terminated:
+            raise RuntimeError("FystashSandboxPool has been terminated")
+        if not self._started:
+            await self.start()
+        sb = await self._warm_pool.get()
+        self._active_count += 1
+        if timeout is not None:
+            sb._timeout = timeout
+        return sb
+
+    async def run_in_workdir(
+        self,
+        files: dict[str, str],
+        command: list[str],
+        timeout: int | None = None,
+    ) -> SandboxResult:
+        """code_rl-shaped helper: borrow → write files → run → cleanup."""
+        if self._terminated:
+            raise RuntimeError("FystashSandboxPool has been terminated")
+        sandbox = await self.acquire(timeout=timeout or self._sandbox_timeout_secs)
+        try:
+            workdir = f"/tmp/fystash-pool-{uuid.uuid4().hex[:12]}"
+            mkdir = await sandbox.run_command(
+                f"mkdir -p {shlex.quote(workdir)}", timeout=timeout or 60
+            )
+            if mkdir.exit_code != 0:
+                return SandboxResult(
+                    stdout="",
+                    stderr=f"Failed to create workdir: {workdir}",
+                    exit_code=mkdir.exit_code,
+                )
+            if files:
+                await asyncio.gather(
+                    *(
+                        sandbox.write_file(f"{workdir}/{filename}", content)
+                        for filename, content in files.items()
+                    )
+                )
+            return await sandbox.run_command(
+                shlex.join(command),
+                workdir=workdir,
+                timeout=timeout or self._sandbox_timeout_secs,
+            )
+        finally:
+            await sandbox.cleanup()
+
+    async def terminate(self) -> None:
+        """Stop replenish, destroy warm rooms, release capacity."""
+        self._terminated = True
+        if self._maintain_task is not None:
+            self._maintain_task.cancel()
+            try:
+                await self._maintain_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._maintain_task = None
+
+        while self._active_count > 0:
+            await asyncio.sleep(0.2)
+
+        leftover: list[FystashSandbox] = []
+        while not self._warm_pool.empty():
+            try:
+                leftover.append(self._warm_pool.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        await asyncio.gather(
+            *(sb.cleanup() for sb in leftover),
+            return_exceptions=True,
+        )
+
+        for batch_id in list(self._batch_ids):
+            try:
+                await asyncio.to_thread(self._api.destroy_episode_batch, batch_id)
+            except Exception:  # noqa: BLE001
+                pass
+        self._batch_ids.clear()
+
+        if self._reservation_id:
+            try:
+                await asyncio.to_thread(
+                    self._api.release_capacity, self._reservation_id
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            self._reservation_id = None
+
+        self._api.close()
+        self._started = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": "fystash-sandbox-pool",
+            "pool_size": self._pool_size,
+            "create_rate": self._create_rate,
+            "capacity_ttl_s": self._capacity_ttl_s,
+            "template_id": self._template_id,
+            "dind": self._dind,
+            "reservation_id": self._reservation_id,
+            "warm_qsize": self._warm_pool.qsize(),
+            "active_count": self._active_count,
+            "start_wall_ms": self.start_wall_ms,
+            "terminated": self._terminated,
+        }
+
+
+_POOL: FystashSandboxPool | None = None
+_POOL_LOCK = asyncio.Lock()
+
+
+async def get_or_start_pool(**kwargs: Any) -> FystashSandboxPool:
+    """Process-level singleton pool (lazy start)."""
+    global _POOL
+    async with _POOL_LOCK:
+        if _POOL is None or _POOL._terminated:
+            _POOL = FystashSandboxPool(**kwargs)
+            await _POOL.start()
+        return _POOL
+
+
+def reset_pool_singleton() -> None:
+    """Test helper — drop the process singleton without awaiting terminate."""
+    global _POOL
+    _POOL = None

--- a/tinker_cookbook/sandbox/fystash_sandbox.py
+++ b/tinker_cookbook/sandbox/fystash_sandbox.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 import os
 import shlex
@@ -88,7 +89,7 @@ class _RoomApi:
             try:
                 parsed = json.loads(detail)
                 detail = str(parsed.get("detail", detail))
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
             raise FystashApiError(exc.code, detail) from exc
 
@@ -362,10 +363,8 @@ class FystashSandbox:
                 await sb._prepare_dind(image)
             return sb
         except Exception:
-            try:
+            with contextlib.suppress(Exception):
                 await asyncio.to_thread(api.destroy, room_id)
-            except Exception:  # noqa: BLE001
-                pass
             api.close()
             raise
 
@@ -395,7 +394,7 @@ class FystashSandbox:
                 timeout_ms=timeout_ms,
                 stdin=stdin,
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             msg = str(exc).lower()
             if any(k in msg for k in ("not found", "destroyed", "terminated", "404")):
                 raise SandboxTerminatedError(str(exc)) from exc
@@ -519,7 +518,7 @@ class FystashSandbox:
         self._cleaned = True
         try:
             await asyncio.to_thread(self._api.destroy, self._room_id)
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
         finally:
             if self._on_cleanup is not None:
@@ -527,7 +526,7 @@ class FystashSandbox:
                     maybe = self._on_cleanup(self)
                     if asyncio.iscoroutine(maybe):
                         await maybe
-                except Exception:  # noqa: BLE001
+                except Exception:
                     pass
             if self._owns_api:
                 self._api.close()

--- a/tinker_cookbook/sandbox/fystash_sandbox.py
+++ b/tinker_cookbook/sandbox/fystash_sandbox.py
@@ -1,0 +1,447 @@
+"""Fystash cloud sandbox backend for Tinker (SandboxInterface peer of ModalSandbox).
+
+Warm Firecracker rooms via the Fystash Room HTTP API (stdlib urllib — no extra deps).
+
+Honesty / v1 limits:
+
+- Does **not** build Harbor task ``environment/Dockerfile`` (Modal default does).
+- Template path by default (``FYSTASH_TEMPLATE_ID``, usually ``default``).
+- Optional DinD: set ``FYSTASH_DOCKER_IMAGE`` → ``template_id=docker`` + pull + run.
+
+Docs: https://fystash.ai · https://docs.fystash.ai
+Requires ``FYSTASH_API_KEY``. Optional: ``FYSTASH_API`` (default ``https://api.fystash.ai``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import shlex
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from tinker_cookbook.sandbox.sandbox_interface import SandboxResult, SandboxTerminatedError
+
+_CTR_NAME = "tinker-task"
+_PULL_TIMEOUT_S = 1800.0
+_DOCKER_READY_S = 120.0
+_MAX_EXEC_TIMEOUT_MS = 3_600_000
+_HTTP_TIMEOUT_S = 3900.0
+
+
+class FystashApiError(RuntimeError):
+    def __init__(self, status: int, detail: str) -> None:
+        super().__init__(f"Fystash API HTTP {status}: {detail}")
+        self.status = status
+        self.detail = detail
+
+
+class _RoomApi:
+    """Sync Room API client (urllib)."""
+
+    def __init__(
+        self, base_url: str, api_key: str, *, timeout: float = _HTTP_TIMEOUT_S
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+
+    def close(self) -> None:
+        return
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> Any:
+        url = f"{self._base}{path}"
+        if params:
+            from urllib.parse import urlencode
+
+            url = f"{url}?{urlencode(params)}"
+        data: bytes | None = None
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Accept": "application/json",
+        }
+        if json_body is not None:
+            data = json.dumps(json_body).encode()
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                raw = resp.read()
+                if not raw:
+                    return {}
+                return json.loads(raw.decode())
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            try:
+                parsed = json.loads(detail)
+                detail = str(parsed.get("detail", detail))
+            except Exception:  # noqa: BLE001
+                pass
+            raise FystashApiError(exc.code, detail) from exc
+
+    def create_room(self, room_id: str) -> dict[str, Any]:
+        return self._request("POST", "/v1/rooms", json_body={"room_id": room_id})
+
+    def create_from_template(
+        self,
+        room_id: str,
+        agent_id: str,
+        *,
+        guest_cid: int,
+        template_id: str,
+        memory_mib: int,
+        vcpu_count: int,
+        attach_fabric: bool = True,
+    ) -> dict[str, Any]:
+        body = {
+            "agent_id": agent_id,
+            "guest_cid": guest_cid,
+            "template_id": template_id,
+            "vcpu_count": vcpu_count,
+            "memory_mib": memory_mib,
+            "enable_guest_net": True,
+            "attach_fabric": attach_fabric,
+        }
+        last_exc: Exception | None = None
+        for attempt in range(1, 13):
+            try:
+                return self._request(
+                    "POST",
+                    f"/v1/rooms/{room_id}/sandboxes/from-template",
+                    json_body=body,
+                )
+            except FystashApiError as exc:
+                last_exc = exc
+                if exc.status not in (502, 503) or attempt >= 12:
+                    raise
+                detail = exc.detail.lower()
+                if exc.status == 502 and not any(
+                    tok in detail
+                    for tok in ("timed out", "connection refused", "reset by peer")
+                ):
+                    raise
+                time.sleep(min(30.0, 5.0 * attempt))
+        if last_exc is None:
+            raise RuntimeError("create_from_template exhausted retries")
+        raise last_exc
+
+    def exec(
+        self,
+        room_id: str,
+        agent_id: str,
+        argv: list[str],
+        *,
+        cwd: str | None = None,
+        timeout_ms: int = 120_000,
+        stdin: bytes | None = None,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"argv": argv, "timeout_ms": timeout_ms}
+        if cwd is not None:
+            body["cwd"] = cwd
+        if stdin is not None:
+            body["stdin_b64"] = base64.b64encode(stdin).decode()
+        if env:
+            body["env"] = env
+        return self._request(
+            "POST",
+            f"/v1/rooms/{room_id}/sandboxes/{agent_id}/exec",
+            json_body=body,
+        )
+
+    def destroy(self, room_id: str) -> dict[str, Any]:
+        return self._request("DELETE", f"/v1/rooms/{room_id}")
+
+
+def _decode_b64(value: str | None) -> str:
+    if not value:
+        return ""
+    return base64.b64decode(value).decode(errors="replace")
+
+
+def _memory_for_template(template_id: str) -> int:
+    return {
+        "default": 256,
+        "docker": 2048,
+        "browser": 2048,
+        "desktop": 2048,
+    }.get(template_id, 256)
+
+
+class FystashSandbox:
+    """Persistent Fystash room sandbox. Conforms to SandboxInterface."""
+
+    def __init__(
+        self,
+        *,
+        api: _RoomApi,
+        room_id: str,
+        agent_id: str,
+        timeout: int,
+        template_id: str,
+        docker_image: str | None,
+        create_wall_ms: float | None,
+        dind: bool,
+        max_stream_output_bytes: int = 128 * 1024,
+    ) -> None:
+        self._api = api
+        self._room_id = room_id
+        self._agent_id = agent_id
+        self._timeout = timeout
+        self._template_id = template_id
+        self._docker_image = docker_image
+        self._dind = dind
+        self._max_stream_output_bytes = max_stream_output_bytes
+        self.create_wall_ms = create_wall_ms
+        self._cleaned = False
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        timeout: int = 600,
+        template_id: str | None = None,
+        docker_image: str | None = None,
+        agent_id: str | None = None,
+        api_url: str | None = None,
+        api_key: str | None = None,
+        max_stream_output_bytes: int = 128 * 1024,
+    ) -> FystashSandbox:
+        """Create a room and start a sandbox (template or DinD)."""
+        key = api_key or os.environ.get("FYSTASH_API_KEY") or ""
+        if not key:
+            raise RuntimeError(
+                "FYSTASH_API_KEY is required for FystashSandbox. "
+                "Signup: https://fystash.ai/signup"
+            )
+        base = (
+            api_url or os.environ.get("FYSTASH_API") or "https://api.fystash.ai"
+        ).rstrip("/")
+        image = (
+            docker_image
+            if docker_image is not None
+            else (os.environ.get("FYSTASH_DOCKER_IMAGE") or None)
+        )
+        if image:
+            tpl = "docker"
+            dind = True
+        else:
+            tpl = template_id or os.environ.get("FYSTASH_TEMPLATE_ID") or "default"
+            dind = False
+        aid = agent_id or os.environ.get("FYSTASH_AGENT_ID") or "tinker"
+        room_id = f"tk-{uuid.uuid4().hex[:10]}"
+        guest_cid = 9600 + (int(uuid.uuid4().hex[:4], 16) % 300)
+        api = _RoomApi(base, key)
+        t0 = time.perf_counter()
+        try:
+            await asyncio.to_thread(api.create_room, room_id)
+            created = await asyncio.to_thread(
+                api.create_from_template,
+                room_id,
+                aid,
+                guest_cid=guest_cid,
+                template_id=tpl,
+                memory_mib=_memory_for_template(tpl),
+                vcpu_count=1 if not dind else 2,
+                attach_fabric=True,
+            )
+            create_wall_ms = (
+                float(created["create_wall_ms"])
+                if created.get("create_wall_ms") is not None
+                else (time.perf_counter() - t0) * 1000.0
+            )
+            sb = cls(
+                api=api,
+                room_id=room_id,
+                agent_id=aid,
+                timeout=timeout,
+                template_id=tpl,
+                docker_image=image,
+                create_wall_ms=create_wall_ms,
+                dind=dind,
+                max_stream_output_bytes=max_stream_output_bytes,
+            )
+            if dind and image:
+                await sb._prepare_dind(image)
+            return sb
+        except Exception:
+            try:
+                await asyncio.to_thread(api.destroy, room_id)
+            except Exception:  # noqa: BLE001
+                pass
+            api.close()
+            raise
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._room_id
+
+    async def _host_exec(
+        self,
+        command: str,
+        *,
+        timeout: int = 60,
+        cwd: str | None = None,
+        stdin: bytes | None = None,
+        max_output_bytes: int | None = None,
+    ) -> SandboxResult:
+        if self._cleaned:
+            raise SandboxTerminatedError("sandbox cleaned up")
+        timeout_ms = min(max(timeout, 1) * 1000, _MAX_EXEC_TIMEOUT_MS)
+        try:
+            resp = await asyncio.to_thread(
+                self._api.exec,
+                self._room_id,
+                self._agent_id,
+                ["/bin/bash", "-lc", command],
+                cwd=cwd,
+                timeout_ms=timeout_ms,
+                stdin=stdin,
+            )
+        except Exception as exc:  # noqa: BLE001
+            msg = str(exc).lower()
+            if any(k in msg for k in ("not found", "destroyed", "terminated", "404")):
+                raise SandboxTerminatedError(str(exc)) from exc
+            return SandboxResult(stdout="", stderr=str(exc), exit_code=-1)
+        stdout = _decode_b64(resp.get("stdout_b64"))
+        stderr = _decode_b64(resp.get("stderr_b64"))
+        cap = (
+            max_output_bytes
+            if max_output_bytes is not None
+            else self._max_stream_output_bytes
+        )
+        if len(stdout.encode()) > cap:
+            stdout = stdout.encode()[:cap].decode(errors="replace")
+        if len(stderr.encode()) > cap:
+            stderr = stderr.encode()[:cap].decode(errors="replace")
+        code = resp.get("exit_code")
+        return SandboxResult(
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=int(code) if code is not None else 1,
+        )
+
+    async def _prepare_dind(self, image: str) -> None:
+        deadline = time.monotonic() + _DOCKER_READY_S
+        while time.monotonic() < deadline:
+            r = await self._host_exec(
+                "docker info >/dev/null 2>&1 && echo ready", timeout=30
+            )
+            if r.exit_code == 0 and "ready" in r.stdout:
+                break
+            await asyncio.sleep(2.0)
+        else:
+            raise RuntimeError("dockerd not ready in guest")
+        pull = await self._host_exec(
+            f"docker pull {shlex.quote(image)}",
+            timeout=int(_PULL_TIMEOUT_S),
+        )
+        if pull.exit_code != 0:
+            raise RuntimeError(
+                f"docker pull failed for {image!r}: {(pull.stderr or pull.stdout)[:800]}"
+            )
+        run = await self._host_exec(
+            f"docker rm -f {shlex.quote(_CTR_NAME)} >/dev/null 2>&1 || true; "
+            f"docker run -d --name {shlex.quote(_CTR_NAME)} "
+            f"--entrypoint sleep {shlex.quote(image)} infinity",
+            timeout=120,
+        )
+        if run.exit_code != 0:
+            raise RuntimeError(
+                f"docker run failed for {image!r}: {(run.stderr or run.stdout)[:800]}"
+            )
+
+    def _wrap_for_dind(self, command: str, workdir: str | None) -> str:
+        work = f"-w {shlex.quote(workdir)} " if workdir else ""
+        return (
+            f"docker exec {work}{shlex.quote(_CTR_NAME)} "
+            f"bash -lc {shlex.quote(command)}"
+        )
+
+    async def send_heartbeat(self, timeout: int = 30) -> None:
+        result = await self._host_exec("true", timeout=timeout)
+        if result.exit_code != 0:
+            raise SandboxTerminatedError(
+                f"heartbeat failed: {result.stderr or result.stdout}"
+            )
+
+    async def run_command(
+        self,
+        command: str,
+        workdir: str | None = None,
+        timeout: int = 60,
+        max_output_bytes: int | None = None,
+    ) -> SandboxResult:
+        if self._dind:
+            wrapped = self._wrap_for_dind(command, workdir)
+            return await self._host_exec(
+                wrapped,
+                timeout=timeout,
+                max_output_bytes=max_output_bytes,
+            )
+        return await self._host_exec(
+            command,
+            timeout=timeout,
+            cwd=workdir,
+            max_output_bytes=max_output_bytes,
+        )
+
+    async def read_file(
+        self, path: str, max_bytes: int | None = None, timeout: int = 60
+    ) -> SandboxResult:
+        if max_bytes is not None:
+            cmd = f"head -c {int(max_bytes)} {shlex.quote(path)}"
+        else:
+            cmd = f"cat {shlex.quote(path)}"
+        return await self.run_command(cmd, timeout=timeout)
+
+    async def write_file(
+        self,
+        path: str,
+        content: str | bytes = "",
+        executable: bool = False,
+        timeout: int = 60,
+    ) -> SandboxResult:
+        data = content.encode() if isinstance(content, str) else content
+        parent = str(PurePosixPath(path).parent)
+        inner = f"mkdir -p {shlex.quote(parent)} && cat > {shlex.quote(path)}"
+        if executable:
+            inner += f" && chmod +x {shlex.quote(path)}"
+        if self._dind:
+            script = (
+                f"docker exec -i -u root {shlex.quote(_CTR_NAME)} bash -lc "
+                f"{shlex.quote(inner)}"
+            )
+        else:
+            script = inner
+        return await self._host_exec(script, timeout=timeout, stdin=data)
+
+    async def cleanup(self) -> None:
+        if self._cleaned:
+            return
+        self._cleaned = True
+        try:
+            await asyncio.to_thread(self._api.destroy, self._room_id)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            self._api.close()
+
+
+async def fystash_sandbox_factory(env_dir: Path, timeout: int) -> FystashSandbox:
+    """SandboxFactory for Harbor RL — env_dir accepted but Dockerfile not built."""
+    _ = env_dir
+    return await FystashSandbox.create(timeout=timeout)

--- a/tinker_cookbook/sandbox/fystash_sandbox.py
+++ b/tinker_cookbook/sandbox/fystash_sandbox.py
@@ -165,6 +165,56 @@ class _RoomApi:
     def destroy(self, room_id: str) -> dict[str, Any]:
         return self._request("DELETE", f"/v1/rooms/{room_id}")
 
+    def create_episode_batch(
+        self,
+        *,
+        count: int,
+        template_id: str = "default",
+        agent_id: str = "tinker",
+        room_id_prefix: str = "tkp",
+        memory_mib: int = 256,
+        strategy: str = "wave",
+        attach_fabric: bool = True,
+        labels: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "count": int(count),
+            "template_id": template_id,
+            "agent_id": agent_id,
+            "room_id_prefix": room_id_prefix,
+            "memory_mib": int(memory_mib),
+            "strategy": strategy,
+            "attach_fabric": attach_fabric,
+        }
+        if labels is not None:
+            body["labels"] = labels
+        return self._request("POST", "/v1/episodes/batch", json_body=body)
+
+    def destroy_episode_batch(self, batch_id: str) -> dict[str, Any]:
+        return self._request("DELETE", f"/v1/episodes/batch/{batch_id}")
+
+    def reserve_capacity(
+        self,
+        *,
+        count: int,
+        template_id: str = "default",
+        ttl_s: int = 3600,
+        kind: str = "hard_l1_fence",
+        labels: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "count": int(count),
+            "template_id": template_id,
+            "ttl_s": int(ttl_s),
+            "kind": kind,
+        }
+        if labels is not None:
+            body["labels"] = labels
+        return self._request("POST", "/v1/capacity/reserve", json_body=body)
+
+    def release_capacity(self, reservation_id: str) -> dict[str, Any]:
+        return self._request("DELETE", f"/v1/capacity/reservations/{reservation_id}")
+
 
 def _decode_b64(value: str | None) -> str:
     if not value:
@@ -196,6 +246,8 @@ class FystashSandbox:
         create_wall_ms: float | None,
         dind: bool,
         max_stream_output_bytes: int = 128 * 1024,
+        owns_api: bool = True,
+        on_cleanup: Any | None = None,
     ) -> None:
         self._api = api
         self._room_id = room_id
@@ -207,6 +259,38 @@ class FystashSandbox:
         self._max_stream_output_bytes = max_stream_output_bytes
         self.create_wall_ms = create_wall_ms
         self._cleaned = False
+        self._owns_api = owns_api
+        self._on_cleanup = on_cleanup
+
+    @classmethod
+    def from_existing(
+        cls,
+        api: _RoomApi,
+        *,
+        room_id: str,
+        agent_id: str,
+        timeout: int = 600,
+        template_id: str = "default",
+        docker_image: str | None = None,
+        create_wall_ms: float | None = None,
+        dind: bool = False,
+        max_stream_output_bytes: int = 128 * 1024,
+        on_cleanup: Any | None = None,
+    ) -> FystashSandbox:
+        """Wrap an already-running room (episode batch / pool replenish)."""
+        return cls(
+            api=api,
+            room_id=room_id,
+            agent_id=agent_id,
+            timeout=timeout,
+            template_id=template_id,
+            docker_image=docker_image,
+            create_wall_ms=create_wall_ms,
+            dind=dind,
+            max_stream_output_bytes=max_stream_output_bytes,
+            owns_api=False,
+            on_cleanup=on_cleanup,
+        )
 
     @classmethod
     async def create(
@@ -438,10 +522,30 @@ class FystashSandbox:
         except Exception:  # noqa: BLE001
             pass
         finally:
-            self._api.close()
+            if self._on_cleanup is not None:
+                try:
+                    maybe = self._on_cleanup(self)
+                    if asyncio.iscoroutine(maybe):
+                        await maybe
+                except Exception:  # noqa: BLE001
+                    pass
+            if self._owns_api:
+                self._api.close()
 
 
 async def fystash_sandbox_factory(env_dir: Path, timeout: int) -> FystashSandbox:
-    """SandboxFactory for Harbor RL — env_dir accepted but Dockerfile not built."""
+    """SandboxFactory for Harbor RL — env_dir accepted but Dockerfile not built.
+
+    When ``FYSTASH_POOL_SIZE>0``, acquire from the capacity-backed pool.
+    """
     _ = env_dir
+    try:
+        pool_size = int(os.environ.get("FYSTASH_POOL_SIZE", "0"))
+    except ValueError:
+        pool_size = 0
+    if pool_size > 0:
+        from tinker_cookbook.sandbox.fystash_pool import get_or_start_pool
+
+        pool = await get_or_start_pool()
+        return await pool.acquire(timeout=timeout)
     return await FystashSandbox.create(timeout=timeout)

--- a/tinker_cookbook/sandbox/fystash_sandbox_test.py
+++ b/tinker_cookbook/sandbox/fystash_sandbox_test.py
@@ -61,3 +61,23 @@ def test_fystash_create_requires_api_key() -> None:
 
         with pytest.raises(RuntimeError, match="FYSTASH_API_KEY"):
             asyncio.run(_run())
+
+
+def test_pool_start_requires_api_key() -> None:
+    from tinker_cookbook.sandbox.fystash_pool import FystashSandboxPool
+
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("FYSTASH_API_KEY", None)
+        with pytest.raises(RuntimeError, match="FYSTASH_API_KEY"):
+            FystashSandboxPool(pool_size=2)
+
+
+def test_from_existing_does_not_own_api() -> None:
+    from tinker_cookbook.sandbox.fystash_sandbox import _RoomApi
+
+    api = _RoomApi("https://api.fystash.ai", "dummy")
+    sb = FystashSandbox.from_existing(
+        api, room_id="r1", agent_id="tinker", template_id="default"
+    )
+    assert sb._owns_api is False
+    assert sb.sandbox_id == "r1"

--- a/tinker_cookbook/sandbox/fystash_sandbox_test.py
+++ b/tinker_cookbook/sandbox/fystash_sandbox_test.py
@@ -1,0 +1,63 @@
+"""Unit tests for Fystash sandbox backend (no live network)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest import mock
+
+import pytest
+
+from tinker_cookbook.recipes.harbor_rl.harbor_env import (
+    default_sandbox_factory,
+    resolve_sandbox_factory,
+)
+from tinker_cookbook.sandbox import SandboxBackend
+from tinker_cookbook.sandbox.fystash_sandbox import FystashSandbox, fystash_sandbox_factory
+
+
+def test_sandbox_backend_enum_includes_fystash() -> None:
+    assert SandboxBackend.FYSTASH == "fystash"
+
+
+def test_resolve_default_is_modal() -> None:
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("TINKER_SANDBOX_BACKEND", None)
+        factory = resolve_sandbox_factory()
+    assert factory is default_sandbox_factory
+
+
+def test_resolve_fystash_backend_string() -> None:
+    factory = resolve_sandbox_factory(sandbox_backend="fystash")
+    assert factory is fystash_sandbox_factory
+
+
+def test_resolve_fystash_from_env() -> None:
+    with mock.patch.dict(os.environ, {"TINKER_SANDBOX_BACKEND": "fystash"}):
+        factory = resolve_sandbox_factory()
+    assert factory is fystash_sandbox_factory
+
+
+def test_resolve_explicit_factory_wins() -> None:
+    sentinel = default_sandbox_factory
+    factory = resolve_sandbox_factory(
+        sandbox_backend="fystash",
+        sandbox_factory=sentinel,
+    )
+    assert factory is sentinel
+
+
+def test_resolve_unknown_backend() -> None:
+    with pytest.raises(ValueError, match="Unknown sandbox_backend"):
+        resolve_sandbox_factory(sandbox_backend="daytona")
+
+
+def test_fystash_create_requires_api_key() -> None:
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("FYSTASH_API_KEY", None)
+
+        async def _run() -> None:
+            await FystashSandbox.create(timeout=60)
+
+        with pytest.raises(RuntimeError, match="FYSTASH_API_KEY"):
+            asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Add in-tree `FystashSandbox` + `SandboxBackend.FYSTASH` (stdlib HTTP, no new extra)
- Wire harbor_rl via `sandbox_backend=fystash` / `TINKER_SANDBOX_BACKEND`
- Optional `FystashSandboxPool` when `FYSTASH_POOL_SIZE>0` (capacity reserve + episode batch)
- Docs + offline unit tests; skip-gated live smoke in `tests/test_fystash_sandbox.py`

## Honesty
Modal builds `environment/Dockerfile`. Fystash does **not** — template or `FYSTASH_DOCKER_IMAGE` pull only.

## Test plan
- [x] `uv run pytest tinker_cookbook/sandbox/fystash_sandbox_test.py`
- [x] ruff + pyright on Fystash modules
- [x] Live create/write/read/cleanup + pool smoke against api.fystash.ai
- [ ] Maintainer: optional live run with `FYSTASH_API_KEY` set


Made with [Cursor](https://cursor.com)