### PR TITLE
Fix periodic/rolling checkpoint name collision that poisons the TrainingClient

### DIFF
--- a/tinker_cookbook/checkpoint_utils.py
+++ b/tinker_cookbook/checkpoint_utils.py
@@ -535,7 +535,13 @@ class CheckpointManager:
     * **Rolling** – cheap resume-only checkpoints (state only, no sampler
       export) saved every ``rolling_save_every`` steps.  After each save the
       previous rolling checkpoint is deleted to bound storage.  A short TTL
-      acts as a safety net if deletion fails.
+      acts as a safety net if deletion fails.  Rolling checkpoints are named
+      ``{step:06d}-rolling`` so they can never collide with a periodic
+      checkpoint saved at the same step — a same-name double save fails with
+      "Checkpoint already exists", and the failed request poisons the
+      training client, killing the run.  Rolling saves are also skipped
+      entirely on steps where a periodic save fires, since the periodic
+      checkpoint already contains the training state.
     * **Final** – a permanent checkpoint saved at the end of training with no
       TTL, followed by cleanup of any remaining rolling checkpoint.  The final
       checkpoint always blocks (never fire-and-forget).
@@ -590,6 +596,9 @@ class CheckpointManager:
         self._pending_rolling_task: asyncio.Task[None] | None = None
         self._pending_periodic_task: asyncio.Task[dict[str, str]] | None = None
         self._prev_state_path: str | None = None
+        # Step of the most recent periodic save; lets _should_save_rolling
+        # skip the redundant same-step rolling save (see class docstring).
+        self._last_periodic_step: int | None = None
 
         self._last_saved_tokens: int = 0
         self._last_saved_wall_time: float = time.perf_counter()
@@ -623,6 +632,7 @@ class CheckpointManager:
         sampling client) should call :meth:`should_save_periodic` first, then
         this method directly.
         """
+        self._last_periodic_step = step
         async with trace.scope_span("save_checkpoint"):
             return await save_checkpoint_async(
                 training_client=self._training_client,
@@ -636,6 +646,7 @@ class CheckpointManager:
 
     def save_periodic(self, step: int, loop_state: dict[str, Any]) -> dict[str, str]:
         """Synchronous version of :meth:`save_periodic_async`."""
+        self._last_periodic_step = step
         with trace.scope_span_sync("save_checkpoint"):
             return save_checkpoint(
                 training_client=self._training_client,
@@ -657,7 +668,11 @@ class CheckpointManager:
             return False
         if step % self._rolling_save_every != 0:
             return False
-        # Skip when a periodic checkpoint fires on the same step.
+        # Skip when a periodic save fired on this step: it already contains
+        # the training state. _last_periodic_step covers token- and wall-clock-
+        # triggered saves, which the save_every modulo below can't predict.
+        if step == self._last_periodic_step:
+            return False
         return not (self._save_every > 0 and step % self._save_every == 0)
 
     async def maybe_save_rolling_async(self, step: int, loop_state: dict[str, Any]) -> None:
@@ -712,6 +727,9 @@ class CheckpointManager:
         """
         result: dict[str, str] | None = None
         if self.should_save_periodic(step, elapsed_tokens=elapsed_tokens):
+            # Mark before the save is submitted so the rolling check below sees
+            # it even when the periodic save runs as a background task.
+            self._last_periodic_step = step
             if self._async_periodic_saves:
                 await self._resolve_pending_periodic_async()
                 self._pending_periodic_task = asyncio.create_task(
@@ -829,7 +847,9 @@ class CheckpointManager:
         self._pending_periodic_task = None
 
     async def _do_rolling_save_async(self, step: int, loop_state: dict[str, Any]) -> None:
-        name = f"{step:06d}"
+        # The "-rolling" suffix keeps rolling checkpoints in a distinct
+        # namespace from periodic ones (see class docstring).
+        name = f"{step:06d}-rolling"
         paths = await save_checkpoint_async(
             training_client=self._training_client,
             name=name,

--- a/tinker_cookbook/checkpoint_utils_test.py
+++ b/tinker_cookbook/checkpoint_utils_test.py
@@ -220,6 +220,20 @@ class TestCheckpointManagerShouldSave:
         assert not mgr._should_save_rolling(5)
         assert not mgr._should_save_rolling(10)
 
+    def test_skips_step_of_last_periodic_save(self):
+        """A periodic save at a step suppresses the rolling save for that step.
+
+        This covers token- and wall-clock-triggered periodic saves, which fire
+        on steps the ``save_every`` modulo check can't predict. Without the
+        suppression, both saves would race to create the same checkpoint name
+        and the loser would poison the TrainingClient.
+        """
+        mgr = self._make_mgr(rolling_save_every=10, save_every=0)
+        assert mgr._should_save_rolling(50)
+        mgr._last_periodic_step = 50  # e.g. a token-triggered periodic save
+        assert not mgr._should_save_rolling(50)
+        assert mgr._should_save_rolling(60)
+
 
 class TestCheckpointManagerShouldSavePeriodic:
     """Tests for should_save_periodic logic."""
@@ -672,3 +686,115 @@ async def test_sync_periodic_saves_still_work():
         assert result["state_path"] == "tinker://run/state/000005"
         assert result["sampler_path"] == "tinker://run/sampler/000005"
         assert mgr._pending_periodic_task is None
+
+
+# ---------------------------------------------------------------------------
+# Periodic/rolling same-step collision tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_periodic_and_rolling_same_step_saves_once():
+    """Regression: a token-triggered periodic save must suppress the rolling save.
+
+    With save_every=0 + save_every_tokens set, a token-threshold crossing can
+    land on a rolling-cadence step. Both saves used to fire with the same
+    checkpoint name; the server rejects the duplicate ("Checkpoint already
+    exists") and the failed request poisons the TrainingClient, killing the
+    run. Only the periodic save (state + sampler) should happen.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_training_client = MagicMock()
+        state_mock, sampler_mock = _make_both_save_mocks(
+            ["tinker://run/state/000050"], ["tinker://run/sampler/000050"]
+        )
+        mock_training_client.save_state_async = state_mock
+        mock_training_client.save_weights_for_sampler_async = sampler_mock
+
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=MagicMock(),
+            log_path=tmpdir,
+            save_every=0,
+            save_every_tokens=2_000_000,
+            rolling_save_every=10,
+            async_periodic_saves=True,
+        )
+
+        # Step 50 crosses the token threshold AND is a rolling-cadence step.
+        await mgr.maybe_save_async(step=50, loop_state={"batch": 50}, elapsed_tokens=2_100_000)
+        await mgr.finalize_async()
+
+        # Exactly one state save (the periodic one), under the periodic name.
+        assert mock_training_client.save_state_async.call_count == 1
+        assert mock_training_client.save_state_async.call_args.args[0] == "000050"
+        assert mock_training_client.save_weights_for_sampler_async.call_count == 1
+
+        ckpts = [
+            CheckpointRecord.from_dict(json.loads(line))
+            for line in (Path(tmpdir) / "checkpoints.jsonl").read_text().strip().split("\n")
+        ]
+        assert len(ckpts) == 1
+        assert ckpts[0].name == "000050"
+        assert ckpts[0].extra.get("rolling") is None
+
+
+@pytest.mark.asyncio
+async def test_rolling_checkpoints_use_distinct_names():
+    """Rolling checkpoints get a '-rolling' suffix so they can never collide
+    with a periodic checkpoint saved at the same step."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_training_client = MagicMock()
+        mock_service_client = MagicMock()
+        mock_rest_client = MagicMock()
+        mock_service_client.create_rest_client.return_value = mock_rest_client
+        mock_rest_client.delete_checkpoint_from_tinker_path_async = AsyncMock()
+
+        mock_training_client.save_state_async = _make_save_state_mock(
+            ["tinker://run/state/000001-rolling", "tinker://run/state/000002-rolling"]
+        )
+
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=mock_service_client,
+            log_path=tmpdir,
+            rolling_save_every=1,
+        )
+
+        await mgr.maybe_save_async(step=1, loop_state={"batch": 1})
+        await mgr.maybe_save_async(step=2, loop_state={"batch": 2})
+        await mgr.finalize_async()
+
+        names = [c.args[0] for c in mock_training_client.save_state_async.call_args_list]
+        assert names == ["000001-rolling", "000002-rolling"]
+
+
+@pytest.mark.asyncio
+async def test_direct_save_periodic_suppresses_same_step_rolling():
+    """The RL loop calls save_periodic_async directly (not via maybe_save_async);
+    a later rolling check for the same step must still be suppressed."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mock_training_client = MagicMock()
+        state_mock, sampler_mock = _make_both_save_mocks(
+            ["tinker://run/state/000010"], ["tinker://run/sampler/000010"]
+        )
+        mock_training_client.save_state_async = state_mock
+        mock_training_client.save_weights_for_sampler_async = sampler_mock
+
+        mgr = CheckpointManager(
+            training_client=mock_training_client,
+            service_client=MagicMock(),
+            log_path=tmpdir,
+            save_every=0,
+            save_every_tokens=1_000_000,
+            rolling_save_every=10,
+        )
+
+        await mgr.save_periodic_async(step=10, loop_state={"batch": 10})
+        # Same step: rolling must not fire on top of the periodic save.
+        await mgr.maybe_save_rolling_async(step=10, loop_state={"batch": 10})
+        await mgr.finalize_async()
+        assert mock_training_client.save_state_async.call_count == 1
+
+        # A later rolling-cadence step still fires normally.
+        assert mgr._should_save_rolling(20)


### PR DESCRIPTION
## Problem

`CheckpointManager` has two save cadences that can land on the same step:

- **Periodic** (state + sampler weights) — triggered by `save_every` steps, `save_every_tokens`, or `save_every_seconds`; optionally run as background tasks with `async_periodic_saves=True`.
- **Rolling** (state only, cheap resume points) — every `rolling_save_every` steps.

Both name their checkpoint `f"{step:06d}"`. `_should_save_rolling` already skips steps where the step-modulo periodic cadence fires, but token- and wall-clock-triggered periodic saves land on steps the modulo check cannot predict. When one lands on a rolling-cadence step, both saves are issued under the same name. The server rejects the duplicate (`"Checkpoint already exists"`), and the failed request poisons the `TrainingClient` — the run dies, not just the save.

Minimal trigger config: `save_every=0`, `save_every_tokens=2_000_000`, `rolling_save_every=10` → the token boundary crossed at step 50 makes both saves fire as `000050`, and the run is killed. We hit exactly this in a real SFT run; with this fix applied locally, subsequent multi-hundred-step runs with both cadences enabled (including async periodic saves) completed.

## Fix

1. **Distinct namespace** — rolling checkpoints are named `{step:06d}-rolling`, so collision with a periodic checkpoint is structurally impossible rather than merely avoided.
2. **Same-step suppression** — `CheckpointManager` tracks `_last_periodic_step`, and `_should_save_rolling` returns `False` for that step: the periodic checkpoint already contains the training state, so the rolling save would be redundant. The mark is set before the async periodic task is submitted (so it also covers background saves) and in `save_periodic_async` / `save_periodic` (so it covers callers like the RL loop that invoke them directly rather than via `maybe_save_async`).
3. The existing step-modulo skip is retained; docstrings updated to document the naming and skip behavior.

## Compatibility

Audited all in-repo consumers of checkpoint names: resume discovery (`get_last_checkpoint`) selects records by file order and reads `state_path`/`batch` — nothing parses or sorts names; rolling deletion and TTL cleanup key off the stored `tinker://` path, not the name; nothing reconstructs a name from a step number for lookup. Non-numeric names are already established in the namespace (`final`; existing integration tests save `tmp-checkpoint` against the live service), so the `-rolling` suffix adds no new format constraint.

## Tests

Four added: a unit test for the suppression; a regression test for the exact token-triggered same-step scenario (asserts exactly one save, one `checkpoints.jsonl` record, periodic name); a distinct-names test for the suffix; and a direct-`save_periodic_async`-then-rolling test covering the RL-loop call pattern. `pytest tinker_cookbook/checkpoint_utils_test.py`: 41 passed.

