### PR TITLE
[renderers] the kimi think prefill is observation, not something the turn produced

### DIFF
--- a/tinker_cookbook/renderers/kimi_k25.py
+++ b/tinker_cookbook/renderers/kimi_k25.py
@@ -10,6 +10,8 @@ from tinker_cookbook.renderers.base import (
     ContentPart,
     ImageProcessorProtocol,
     Message,
+    RenderContext,
+    RenderedMessage,
     Role,
     ToolSpec,
     image_to_chunk,
@@ -114,6 +116,31 @@ class KimiK25Renderer(KimiK2Renderer):
         if prefill is None:
             prefill = "<think>"
         return super().build_generation_prompt(messages, role=role, prefill=prefill)
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        """Render a message, keeping the `<think>` prefill on the observation side.
+
+        `build_generation_prompt` prefills `<think>`, so the model is handed that token
+        rather than sampling it. Left in the output it is trained anyway -- an example
+        whose observation stops short of the prompt its turn is sampled after.
+        """
+        rendered = super().render_message(message, ctx)
+        if message["role"] != "assistant" or not ctx.is_last:
+            return rendered
+        chunks = list(rendered.output)
+        first = chunks[0] if chunks else None
+        if not isinstance(first, tinker.types.EncodedTextChunk) or not first.tokens:
+            return rendered
+        if first.tokens[0] != self._think_open_token:
+            return rendered
+
+        header_tokens = list(rendered.header.tokens) if rendered.header else []
+        chunks[0] = tinker.types.EncodedTextChunk(tokens=list(first.tokens[1:]))
+        return RenderedMessage(
+            header=tinker.types.EncodedTextChunk(tokens=header_tokens + [self._think_open_token]),
+            output=chunks,
+            stop_overlap=rendered.stop_overlap,
+        )
 
     def _normalize_response_tokens(self, response: list[int]) -> list[int]:
         """Restore the synthetic <think> prefill before parsing sampled tokens."""

--- a/tinker_cookbook/renderers/kimi_k25_test.py
+++ b/tinker_cookbook/renderers/kimi_k25_test.py
@@ -811,3 +811,26 @@ def test_kimi_k25_image_content(image_dimensions_and_expected_tokens: tuple[int,
         else:
             raise ValueError(f"Unknown chunk type: {type(chunk)}")
     assert hf_offset == len(hf_output)
+
+
+@pytest.mark.parametrize("renderer_name", ["kimi_k25", "kimi_k26"])
+def test_the_think_prefill_is_observation_not_something_the_turn_produced(renderer_name: str):
+    """A supervised example ends its observation where sampling begins.
+
+    `build_generation_prompt` prefills `<think>`, so the model is handed that token. Left in
+    the message's output it is trained anyway, and the example's observation stops one token
+    short of the prompt the same turn is sampled after.
+    """
+    tokenizer = get_tokenizer(KIMI_K25_MODEL)
+    renderer = get_renderer(renderer_name, tokenizer)
+    prefix: list[Message] = [{"role": "user", "content": "What is 2+2?"}]
+    messages = prefix + [{"role": "assistant", "content": "4"}]
+
+    model_input, weights = renderer.build_supervised_example(messages)
+    ids, w = model_input.to_ints(), list(weights)
+    observation = ids[: next(i for i, x in enumerate(w) if x > 0)]
+
+    assert observation == renderer.build_generation_prompt(prefix).to_ints(), (
+        f"trains after {tokenizer.decode(observation)!r}, sampled after "
+        f"{tokenizer.decode(renderer.build_generation_prompt(prefix).to_ints())!r}"
+    )


### PR DESCRIPTION
## What

```diff
  build_supervised_example([user, assistant "4"]), kimi_k25 and kimi_k26
- observation: …<|im_assistant|>assistant<|im_middle|>            trains '<think></think>4<|im_end|>'
+ observation: …<|im_assistant|>assistant<|im_middle|><think>     trains '</think>4<|im_end|>'
  generation prompt: …<|im_assistant|>assistant<|im_middle|><think>
```

## Why

`build_generation_prompt` prefills `<think>`, so the model is handed that token rather than
sampling it. Left in the message's output it is trained anyway, and the example's observation
stops one token short of the prompt the same turn is sampled after -- which is what
`build_supervised_example` documents it must match:

> The supervised example tokens should match what `build_generation_prompt` would produce for
> the same conversation prefix, so the model trains on the same distribution it sees at
> inference time.

Moving it to the header is what `Qwen3DisableThinkingRenderer` already does with its own empty
block, for the same reason and with the same comment.

The document form stays a strict extension of the generation prompt either way, so nothing
about the rendered tokens changes -- only which side of the observation boundary the prefill
falls on, and therefore whether it is trained.

## Test

`pytest tinker_cookbook/renderers/` -- 532 passed, 46 skipped, from 530 on `main`.

`test_the_think_prefill_is_observation_not_something_the_turn_produced`, over `kimi_k25` and
`kimi_k26`, verified red against `main`:

    trains after  '…<|im_middle|>'
    sampled after '…<|im_middle|><think>'

Found by a check from an internal conformance harness -- an example's observation must equal
the generation prompt for its prefix. It needs no chat template and no second implementation.
Two other renderers fail it for related reasons; those are #860, since one of them cannot be
fixed here.