### PR TITLE
[renderers] the produced turn is a concept, not a lie about is_last

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -705,6 +705,15 @@ class RenderContext:
     differently based on whether they come before or after the last user message.
     """
 
+    in_produced_turn: bool = False
+    """Whether this message belongs to the turn the model is being asked to produce.
+
+    Distinct from ``is_last``, which is literally the final message. A turn can span several
+    messages -- an assistant message, a tool response, the assistant's follow-up -- so a
+    renderer that keeps reasoning in the produced turn while stripping it from history has to
+    ask about the turn, not the message. ``_produced_turn_start_index`` says where it starts.
+    """
+
 
 class ToolSpec(TypedDict):
     """
@@ -1638,12 +1647,15 @@ class Renderer(ABC):
             default=-1,
         )
 
+        turn_start = self._produced_turn_start_index(messages)
+
         for idx, message in enumerate(messages):
             ctx = RenderContext(
                 idx=idx,
                 is_last=(idx == len(messages) - 1),
                 prev_message=messages[idx - 1] if idx > 0 else None,
                 last_user_index=last_user_idx,
+                in_produced_turn=idx >= turn_start,
             )
             rendered_message = self.render_message(message, ctx)
             header_chunk = rendered_message.header
@@ -1660,6 +1672,7 @@ class Renderer(ABC):
             is_last=True,
             prev_message=messages[-1] if messages else None,
             last_user_index=last_user_idx,
+            in_produced_turn=True,
         )
         suffix_tokens = self._get_generation_suffix(role, suffix_ctx)
         if suffix_tokens:
@@ -1763,6 +1776,8 @@ class Renderer(ABC):
             default=-1,
         )
 
+        turn_start = self._produced_turn_start_index(messages)
+
         for idx, message in enumerate(messages):
             if train_on_what == TrainOnWhat.CUSTOMIZED:
                 assert "trainable" in message, (
@@ -1776,7 +1791,7 @@ class Renderer(ABC):
             is_last_message = idx == len(messages) - 1
             is_assistant = message["role"] == "assistant"
             is_user_or_system = message["role"] in ["user", "system"]
-            is_after_last_user = last_user_idx == -1 or idx > last_user_idx
+            in_produced_turn = idx >= turn_start
 
             # only apply weight to header if train_on_what is ALL_TOKENS
             ctx = RenderContext(
@@ -1784,6 +1799,7 @@ class Renderer(ABC):
                 is_last=is_last_message,
                 prev_message=messages[idx - 1] if idx > 0 else None,
                 last_user_index=last_user_idx,
+                in_produced_turn=in_produced_turn,
             )
             rendered_message = self.render_message(message, ctx)
             header_part = rendered_message.header
@@ -1798,7 +1814,7 @@ class Renderer(ABC):
                 case TrainOnWhat.LAST_ASSISTANT_MESSAGE:
                     output_has_weight = is_last_message and is_assistant
                 case TrainOnWhat.LAST_ASSISTANT_TURN:
-                    output_has_weight = is_assistant and is_after_last_user
+                    output_has_weight = is_assistant and in_produced_turn
                 case TrainOnWhat.ALL_ASSISTANT_MESSAGES:
                     output_has_weight = is_assistant
                 case TrainOnWhat.ALL_MESSAGES:
@@ -1858,6 +1874,15 @@ class Renderer(ABC):
 
         return torch.cat([torch.zeros(len(prompt)), weights[len(prompt) :]])
 
+    def _produced_turn_start_index(self, messages: list[Message]) -> int:
+        """Index of the first message in the turn the model is being asked to produce.
+
+        Everything from here on is the produced turn; everything before it is history. The
+        default is the message after the last user one. Renderers whose template draws the
+        line elsewhere override this rather than reinterpreting ``ctx.is_last``.
+        """
+        return max((idx for idx, m in enumerate(messages) if m["role"] == "user"), default=-1) + 1
+
     def _first_trained_message_index(
         self, messages: list[Message], train_on_what: TrainOnWhat
     ) -> int | None:
@@ -1865,16 +1890,17 @@ class Renderer(ABC):
 
         Only the modes that mean "train the turn sampling would produce" have such a point; the
         others weight messages the generation prompt would have rendered as history.
+
+        Deliberately not ``_produced_turn_start_index``: that says where reasoning starts being
+        preserved, which a renderer may put earlier than the prompt ends. This says where the
+        prompt ends, and it is always the message after the last user one.
         """
         match train_on_what:
             case TrainOnWhat.LAST_ASSISTANT_MESSAGE:
                 boundary = len(messages) - 1
             case TrainOnWhat.LAST_ASSISTANT_TURN:
                 boundary = (
-                    max(
-                        (idx for idx, m in enumerate(messages) if m["role"] == "user"),
-                        default=-1,
-                    )
+                    max((idx for idx, m in enumerate(messages) if m["role"] == "user"), default=-1)
                     + 1
                 )
             case _:

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -7,7 +7,6 @@ import warnings
 import tinker
 import torch
 
-from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers.base import (
     ContentPart,
     Message,
@@ -200,8 +199,8 @@ class KimiK2Renderer(Renderer):
 
         Each message uses role-specific tokens (``<|im_user|>``, ``<|im_assistant|>``,
         ``<|im_system|>``) with ``<|im_middle|>`` separating the role from content.
-        For assistant messages, ``ctx.is_last`` controls whether thinking is preserved
-        or replaced with empty ``<think></think>``.
+        For assistant messages, ``ctx.in_produced_turn`` controls whether thinking is
+        preserved or replaced with empty ``<think></think>``.
 
         Args:
             message (Message): The chat message to render.
@@ -262,7 +261,7 @@ class KimiK2Renderer(Renderer):
 
             # Preserve thinking for the last assistant message, or for all messages
             # when strip_thinking_from_history is False.
-            if (ctx.is_last or not self.strip_thinking_from_history) and thinking_content:
+            if (ctx.in_produced_turn or not self.strip_thinking_from_history) and thinking_content:
                 output_str = f"<think>{thinking_content}</think>"
             else:
                 output_str = "<think></think>"
@@ -333,12 +332,11 @@ class KimiK2Renderer(Renderer):
                 last_assistant_idx == -1 or idx > last_assistant_idx
             )
 
-            # We cannot simply set is_last=False since we might be generating a new assistant message following a tool response,
-            # and we need to preserve the thinking that leads to the tool call.
             ctx = RenderContext(
                 idx=idx,
-                is_last=is_last_assistant,
+                is_last=idx == len(messages) - 1,
                 prev_message=messages[idx - 1] if idx > 0 else None,
+                in_produced_turn=is_last_assistant,
             )
             rendered_message = self.render_message(message, ctx)
             header_chunk = rendered_message.header
@@ -415,105 +413,27 @@ class KimiK2Renderer(Renderer):
 
         return supervised_examples
 
+    def _produced_turn_start_index(self, messages: list[Message]) -> int:
+        """The turn starts after the last assistant message that did not call a tool.
+
+        Kimi's template keeps the reasoning of every assistant message after that point, so
+        a turn spans the whole assistant/tool exchange rather than the messages after the
+        last user one. The final message is excluded from the scan: it is the target, and a
+        turn cannot start after itself.
+        """
+        for idx in range(len(messages) - 2, -1, -1):
+            if messages[idx]["role"] == "assistant" and not messages[idx].get("tool_calls"):
+                return idx + 1
+        return 0
+
     def build_supervised_example(
         self,
         messages: list[Message],
         train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
     ) -> tuple[tinker.ModelInput, torch.Tensor]:
-        """Build a single supervised training example with proper thinking preservation.
-
-        Ensures a default system message is present and preserves thinking content
-        for assistant messages in the last assistant turn (after the last non-tool-call
-        assistant message).
-
-        Args:
-            messages (list[Message]): The conversation messages for supervised training.
-            train_on_what (TrainOnWhat): Which message tokens to assign training weight.
-
-        Returns:
-            tuple[tinker.ModelInput, torch.Tensor]: The tokenized model input and
-                per-token weight tensor.
-        """
-        messages = self._ensure_system_message(messages)
-
-        # Kimi K2 hf template preserves the thinking of the assistant messages after the last non-tool-call assistant message.
-        # We do the same in general. However, we intentionally skip the last message (which differs from HF template behavior) since for a complete conversation,
-        # we would want to preserve the thinking of the last round of conversation between the user and the assistant (which could include multiple assistant messages and tool calls).
-        # This is because the trajectory would then be taken for SFT without losing all the thinking content.
-        last_assistant_idx = -1
-        for idx in range(len(messages) - 2, -1, -1):
-            if messages[idx]["role"] == "assistant" and not messages[idx].get("tool_calls"):
-                last_assistant_idx = idx
-                break
-
-        model_input_chunks_weights: list[tuple[tinker.types.ModelInputChunk, float]] = []
-
-        for idx, message in enumerate(messages):
-            if train_on_what == TrainOnWhat.CUSTOMIZED:
-                assert "trainable" in message, (
-                    "When using CUSTOMIZED train_on_what, each message must have a trainable field"
-                )
-            else:
-                assert "trainable" not in message, (
-                    "When using non-CUSTOMIZED train_on_what, each message must not have a trainable field"
-                )
-
-            is_assistant = message["role"] == "assistant"
-            is_last_message = idx == len(messages) - 1
-            is_user_or_system = message["role"] in ["user", "system"]
-
-            # For Kimi K2, preserve thinking only for the suffix after the last non-tool-call assistant.
-            # If no such assistant exists, the suffix is the entire message list.
-            # Preserve thinking only for assistants after the last non-tool-call assistant.
-            is_last_assistant_turn = is_assistant and (
-                last_assistant_idx == -1 or idx > last_assistant_idx
-            )
-
-            is_last_assistant = is_assistant and is_last_message
-            ctx = RenderContext(
-                idx=idx,
-                is_last=is_last_assistant_turn,
-                prev_message=messages[idx - 1] if idx > 0 else None,
-            )
-            rendered_message = self.render_message(message, ctx)
-
-            header_part = rendered_message.header
-            output_parts = rendered_message.output
-
-            header_weight = int(train_on_what == TrainOnWhat.ALL_TOKENS)
-            if header_part:
-                model_input_chunks_weights += [(header_part, header_weight)]
-
-            # We include all assistant messages in the last round of assistant-tool interactions as the last assistant message.
-            match train_on_what:
-                case TrainOnWhat.LAST_ASSISTANT_MESSAGE:
-                    output_has_weight = is_last_assistant
-                case TrainOnWhat.LAST_ASSISTANT_TURN:
-                    output_has_weight = is_last_assistant_turn
-                case TrainOnWhat.ALL_ASSISTANT_MESSAGES:
-                    output_has_weight = is_assistant
-                case TrainOnWhat.ALL_MESSAGES:
-                    output_has_weight = True
-                case TrainOnWhat.ALL_TOKENS:
-                    output_has_weight = True
-                case TrainOnWhat.ALL_USER_AND_SYSTEM_MESSAGES:
-                    output_has_weight = is_user_or_system
-                case TrainOnWhat.CUSTOMIZED:
-                    output_has_weight = message.get("trainable", False)
-                case _:
-                    raise RendererError(f"Unknown train_on_what: {train_on_what}")
-
-            model_input_chunks_weights += [
-                (output_part, int(output_has_weight)) for output_part in output_parts if output_part
-            ]
-
-        weights_data = [w for chunk, w in model_input_chunks_weights for _ in range(chunk.length)]
-        weights_tensor = torch.tensor(weights_data)
-
-        model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        model_input = tinker.ModelInput(chunks=model_input_chunks)
-        return model_input, self._train_after_the_generation_prompt(
-            messages, train_on_what, model_input, weights_tensor
+        """Build a supervised example, prepending the default system message if absent."""
+        return super().build_supervised_example(
+            self._ensure_system_message(messages), train_on_what=train_on_what
         )
 
     @property

--- a/tinker_cookbook/renderers/parsing_test.py
+++ b/tinker_cookbook/renderers/parsing_test.py
@@ -390,7 +390,13 @@ def test_thinking_generation_parse_correspondence(model_name, renderer_cls, rend
     # Render expected message to get full response tokens
     rendered = renderer.render_message(
         expected_message,
-        RenderContext(idx=1, is_last=True, prev_message=user_message, last_user_index=0),
+        RenderContext(
+            idx=1,
+            is_last=True,
+            prev_message=user_message,
+            last_user_index=0,
+            in_produced_turn=True,
+        ),
     )
     full_response_tokens = [t for chunk in rendered.output for t in chunk.tokens]
 

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -52,6 +52,7 @@ from tinker_cookbook.renderers.base import (
     ensure_list,
     ensure_text,
     format_content_as_string,
+    has_thinking,
 )
 from tinker_cookbook.renderers.deepseek_v3 import DeepSeekV3ThinkingRenderer
 from tinker_cookbook.renderers.kimi_k2 import KimiK2Renderer
@@ -985,6 +986,51 @@ _RENDERERS_THAT_DIVERGE_FROM_HF_FOR_THE_TARGET = {"deepseekv3_thinking"}
 # Renderers whose supervised target keeps a header the generation prompt does not end with, so
 # observation != generation_prompt however the boundary moves.
 _RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"nemotron3"}
+
+
+@pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)
+@pytest.mark.parametrize("model_name,renderer_name", _CONSISTENCY_RENDERERS)
+def test_last_assistant_turn_observes_the_prefill_too(
+    model_name: str, renderer_name: str, conversation_fn
+):
+    """LAST_ASSISTANT_TURN stops training where LAST_ASSISTANT_MESSAGE does.
+
+    The two modes weight different amounts -- a turn can span several messages -- but both are
+    sampled from the prompt for the conversation up to the last user message, so both must
+    observe its prefill. Only LAST_ASSISTANT_MESSAGE was covered, which let the boundary move
+    here without changing a token or failing a test.
+    """
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer(renderer_name, tokenizer)
+    messages = conversation_fn()
+
+    last_user = max((idx for idx, m in enumerate(messages) if m["role"] == "user"), default=-1)
+    if last_user + 1 >= len(messages) or messages[last_user + 1]["role"] != "assistant":
+        pytest.skip("no assistant turn after the last user message")
+    if len(messages) - (last_user + 1) > 1 and not renderer.has_extension_property:
+        # A turn spanning several messages needs one example per message, which is what
+        # build_supervised_examples is for; a single sequence cannot show them all.
+        pytest.skip("multi-message turn on a renderer that does not extend")
+    if _conversation_has_tools(messages) and renderer_name in _RENDERERS_WITHOUT_TOOL_SUPPORT:
+        pytest.skip(f"{renderer_name} doesn't support tool calling")
+    if any(has_thinking(m["content"]) for m in messages) and (
+        renderer_name in _RENDERERS_WITHOUT_THINKING_SUPPORT
+        or renderer_name in _RENDERERS_WITH_THINKING_STRIPPING
+    ):
+        pytest.skip(f"{renderer_name} cannot round-trip thinking here")
+    if renderer_name in _RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS:
+        pytest.skip(f"{renderer_name} has different headers for supervised vs generation")
+
+    model_input, weights = renderer.build_supervised_example(
+        messages, train_on_what=TrainOnWhat.LAST_ASSISTANT_TURN
+    )
+    tokens = model_input.to_ints()
+    trained = [w > 0 for w in weights.tolist()]
+    if True not in trained:
+        pytest.skip("nothing trained")
+    observation = tokens[: trained.index(True)]
+
+    assert observation == renderer.build_generation_prompt(messages[: last_user + 1]).to_ints()
 
 
 @pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)


### PR DESCRIPTION
`ctx.is_last` means "the final message". Four renderers were using it to mean "part of the
turn being produced", and two had to falsify it to get the right answer:

```python
kimi_k2       is_last=is_last_assistant_turn            # not the last message
nemotron3     dataclasses.replace(ctx, is_last=True)    # to defeat the base's check
```

A turn can span several messages -- an assistant message, a tool response, the assistant's
follow-up -- so "is this the last message" cannot answer "should this keep its reasoning".
`RenderContext.in_produced_turn` answers it, from one overridable
`_produced_turn_start_index`.

**`KimiK2Renderer.build_supervised_example` goes away.** It was 100 lines reimplementing the
base loop to change two things: where the turn starts, and that `ctx` should report it. Both
are the base's job now, so what is left is the boundary:

```python
def _produced_turn_start_index(self, messages):
    for idx in range(len(messages) - 2, -1, -1):
        if messages[idx]["role"] == "assistant" and not messages[idx].get("tool_calls"):
            return idx + 1
    return 0
```

`kimi_k2.py` **-100/+21**; `RendererError` became unused, its only `raise` having been in the
duplicated `train_on_what` dispatch.

Where the turn starts is **not** where the prompt ends. Kimi puts the first at 0 when no
earlier assistant qualifies, while the prompt still ends after the last user message, so
`_first_trained_message_index` keeps computing its own boundary. Conflating them retrained
kimi's `<think>` prefill -- the exact thing the PR below this one fixes.

`nemotron3`'s patch stays. Rewriting `qwen3` to read `in_produced_turn` so it could go was
tried and reverted: it fails `test_generation_against_hf_chat_templates[Qwen3-8B-tool_call_gen]`,
because Qwen3's template strips reasoning from every message but the literal last while
Nemotron-3's keeps the whole turn. That patch encodes a template difference.

## Test Plan

`test_last_assistant_turn_observes_the_prefill_too` is new, and is what should have existed
already: `LAST_ASSISTANT_TURN` weights a different amount than `LAST_ASSISTANT_MESSAGE` but
is sampled from the same prompt, so it must observe the same prefill. Only the latter was
covered. **6 failed / 6 passed against the conflated boundary, 12 pass now.**

Verified by differential rather than by test count: 40 (renderer x conversation x
`train_on_what`) cases dumped as tokens and weights before and after, **0 differ**. The
conflation bug above changed 5 of them while all 551 tests stayed green, which is why the
new test exists.

`pytest tinker_cookbook/renderers/` -- 563 passed / 37 skipped.

---

**Stack** (base → top): #866 → #864 → #859 → #865 → #862 → #867 → #868
