### PR TITLE
[renderers] the empty think block has one writer (#858)

### DIFF
--- a/tinker_cookbook/renderers/parsing_test.py
+++ b/tinker_cookbook/renderers/parsing_test.py
@@ -389,7 +389,8 @@ def test_thinking_generation_parse_correspondence(model_name, renderer_cls, rend
 
     # Render expected message to get full response tokens
     rendered = renderer.render_message(
-        expected_message, RenderContext(idx=1, is_last=True, prev_message=user_message)
+        expected_message,
+        RenderContext(idx=1, is_last=True, prev_message=user_message, last_user_index=0),
     )
     full_response_tokens = [t for chunk in rendered.output for t in chunk.tokens]
 

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -141,6 +141,11 @@ class Qwen3Renderer(Renderer):
         """
         if not self.frames_thinking or message["role"] != "assistant":
             return False
+        if ctx.last_user_index < 0:
+            # The template gates on `loop.index0 > ns.last_query_index`, and that defaults to
+            # the final index when no user message exists -- so a conversation without one is
+            # never framed, however it ends.
+            return False
         return ctx.is_last or not self.strip_thinking_from_history
 
     def __init__(self, tokenizer: Tokenizer, strip_thinking_from_history: bool = True):
@@ -206,6 +211,8 @@ class Qwen3Renderer(Renderer):
         header_str = f"{maybe_newline}<|im_start|>{role}\n"
 
         content = message["content"]
+        frames = self._frames_produced_turn(message, ctx)
+        has_reasoning = has_thinking(content)
 
         if isinstance(content, list):
             # Structured content - handle with list operations
@@ -219,7 +226,6 @@ class Qwen3Renderer(Renderer):
                 parts = remove_thinking(parts)
             # Render parts in order, preserving interleaved thinking/text structure.
             # No separator needed - whitespace is preserved in TextPart for roundtrip identity.
-            frames = self._frames_produced_turn(message, ctx)
             rendered_parts = []
             after_block = False
             for p in parts:
@@ -236,11 +242,7 @@ class Qwen3Renderer(Renderer):
                     rendered_parts.append(p["text"].lstrip("\n") if after_block else p["text"])
                     after_block = False
             output_content = "".join(rendered_parts)
-            # The template opens the block on the turn being produced whether or not it
-            # reasoned, so a turn with no thinking part still gets an empty one.
-            if frames and not any(p["type"] == "thinking" for p in parts):
-                output_content = _frame_thinking("") + output_content.lstrip("\n")
-        elif self._frames_produced_turn(message, ctx) and "</think>" in content:
+        elif frames and "</think>" in content:
             # An inline block in string content is normalized the way the template
             # normalizes it, so `<think>\n\n</think>\nx` and `<think>\n\n</think>\n\nx`
             # both render as the latter rather than passing through as written.
@@ -252,6 +254,12 @@ class Qwen3Renderer(Renderer):
             # For stripping to work on historical messages, use structured content
             # with ThinkingPart separated from text (as returned by parse_response).
             output_content = content
+
+        # The template opens the block on the turn being produced whether or not it
+        # reasoned, so a turn that did not reason still gets an empty one -- whatever
+        # shape its content arrived in.
+        if frames and not has_reasoning:
+            output_content = _frame_thinking("") + output_content.lstrip("\n")
 
         # Handle tool response wrapping
         if message["role"] == "tool":
@@ -517,37 +525,16 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
     "non-thinking" mode while maintaining compatibility with the OpenAI endpoint.
     """
 
-    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
-        """Render a message, prepending an empty thinking block to the last assistant message.
+    def _get_generation_suffix(self, role: str, ctx: RenderContext) -> list[int]:
+        """The empty block is part of the prompt, so sampling starts after it.
 
-        For the last assistant message that lacks a thinking block, an empty
-        ``<think>\\n\\n</think>\\n\\n`` is added to the header to signal non-thinking mode.
-
-        Args:
-            message (Message): The chat message to render.
-            ctx (RenderContext): Positional context including index and is_last flag.
-
-        Returns:
-            RenderedMessage: Header (with optional empty think block) and output token chunks.
+        The Qwen3.5 disable-thinking renderer says the same thing the same way.
         """
-        # Get the base rendered message
-        rendered = super().render_message(message, ctx)
-
-        # Add empty thinking block to header for last assistant message
-        # This goes in header (weight=0) so observation matches generation prompt.
-        if message["role"] == "assistant" and ctx.is_last:
-            content = message.get("content", "")
-            if not has_thinking(content):
-                empty_think_tokens = self.tokenizer.encode(
-                    "<think>\n\n</think>\n\n", add_special_tokens=False
-                )
-                old_header_tokens = list(rendered.header.tokens) if rendered.header else []
-                new_header = tinker.EncodedTextChunk(tokens=old_header_tokens + empty_think_tokens)
-                rendered = RenderedMessage(
-                    header=new_header, output=rendered.output, stop_overlap=rendered.stop_overlap
-                )
-
-        return rendered
+        maybe_newline = "\n" if ctx.idx > 0 else ""
+        return self.tokenizer.encode(
+            f"{maybe_newline}<|im_start|>{role}\n<think>\n\n</think>\n\n",
+            add_special_tokens=False,
+        )
 
 
 class Qwen3InstructRenderer(Qwen3Renderer):

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -783,3 +783,44 @@ def test_qwen3_produced_turn_survives_a_render_parse_roundtrip(reasoning: str | 
 
     assert termination.is_clean
     assert ensure_list(parsed["content"]) == parts
+
+
+@pytest.mark.parametrize("renderer_name", ["qwen3", "qwen3_disable_thinking"])
+@pytest.mark.parametrize(
+    "content",
+    ["I'm fine, thank you!", [{"type": "text", "text": "I'm fine, thank you!"}]],
+    ids=["str", "list"],
+)
+def test_a_turn_that_did_not_reason_gets_exactly_one_empty_block(
+    renderer_name: str, content: str | list[dict[str, str]]
+):
+    """The block has one writer, whatever shape the content arrived in.
+
+    #849 gave the produced turn its empty block for list-shaped content. A plain string
+    went through the branch below it and got none, and `Qwen3DisableThinkingRenderer` --
+    which writes the block into the header itself -- got a second one on top.
+    """
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+    renderer = get_renderer(renderer_name, tokenizer)
+    messages = [
+        {"role": "user", "content": "Hello, how are you?"},
+        {"role": "assistant", "content": content},
+    ]
+
+    model_input, _ = renderer.build_supervised_example(cast(list[Message], messages))
+    rendered = tokenizer.decode(model_input.to_ints())
+
+    assert rendered.count("<think>") == 1, f"expected one empty block, got: {rendered!r}"
+    # A supervised example is the generation prompt for the prefix, then the turn -- what
+    # `build_supervised_example` documents, and the sequence the model is sampled from.
+    # Comparing against the whole-document form instead would need its trailing separator
+    # explained away; nothing here needs explaining away.
+    expected = (
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "Hello, how are you?"}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        + "<think>\n\n</think>\n\nI'm fine, thank you!<|im_end|>"
+    )
+    assert rendered == expected, f"renderer:\n{rendered!r}\n\nexpected:\n{expected!r}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #882
* #881
* #880
* #879
* #878
* #877
* #876
* #875
* __->__ #874
* #873
* #872

## Why is this change needed?

The template writes an empty `<think></think>` on a produced turn that didn't reason. #849 only did that for list-shaped content, so a plain string got none:

```diff
- <|im_start|>assistant\nI'm fine, thank you!<|im_end|>
+ <|im_start|>assistant\n<think>\n\n</think>\n\nI'm fine, thank you!<|im_end|>
```

And `Qwen3DisableThinkingRenderer` wrote its own on top — so that renderer got **two**. Now written once. That renderer overrides `_get_generation_suffix` instead of `render_message`, the way its Qwen3.5 sibling always has: **−31 lines**, no coordinating flag.

Divergences retired: **6** — `qwen3` × {single-turn, multi-turn, system-prompt} in SFT, plus the three matching template rows. (Half of `tool-call-then-result` too; #875 finishes it.)

## Test Plan

`test_a_turn_that_did_not_reason_gets_exactly_one_empty_block` — 2 renderers × string/list content. **All four cells fail on `main`.**