### PR TITLE
[renderers] one writer for "does this content carry reasoning"

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -851,6 +851,18 @@ def message_to_jsonable(message: Message) -> dict[str, Any]:
     return result
 
 
+def has_thinking(content: Content) -> bool:
+    """Whether content carries reasoning, in either shape it can arrive in.
+
+    Structured content carries a ThinkingPart; a string carries an opening ``<think>``,
+    closed or not. Renderers ask this to decide whether to write the empty block their
+    template puts on a turn that did not reason.
+    """
+    if isinstance(content, list):
+        return any(p["type"] == "thinking" for p in content)
+    return "<think>" in content
+
+
 def remove_thinking(parts: list[ContentPart]) -> list[ContentPart]:
     """Filter out ThinkingPart elements from a content part list.
 

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -71,6 +71,7 @@ from tinker_cookbook.renderers.base import (
     Role,
     TextPart,
     ToolSpec,
+    has_thinking,
 )
 from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
 from tinker_cookbook.tokenizer_utils import Tokenizer
@@ -208,11 +209,7 @@ class Nemotron3Renderer(Qwen3_5Renderer):
         """
         is_historical = ctx.idx < ctx.last_user_index
         content = message.get("content", "")
-        has_think = False
-        if isinstance(content, list):
-            has_think = any(p["type"] == "thinking" for p in content)
-        elif isinstance(content, str):
-            has_think = "<think>" in content
+        has_think = has_thinking(content)
         # No empty prefix when the thinking itself will be rendered in the output:
         # always for the current turn, and for history when it is preserved.
         if has_think and (not is_historical or not self.strip_thinking_from_history):
@@ -277,13 +274,18 @@ class Nemotron3Renderer(Qwen3_5Renderer):
         """
         assert "tool_calls" in message
         content = message.get("content", "")
-        has_thinking = isinstance(content, list) and any(p["type"] == "thinking" for p in content)
+        # Deliberately not `has_thinking`: this asks whether `_format_thinking_text` ran, and
+        # it only runs on a ThinkingPart. An inline `<think>` in a string never went through
+        # it and so never wrote the trailing \n this is compensating for.
+        has_thinking_part = isinstance(content, list) and any(
+            p["type"] == "thinking" for p in content
+        )
         has_nonempty_text = isinstance(content, list) and any(
             p["type"] == "text" and p.get("text", "") for p in content
         )
         # Thinking ends with \n; only add \n prefix if there's text after thinking
         # (which won't end with \n) or no thinking at all.
-        prefix = "" if (has_thinking and not has_nonempty_text) else "\n"
+        prefix = "" if (has_thinking_part and not has_nonempty_text) else "\n"
         calls = "".join(self._format_tool_call_xml(tc) + "\n" for tc in message["tool_calls"])
         return [TextPart(type="text", text=prefix + calls)]
 
@@ -446,11 +448,7 @@ class Nemotron3UltraRenderer(Nemotron3Renderer):
         """
         is_historical = ctx.idx < ctx.last_user_index
         content = message.get("content", "")
-        has_think = False
-        if isinstance(content, list):
-            has_think = any(p["type"] == "thinking" for p in content)
-        elif isinstance(content, str):
-            has_think = "<think>" in content
+        has_think = has_thinking(content)
         if has_think and (not is_historical or not self.strip_thinking_from_history):
             return ""
         return "<think></think>"

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -30,6 +30,7 @@ from tinker_cookbook.renderers.base import (
     UnparsedToolCall,
     _tool_call_payload,
     detect_unterminated_tool_block,
+    has_thinking,
     image_to_chunk,
     parse_content_blocks,
     parse_response_for_stop_token,
@@ -536,12 +537,7 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
         # This goes in header (weight=0) so observation matches generation prompt.
         if message["role"] == "assistant" and ctx.is_last:
             content = message.get("content", "")
-            if isinstance(content, str):
-                has_think = "<think>" in content
-            else:
-                has_think = any(p["type"] == "thinking" for p in content)
-
-            if not has_think:
+            if not has_thinking(content):
                 empty_think_tokens = self.tokenizer.encode(
                     "<think>\n\n</think>\n\n", add_special_tokens=False
                 )

--- a/tinker_cookbook/renderers/qwen3_5.py
+++ b/tinker_cookbook/renderers/qwen3_5.py
@@ -32,6 +32,7 @@ from tinker_cookbook.renderers.base import (
     ToolCall,
     ToolSpec,
     UnparsedToolCall,
+    has_thinking,
 )
 from tinker_cookbook.renderers.qwen3 import Qwen3VLRenderer
 
@@ -78,11 +79,7 @@ class Qwen3_5Renderer(Qwen3VLRenderer):
             return ""
 
         content = message.get("content", "")
-        has_think = False
-        if isinstance(content, list):
-            has_think = any(p["type"] == "thinking" for p in content)
-        elif isinstance(content, str):
-            has_think = "<think>" in content
+        has_think = has_thinking(content)
 
         return "" if has_think else "<think>\n\n</think>\n\n"
 


### PR DESCRIPTION
Four renderers each spelled the same predicate inline, and a fifth spelled a different
one under the same name:

| site | list | string |
|---|---|---|
| `qwen3.Qwen3DisableThinkingRenderer` | any ThinkingPart | `"<think>" in content` |
| `qwen3_5._assistant_header_suffix` | any ThinkingPart | `"<think>" in content` |
| `nemotron3._assistant_header_suffix` (x2) | any ThinkingPart | `"<think>" in content` |
| `nemotron3._format_tool_calls_chunks` | any ThinkingPart | **always False** |

The first four are byte-identical and become `has_thinking(content)`, next to its siblings
`remove_thinking` / `ensure_list` / `parse_think_blocks` in `base.py`.

The fifth is deliberately different and stays inline, renamed `has_thinking_part` so it no
longer shadows the helper: it asks whether `_format_thinking_text` ran, and that only runs
on a ThinkingPart. An inline `<think>` in a string never went through it, so it never wrote
the trailing newline that code is compensating for. Answering it with the general predicate
would be a behaviour change, not a refactor.

## Test Plan

`pytest tinker_cookbook/renderers/` -- 530 passed / 46 skipped, identical to main. This is a
pure extraction: no call site changes which question it asks.

---

**Stack** (base → top): **#866** → #864 → #858 → #859 → #865 → #862 → #867