### PR TITLE
Withhold loss from what the generation prompt already supplied

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1825,7 +1825,63 @@ class Renderer(ABC):
         weights_tensor = torch.tensor(weights_data)
 
         model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        model_input = tinker.ModelInput(chunks=model_input_chunks)
+        return model_input, self._train_after_the_generation_prompt(
+            messages, train_on_what, model_input, weights_tensor
+        )
+
+    def _train_after_the_generation_prompt(
+        self,
+        messages: list[Message],
+        train_on_what: TrainOnWhat,
+        model_input: tinker.ModelInput,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        """Withhold loss from everything build_generation_prompt would have supplied.
+
+        A renderer whose generation prompt ends in a prefill -- an open ``<think>`` -- leaves
+        that prefill on whichever side its header logic puts it, so the model is trained to
+        produce a token it is always given. Only the weights move; the tokens are untouched.
+
+        Returns them unchanged when the render does not begin with the prompt, which means the
+        two disagree about more than where the boundary falls.
+        """
+        boundary = self._first_trained_message_index(messages, train_on_what)
+        if boundary is None:
+            return weights
+        if not all(isinstance(c, tinker.types.EncodedTextChunk) for c in model_input.chunks):
+            return weights
+
+        prompt = self.build_generation_prompt(messages[:boundary]).to_ints()
+        if model_input.to_ints()[: len(prompt)] != prompt:
+            return weights
+
+        return torch.cat([torch.zeros(len(prompt)), weights[len(prompt) :]])
+
+    def _first_trained_message_index(
+        self, messages: list[Message], train_on_what: TrainOnWhat
+    ) -> int | None:
+        """Index of the message the generation prompt stops before, or None if there isn't one.
+
+        Only the modes that mean "train the turn sampling would produce" have such a point; the
+        others weight messages the generation prompt would have rendered as history.
+        """
+        match train_on_what:
+            case TrainOnWhat.LAST_ASSISTANT_MESSAGE:
+                boundary = len(messages) - 1
+            case TrainOnWhat.LAST_ASSISTANT_TURN:
+                boundary = (
+                    max(
+                        (idx for idx, m in enumerate(messages) if m["role"] == "user"),
+                        default=-1,
+                    )
+                    + 1
+                )
+            case _:
+                return None
+        if not 0 <= boundary < len(messages):
+            return None
+        return boundary if messages[boundary]["role"] == "assistant" else None
 
 
 def tokens_weights_from_strings_weights(

--- a/tinker_cookbook/renderers/kimi_k2.py
+++ b/tinker_cookbook/renderers/kimi_k2.py
@@ -511,7 +511,10 @@ class KimiK2Renderer(Renderer):
         weights_tensor = torch.tensor(weights_data)
 
         model_input_chunks = [chunk for chunk, _ in model_input_chunks_weights]
-        return tinker.ModelInput(chunks=model_input_chunks), weights_tensor
+        model_input = tinker.ModelInput(chunks=model_input_chunks)
+        return model_input, self._train_after_the_generation_prompt(
+            messages, train_on_what, model_input, weights_tensor
+        )
 
     @property
     def _end_message_token(self) -> int:

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -941,6 +941,7 @@ _CONSISTENCY_RENDERERS = [
     ("deepseek-ai/DeepSeek-V3.1", "deepseekv3_thinking"),
     ("openai/gpt-oss-20b", "gpt_oss_medium_reasoning"),
     ("moonshotai/Kimi-K2-Thinking", "kimi_k2"),
+    ("moonshotai/Kimi-K2.5", "kimi_k25"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3_disable_thinking"),
 ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #882
* #881
* #880
* #879
* #878
* #877
* #876
* #875
* #874
* __->__ #873
* #872

## Why is this change needed?

Kimi's generation prompt ends in an open `<think>`, but the supervised example trained it — so the model learned to *produce* a token it is always *given*:

```diff
  sampled from …<|im_assistant|>assistant<|im_middle|><think>
- observation …<|im_middle|>          action <think>R</think>4<|im_end|>
+ observation …<|im_middle|><think>   action R</think>4<|im_end|>
```

**Weights only — no token changes.** The observation is `build_generation_prompt(...)`, compared as a token prefix purely to place the boundary. If the render doesn't start with the prompt, weights come back untouched.

Divergences retired: **none** — a renderer-vs-itself property, which no ledger tracks.

## Test Plan

`kimi_k25` was missing from `_CONSISTENCY_RENDERERS` while `kimi_k2` was present — and k25 is the one with the prefill, so the bug was untested. Adding it: **6 failed before, 9 pass after.**

536 / 46, from 530 / 46.