### PR TITLE
Fix Qwen3.5 message content trimming

### DIFF
--- a/tinker_cookbook/renderers/qwen3_5.py
+++ b/tinker_cookbook/renderers/qwen3_5.py
@@ -26,6 +26,7 @@ from tinker_cookbook.renderers.base import (
     Message,
     ParseTermination,
     RenderContext,
+    RenderedMessage,
     Role,
     TextPart,
     ToolCall,
@@ -55,6 +56,11 @@ class Qwen3_5Renderer(Qwen3VLRenderer):
     the last user message. This is handled via ctx.last_user_index, which is
     populated by the base build_generation_prompt/build_supervised_example.
     """
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        if isinstance(message["content"], str):
+            message = {**message, "content": message["content"].strip()}
+        return super().render_message(message, ctx)
 
     def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
         """Override to produce the full generation suffix directly.

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -630,6 +630,17 @@ def qwen3_5_renderer(qwen3_5_tokenizer):
     return Qwen3_5Renderer(qwen3_5_tokenizer)
 
 
+def test_qwen3_5_trims_message_content(qwen3_5_renderer):
+    messages = [{"role": "user", "content": "hi\n"}]
+    actual = qwen3_5_renderer.build_generation_prompt(messages).to_ints()
+    expected = extract_token_ids(
+        AutoTokenizer.from_pretrained("Qwen/Qwen3.6-35B-A3B").apply_chat_template(
+            messages, tokenize=True, add_generation_prompt=True
+        )
+    )
+    assert actual == expected
+
+
 def test_qwen3_5_parse_response_restores_prefilled_think_tag(qwen3_5_tokenizer, qwen3_5_renderer):
     """parse_response should restore <think>\\n when it was prefilled by generation prompt."""
     # Simulate sampled tokens after <think>\n prefill: "reasoning\n</think>\n\nanswer<|im_end|>"


### PR DESCRIPTION
## Summary

Trim Qwen3.5 message content before rendering to match the Hugging Face chat template, with one token-parity regression test.

References: [Qwen3.5 chat template](https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/tokenizer_config.json) · [Prime RL implementation](https://github.com/PrimeIntellect-ai/renderers/blob/d4707862ac83aa3773c21f4096aec72bd17b91e4/renderers/qwen35.py#L475)

### Example

```json
// Input
{"role": "user", "content": "hi\n"}

// Content produced by the renderer before
"hi\n"

// Content produced by the renderer after
"hi"
```