### PR TITLE
Train the turn after the prompt it is sampled from

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -22,6 +22,7 @@ from typing import (
     Protocol,
     TypedDict,
     Union,
+    cast,
 )
 
 import pydantic
@@ -1813,7 +1814,63 @@ class Renderer(ABC):
         weights_tensor = torch.tensor(weights_data)
 
         model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        return self._observation_is_the_generation_prompt(
+            messages, train_on_what, tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        )
+
+    def _observation_is_the_generation_prompt(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat,
+        model_input: tinker.ModelInput,
+        weights: torch.Tensor,
+    ) -> tuple[tinker.ModelInput, torch.Tensor]:
+        """Put the observation/action boundary where sampling begins.
+
+        Splits on text rather than tokens: the boundary can fall inside a merge, where
+        `<think>\n` is `<think>`,`\n\n` in a conversation tokenised at once and
+        `<think>`,`\n` in a prompt that stops between them. Sampling produces the second.
+
+        Returns the example unchanged when it cannot tell where the boundary belongs.
+        """
+        unchanged = (model_input, weights)
+        if train_on_what not in (
+            TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+            TrainOnWhat.LAST_ASSISTANT_TURN,
+        ):
+            return unchanged
+        if not messages or messages[-1]["role"] != "assistant":
+            return unchanged
+        if not all(isinstance(c, tinker.types.EncodedTextChunk) for c in model_input.chunks):
+            return unchanged
+
+        trained: list[bool] = (weights > 0).tolist()
+        if True not in trained:
+            return unchanged
+        start = trained.index(True)
+        if not all(trained[start:]):
+            return unchanged
+
+        tokens = model_input.to_ints()
+        prompt = self.build_generation_prompt(messages[:-1]).to_ints()
+        if tokens[:start] == prompt:
+            return unchanged
+
+        text = cast(str, self.tokenizer.decode(tokens))
+        prompt_text = cast(str, self.tokenizer.decode(prompt))
+        if not text.startswith(prompt_text):
+            return unchanged
+
+        action = self.tokenizer.encode(text[len(prompt_text) :], add_special_tokens=False)
+        return (
+            tinker.ModelInput(
+                chunks=[
+                    tinker.types.EncodedTextChunk(tokens=prompt),
+                    tinker.types.EncodedTextChunk(tokens=action),
+                ]
+            ),
+            torch.tensor([0.0] * len(prompt) + [1.0] * len(action)),
+        )
 
 
 def tokens_weights_from_strings_weights(

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -696,14 +696,13 @@ def test_supervised_example_against_hf_chat_templates(
         hf_convo, tools=tools_for_hf, tokenize=False, add_generation_prompt=False, **hf_kwargs
     )
     assert isinstance(hf_output, str)
-    hf_tokens = tokenizer.encode(hf_output.rstrip("\n"), add_special_tokens=False)
 
-    assert cookbook_tokens == hf_tokens, (
-        f"[{conv_desc}] Cookbook tokens: {cookbook_tokens}\n"
-        f"Cookbook string: {tokenizer.decode(cookbook_tokens)}\n"
-        f"HF tokens: {hf_tokens}\n"
-        f"HF string: {tokenizer.decode(hf_tokens)}"
-    )
+    # Compared as text: a supervised example splits where sampling begins, and that split
+    # can fall inside a token merge, so the two segmentations legitimately differ.
+    cookbook_text = tokenizer.decode(cookbook_tokens)
+    hf_text = hf_output.removesuffix("\n")
+
+    assert cookbook_text == hf_text, f"[{conv_desc}] cookbook != HF chat template"
 
 
 @pytest.mark.parametrize(
@@ -972,10 +971,10 @@ _RENDERERS_WITH_THINKING_STRIPPING = {
     "kimi_k2",
 }
 
-# Renderers where supervised and generation have different headers (HF thinking=True behavior).
-# These add </think> to supervised assistant headers but <think> to generation prompt,
-# so observation != generation_prompt by design.
-_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"deepseekv3_thinking", "qwen3_5", "nemotron3"}
+# Renderers where a supervised target with no ThinkingPart keeps a header of its own -- HF's
+# `</think>`, or an empty `<think></think>` -- while build_generation_prompt ends with an open
+# `<think>`. A target that does carry a ThinkingPart has matching headers and is not exempt.
+_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"deepseekv3_thinking", "nemotron3"}
 
 
 @pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)


### PR DESCRIPTION
## Why is this change needed?

`build_supervised_example` should produce the tokens `build_generation_prompt` produces for the same prefix, so training and sampling see the same context. Renderers whose prompt ends in a prefill — an open `<think>` — left it on the wrong side, training the model to produce a token it is always given:

```diff
  deepseekv3_thinking, a turn that reasons
  sampled from:  <｜User｜>q<｜Assistant｜><think>
- observation:   <｜User｜>q<｜Assistant｜>          action: <think>R</think>4<eos>
+ observation:   <｜User｜>q<｜Assistant｜><think>   action: R</think>4<eos>
```

| renderer | effect |
|---|---|
| `qwen3_5` | fixed; leaves `_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS` |
| `deepseekv3_thinking`, `nemotron3` | fixed for turns that reason |
| `kimi_k25` | unchanged — overrides `build_supervised_example`, so #861 is still needed |
| everything else | untouched; the guard returns early |

Normalised in the assembly rather than per renderer because the fix needs the prefix's generation prompt, and `render_message` — where #862 and #861 put it — only ever sees one message. Supersedes #862.

The split is on text, since a boundary can fall inside a token merge, so `test_supervised_example_against_hf_chat_templates` compares text. A supervised target with no ThinkingPart stays exempt for `deepseekv3_thinking` and `nemotron3`: it keeps a header of its own where `build_generation_prompt` ends with an open `<think>`, which is the case `_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS` is named for.

## Test Plan

`pytest tinker_cookbook/renderers/` — **536 passed / 40 skipped**, from 530 / 46 on `main`. The six are `qwen3_5` cases that previously skipped `test_supervised_generation_parse_consistency`, which asserts `observation == build_generation_prompt(messages[:-1])`; they fail without this change.

`ALL_TOKENS` / `ALL_MESSAGES` / `ALL_ASSISTANT_MESSAGES` verified untouched — they weight the prompt region deliberately, so the normalisation is gated to the two last-turn modes.

Related: #858, #859, #860, #861, #862.
