### PR TITLE
Pipeline DPO optimizer requests before awaiting results

### DIFF
--- a/tinker_cookbook/preference/train_dpo.py
+++ b/tinker_cookbook/preference/train_dpo.py
@@ -4,6 +4,7 @@ Direct Preference Optimization (DPO) training
 
 import asyncio
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -259,6 +260,37 @@ def compute_dpo_loss(
     return loss, metrics
 
 
+@trace.scope
+async def _run_dpo_optimizer_step(
+    training_client: tinker.TrainingClient,
+    data: list[tinker.Datum],
+    dpo_loss_fn: Callable[
+        [list[tinker.Datum], list[torch.Tensor]], tuple[torch.Tensor, dict[str, float]]
+    ],
+    adam_params: tinker.AdamParams,
+) -> tuple[tinker.ForwardBackwardOutput, tinker.OptimStepResponse]:
+    """Submit a custom DPO backward pass and optimizer update in one clock cycle.
+
+    ``forward_backward_custom_async`` first obtains policy log-probabilities so the
+    client-side custom loss can produce gradients. Once it returns the backward
+    request has been submitted, and the optimizer request must be submitted before
+    either result is consumed. Waiting for the backward result first can miss the
+    optimizer slot in the same worker-pool clock cycle and substantially increase
+    step latency.
+    """
+    async with trace.scope_span("enqueue_forward_backward_custom"):
+        fwd_bwd_future = await training_client.forward_backward_custom_async(data, dpo_loss_fn)
+    async with trace.scope_span("enqueue_optim_step"):
+        optim_future = await training_client.optim_step_async(adam_params)
+
+    async with trace.scope_span("consume_dpo_update"):
+        fwd_bwd_result, optim_result = await asyncio.gather(
+            fwd_bwd_future.result_async(),
+            optim_future.result_async(),
+        )
+    return fwd_bwd_result, optim_result
+
+
 def do_update(
     epoch_idx: int,
     batch_idx: int,
@@ -435,12 +467,10 @@ def do_update(
             )
 
         with trace.scope_span_sync("step"):
-            # Do forward-backward with custom DPO loss
-            backward_result = training_client.forward_backward_custom(data, dpo_loss_fn).result()
+            backward_result, optim_result = asyncio.run(
+                _run_dpo_optimizer_step(training_client, data, dpo_loss_fn, adam_params)
+            )
             dpo_metrics = backward_result.metrics
-
-            # Optimizer step
-            training_client.optim_step(adam_params).result()
 
         # Prepare metrics
         metrics.update(
@@ -450,6 +480,8 @@ def do_update(
             progress=step / total_steps,
             **dpo_metrics,
         )
+        if optim_result.metrics:
+            metrics.update(optim_result.metrics)
 
     # Log timing metrics from trace_iteration window
     metrics.update(window.get_timing_metrics())

--- a/tinker_cookbook/preference/train_dpo_test.py
+++ b/tinker_cookbook/preference/train_dpo_test.py
@@ -1,0 +1,81 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+import tinker
+import torch
+
+from tinker_cookbook.preference.train_dpo import _run_dpo_optimizer_step
+
+_DpoLossFn = Callable[
+    [list[tinker.Datum], list[torch.Tensor]], tuple[torch.Tensor, dict[str, float]]
+]
+
+
+@dataclass
+class _FakeResult:
+    metrics: dict[str, float]
+
+
+class _FakeFuture:
+    def __init__(self, name: str, events: list[str], result: _FakeResult):
+        self.name = name
+        self.events = events
+        self.result = result
+
+    async def result_async(self) -> _FakeResult:
+        self.events.append(f"consume:{self.name}")
+        return self.result
+
+
+class _FakeTrainingClient:
+    def __init__(self, events: list[str]):
+        self.events = events
+        self.fwd_result = _FakeResult(metrics={"dpo_loss": 0.25})
+        self.optim_result = _FakeResult(metrics={"learning_rate": 1e-5})
+        self.data: list[tinker.Datum] | None = None
+        self.loss_fn: _DpoLossFn | None = None
+        self.adam_params: tinker.AdamParams | None = None
+
+    async def forward_backward_custom_async(
+        self, data: list[tinker.Datum], loss_fn: _DpoLossFn
+    ) -> _FakeFuture:
+        self.events.append("enqueue:forward_backward_custom")
+        self.data = data
+        self.loss_fn = loss_fn
+        return _FakeFuture("forward_backward_custom", self.events, self.fwd_result)
+
+    async def optim_step_async(self, adam_params: tinker.AdamParams) -> _FakeFuture:
+        self.events.append("enqueue:optim_step")
+        self.adam_params = adam_params
+        return _FakeFuture("optim_step", self.events, self.optim_result)
+
+
+@pytest.mark.asyncio
+async def test_dpo_optimizer_is_enqueued_before_either_result_is_consumed() -> None:
+    events: list[str] = []
+    client = _FakeTrainingClient(events)
+    data: list[tinker.Datum] = []
+
+    def loss_fn(
+        data: list[tinker.Datum], logprobs: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        del data, logprobs
+        return torch.tensor(0.0), {}
+
+    adam_params = tinker.AdamParams(learning_rate=1e-5)
+    fwd_result, optim_result = await _run_dpo_optimizer_step(
+        cast(tinker.TrainingClient, client),
+        data,
+        loss_fn,
+        adam_params,
+    )
+
+    assert events[:2] == ["enqueue:forward_backward_custom", "enqueue:optim_step"]
+    assert set(events[2:]) == {"consume:forward_backward_custom", "consume:optim_step"}
+    assert fwd_result is client.fwd_result
+    assert optim_result is client.optim_result
+    assert client.data is data
+    assert client.loss_fn is loss_fn
+    assert client.adam_params is adam_params


### PR DESCRIPTION
## Summary

- submit the DPO optimizer request immediately after the custom backward request is enqueued
- consume the backward and optimizer futures together instead of blocking before optimizer submission
- add trace spans for custom-backward enqueue, optimizer enqueue, and result consumption
- propagate optimizer metrics and add a regression test for the required request ordering

## Root cause

The DPO loop previously called `.result()` on `forward_backward_custom()` before it submitted `optim_step()`. On Tinker's clocked worker pools, that ordering can miss the optimizer slot in the current cycle and increase step latency.

The SDK contract makes the safe ordering precise: `forward_backward_custom_async()` performs the policy-logprob forward and the client-side custom loss, enqueues the resulting backward request, and only then returns its future. Submitting `optim_step_async()` immediately afterward therefore preserves the gradient/update dependency while allowing both queued operations to occupy the intended worker-pool schedule.

This is also the established cookbook pattern for custom-loss training: `tinker_cookbook/distillation/sdft.py::_train_step_reverse_kl` already enqueues `forward_backward_custom_async()` and `optim_step_async()` back-to-back before consuming either result.

This patch changes request scheduling only. It passes the same ordered datums, custom loss callable, and Adam parameters, and it does not pipeline gradients across optimizer steps.

## Validation

- `uv run pytest tinker_cookbook/preference -q`
- `uv run ruff check tinker_cookbook/preference/train_dpo.py tinker_cookbook/preference/train_dpo_test.py`
- `uv run pyright tinker_cookbook/preference/train_dpo.py tinker_cookbook/preference/train_dpo_test.py`
- `uv run pre-commit run --files tinker_cookbook/preference/train_dpo.py tinker_cookbook/preference/train_dpo_test.py`
- upstream CI: pytest, pyright, pre-commit, downstream compatibility, and stack freshness all pass

The regression test fails if either result is consumed before both operations have been enqueued. No paid service run was used for this correctness validation.