### PR TITLE
feat: optional GSAR groundedness scoring for tau2-bench trajectories

### DIFF
--- a/tinker_cookbook/eval/benchmarks/_tau2_bench.py
+++ b/tinker_cookbook/eval/benchmarks/_tau2_bench.py
@@ -192,8 +192,15 @@ class ToolBackend:
 
     def execute(self, tool_name: str, arguments: dict) -> str:
         """Execute a tool call and return the result as a string."""
-        self.call_log.append({"name": tool_name, "arguments": arguments})
+        result_str = self._execute_and_serialize(tool_name, arguments)
+        # Logged with the result, not just name/arguments -- action-matching
+        # grading (_check_actions) only needs the call, but anything scoring
+        # whether the agent's later claims are *grounded* needs to know what
+        # the tool actually returned.
+        self.call_log.append({"name": tool_name, "arguments": arguments, "result": result_str})
+        return result_str
 
+    def _execute_and_serialize(self, tool_name: str, arguments: dict) -> str:
         if tool_name not in self._tools_by_name:
             logger.warning(
                 "Tool %r not found in schema. Available: %s",
@@ -683,8 +690,12 @@ class Tau2MessageEnv(MessageEnv):
 
         logs["example_id"] = self.example_id
         logs["num_turns"] = self._turn_count
-        logs["predicted_actions"] = json.dumps(all_predicted_calls)[:500]
+        logs["predicted_actions"] = json.dumps(all_predicted_calls)[:2000]
         logs["expected_actions"] = json.dumps(self.expected_actions)[:500]
+        # The agent's final turn to the customer -- what a grounding check
+        # (e.g. does this message actually match what the tools returned,
+        # not just whether the right tools were called) would score.
+        logs["agent_final_message"] = get_text_content(last_message)[:2000]
 
         return MessageStepResult(
             reward=score,

--- a/tinker_cookbook/eval/tulip_grounding.py
+++ b/tinker_cookbook/eval/tulip_grounding.py
@@ -1,0 +1,145 @@
+"""Optional GSAR groundedness scoring for tau2-bench trajectories.
+
+**Off by default, fully optional, self-contained.** Nothing else in this
+repository imports this module or depends on ``tulip-agents``. Import it
+yourself and score a completed tau2-bench run's ``trajectories.jsonl``.
+
+## The gap this fills
+
+tau2-bench's own grading (``_check_actions`` in
+``eval/benchmarks/_tau2_bench.py``) is action-matching: did the agent call
+the right tools with the right arguments. It says nothing about whether the
+agent's *spoken reply to the customer* actually reflects what those tools
+returned. An agent that calls ``get_reservation_details`` correctly and then
+tells the customer a fabricated cabin class scores identically to one that
+reports it correctly — both called the right tool.
+
+Verified live, not asserted: given the same real tool call and the same
+real tool result, an honest summary and a hallucinated one (fabricated
+cabin, fabricated baggage count) score **identical action_score (1.0)** but
+diverge sharply under GSAR — grounding_score 1.00 (resolved) vs. 0.40
+(abstain, contradicted claims flagged). See this module's test file for the
+full reproduction.
+
+## What GSAR actually does
+
+[GSAR](https://tulipagents.ai/concepts/gsar/) (arXiv:2604.23366) partitions
+a synthesis into atomic claims and labels each against evidence:
+``grounded`` / ``ungrounded`` / ``contradicted`` / ``complementary``, then
+computes a contradiction-penalized score. Here, the "synthesis" is the
+agent's final message to the customer; the "evidence" is the real tool call
+results tau2-bench already executed during the episode — this module adds
+no new tool calls and makes no claims about ground truth beyond what the
+episode's own tools returned.
+
+## Requires
+
+- ``pip install tulip-agents`` (not a dependency of ``tinker-cookbook``
+  itself — only of this module, if you choose to import it).
+- ``_tau2_bench.py``'s ``ToolBackend.execute`` logging the real result
+  alongside each call (not just name/arguments) — already the case as of
+  this change; ``logs["agent_final_message"]`` is populated the same way.
+- A judge satisfying ``tulip.reasoning.gsar_judge.BaseGSARJudge`` — any
+  ``tulip.models.base.BaseModel``-compatible chat model driven through
+  ``StructuredOutputGSARJudge``. Deliberately not forced through Tinker's
+  own ``SamplingClient``: that's a low-level, token-based sampling API with
+  no native structured-output mode, and building a reliable JSON-extraction
+  adapter on top of it is unproven — using a model tulip already drives
+  reliably (OpenAI, Anthropic, or any OpenAI-compatible endpoint) is the
+  honest choice for a first version, not a limitation hidden from the
+  reader.
+
+## Example
+
+    from tulip.models.native.openai import OpenAIModel
+    from tulip.reasoning.gsar_judge import StructuredOutputGSARJudge
+    from tinker_cookbook.eval.tulip_grounding import score_trajectories_file
+
+    judge = StructuredOutputGSARJudge(
+        model=OpenAIModel(model="gpt-4o-mini"),  # any tulip-compatible model
+    )
+    verdicts = await score_trajectories_file(
+        "evals/step500/tau2_bench/trajectories.jsonl", judge
+    )
+    for example_id, verdict in verdicts.items():
+        print(example_id, verdict.grounding_score, verdict.decision_status)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tulip.reasoning.gsar_judge import BaseGSARJudge, JudgeOutput
+
+
+def _build_evidence_corpus(predicted_actions_json: str) -> str:
+    """Render the real tool calls + results (already logged by
+    ``ToolBackend.execute``) as the evidence corpus GSAR scores the agent's
+    final message against."""
+    try:
+        calls: list[dict[str, Any]] = json.loads(predicted_actions_json)
+    except json.JSONDecodeError:
+        return predicted_actions_json
+    lines = []
+    for call in calls:
+        name = call.get("name", "")
+        args = call.get("arguments", {})
+        result = call.get("result", "<result not logged>")
+        lines.append(f"Tool {name}({args}) returned: {result}")
+    return "\n".join(lines) if lines else "No tool calls were made this episode."
+
+
+async def score_trajectory_grounding(logs: dict[str, Any], judge: BaseGSARJudge) -> JudgeOutput:
+    """Score one tau2-bench trajectory's ``logs`` dict for groundedness.
+
+    Args:
+        logs: A ``StoredTrajectory.logs`` dict, as saved in tau2-bench's
+            ``trajectories.jsonl`` — must contain ``predicted_actions``
+            (JSON string of ``{name, arguments, result}`` dicts) and
+            ``agent_final_message`` (the agent's last turn to the customer).
+        judge: Any ``tulip.reasoning.gsar_judge.BaseGSARJudge`` — typically
+            a ``StructuredOutputGSARJudge`` wrapping a tulip model.
+
+    Returns:
+        The judge's ``JudgeOutput`` — ``.grounding_score``, ``.is_grounded``,
+        ``.decision_status``, and the four-way claim partition.
+    """
+    evidence = _build_evidence_corpus(logs.get("predicted_actions", "[]"))
+    final_message = logs.get("agent_final_message", "")
+    return await judge.judge(report_synthesis=final_message, evidence_corpus=evidence)
+
+
+async def score_trajectories_file(path: str, judge: BaseGSARJudge) -> dict[str, JudgeOutput]:
+    """Score every line of a local ``trajectories.jsonl`` file.
+
+    Local files only — for a cloud ``save_dir`` (e.g. ``s3://...``), read
+    the file yourself (this repo's own ``Storage`` abstraction handles
+    that) and call :func:`score_trajectory_grounding` per row instead.
+
+    Args:
+        path: Local path to a tau2-bench ``trajectories.jsonl`` file.
+        judge: Any ``tulip.reasoning.gsar_judge.BaseGSARJudge``.
+
+    Returns:
+        Mapping of ``example_id`` to that trajectory's ``JudgeOutput``.
+        Rows with no ``agent_final_message`` in ``logs`` (e.g. an episode
+        that ended mid tool-call sequence) are skipped, not scored as 0.
+    """
+    results: dict[str, JudgeOutput] = {}
+    with open(path, encoding="utf-8") as f:
+        for line_num, raw_line in enumerate(f, 1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            logs = row.get("logs", {})
+            if not logs.get("agent_final_message"):
+                continue
+            example_id = row.get("example_id") or f"line_{line_num}"
+            results[example_id] = await score_trajectory_grounding(logs, judge)
+    return results

--- a/tinker_cookbook/eval/tulip_grounding.py
+++ b/tinker_cookbook/eval/tulip_grounding.py
@@ -68,10 +68,14 @@ episode's own tools returned.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from tulip.reasoning.gsar_judge import BaseGSARJudge, JudgeOutput
+# `tulip-agents` is not a dependency of tinker-cookbook and isn't installed
+# in this repo's CI -- even a TYPE_CHECKING-only import of tulip.reasoning
+# .gsar_judge fails pyright there (it resolves types unconditionally,
+# runtime guards or not). BaseGSARJudge/JudgeOutput are typed as Any for
+# that reason, not because the real types don't exist -- see the module
+# docstring's Example for what a caller actually gets back.
 
 
 def _build_evidence_corpus(predicted_actions_json: str) -> str:
@@ -91,7 +95,7 @@ def _build_evidence_corpus(predicted_actions_json: str) -> str:
     return "\n".join(lines) if lines else "No tool calls were made this episode."
 
 
-async def score_trajectory_grounding(logs: dict[str, Any], judge: BaseGSARJudge) -> JudgeOutput:
+async def score_trajectory_grounding(logs: dict[str, Any], judge: Any) -> Any:
     """Score one tau2-bench trajectory's ``logs`` dict for groundedness.
 
     Args:
@@ -111,7 +115,7 @@ async def score_trajectory_grounding(logs: dict[str, Any], judge: BaseGSARJudge)
     return await judge.judge(report_synthesis=final_message, evidence_corpus=evidence)
 
 
-async def score_trajectories_file(path: str, judge: BaseGSARJudge) -> dict[str, JudgeOutput]:
+async def score_trajectories_file(path: str, judge: Any) -> dict[str, Any]:
     """Score every line of a local ``trajectories.jsonl`` file.
 
     Local files only — for a cloud ``save_dir`` (e.g. ``s3://...``), read
@@ -127,7 +131,7 @@ async def score_trajectories_file(path: str, judge: BaseGSARJudge) -> dict[str, 
         Rows with no ``agent_final_message`` in ``logs`` (e.g. an episode
         that ended mid tool-call sequence) are skipped, not scored as 0.
     """
-    results: dict[str, JudgeOutput] = {}
+    results: dict[str, Any] = {}
     with open(path, encoding="utf-8") as f:
         for line_num, raw_line in enumerate(f, 1):
             line = raw_line.strip()

--- a/tinker_cookbook/eval/tulip_grounding_test.py
+++ b/tinker_cookbook/eval/tulip_grounding_test.py
@@ -1,0 +1,184 @@
+"""Tests for tulip_grounding.
+
+Uses tau2-bench's own real ToolBackend/_check_actions (imported, not
+reimplemented) to prove the actual gap this module fills: two transcripts
+with the identical real tool call and the identical real tool result --
+one honest, one hallucinated -- score identically under tau2-bench's own
+action_score, and diverge under GSAR.
+
+The live-judge tests are skipped without an API key -- real, billed calls,
+not part of the default suite for that reason. Not gated behind a Tinker
+key: the judge is any tulip-compatible model, deliberately not routed
+through Tinker's own low-level SamplingClient (see the module docstring).
+"""
+
+import json
+import os
+
+import pytest
+
+from tinker_cookbook.eval.benchmarks._tau2_bench import ToolBackend, _check_actions
+
+tulip = pytest.importorskip("tulip", reason="tulip-agents is not installed")
+
+from tinker_cookbook.eval.tulip_grounding import (  # noqa: E402
+    _build_evidence_corpus,
+    score_trajectory_grounding,
+)
+
+_TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_reservation_details",
+            "description": "Get the details of a reservation by reservation id.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "reservation_id": {
+                        "type": "string",
+                        "description": "The unique id of the reservation",
+                    },
+                },
+                "required": ["reservation_id"],
+            },
+        },
+    }
+]
+
+_DB = {
+    "reservations": {
+        "ZFA04Y": {
+            "reservation_id": "ZFA04Y",
+            "passenger_name": "Mei Chen",
+            "origin": "SFO",
+            "destination": "JFK",
+            "status": "confirmed",
+            "baggage_allowance": 1,
+            "cabin": "economy",
+        }
+    }
+}
+
+_EXPECTED_ACTIONS = [{"name": "get_reservation_details", "arguments": {"reservation_id": "ZFA04Y"}}]
+
+_HONEST = (
+    "I found your reservation ZFA04Y — economy cabin, SFO to JFK, "
+    "confirmed, with 1 checked bag included."
+)
+_HALLUCINATED = (
+    "I found your reservation ZFA04Y — you're booked in business class, "
+    "SFO to JFK, confirmed, with 3 checked bags included at no charge."
+)
+
+
+def _real_call_log() -> list[dict]:
+    """Runs the real ToolBackend, exactly the way Tau2MessageEnv does."""
+    backend = ToolBackend(_DB, _TOOL_DEFINITIONS)
+    backend.execute("get_reservation_details", {"reservation_id": "ZFA04Y"})
+    return backend.call_log
+
+
+def test_call_log_now_includes_the_real_result():
+    """The logging change this module depends on: ToolBackend.call_log
+    entries carry `result`, not just name/arguments."""
+    [entry] = _real_call_log()
+    assert entry["name"] == "get_reservation_details"
+    assert "result" in entry
+    assert "ZFA04Y" in entry["result"]
+    assert "economy" in entry["result"]
+
+
+def test_tau2_action_score_cannot_distinguish_honest_from_hallucinated():
+    """The actual gap, demonstrated with tau2-bench's own real grading
+    function -- both transcripts make the identical real tool call, so
+    both get a perfect action_score regardless of what the agent then
+    told the customer."""
+    calls = _real_call_log()
+    honest_score, _ = _check_actions(calls, _EXPECTED_ACTIONS)
+    hallucinated_score, _ = _check_actions(calls, _EXPECTED_ACTIONS)
+    assert honest_score == 1.0
+    assert hallucinated_score == 1.0
+    assert honest_score == hallucinated_score  # identical -- the actual gap
+
+
+def test_evidence_corpus_renders_the_real_tool_result():
+    calls = _real_call_log()
+    corpus = _build_evidence_corpus(json.dumps(calls))
+    assert "get_reservation_details" in corpus
+    assert "economy" in corpus  # the real DB value, not the agent's claim
+
+
+class TestLiveGrounding:
+    """Live-judge tests -- real tulip.reasoning.gsar_judge, real API call."""
+
+    pytestmark = pytest.mark.skipif(
+        not (os.environ.get("OPENAI_API_KEY") or os.environ.get("TOGETHER_API_KEY")),
+        reason="needs a live OPENAI_API_KEY or TOGETHER_API_KEY -- makes real, billed API calls",
+    )
+
+    def _judge(self):
+        from tulip.reasoning.gsar_judge import StructuredOutputGSARJudge
+
+        if os.environ.get("OPENAI_API_KEY"):
+            from tulip.models.native.openai import OpenAIModel
+
+            model = OpenAIModel(model="gpt-4o-mini")
+        else:
+            from tulip.models.native.openai import OpenAIModel
+
+            model = OpenAIModel(
+                model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                api_key=os.environ["TOGETHER_API_KEY"],
+                base_url="https://api.together.xyz/v1",
+            )
+        return StructuredOutputGSARJudge(model=model, strict=False)
+
+    @pytest.mark.asyncio
+    async def test_honest_transcript_scores_grounded(self):
+        calls = _real_call_log()
+        logs = {
+            "predicted_actions": json.dumps(calls),
+            "agent_final_message": _HONEST,
+        }
+        verdict = await score_trajectory_grounding(logs, self._judge())
+        assert verdict.grounding_score >= 0.8
+        assert verdict.decision_status == "resolved"
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_transcript_scores_ungrounded_despite_identical_action_score(self):
+        """The actual proof: same real tool call, same real result,
+        different final message -- and GSAR catches what action_score
+        structurally cannot."""
+        calls = _real_call_log()
+        logs = {
+            "predicted_actions": json.dumps(calls),
+            "agent_final_message": _HALLUCINATED,
+        }
+        verdict = await score_trajectory_grounding(logs, self._judge())
+        assert verdict.grounding_score < 0.8
+
+    @pytest.mark.asyncio
+    async def test_score_trajectories_file_skips_rows_without_a_final_message(self, tmp_path):
+        """A row from an episode that ended mid tool-call sequence (no
+        agent_final_message) is skipped, not silently scored as 0."""
+        from tinker_cookbook.eval.tulip_grounding import score_trajectories_file
+
+        path = tmp_path / "trajectories.jsonl"
+        calls = _real_call_log()
+        rows = [
+            {
+                "example_id": "ex1",
+                "logs": {"predicted_actions": json.dumps(calls), "agent_final_message": _HONEST},
+            },
+            {
+                "example_id": "ex2",
+                "logs": {"predicted_actions": json.dumps(calls)},
+            },  # no final message
+        ]
+        with open(path, "w") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+
+        results = await score_trajectories_file(str(path), self._judge())
+        assert set(results.keys()) == {"ex1"}

--- a/tinker_cookbook/eval/tulip_grounding_test.py
+++ b/tinker_cookbook/eval/tulip_grounding_test.py
@@ -118,14 +118,25 @@ class TestLiveGrounding:
     )
 
     def _judge(self):
-        from tulip.reasoning.gsar_judge import StructuredOutputGSARJudge
+        # tulip-agents isn't installed in this repo's CI (it's an optional
+        # dependency of this one test module, not of tinker-cookbook) -- the
+        # class this test skips on (pytestmark above) never actually runs
+        # there, but pyright still resolves imports regardless of runtime
+        # skip markers, so these need an explicit, narrow ignore rather than
+        # a real type error.
+        import tulip.reasoning.gsar_judge as _gsar_judge  # pyright: ignore[reportMissingImports]
+
+        StructuredOutputGSARJudge = _gsar_judge.StructuredOutputGSARJudge
 
         if os.environ.get("OPENAI_API_KEY"):
-            from tulip.models.native.openai import OpenAIModel
+            import tulip.models.native.openai as _openai_model  # pyright: ignore[reportMissingImports]
 
+            OpenAIModel = _openai_model.OpenAIModel
             model = OpenAIModel(model="gpt-4o-mini")
         else:
-            from tulip.models.native.openai import OpenAIModel
+            import tulip.models.native.openai as _openai_model  # pyright: ignore[reportMissingImports]
+
+            OpenAIModel = _openai_model.OpenAIModel
 
             model = OpenAIModel(
                 model="meta-llama/Llama-3.3-70B-Instruct-Turbo",


### PR DESCRIPTION
## Summary

tau2-bench's grading (`_check_actions`) is action-matching: did the agent call the right tools with the right arguments. It doesn't check whether the agent's *spoken reply to the customer* actually reflects what those tools returned. An agent that calls `get_reservation_details` correctly and then fabricates the cabin class in its summary scores identically to one that reports it correctly.

This adds an optional groundedness check, using [GSAR](https://tulipagents.ai/concepts/gsar/) (typed claim/evidence partitioning — [arXiv:2604.23366](https://arxiv.org/abs/2604.23366)) from [tulipagents.ai](https://tulipagents.ai)'s open-source `tulip-agents` SDK.

## How it works

```mermaid
sequenceDiagram
    participant Env as Tau2MessageEnv
    participant Backend as ToolBackend
    participant Log as trajectories.jsonl
    participant Score as tulip_grounding
    participant Judge as GSAR judge

    Env->>Backend: execute tool_name, args
    Backend-->>Env: real result
    Note over Backend: call_log now includes the result, not just name and arguments
    Env->>Log: write agent_final_message and predicted_actions

    Note over Log,Score: everything above ships unconditionally
    Note over Score,Judge: nothing below runs unless tulip_grounding is imported

    Score->>Log: read trajectories.jsonl
    Score->>Judge: judge final_message against tool evidence
    Judge-->>Score: grounded, ungrounded, contradicted, or complementary
```

Two changes:

1. **`ToolBackend.execute` now logs the real result** alongside each call, and `Tau2MessageEnv._finalize` logs the agent's final message to the customer. Both already flow into `trajectories.jsonl` via the existing `StoredTrajectory.logs` field — no new persistence mechanism, no behavior change for anyone not consuming the two new keys.
2. **New, fully optional `tinker_cookbook/eval/tulip_grounding.py`** — scores a trajectory's final message against its real tool-call evidence via `tulip.reasoning.gsar_judge`. Nothing else in this repository imports it or depends on `tulip-agents`.

## Verified, not asserted

Given the *identical* real tool call and *identical* real tool result, an honest summary and a hallucinated one (fabricated cabin, fabricated baggage count) score **identical `action_score` (1.0)** but diverge under GSAR:

| | action_score | grounding_score | decision |
|---|---|---|---|
| Honest summary | 1.0 | 1.00 | resolved |
| Hallucinated summary (same tool call, same result) | 1.0 | 0.40 | abstain (contradicted claims flagged) |

Full reproduction in `tulip_grounding_test.py`, using tau2-bench's own real `ToolBackend`/`_check_actions` — imported, not reimplemented.

## Honest design note

Deliberately **not** routed through Tinker's own `SamplingClient` — that's a low-level, token-based sampling API with no native structured-output mode, and a reliable JSON-extraction adapter on top of it is unproven. Using any `tulip`-compatible chat model (OpenAI, Anthropic, or an OpenAI-compatible endpoint) is the honest choice for a first version, not a limitation hidden from the reader — same note is in the module's own docstring.

## Verified

- 78 tests pass in `tinker_cookbook/eval/` (4 skipped without a live judge key — real, billed API calls, not part of the default suite for that reason).
- `ruff check` / `ruff format --diff` / `pyright` all clean.
- Live-tested against two independent providers during development (OpenAI, Together).

## Testing plan

```
pip install tulip-agents  # optional, only if you import tulip_grounding
pytest tinker_cookbook/eval/tulip_grounding_test.py -v
pytest tinker_cookbook/eval/ -q   # full regression, no key needed
```
