### PR TITLE
[renderers] qwen3 with thinking disabled refuses a turn with no query

### DIFF
--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -14,6 +14,7 @@ from typing import cast
 
 import tinker
 
+from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.image_processing_utils import ImageProcessor
 from tinker_cookbook.renderers.base import (
     ContentPart,
@@ -532,6 +533,28 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
     Use this renderer when you want to train or sample from Qwen3 models in
     "non-thinking" mode while maintaining compatibility with the OpenAI endpoint.
     """
+
+    def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
+        """Refuse a produced turn in a conversation with no user message.
+
+        The template gates the empty block on `loop.index0 > ns.last_query_index`, and with
+        no user message `last_query_index` is the final index -- so nothing is ever after it
+        and the document carries no block. `add_generation_prompt` writes one regardless. The
+        two cannot both be honoured: the turn would train after a prompt that always opens a
+        block the training sequence does not contain.
+        """
+        if (
+            message["role"] == "assistant"
+            and ctx.is_last
+            and message.get("content")
+            and ctx.last_user_index < 0
+        ):
+            raise RendererError(
+                "this conversation has no user message, so Qwen3's template writes no empty "
+                "think block on the produced turn -- but the generation prompt always opens "
+                "one. Add a user message, or render with thinking enabled."
+            )
+        return super().render_message(message, ctx)
 
     def _get_generation_suffix(self, role: str, ctx: RenderContext) -> list[int]:
         """The empty block is part of the prompt, so sampling starts after it.

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -9,6 +9,7 @@ from typing import TypeGuard, cast
 import pytest
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
+from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers import (
     Message,
     StreamingMessageHeader,
@@ -856,3 +857,33 @@ def test_qwen3_tool_call_separator_follows_the_template(content: str, separator:
         "<|im_end|>"
     )
     assert rendered == expected
+
+
+def test_qwen3_disable_thinking_refuses_a_turn_with_no_query():
+    """No user message means the template writes no block, but the prompt always opens one.
+
+    `loop.index0 > ns.last_query_index` gates the block, and `last_query_index` defaults to
+    the final index -- so a conversation with no user turn has nothing after it. Rendering it
+    anyway trains a turn after a prompt that opens a block the sequence does not contain.
+    """
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+    renderer = get_renderer("qwen3_disable_thinking", tokenizer)
+    messages = [{"role": "system", "content": "s"}, {"role": "assistant", "content": "a"}]
+
+    with pytest.raises(RendererError, match="no user message"):
+        renderer.build_supervised_example(cast(list[Message], messages))
+
+    # With a user message the same turn renders, and observes the block it is sampled after.
+    with_query = [
+        {"role": "system", "content": "s"},
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+    ]
+    model_input, weights = renderer.build_supervised_example(cast(list[Message], with_query))
+    tokens = model_input.to_ints()
+    trained = [w > 0 for w in weights.tolist()]
+    observation = tokens[: trained.index(True)]
+    assert (
+        observation
+        == renderer.build_generation_prompt(cast(list[Message], with_query[:-1])).to_ints()
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #882
* #881
* #880
* #879
* #878
* #877
* #876
* #875
* #874
* #873
* #872

## Why is this change needed?

A supervised example is normally the generation prompt plus what the model wrote — the finished conversation *starts with* the prompt, so the observation/action boundary falls out for free:

```
apply_chat_template(prefix, add_generation_prompt=True)   …assistant\n<think>\n\n</think>\n\n
apply_chat_template(whole,  add_generation_prompt=False)  …assistant\n<think>\n\n</think>\n\na<|im_end|>\n
                                                          ^--------- the prompt --------^
```

With no user message Qwen3's template stops doing that: it still writes the block into the prompt, but leaves it out of the finished conversation. There is then no split point, and we rendered one anyway —

```diff
  qwen3_disable_thinking, [system, assistant]
  sampled after  '…<|im_start|>assistant\n<think>\n\n</think>\n\n'
- observation    '…<|im_start|>assistant\n'                      ← block missing
- action         'a<|im_end|>'
+ RendererError: this conversation has no user message, so Qwen3's template writes no
+ empty think block on the produced turn -- but the generation prompt always opens one.
```

The example trained the turn after a context the model is never handed. A template can't arbitrate the boundary — it has no loss weights, and Qwen3's carries no `{% generation %}` markers — so there is no rendering to fall back to.

**The caller has a working alternative**; only the disable-thinking variant has this conflict:

| renderer | `[system, assistant]` |
|---|---|
| `qwen3` | renders, `observation == prompt` |
| `qwen3_instruct` | renders, `observation == prompt` |
| `qwen3_disable_thinking` | **refuses** |

Not fixable by always writing the block: tested, and it makes **plain `qwen3`'s prompt** diverge from the template — 4 harness failures, on a renderer this conflict never touched.

Divergences retired: **none** — it turns three silently mis-rendered conversations into refusals, which the harness records as skips.

## Test Plan

`test_qwen3_disable_thinking_refuses_a_turn_with_no_query` **fails on `main`** — without the refusal the render succeeds. Also asserts the turn still renders once a user message is present.