### PR TITLE
[renderers] kimi's generation prompt is the base's too

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1796,7 +1796,10 @@ class Renderer(ABC):
             default=-1,
         )
 
-        turn_start = self._produced_turn_start_index(messages)
+        # Without the target: the produced turn is the last message here, and a turn cannot
+        # start after itself. build_generation_prompt passes the whole list, where the turn
+        # it is prompting for comes after the end.
+        turn_start = self._produced_turn_start_index(messages[:-1])
 
         for idx, message in enumerate(messages):
             if train_on_what == TrainOnWhat.CUSTOMIZED:

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -302,55 +302,10 @@ class KimiK2Renderer(Renderer):
     def build_generation_prompt(
         self, messages: list[Message], role: Role = "assistant", prefill: str | None = None
     ) -> tinker.ModelInput:
-        """Build a generation prompt with Kimi K2 formatting.
-
-        Ensures a default system message is present, renders all messages, and
-        appends the assistant generation header. Preserves thinking for assistant
-        messages after the last non-tool-call assistant message.
-
-        Args:
-            messages (list[Message]): The conversation messages.
-            role (Role): The role for the generation prompt (default "assistant").
-            prefill (str | None): Optional prefill text to append after the prompt header.
-
-        Returns:
-            tinker.ModelInput: The tokenized model input ready for sampling.
-        """
-        messages = self._ensure_system_message(messages)
-        chunks: list[tinker.types.ModelInputChunk] = []
-
-        # Find last assistant message without tool calls (matches hf template behavior).
-        last_assistant_idx = -1
-        for idx in range(len(messages) - 1, -1, -1):
-            if messages[idx]["role"] == "assistant" and not messages[idx].get("tool_calls"):
-                last_assistant_idx = idx
-                break
-
-        for idx, message in enumerate(messages):
-            is_assistant = message["role"] == "assistant"
-            is_last_assistant = is_assistant and (
-                last_assistant_idx == -1 or idx > last_assistant_idx
-            )
-
-            ctx = RenderContext(
-                idx=idx,
-                is_last=idx == len(messages) - 1,
-                prev_message=messages[idx - 1] if idx > 0 else None,
-                in_produced_turn=is_last_assistant,
-            )
-            rendered_message = self.render_message(message, ctx)
-            header_chunk = rendered_message.header
-            output_chunks = rendered_message.output
-            if header_chunk:
-                chunks.append(header_chunk)
-            chunks.extend([x for x in output_chunks if x])
-
-        # Add generation prompt for new assistant message
-        gen_prompt = f"<|im_assistant|>{role}<|im_middle|>"
-        chunks.append(tinker.types.EncodedTextChunk(tokens=self.tokenizer.encode(gen_prompt)))
-        if prefill:
-            chunks.append(tinker.types.EncodedTextChunk(tokens=self.tokenizer.encode(prefill)))
-        return tinker.ModelInput(chunks=chunks)
+        """Build a generation prompt, prepending the default system message if absent."""
+        return super().build_generation_prompt(
+            self._ensure_system_message(messages), role=role, prefill=prefill
+        )
 
     def build_supervised_examples(
         self,
@@ -421,7 +376,7 @@ class KimiK2Renderer(Renderer):
         last user one. The final message is excluded from the scan: it is the target, and a
         turn cannot start after itself.
         """
-        for idx in range(len(messages) - 2, -1, -1):
+        for idx in range(len(messages) - 1, -1, -1):
             if messages[idx]["role"] == "assistant" and not messages[idx].get("tool_calls"):
                 return idx + 1
         return 0


### PR DESCRIPTION
`KimiK2Renderer.build_generation_prompt` was a hand-rolled copy of the base loop -- the
sibling of the `build_supervised_example` copy deleted two PRs below -- differing only in
where the turn starts and in writing its own suffix inline. The base's default suffix
already produces exactly what it wrote:

    '<|im_assistant|>assistant<|im_middle|>'

so what is left is the system-message normalisation, and **-51 lines** go.

The turn boundary is what kept the two apart. The paths ask the same question of different
lists: `build_generation_prompt` is prompting for a turn that comes *after* its messages,
while `build_supervised_example` is rendering a turn that *is* the last of its own. Kimi
answered that with two scans, `range(len - 1, ...)` and `range(len - 2, ...)`, which disagree
on three of the four message shapes that reach them.

One scan, and the caller says which list to look at:

```python
# build_generation_prompt: the turn comes after these
turn_start = self._produced_turn_start_index(messages)
# build_supervised_example: the turn is the last of these, and cannot start after itself
turn_start = self._produced_turn_start_index(messages[:-1])
```

The indices returned still address the full list either way, so nothing downstream changes.
This also removes the last reason `<think>` had to be written through the caller's `prefill`
parameter -- `_get_generation_suffix` is now reachable from kimi, which is what the PR below
this one worked around.

## Test Plan

`pytest tinker_cookbook/renderers/` -- 638 passed / 132 skipped, unchanged.

Verified by differential rather than by test count, the way the earlier boundary regression
should have been: 40 (renderer x conversation x `train_on_what`) cases dumped as tokens and
weights, plus generation prompts, before and after -- **0 differ**.

---

**Stack** (base → top): #866 → #864 → #859 → #865 → #862 → #867 → #868 → #869 → **#870**
