### PR TITLE
[renderers] the qwen3_5 boundary falls inside a token merge

### DIFF
--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -739,10 +739,32 @@ class Qwen3VLRenderer(Qwen3Renderer):
                     )
                 )
 
+        # The generation prompt may end partway through this header. Splitting the string
+        # before encoding puts the boundary where sampling starts and keeps both sides
+        # tokenised the way the model will see them.
+        prefix_str = self._produced_turn_prefix_str(message, ctx)
+        if prefix_str and header_str.startswith(prefix_str):
+            rest = header_str[len(prefix_str) :]
+            if rest:
+                output_chunks_encoded.insert(
+                    0,
+                    tinker.EncodedTextChunk(
+                        tokens=self.tokenizer.encode(rest, add_special_tokens=False)
+                    ),
+                )
+            header_str = prefix_str
+
         header = tinker.types.EncodedTextChunk(
             tokens=self.tokenizer.encode(header_str, add_special_tokens=False)
         )
         return RenderedMessage(header=header, output=output_chunks_encoded)
+
+    def _produced_turn_prefix_str(self, message: Message, ctx: RenderContext) -> str:
+        """How much of this message's header the generation prompt already wrote.
+
+        Empty when the prompt stops before the header does, which is the usual case.
+        """
+        return ""
 
 
 class Qwen3VLInstructRenderer(Qwen3VLRenderer):

--- a/tinker_cookbook/renderers/qwen3_5.py
+++ b/tinker_cookbook/renderers/qwen3_5.py
@@ -63,15 +63,26 @@ class Qwen3_5Renderer(Qwen3VLRenderer):
             message = {**message, "content": message["content"].strip()}
         return super().render_message(message, ctx)
 
-    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
-        """Override to produce the full generation suffix directly.
-
-        Builds the header tokens manually and appends <think>\\n. This matches
-        the Qwen3.5 template's add_generation_prompt behavior for thinking mode.
-        """
+    def _generation_suffix_str(self, role: Role, ctx: RenderContext) -> str:
+        """The header the generation prompt ends with, including the `<think>` prefill."""
         maybe_newline = "\n" if ctx.idx > 0 else ""
-        header_str = f"{maybe_newline}<|im_start|>{role}\n<think>\n"
-        return self.tokenizer.encode(header_str, add_special_tokens=False)
+        return f"{maybe_newline}<|im_start|>{role}\n<think>\n"
+
+    def _produced_turn_prefix_str(self, message: Message, ctx: RenderContext) -> str:
+        """The produced turn is sampled after the prefill, so the prefill is observed.
+
+        Only the turn actually being produced sits at that boundary; an earlier assistant
+        turn is history however the framing gate classifies it.
+        """
+        if message["role"] != "assistant" or not ctx.is_last:
+            return ""
+        return self._generation_suffix_str(self._get_qwen_role_for_message(message), ctx)
+
+    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
+        """The full generation suffix: the role header plus the `<think>` prefill."""
+        return self.tokenizer.encode(
+            self._generation_suffix_str(role, ctx), add_special_tokens=False
+        )
 
     def _assistant_header_suffix(self, message: Message, ctx: RenderContext) -> str:
         """Insert empty think block for assistant messages after the last user query."""
@@ -309,7 +320,6 @@ class Qwen3_5DisableThinkingRenderer(Qwen3_5Renderer):
     of <think>\\n, signaling to the model to respond directly without reasoning.
     """
 
-    def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
+    def _generation_suffix_str(self, role: Role, ctx: RenderContext) -> str:
         maybe_newline = "\n" if ctx.idx > 0 else ""
-        header_str = f"{maybe_newline}<|im_start|>{role}\n<think>\n\n</think>\n\n"
-        return self.tokenizer.encode(header_str, add_special_tokens=False)
+        return f"{maybe_newline}<|im_start|>{role}\n<think>\n\n</think>\n\n"

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -695,14 +695,18 @@ def test_supervised_example_against_hf_chat_templates(
         hf_convo, tools=tools_for_hf, tokenize=False, add_generation_prompt=False, **hf_kwargs
     )
     assert isinstance(hf_output, str)
-    hf_tokens = tokenizer.encode(hf_output.rstrip("\n"), add_special_tokens=False)
+    # The text, not the tokens. `apply_chat_template` tokenizes a whole conversation at once
+    # and an example is a prompt plus what was sampled after it, so the two segment the same
+    # string differently wherever a boundary falls inside a merge: `<think>\n` is
+    # `<think>`,`\n` in a prompt that stops between them and `<think>`,`\n\n` in a document
+    # that does not. Both decode the same, and only one is reachable by sampling.
+    rendered = tokenizer.decode(cookbook_tokens)
+    # Templates differ on whether the last turn ends with the turn separator; ours writes it
+    # before the *next* turn, so a whole-conversation render never carries a trailing one.
+    # `removesuffix` takes exactly that one and is a no-op where the template wrote none.
+    expected = hf_output.removesuffix("\n")
 
-    assert cookbook_tokens == hf_tokens, (
-        f"[{conv_desc}] Cookbook tokens: {cookbook_tokens}\n"
-        f"Cookbook string: {tokenizer.decode(cookbook_tokens)}\n"
-        f"HF tokens: {hf_tokens}\n"
-        f"HF string: {tokenizer.decode(hf_tokens)}"
-    )
+    assert rendered == expected, f"[{conv_desc}]\nrendered: {rendered!r}\nexpected: {expected!r}"
 
 
 @pytest.mark.parametrize(
@@ -980,7 +984,7 @@ _RENDERERS_THAT_DIVERGE_FROM_HF_FOR_THE_TARGET = {"deepseekv3_thinking"}
 
 # Renderers whose supervised target keeps a header the generation prompt does not end with, so
 # observation != generation_prompt however the boundary moves.
-_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"qwen3_5", "nemotron3"}
+_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"nemotron3"}
 
 
 @pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)


### PR DESCRIPTION
The PR below this one puts the observation/action boundary at `build_generation_prompt` for
every renderer by re-weighting -- it compares the prompt as a **token** prefix of the render,
so it changes no tokens. `qwen3_5` is the one case that cannot reach:

```
prompt ends    [248068, 198]      = '<think>', '\n'
render has     [… 248068, 271 …]  = '<think>', '\n\n'
```

Token `271` (`\n\n`) **straddles the boundary**. No slice of the render is what the model is
handed, because the prompt stops mid-pair and sampling must start a fresh token there.

So the split has to happen before the tokenizer sees it. The header is assembled as a string
and the generation suffix is a string prefix of it, so the renderer cuts the string it just
built and encodes the two halves separately:

```python
prefix_str = self._produced_turn_prefix_str(message, ctx)
if prefix_str and header_str.startswith(prefix_str):
    output_chunks_encoded.insert(0, encode(header_str[len(prefix_str):]))
    header_str = prefix_str
```

Both sides come out tokenised the way the model will see them, by construction. Nothing is
decoded, no chunk is rebuilt, and image chunks pass through untouched -- an earlier version
of this did the same split by decoding the whole message back to text and re-encoding it,
which had to bail on any non-text chunk.

`_generation_suffix_str` is now the single place the prompt's tail is written.
`Qwen3_5DisableThinkingRenderer` overrides that string rather than `_get_generation_suffix`,
so the prompt it emits and the split it takes cannot drift apart -- overriding only the
encoding is exactly how they did drift while this was being written.

`qwen3_5` leaves `_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS`, which drops to
`{nemotron3}`.

## Test Plan

`test_supervised_generation_parse_consistency` asserts
`observation == build_generation_prompt(messages[:-1])` and exempted `qwen3_5` by name.
Removing the exemption runs its cases; they fail without the renderer change and pass with it.

`pytest tinker_cookbook/renderers/` -- 554 passed / 34 skipped, unchanged by the rewrite from
the decode-and-re-encode version to the string split.

---

**Stack** (base → top): #866 → #864 → #859 → #865 → #862 → #867 → #868
