### PR TITLE
[renderers] a caller's prefill composes with the format's own

### DIFF
--- a/tinker_cookbook/renderers/kimi_k25.py
+++ b/tinker_cookbook/renderers/kimi_k25.py
@@ -110,10 +110,11 @@ class KimiK25Renderer(KimiK2Renderer):
         Returns:
             tinker.ModelInput: The tokenized model input ready for sampling.
         """
-        # If no prefill specified, use <think> to enable thinking
-        if prefill is None:
-            prefill = "<think>"
-        return super().build_generation_prompt(messages, role=role, prefill=prefill)
+        # The open tag belongs to the format, not the caller, so a caller's prefill is
+        # appended after it rather than replacing it.
+        return super().build_generation_prompt(
+            messages, role=role, prefill="<think>" + (prefill or "")
+        )
 
     def _normalize_response_tokens(self, response: list[int]) -> list[int]:
         """Restore the synthetic <think> prefill before parsing sampled tokens."""
@@ -185,9 +186,7 @@ class KimiK25DisableThinkingRenderer(KimiK25Renderer):
         Returns:
             tinker.ModelInput: The tokenized model input ready for sampling.
         """
-        # If no prefill specified, use <think></think> to disable thinking
-        if prefill is None:
-            prefill = "<think></think>"
+        # The closed pair belongs to the format, not the caller; see KimiK25Renderer.
         return super(KimiK25Renderer, self).build_generation_prompt(
-            messages, role=role, prefill=prefill
+            messages, role=role, prefill="<think></think>" + (prefill or "")
         )

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -27,6 +27,7 @@ import json
 import random
 import uuid
 from collections.abc import Callable
+from typing import cast
 
 import pytest
 from PIL import Image
@@ -1042,6 +1043,30 @@ _RENDERERS_WITH_A_GENERATION_PREFILL = [
     ("moonshotai/Kimi-K2-Thinking", "kimi_k2"),
     ("moonshotai/Kimi-K2.5", "kimi_k25"),
 ]
+
+
+@pytest.mark.parametrize("model_name,renderer_name", _CONSISTENCY_RENDERERS)
+def test_a_caller_prefill_composes_with_the_format_one(model_name: str, renderer_name: str):
+    """`prefill` is the caller's slot; a format's own prefill must not consume it.
+
+    Renderers whose prompt ends in `<think>` write it through that same parameter, so one of
+    them defaulted rather than composed: any caller passing a prefill silently turned thinking
+    mode off.
+    """
+    skip_if_deepseek_tokenizer_bug(model_name)
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer(renderer_name, tokenizer)
+    messages = [Message(role="user", content="q")]
+
+    plain = cast(str, tokenizer.decode(renderer.build_generation_prompt(messages).to_ints()))
+    prefilled = cast(
+        str, tokenizer.decode(renderer.build_generation_prompt(messages, prefill="Sure").to_ints())
+    )
+
+    assert prefilled == plain + "Sure", (
+        f"{renderer_name} did not append the caller's prefill to its own prompt:\n"
+        f"  without: {plain!r}\n  with:    {prefilled!r}"
+    )
 
 
 @pytest.mark.parametrize("conversation_fn", _CONSISTENCY_CONVERSATIONS)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #882
* #881
* __->__ #880
* #879
* #878
* #877
* #876
* #875
* #874
* #873
* #872

## Why is this change needed?

`prefill` is the caller's slot. Two renderers also use it for something the *format* requires, and disagreed on what happens when a caller wants both:

```python
deepseek   "<think>" + (prefill or "")     # composes
kimi_k25   if prefill is None: "<think>"   # replaces
```

So on `kimi_k25`, any caller prefill silently turned thinking off:

```diff
- <|im_assistant|>assistant<|im_middle|>Sure
+ <|im_assistant|>assistant<|im_middle|><think>Sure
```

Divergences retired: **none** — the harness never passes a prefill.

## Test Plan

`test_a_caller_prefill_composes_with_the_format_one`, across every consistency renderer. **`kimi_k25` fails without this; the other 13 pass either way.**