### PR TITLE
Withhold loss from what the generation prompt already supplied

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1825,7 +1825,63 @@ class Renderer(ABC):
         weights_tensor = torch.tensor(weights_data)
 
         model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        model_input = tinker.ModelInput(chunks=model_input_chunks)
+        return model_input, self._train_after_the_generation_prompt(
+            messages, train_on_what, model_input, weights_tensor
+        )
+
+    def _train_after_the_generation_prompt(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat,
+        model_input: tinker.ModelInput,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        """Withhold loss from everything build_generation_prompt would have supplied.
+
+        A renderer whose generation prompt ends in a prefill -- an open ``<think>`` -- leaves
+        that prefill on whichever side its header logic puts it, so the model is trained to
+        produce a token it is always given. Only the weights move; the tokens are untouched.
+
+        Returns them unchanged when the render does not begin with the prompt, which means the
+        two disagree about more than where the boundary falls.
+        """
+        boundary = self._first_trained_message_index(messages, train_on_what)
+        if boundary is None:
+            return weights
+        if not all(isinstance(c, tinker.types.EncodedTextChunk) for c in model_input.chunks):
+            return weights
+
+        prompt = self.build_generation_prompt(messages[:boundary]).to_ints()
+        if model_input.to_ints()[: len(prompt)] != prompt:
+            return weights
+
+        return torch.cat([torch.zeros(len(prompt)), weights[len(prompt) :]])
+
+    def _first_trained_message_index(
+        self, messages: list[Message], train_on_what: TrainOnWhat
+    ) -> int | None:
+        """Index of the message the generation prompt stops before, or None if there isn't one.
+
+        Only the modes that mean "train the turn sampling would produce" have such a point; the
+        others weight messages the generation prompt would have rendered as history.
+        """
+        match train_on_what:
+            case TrainOnWhat.LAST_ASSISTANT_MESSAGE:
+                boundary = len(messages) - 1
+            case TrainOnWhat.LAST_ASSISTANT_TURN:
+                boundary = (
+                    max(
+                        (idx for idx, m in enumerate(messages) if m["role"] == "user"),
+                        default=-1,
+                    )
+                    + 1
+                )
+            case _:
+                return None
+        if not 0 <= boundary < len(messages):
+            return None
+        return boundary if messages[boundary]["role"] == "assistant" else None
 
 
 def tokens_weights_from_strings_weights(

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -511,7 +511,10 @@ class KimiK2Renderer(Renderer):
         weights_tensor = torch.tensor(weights_data)
 
         model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        model_input = tinker.ModelInput(chunks=model_input_chunks)
+        return model_input, self._train_after_the_generation_prompt(
+            messages, train_on_what, model_input, weights_tensor
+        )
 
     @property
     def _end_message_token(self) -> int:

--- a/tinker_cookbook/renderers/parsing_test.py
+++ b/tinker_cookbook/renderers/parsing_test.py
@@ -389,7 +389,8 @@ def test_thinking_generation_parse_correspondence(model_name, renderer_cls, rend
 
     # Render expected message to get full response tokens
     rendered = renderer.render_message(
-        expected_message, RenderContext(idx=1, is_last=True, prev_message=user_message)
+        expected_message,
+        RenderContext(idx=1, is_last=True, prev_message=user_message, last_user_index=0),
     )
     full_response_tokens = [t for chunk in rendered.output for t in chunk.tokens]
 

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -141,6 +141,11 @@ class Qwen3Renderer(Renderer):
         """
         if not self.frames_thinking or message["role"] != "assistant":
             return False
+        if ctx.last_user_index < 0:
+            # The template gates on `loop.index0 > ns.last_query_index`, and that defaults to
+            # the final index when no user message exists -- so a conversation without one is
+            # never framed, however it ends.
+            return False
         return ctx.is_last or not self.strip_thinking_from_history
 
     def __init__(self, tokenizer: Tokenizer, strip_thinking_from_history: bool = True):
@@ -206,6 +211,8 @@ class Qwen3Renderer(Renderer):
         header_str = f"{maybe_newline}<|im_start|>{role}\n"
 
         content = message["content"]
+        frames = self._frames_produced_turn(message, ctx)
+        has_reasoning = has_thinking(content)
 
         if isinstance(content, list):
             # Structured content - handle with list operations
@@ -219,7 +226,6 @@ class Qwen3Renderer(Renderer):
                 parts = remove_thinking(parts)
             # Render parts in order, preserving interleaved thinking/text structure.
             # No separator needed - whitespace is preserved in TextPart for roundtrip identity.
-            frames = self._frames_produced_turn(message, ctx)
             rendered_parts = []
             after_block = False
             for p in parts:
@@ -236,11 +242,7 @@ class Qwen3Renderer(Renderer):
                     rendered_parts.append(p["text"].lstrip("\n") if after_block else p["text"])
                     after_block = False
             output_content = "".join(rendered_parts)
-            # The template opens the block on the turn being produced whether or not it
-            # reasoned, so a turn with no thinking part still gets an empty one.
-            if frames and not any(p["type"] == "thinking" for p in parts):
-                output_content = _frame_thinking("") + output_content.lstrip("\n")
-        elif self._frames_produced_turn(message, ctx) and "</think>" in content:
+        elif frames and "</think>" in content:
             # An inline block in string content is normalized the way the template
             # normalizes it, so `<think>\n\n</think>\nx` and `<think>\n\n</think>\n\nx`
             # both render as the latter rather than passing through as written.
@@ -252,6 +254,12 @@ class Qwen3Renderer(Renderer):
             # For stripping to work on historical messages, use structured content
             # with ThinkingPart separated from text (as returned by parse_response).
             output_content = content
+
+        # The template opens the block on the turn being produced whether or not it
+        # reasoned, so a turn that did not reason still gets an empty one -- whatever
+        # shape its content arrived in.
+        if frames and not has_reasoning:
+            output_content = _frame_thinking("") + output_content.lstrip("\n")
 
         # Handle tool response wrapping
         if message["role"] == "tool":
@@ -517,37 +525,16 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
     "non-thinking" mode while maintaining compatibility with the OpenAI endpoint.
     """
 
-    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
-        """Render a message, prepending an empty thinking block to the last assistant message.
+    def _get_generation_suffix(self, role: str, ctx: RenderContext) -> list[int]:
+        """The empty block is part of the prompt, so sampling starts after it.
 
-        For the last assistant message that lacks a thinking block, an empty
-        ``<think>\\n\\n</think>\\n\\n`` is added to the header to signal non-thinking mode.
-
-        Args:
-            message (Message): The chat message to render.
-            ctx (RenderContext): Positional context including index and is_last flag.
-
-        Returns:
-            RenderedMessage: Header (with optional empty think block) and output token chunks.
+        The Qwen3.5 disable-thinking renderer says the same thing the same way.
         """
-        # Get the base rendered message
-        rendered = super().render_message(message, ctx)
-
-        # Add empty thinking block to header for last assistant message
-        # This goes in header (weight=0) so observation matches generation prompt.
-        if message["role"] == "assistant" and ctx.is_last:
-            content = message.get("content", "")
-            if not has_thinking(content):
-                empty_think_tokens = self.tokenizer.encode(
-                    "<think>\n\n</think>\n\n", add_special_tokens=False
-                )
-                old_header_tokens = list(rendered.header.tokens) if rendered.header else []
-                new_header = tinker.EncodedTextChunk(tokens=old_header_tokens + empty_think_tokens)
-                rendered = RenderedMessage(
-                    header=new_header, output=rendered.output, stop_overlap=rendered.stop_overlap
-                )
-
-        return rendered
+        maybe_newline = "\n" if ctx.idx > 0 else ""
+        return self.tokenizer.encode(
+            f"{maybe_newline}<|im_start|>{role}\n<think>\n\n</think>\n\n",
+            add_special_tokens=False,
+        )
 
 
 class Qwen3InstructRenderer(Qwen3Renderer):

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -783,3 +783,44 @@ def test_qwen3_produced_turn_survives_a_render_parse_roundtrip(reasoning: str | 
 
     assert termination.is_clean
     assert ensure_list(parsed["content"]) == parts
+
+
+@pytest.mark.parametrize("renderer_name", ["qwen3", "qwen3_disable_thinking"])
+@pytest.mark.parametrize(
+    "content",
+    ["I'm fine, thank you!", [{"type": "text", "text": "I'm fine, thank you!"}]],
+    ids=["str", "list"],
+)
+def test_a_turn_that_did_not_reason_gets_exactly_one_empty_block(
+    renderer_name: str, content: str | list[dict[str, str]]
+):
+    """The block has one writer, whatever shape the content arrived in.
+
+    #849 gave the produced turn its empty block for list-shaped content. A plain string
+    went through the branch below it and got none, and `Qwen3DisableThinkingRenderer` --
+    which writes the block into the header itself -- got a second one on top.
+    """
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+    renderer = get_renderer(renderer_name, tokenizer)
+    messages = [
+        {"role": "user", "content": "Hello, how are you?"},
+        {"role": "assistant", "content": content},
+    ]
+
+    model_input, _ = renderer.build_supervised_example(cast(list[Message], messages))
+    rendered = tokenizer.decode(model_input.to_ints())
+
+    assert rendered.count("<think>") == 1, f"expected one empty block, got: {rendered!r}"
+    # A supervised example is the generation prompt for the prefix, then the turn -- what
+    # `build_supervised_example` documents, and the sequence the model is sampled from.
+    # Comparing against the whole-document form instead would need its trailing separator
+    # explained away; nothing here needs explaining away.
+    expected = (
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Hello, how are you?"}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        + "<think>\n\n</think>\n\nI'm fine, thank you!<|im_end|>"
+    )
+    assert rendered == expected, f"renderer:\n{rendered!r}\n\nexpected:\n{expected!r}"

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -941,6 +941,7 @@ _CONSISTENCY_RENDERERS = [
     ("deepseek-ai/DeepSeek-V3.1", "deepseekv3_thinking"),
     ("openai/gpt-oss-20b", "gpt_oss_medium_reasoning"),
     ("moonshotai/Kimi-K2-Thinking", "kimi_k2"),
+    ("moonshotai/Kimi-K2.5", "kimi_k25"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3_disable_thinking"),
 ]


### PR DESCRIPTION
A renderer whose generation prompt ends in a prefill -- kimi's open `<think>` -- left it
on whichever side its own header logic put it, so the model was trained to produce a token
it is always given. Only the weights move; **the tokens are untouched**:

```diff
  kimi_k25, sampled from …<|im_assistant|>assistant<|im_middle|><think>
- observation …<|im_assistant|>assistant<|im_middle|>          action <think>R</think>4
+ observation …<|im_assistant|>assistant<|im_middle|><think>   action R</think>4
```

The observation is `build_generation_prompt(messages[:boundary])`, compared as tokens and
used only to place the boundary, so no chunk is rebuilt and nothing is re-encoded. When the
render does not begin with the prompt the weights are returned unchanged -- that means the
two disagree about more than the boundary, which is a renderer bug and not something a
re-weight can fix.

| renderer | before | after |
|---|---|---|
| `kimi_k2`, `kimi_k25` | prefill trained | **prefill observed** |
| `qwen3_5`, `nemotron3`, `deepseekv3_thinking`, turn with reasoning | prefill trained | **prefill observed** |
| same three, turn with no reasoning | wrong | unchanged; still exempt |
| `qwen3`, `llama3`, `gpt_oss` | correct | untouched |

`KimiK2Renderer` reimplements `build_supervised_example` rather than delegating, so it calls
the same helper at its own return.

## Test Plan

`kimi_k25` was absent from `_CONSISTENCY_RENDERERS` while `kimi_k2` was present -- and it is
`kimi_k25` that adds the `<think>` prefill, so the bug was untested. Adding it:
**6 failed before this change, 9 passed after.**

`pytest tinker_cookbook/renderers/` -- 536 passed / 46 skipped, from 530 / 46 on main. No
token sequence changes, so the HF chat-template comparisons are untouched.

---

**Stack** (base → top): #866 → **#864** → #858 → #859 → #865 → #862 → #867

> **Note:** #858 ("the empty think block has one writer") was squash-merged into this branch on 2026-08-09 rather than into `main`, because its base was a feature branch and so had no required checks to wait on. Its commit is now part of this PR, which is why the diff is larger than the description above covers. The stack above has been rebased to drop the duplicate.
