### PR TITLE
[renderers] a deepseek supervised target is rendered the way sampling makes it

### DIFF
--- a/tinker_cookbook/renderers/deepseek_v3.py
+++ b/tinker_cookbook/renderers/deepseek_v3.py
@@ -25,6 +25,7 @@ from tinker_cookbook.renderers.base import (
     UnparsedToolCall,
     detect_unterminated_tool_block,
     ensure_text,
+    has_thinking,
     parse_response_for_stop_token,
     parse_think_blocks,
 )
@@ -482,20 +483,37 @@ class DeepSeekV3ThinkingRenderer(_DeepSeekV3BaseRenderer):
         # Add </think> to header for historical assistant messages when stripping thinking.
         # This matches the base class's should_strip_thinking logic - only historical messages
         # (not the last one) get </think> added. The last message is the supervised target and
-        # should preserve its format (including any ThinkingPart).
+        # should preserve its format (including any ThinkingPart) - but a target without one
+        # has no format to preserve, and HF adds </think> there too. Empty content means the
+        # generation prompt's own header, which keeps the open <think>.
         follows_tool = ctx.prev_message is not None and ctx.prev_message["role"] == "tool"
+        content = message.get("content", "")
+        is_assistant_turn = message["role"] == "assistant" and not follows_tool
         should_add_think_close = (
-            message["role"] == "assistant"
-            and not follows_tool
-            and self.strip_thinking_from_history
-            and not ctx.is_last
+            is_assistant_turn and self.strip_thinking_from_history and not ctx.is_last
         )
 
         if should_add_think_close:
             think_close_tokens = self.tokenizer.encode("</think>", add_special_tokens=False)
             old_header_tokens = list(rendered.header.tokens) if rendered.header else []
             new_header = tinker.EncodedTextChunk(tokens=old_header_tokens + think_close_tokens)
-            rendered = RenderedMessage(header=new_header, output=rendered.output)
+            return RenderedMessage(header=new_header, output=rendered.output)
+
+        # The supervised target opens its own block. `build_generation_prompt` prefills
+        # `<think>`, so a turn that did not reason is sampled as `</think>answer` after it --
+        # write the pair and let the boundary land between them. HF renders this turn the way
+        # it renders history, as a bare `</think>`, which is a form no sampling can produce.
+        if is_assistant_turn and ctx.is_last and content and not has_thinking(content):
+            empty_block = self.tokenizer.encode("<think></think>", add_special_tokens=False)
+            first, *rest = rendered.output
+            assert isinstance(first, tinker.types.EncodedTextChunk)
+            return RenderedMessage(
+                header=rendered.header,
+                output=[
+                    tinker.types.EncodedTextChunk(tokens=empty_block + list(first.tokens)),
+                    *rest,
+                ],
+            )
 
         return rendered
 

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -655,11 +655,10 @@ def test_supervised_example_against_hf_chat_templates(
         )
 
     # Skip supervised tests for thinking renderer - we intentionally don't add </think> to the
-    # last message (supervised target) so it can preserve ThinkingPart, unlike HF which always adds it
-    if renderer_override in _RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS:
-        pytest.skip(
-            f"{renderer_override} intentionally differs from HF for supervised target (no </think>)"
-        )
+    # last message (supervised target) so it can preserve ThinkingPart, unlike HF which always
+    # adds it. A target without a ThinkingPart has nothing to preserve and stays HF-compatible.
+    if renderer_override in _RENDERERS_THAT_DIVERGE_FROM_HF_FOR_THE_TARGET:
+        pytest.skip(f"{renderer_override} renders the supervised target the way sampling makes it")
 
     tokenizer = get_tokenizer(model_name)
     attributes = get_model_attributes(model_name)
@@ -973,10 +972,15 @@ _RENDERERS_WITH_THINKING_STRIPPING = {
     "kimi_k2",
 }
 
-# Renderers where supervised and generation have different headers (HF thinking=True behavior).
-# These add </think> to supervised assistant headers but <think> to generation prompt,
-# so observation != generation_prompt by design.
-_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"deepseekv3_thinking", "qwen3_5", "nemotron3"}
+# Renderers whose supervised target is rendered the way sampling produces it rather than the
+# way the template renders history. HF writes a finished turn as history -- deepseek as a bare
+# `</think>`, the opening tag living only in the generation prompt -- and no sampling can
+# produce that, so the document comparison does not apply to the target.
+_RENDERERS_THAT_DIVERGE_FROM_HF_FOR_THE_TARGET = {"deepseekv3_thinking"}
+
+# Renderers whose supervised target keeps a header the generation prompt does not end with, so
+# observation != generation_prompt however the boundary moves.
+_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"qwen3_5", "nemotron3"}
 
 
 @pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)


### PR DESCRIPTION
`build_generation_prompt` prefills `<think>`, so a turn is sampled as `R</think>answer` --
or, when it did not reason, as `</think>answer`. The renderer wrote neither. A target with
no ThinkingPart came out with no think tokens at all:

```diff
  sampled after:  <｜User｜>q<｜Assistant｜><think>
- observation …<｜Assistant｜>          action 4<｜end▁of▁sentence｜>
+ observation …<｜Assistant｜><think>   action </think>4<｜end▁of▁sentence｜>
```

so the model was trained to answer straight after `<｜Assistant｜>` while inference always
hands it `<think>` first. Both shapes now open the block and let the boundary land inside
it, which is what the PR below this one places.

**This deliberately does not match `apply_chat_template`.** HF renders a finished assistant
turn the way it renders *history*: a bare `</think>answer`, with no opening tag anywhere --
the opening `<think>` exists only in the generation prompt. That form is unmatched by
construction and no sampling can produce it, so it is the wrong target to train on even
though it is the right thing for the endpoint to write when the turn later becomes history.

`_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS` was answering two questions at once --
"diverges from the HF document" and "observation != generation prompt" -- which is why
`deepseekv3_thinking` could not leave it. Split, and deepseek leaves the second:

| set | members | governs |
|---|---|---|
| `_RENDERERS_THAT_DIVERGE_FROM_HF_FOR_THE_TARGET` | deepseek, qwen3_5, nemotron3 | the document comparison |
| `_RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS` | qwen3_5, nemotron3 | the boundary comparison |

## Test Plan

`test_supervised_generation_parse_consistency` asserts
`observation == build_generation_prompt(messages[:-1])` and skipped `deepseekv3_thinking`
entirely. It no longer does: **its cases fail on main for both turn shapes and pass here.**

`pytest tinker_cookbook/renderers/` -- 548 passed / 40 skipped, from 545 / 43.

---

**Stack** (base → top): #866 → #864 → ~~#858 merged~~ → #859 → #865 → #862 → #867 → #868
