### PR TITLE
Add `tml_v0_disable_thinking` and make TMLv0 effort a renderer setting

### DIFF
--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -156,6 +156,7 @@ def get_renderer(
             - ``"gpt_oss_low_reasoning"``: GPT-OSS with low reasoning
             - ``"gpt_oss_medium_reasoning"``: GPT-OSS with medium reasoning
             - ``"gpt_oss_high_reasoning"``: GPT-OSS with high reasoning
+            - ``"tml_v0_disable_thinking"``: Inkling with reasoning effort 0.0
             - Custom renderers registered via ``register_renderer()``
         tokenizer (Tokenizer): The tokenizer to use.
         image_processor (ImageProcessor | None): Required for VL renderers.
@@ -290,6 +291,8 @@ def get_renderer(
         renderer = GptOssRenderer(tokenizer, use_system_prompt=True, reasoning_effort="high")
     elif name == "tml_v0":
         renderer = TmlV0Renderer(tokenizer)
+    elif name == "tml_v0_disable_thinking":
+        renderer = TmlV0Renderer(tokenizer, effort=0.0)
     else:
         raise RendererError(
             f"Unknown renderer: {name}. If this is a custom renderer, please register it via register_renderer()."

--- a/tinker_cookbook/renderers/tml_v0.py
+++ b/tinker_cookbook/renderers/tml_v0.py
@@ -406,10 +406,12 @@ class TmlV0Renderer(Renderer):
 
     supports_streaming = False
 
-    def __init__(self, tokenizer: Tokenizer):
+    def __init__(self, tokenizer: Tokenizer, effort: float = DEFAULT_EFFORT):
         super().__init__(tokenizer)
         _validate_torch_version()
+        _validate_effort(effort)
         ensure_tml_renderers_importable()
+        self.effort = effort
         self._tml_tokenizer = _unwrap_tml_tokenizer(tokenizer)
         self._tml_renderer: tml_v0.Renderer = import_module("tml_renderers.v0").Renderer(
             self._tml_tokenizer
@@ -446,7 +448,7 @@ class TmlV0Renderer(Renderer):
         messages: list[Message] | TmlRenderInput,
         role: Role = "assistant",
         prefill: str | None = None,
-        effort: float = DEFAULT_EFFORT,
+        effort: float | None = None,
     ) -> tinker.ModelInput:
         """Build a generation prompt with reasoning-effort conditioning.
 
@@ -455,6 +457,7 @@ class TmlV0Renderer(Renderer):
         ``tml-renderers``.
         """
         self._validate_generation_options(role, prefill)
+        effort = self.effort if effort is None else effort
         _validate_effort(effort)
         render_input = _messages_to_render_input(messages)
         spans, _parser = self._tml_renderer.render_for_completion_with_effort(render_input, effort)
@@ -477,7 +480,7 @@ class TmlV0Renderer(Renderer):
         self,
         messages: list[Message] | TmlRenderInput,
         train_on_what: TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
-        effort: float = DEFAULT_EFFORT,
+        effort: float | None = None,
     ) -> list[tuple[tinker.ModelInput, torch.Tensor]]:
         """Build SFT examples with the same effort conditioning used for generation.
 
@@ -490,13 +493,14 @@ class TmlV0Renderer(Renderer):
         specific effort level.
         """
         render_input = _cookbook_messages_to_sft_input(messages, train_on_what)
+        effort = self.effort if effort is None else effort
         return self._render_sft_examples(_prepare_sft_input(render_input, effort))
 
     def build_supervised_example(
         self,
         messages: list[Message] | TmlRenderInput,
         train_on_what: TrainOnWhat = TrainOnWhat.ALL_ASSISTANT_MESSAGES,
-        effort: float = DEFAULT_EFFORT,
+        effort: float | None = None,
     ) -> tuple[tinker.ModelInput, torch.Tensor]:
         examples = self.build_supervised_examples(messages, train_on_what, effort=effort)
         return self._single_example(examples)

--- a/tinker_cookbook/renderers/tml_v0_test.py
+++ b/tinker_cookbook/renderers/tml_v0_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import pickle
 import wave
 from pathlib import Path
 from typing import Any, cast
@@ -102,6 +103,12 @@ def _renderer() -> tml_v0.TmlV0Renderer:
     _require_tml_renderers()
     tokenizer = get_tokenizer("thinkingmachines/Inkling")
     return cast(tml_v0.TmlV0Renderer, get_renderer("tml_v0", tokenizer))
+
+
+def _disable_thinking_renderer() -> tml_v0.TmlV0Renderer:
+    _require_tml_renderers()
+    tokenizer = get_tokenizer("thinkingmachines/Inkling")
+    return cast(tml_v0.TmlV0Renderer, get_renderer("tml_v0_disable_thinking", tokenizer))
 
 
 def _input_len(model_input) -> int:
@@ -353,6 +360,45 @@ def test_build_supervised_example_effort_validates_range() -> None:
 
     with pytest.raises(ValueError, match=r"thinking effort must be.*\[0, 1\)"):
         renderer.build_supervised_example(_messages(), effort=1.0)
+
+
+def test_constructor_effort_validates_range() -> None:
+    _require_tml_renderers()
+    tokenizer = get_tokenizer("thinkingmachines/Inkling")
+
+    with pytest.raises(ValueError, match=r"thinking effort must be.*\[0, 1\)"):
+        tml_v0.TmlV0Renderer(tokenizer, effort=1.0)
+
+
+def test_disable_thinking_renderer_renders_at_zero_effort() -> None:
+    renderer = _disable_thinking_renderer()
+
+    assert (
+        renderer.build_generation_prompt(_messages()).to_ints()
+        == _renderer().build_generation_prompt(_messages(), effort=0.0).to_ints()
+    )
+
+
+def test_renderer_effort_survives_pickle() -> None:
+    renderer = _disable_thinking_renderer()
+
+    restored = pickle.loads(pickle.dumps(renderer))
+
+    assert (
+        restored.build_generation_prompt(_messages()).to_ints()
+        == renderer.build_generation_prompt(_messages()).to_ints()
+    )
+
+
+def test_conversation_to_datum_uses_renderer_effort() -> None:
+    """The generic supervised path never passes effort; the renderer supplies it."""
+    datum = conversation_to_datum(_messages(), _disable_thinking_renderer(), max_length=None)
+    expected, _ = _renderer().build_supervised_example(_messages(), effort=0.0)
+    default_datum = conversation_to_datum(_messages(), _renderer(), max_length=None)
+
+    # conversation_to_datum shifts, so the datum drops the final rendered token.
+    assert datum.model_input.to_ints() == expected.to_ints()[:-1]
+    assert datum.model_input.to_ints() != default_datum.model_input.to_ints()
 
 
 def test_generation_prompt_is_prefix_of_supervised_example() -> None:


### PR DESCRIPTION
`conversation_to_datum` never passes `effort`, so Inkling SFT through the standard
dataset builders always renders at `0.9` regardless of what effort the run samples at —
a silent train/sample mismatch.

`effort` becomes a `TmlV0Renderer` constructor argument and the default for the three
`build_*` methods, and `tml_v0_disable_thinking` is registered at effort `0.0`.

Registering a name matters here: `Renderer.__reduce__` serializes the renderer name
alone, so a renderer constructed directly with an effort reverts to `0.9` when unpickled
for distributed rollouts.

No behavior change for existing users — `tml_v0` still renders at `0.9`. The three
`build_*` signatures go from `effort: float = DEFAULT_EFFORT` to `effort: float | None =
None`, deferring to the renderer's effort when unset; every in-tree caller passes
`effort` by keyword and is unaffected.
