### PR TITLE
[renderers] role_colon keeps the content whitespace it rendered

### DIFF
--- a/tinker_cookbook/renderers/role_colon.py
+++ b/tinker_cookbook/renderers/role_colon.py
@@ -17,6 +17,11 @@ from tinker_cookbook.renderers.base import (
 logger = logging.getLogger(__name__)
 
 
+# Named once so `render_message` and `parse_response` stay inverses of each other.
+_CONTENT_PREFIX = " "
+_CONTENT_SUFFIX = "\n\n"
+
+
 class RoleColonRenderer(Renderer):
     """Simple role:content format renderer.
 
@@ -49,7 +54,7 @@ class RoleColonRenderer(Renderer):
             RenderedMessage: Header, output, and stop_overlap token chunks.
         """
         header_str = message["role"].capitalize() + ":"
-        output_str = " " + ensure_text(message["content"]) + "\n\n"
+        output_str = _CONTENT_PREFIX + ensure_text(message["content"]) + _CONTENT_SUFFIX
         # stop_overlap completes the stop sequence "\n\nUser:" for assistant messages.
         # For non-assistant messages, we use a placeholder that's never actually concatenated.
         stop_overlap_str = "User:" if message["role"] == "assistant" else "<UNUSED>"
@@ -100,27 +105,27 @@ class RoleColonRenderer(Renderer):
 
         str_response = str(self.tokenizer.decode(response))
         splitted = str_response.split("\n\nUser:")
+        content = splitted[0].removeprefix(_CONTENT_PREFIX).removesuffix(_CONTENT_SUFFIX)
         if len(splitted) == 1:
             if terminated_with_eos:
-                return Message(role="assistant", content=str_response.strip()), ParseTermination.EOS
+                return Message(role="assistant", content=content), ParseTermination.EOS
             # No "\n\nUser:" delimiter and no EOS — the response was likely
             # truncated mid-sentence (max_tokens hit). Best-effort message,
             # MALFORMED termination.
             logger.debug(f"Response is not a valid assistant response: {str_response}")
             return (
-                Message(role="assistant", content=str_response.strip()),
+                Message(role="assistant", content=content),
                 ParseTermination.MALFORMED,
             )
         elif len(splitted) == 2:
-            before, _after = splitted
             if terminated_with_eos:
                 # Malformed: sampling should have stopped at "\n\nUser:" before emitting EOS.
                 return (
-                    Message(role="assistant", content=before.strip()),
+                    Message(role="assistant", content=content),
                     ParseTermination.MALFORMED,
                 )
             return (
-                Message(role="assistant", content=before.strip()),
+                Message(role="assistant", content=content),
                 ParseTermination.STOP_SEQUENCE,
             )
         else:
@@ -130,9 +135,7 @@ class RoleColonRenderer(Renderer):
                 len(splitted) - 1,
                 str_response,
             )
-            return Message(
-                role="assistant", content=splitted[0].strip()
-            ), ParseTermination.MALFORMED
+            return Message(role="assistant", content=content), ParseTermination.MALFORMED
 
     @property
     def _bos_tokens(self) -> list[int]:

--- a/tinker_cookbook/renderers/role_colon_test.py
+++ b/tinker_cookbook/renderers/role_colon_test.py
@@ -91,3 +91,22 @@ def test_parse_response_multiple_user_delimiters_is_malformed(renderer: RoleColo
 
     assert termination == ParseTermination.MALFORMED
     assert message["content"] == "Answer."
+
+
+@pytest.mark.parametrize(
+    "content",
+    [" leading", "trailing ", "  both  ", " "],
+    ids=["leading", "trailing", "both", "only-a-space"],
+)
+def test_parse_response_keeps_the_content_whitespace_it_rendered(
+    renderer: RoleColonRenderer, content: str
+):
+    """Content whose own whitespace is load-bearing: `" leading"` and `"leading"` render
+    differently, so they must parse back differently."""
+    rendered = " " + content + "\n\n"
+    tokens = renderer.tokenizer.encode(rendered + "User:", add_special_tokens=False)
+
+    message, termination = renderer.parse_response(tokens)
+
+    assert termination == ParseTermination.STOP_SEQUENCE
+    assert message["content"] == content


### PR DESCRIPTION

A message whose content begins or ends with a space does not survive
`render_message` -> `parse_response`:

```python
render_message({"role": "assistant", "content": " leading"})   # renders "  leading\n\n"
parse_response(...)                                            # returns "leading"  <- space gone
```

## Why

`render_message` wraps content in one space and one blank line:

```python
output_str = " " + ensure_text(message["content"]) + "\n\n"
```

`parse_response` took that back off with `.strip()`, which removes *every* leading
and trailing whitespace character, not the two things the renderer added:

| content | rendered | parsed, before | parsed, after |
|---|---|---|---|
| `" leading"` | `"  leading\n\n"` | `"leading"` | `" leading"` |
| `"trailing "` | `" trailing \n\n"` | `"trailing"` | `"trailing "` |
| `"  both  "` | `"   both  \n\n"` | `"both"` | `"  both  "` |
| `" "` | `"  \n\n"` | `""` | `" "` |

The information was never lost in the tokens -- `render_message(" leading")` and
`render_message("leading")` differ. Only the parser was discarding it.

## The fix

Take back exactly what was added, and name the two affixes so the adding and the
removing side cannot drift apart:

```diff
+_CONTENT_PREFIX = " "
+_CONTENT_SUFFIX = "\n\n"

-        output_str = " " + ensure_text(message["content"]) + "\n\n"
+        output_str = _CONTENT_PREFIX + ensure_text(message["content"]) + _CONTENT_SUFFIX

-                Message(role="assistant", content=before.strip())
+        content = splitted[0].removeprefix(_CONTENT_PREFIX).removesuffix(_CONTENT_SUFFIX)
```

While there: `parse_response` now computes `content` once instead of five times.
Every branch was applying the same expression to the same value -- `str_response`
and `before` are both `splitted[0]` -- which hid that the branching is only about
*how the turn terminated*, never about what it contained. The returns are now
identical except for their `ParseTermination`.

## Still not fixed

Content containing the `"\n\nUser:"` delimiter, e.g. a message that literally
quotes a turn boundary. `parse_response` splits on that delimiter and cannot tell
it from a real one. That is a property of the format -- there is no escaping -- so
it needs a different fix than this one, if it needs one at all.

## Test Plan

`role_colon_test.py` gains a parametrized regression over the four values above.
CI is green: `test`, `type-check`, `pre-commit`, `downstream-compat`.

Also checked end to end outside this repo. The monorepo's `chat_conformance`
suite renders ~19 text values through this renderer and reads each one back,
asserting it comes out unchanged. With this branch on `PYTHONPATH`:

| | round-trip failures |
|---|---|
| before | 6 |
| after | 2 |

The two remaining are the `"\n\nUser:"` case above, and `ModelEndSampling`, for
which this renderer emits no loss-weighted turn to parse.
