### PR TITLE
[renderers] build_supervised_examples splits a conversation instead of refusing it

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1694,7 +1694,10 @@ class Renderer(ABC):
         """Build tokens and per-token weights for supervised fine-tuning.
 
         Returns a list of (model_input, weights) tuples. Multiple examples are
-        needed when the renderer does not satisfy the extension property.
+        needed when the renderer does not satisfy the extension property: it writes an
+        assistant message one way as history and another as the turn being produced, so a
+        single sequence cannot show every turn the context it was sampled from. One example
+        per trained message can, each ending at the message it trains.
 
         Args:
             messages (list[Message]): The conversation to render.
@@ -1708,11 +1711,28 @@ class Renderer(ABC):
 
         if self.has_extension_property:
             return [self.build_supervised_example(messages, train_on_what=train_on_what)]
-        else:
-            # TODO: Add a default implementation that calls `build_supervised_example` for each message and merges examples with shared prefixes.
-            raise NotImplementedError(
-                "build_supervised_examples has not been implemented for this renderer."
+
+        match train_on_what:
+            case TrainOnWhat.LAST_ASSISTANT_MESSAGE:
+                candidates = range(len(messages) - 1, len(messages))
+            case TrainOnWhat.LAST_ASSISTANT_TURN:
+                candidates = range(self._produced_turn_start_index(messages), len(messages))
+            case TrainOnWhat.ALL_ASSISTANT_MESSAGES:
+                candidates = range(len(messages))
+            case _:
+                raise NotImplementedError(
+                    f"build_supervised_examples cannot split {train_on_what} for a renderer "
+                    "without the extension property: it weights messages that are not turns "
+                    "the model produces, so there is no prompt to end each example at."
+                )
+
+        return [
+            self.build_supervised_example(
+                messages[: idx + 1], train_on_what=TrainOnWhat.LAST_ASSISTANT_MESSAGE
             )
+            for idx in candidates
+            if messages[idx]["role"] == "assistant"
+        ]
 
     def build_supervised_example(
         self,

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -49,6 +49,7 @@ from tinker_cookbook.renderers import (
 from tinker_cookbook.renderers.base import (
     ContentPart,
     ImagePart,
+    Renderer,
     ensure_list,
     ensure_text,
     format_content_as_string,
@@ -986,6 +987,61 @@ _RENDERERS_THAT_DIVERGE_FROM_HF_FOR_THE_TARGET = {"deepseekv3_thinking"}
 # Renderers whose supervised target keeps a header the generation prompt does not end with, so
 # observation != generation_prompt however the boundary moves.
 _RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS = {"nemotron3"}
+
+
+@pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)
+@pytest.mark.parametrize("model_name,renderer_name", _CONSISTENCY_RENDERERS)
+def test_every_example_of_a_split_conversation_starts_where_it_was_sampled(
+    model_name: str, renderer_name: str, conversation_fn
+):
+    """A renderer without the extension property gets one example per trained message.
+
+    Such a renderer writes an assistant message one way as history and another as the turn
+    being produced, so a single sequence cannot show every turn the context it was sampled
+    from -- which is what `build_supervised_examples` is for. It used to raise for every
+    renderer but two, leaving callers with a multi-message turn no correct option at all.
+    """
+    skip_if_deepseek_tokenizer_bug(model_name)
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer(renderer_name, tokenizer)
+    if renderer.has_extension_property:
+        pytest.skip(f"{renderer_name} extends, so one example already shows every turn")
+    if type(renderer).build_supervised_examples is not Renderer.build_supervised_examples:
+        pytest.skip(f"{renderer_name} splits its own way; this covers the default split")
+
+    messages = conversation_fn()
+    has_thinking_content = any(has_thinking(m["content"]) for m in messages)
+    if has_thinking_content and renderer_name in _RENDERERS_WITHOUT_THINKING_SUPPORT:
+        pytest.skip(f"{renderer_name} doesn't support ThinkingPart content")
+    if has_thinking_content and renderer_name in _RENDERERS_WITH_THINKING_STRIPPING:
+        pytest.skip(f"{renderer_name} strips thinking, so a produced turn cannot round-trip")
+    if _conversation_has_tools(messages) and renderer_name in _RENDERERS_WITHOUT_TOOL_SUPPORT:
+        pytest.skip(f"{renderer_name} doesn't support tool calling")
+    if renderer_name in _RENDERERS_WITH_DIFFERENT_SUPERVISED_GEN_HEADERS:
+        pytest.skip(f"{renderer_name} has different headers for supervised vs generation")
+
+    examples = renderer.build_supervised_examples(
+        messages, train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES
+    )
+    assistants = [idx for idx, m in enumerate(messages) if m["role"] == "assistant"]
+    assert len(examples) == len(assistants)
+
+    for idx, (model_input, weights) in zip(assistants, examples):
+        tokens = model_input.to_ints()
+        trained = [w > 0 for w in weights.tolist()]
+        assert True in trained, f"example for message {idx} trains nothing"
+        observation = tokens[: trained.index(True)]
+        assert observation == renderer.build_generation_prompt(messages[:idx]).to_ints(), (
+            f"example for message {idx} does not start where that turn was sampled"
+        )
+
+
+# Renderers whose generation prompt ends in a prefill, so the observation/action boundary is
+# something a renderer can get wrong without changing a single token.
+_RENDERERS_WITH_A_GENERATION_PREFILL = [
+    ("moonshotai/Kimi-K2-Thinking", "kimi_k2"),
+    ("moonshotai/Kimi-K2.5", "kimi_k25"),
+]
 
 
 @pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)


### PR DESCRIPTION
A renderer without the extension property writes an assistant message one way as history
and another as the turn being produced, so one sequence cannot show every turn the context
it was sampled from. `build_supervised_examples` exists for exactly that -- and raised for
every renderer but `kimi_k2` and `tml_v0`:

    NotImplementedError: build_supervised_examples has not been implemented for this renderer.

So a caller with a multi-turn conversation had no correct option. The singular form silently
renders the earlier turns against a prefix they were never sampled from -- the failure its
own `ALL_ASSISTANT_MESSAGES` warning describes -- and the plural form refuses.

The default now does what that warning tells callers to do by hand:

```python
return [
    self.build_supervised_example(messages[: idx + 1], train_on_what=LAST_ASSISTANT_MESSAGE)
    for idx in candidates
    if messages[idx]["role"] == "assistant"
]
```

`LAST_ASSISTANT_MESSAGE` per example is the point: it is the mode whose boundary is already
covered by `test_supervised_generation_parse_consistency`, so each split example inherits an
invariant the whole conversation cannot have.

Modes that weight non-assistant messages still raise, with a reason rather than a TODO:
there is no per-turn prompt to end those examples at.

The `# TODO: ... merges examples with shared prefixes` is deliberately not done. That is a
compute optimisation, not correctness, and bundling it would widen the claim.

## Test Plan

`test_every_example_of_a_split_conversation_starts_where_it_was_sampled` asserts every
example's observation is the generation prompt for its own prefix. **27 failed with
`NotImplementedError` before this change, 27 pass after.**

Scoped to renderers using the default split; `kimi_k2` overrides it with a coarser one
(per user turn rather than per assistant message) and is skipped. That split does not hold
this invariant on tool conversations -- a pre-existing issue in kimi's own implementation,
untouched here.

`pytest tinker_cookbook/renderers/` -- 590 passed / 94 skipped.

---

**Stack** (base → top): #866 → #864 → #859 → #865 → #862 → #867 → #868
