### PR TITLE
[renderers] qwen3 with thinking disabled refuses a turn with no query

### DIFF
--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -14,6 +14,7 @@ from typing import cast
 
 import tinker
 
+from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.image_processing_utils import ImageProcessor
 from tinker_cookbook.renderers.base import (
     ContentPart,
@@ -532,6 +533,28 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
     Use this renderer when you want to train or sample from Qwen3 models in
     "non-thinking" mode while maintaining compatibility with the OpenAI endpoint.
     """
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        """Refuse a produced turn in a conversation with no user message.
+
+        The template gates the empty block on `loop.index0 > ns.last_query_index`, and with
+        no user message `last_query_index` is the final index -- so nothing is ever after it
+        and the document carries no block. `add_generation_prompt` writes one regardless. The
+        two cannot both be honoured: the turn would train after a prompt that always opens a
+        block the training sequence does not contain.
+        """
+        if (
+            message["role"] == "assistant"
+            and ctx.is_last
+            and message.get("content")
+            and ctx.last_user_index < 0
+        ):
+            raise RendererError(
+                "this conversation has no user message, so Qwen3's template writes no empty "
+                "think block on the produced turn -- but the generation prompt always opens "
+                "one. Add a user message, or render with thinking enabled."
+            )
+        return super().render_message(message, ctx)
 
     def _get_generation_suffix(self, role: str, ctx: RenderContext) -> list[int]:
         """The empty block is part of the prompt, so sampling starts after it.

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -9,6 +9,7 @@ from typing import TypeGuard, cast
 import pytest
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
+from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers import (
     Message,
     StreamingMessageHeader,
@@ -856,3 +857,33 @@ def test_qwen3_tool_call_separator_follows_the_template(content: str, separator:
         "<|im_end|>"
     )
     assert rendered == expected
+
+
+def test_qwen3_disable_thinking_refuses_a_turn_with_no_query():
+    """No user message means the template writes no block, but the prompt always opens one.
+
+    `loop.index0 > ns.last_query_index` gates the block, and `last_query_index` defaults to
+    the final index -- so a conversation with no user turn has nothing after it. Rendering it
+    anyway trains a turn after a prompt that opens a block the sequence does not contain.
+    """
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+    renderer = get_renderer("qwen3_disable_thinking", tokenizer)
+    messages = [{"role": "system", "content": "s"}, {"role": "assistant", "content": "a"}]
+
+    with pytest.raises(RendererError, match="no user message"):
+        renderer.build_supervised_example(cast(list[Message], messages))
+
+    # With a user message the same turn renders, and observes the block it is sampled after.
+    with_query = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+    ]
+    model_input, weights = renderer.build_supervised_example(cast(list[Message], with_query))
+    tokens = model_input.to_ints()
+    trained = [w > 0 for w in weights.tolist()]
+    observation = tokens[: trained.index(True)]
+    assert (
+        observation
+        == renderer.build_generation_prompt(cast(list[Message], with_query[:-1])).to_ints()
+    )


### PR DESCRIPTION
Qwen3's template gates the empty think block on `loop.index0 > ns.last_query_index`, and
`last_query_index` defaults to the final index when there is no user message -- so nothing
is ever after it and the document carries no block. `add_generation_prompt` writes one
regardless:

```
[system, assistant]   prompt   <|im_start|>assistant\n<think>\n\n</think>\n\n
                      document <|im_start|>assistant\na<|im_end|>
```

Both are the template's, and they cannot both be honoured: the turn trains after a prompt
that always opens a block the training sequence does not contain. Rendering it anyway is a
silent train/serve gap, so it raises instead. A conversation with a user message is
unaffected, and observes the block it is sampled after.

The renderers below this one made the conflict visible by matching the template on both
sides; before, the block was written unconditionally, diverging from the document and
hiding the question.

## Test Plan

`test_qwen3_disable_thinking_refuses_a_turn_with_no_query` asserts the refusal, and asserts
the same turn renders with `observation == build_generation_prompt(...)` once a user message
is present.

`pytest tinker_cookbook/renderers/` -- 639 passed / 132 skipped.

The monorepo's `lib/chat_conformance` goes to **zero failures** against this stack (from 20
before the ledger update); the three cases this refuses become skips, which is how that
harness records "cannot render" rather than "disagrees".

---

**Stack** (base → top): #866 → #864 → #859 → #865 → #862 → #867 → #868 → #869 → #870 → **#871**
