### PR TITLE
[renderers] a tool call with nothing before it takes no separator

### DIFF
--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -255,6 +255,11 @@ class Qwen3Renderer(Renderer):
             # with ThinkingPart separated from text (as returned by parse_response).
             output_content = content
 
+        # The template's `content` is the message's own text, and the separator below asks
+        # about that -- not about the empty block, which is framing the template writes
+        # itself. Captured before the block is prepended.
+        has_text = bool(output_content)
+
         # The template opens the block on the turn being produced whether or not it
         # reasoned, so a turn that did not reason still gets an empty one -- whatever
         # shape its content arrived in.
@@ -267,13 +272,16 @@ class Qwen3Renderer(Renderer):
 
         # Handle tool_calls field
         if "tool_calls" in message:
-            # Add leading newline to match HF template behavior
-            output_content += "\n" + "\n".join(
+            # The template separates the calls from the text before them, and from each
+            # other, but writes nothing before the first when there is no text:
+            # `{%- if (loop.first and content) or (not loop.first) %}{{- \'\\n\' }}`.
+            calls = "\n".join(
                 [
                     f"<tool_call>\n{json.dumps(_tool_call_payload(tool_call))}\n</tool_call>"
                     for tool_call in message["tool_calls"]
                 ]
             )
+            output_content += ("\n" if has_text else "") + calls
         output_content += "<|im_end|>"
         header = tinker.types.EncodedTextChunk(
             tokens=self.tokenizer.encode(header_str, add_special_tokens=False)

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -16,6 +16,7 @@ from tinker_cookbook.renderers import (
     StreamingThinkingDelta,
     TextPart,
     ThinkingPart,
+    ToolCall,
     get_renderer,
 )
 from tinker_cookbook.renderers.base import ensure_list
@@ -824,3 +825,34 @@ def test_a_turn_that_did_not_reason_gets_exactly_one_empty_block(
         + "<think>\n\n</think>\n\nI'm fine, thank you!<|im_end|>"
     )
     assert rendered == expected, f"renderer:\n{rendered!r}\n\nexpected:\n{expected!r}"
+
+
+@pytest.mark.parametrize(
+    "content,separator",
+    [("", ""), ("Let me check.", "\n")],
+    ids=["no-text", "text"],
+)
+def test_qwen3_tool_call_separator_follows_the_template(content: str, separator: str):
+    """The newline separates the calls from the text before them, and the calls from each
+    other. With no text there is nothing to separate, and the template writes nothing:
+
+        {%- if (loop.first and content) or (not loop.first) %}{{- '\n' }}{%- endif %}
+    """
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+    renderer = get_renderer("qwen3_instruct", tokenizer)
+    call = ToolCall(function=ToolCall.FunctionBody(name="get_weather", arguments='{"city": "SF"}'))
+    messages = [
+        {"role": "user", "content": "weather in SF?"},
+        {"role": "assistant", "content": content, "tool_calls": [call]},
+    ]
+
+    model_input, _ = renderer.build_supervised_example(cast(list[Message], messages))
+    rendered = tokenizer.decode(model_input.to_ints())
+
+    expected = (
+        "<|im_start|>user\nweather in SF?<|im_end|>\n<|im_start|>assistant\n"
+        f"{content}{separator}"
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "SF"}}\n</tool_call>'
+        "<|im_end|>"
+    )
+    assert rendered == expected


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #882
* #881
* #880
* #879
* #878
* #877
* #876
* __->__ #875
* #874
* #873
* #872

## Why is this change needed?

The template writes no separator before a tool call when there's no text before it. We wrote one unconditionally:

```diff
- <|im_start|>assistant\n\n<tool_call>…
+ <|im_start|>assistant\n<tool_call>…
```

The separator now asks about the message's own text, captured before the empty think block is prepended — the block is framing, not content.

Divergences retired: **4** — `tool-call-then-result` for `qwen3`, `qwen3_disable_thinking`, `qwen3_instruct`, plus the template row.

## Test Plan

`test_qwen3_tool_call_separator_follows_the_template`, parametrized text / no-text. **The no-text case fails on `main`; the text case passes either way.**