### PR TITLE
[renderers] a reasoning-off renderer refuses a turn that reasoned

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1905,10 +1905,7 @@ class Renderer(ABC):
         per trained turn, so each turn is checked as the produced turn of its own example.
         """
         if not (
-            self.disables_thinking
-            and is_trained
-            and ctx.is_last
-            and message["role"] == "assistant"
+            self.disables_thinking and is_trained and ctx.is_last and message["role"] == "assistant"
         ):
             return
         content = message.get("content")

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1335,6 +1335,17 @@ class Renderer(ABC):
 
     tokenizer: Tokenizer
 
+    disables_thinking: bool = False
+    """Whether this renderer's generation prompt asserts the turn did not reason.
+
+    A closed ``<think></think>`` in the prompt is a statement about the tokens that follow
+    it, so a turn that reasoned cannot be trained after one. Set this and the assembly
+    refuses that pairing rather than training a sequence sampling never produces.
+
+    Not set by every renderer whose name says ``disable_thinking``: the DeepSeek one strips
+    reasoning out of the content instead, so its render already agrees with its prompt.
+    """
+
     # Pickle metadata — set by get_renderer() via _stamp_pickle_metadata().
     # Class-level defaults ensure these exist even when subclasses bypass super().__init__().
     _renderer_name: str | None = None
@@ -1819,6 +1830,9 @@ class Renderer(ABC):
                 last_user_index=last_user_idx,
                 in_last_assistant_turn=in_last_assistant_turn,
             )
+            output_has_weight = self._output_is_trained(message, ctx, train_on_what)
+            self._refuse_reasoning_the_prompt_disables(message, ctx, output_has_weight)
+
             rendered_message = self.render_message(message, ctx)
             header_part = rendered_message.header
             output_parts = rendered_message.output
@@ -1827,8 +1841,6 @@ class Renderer(ABC):
             header_weight = int(train_on_what == TrainOnWhat.ALL_TOKENS)
             if header_part:
                 model_input_chunks_weights += [(header_part, header_weight)]
-
-            output_has_weight = self._output_is_trained(message, ctx, train_on_what)
 
             model_input_chunks_weights += [
                 (output_part, int(output_has_weight)) for output_part in output_parts if output_part
@@ -1875,6 +1887,38 @@ class Renderer(ABC):
             return weights
 
         return torch.cat([torch.zeros(len(prompt)), weights[len(prompt) :]])
+
+    def _refuse_reasoning_the_prompt_disables(
+        self, message: Message, ctx: RenderContext, is_trained: bool
+    ) -> None:
+        """Refuse to train reasoning under a prompt that says the turn did not reason.
+
+        `disables_thinking` renderers close the think block in the generation prompt, so the
+        reasoning would have to arrive before a marker the model has already been handed.
+        There is no sequence that does that: the example trains one thing and sampling starts
+        from another, and `_train_after_the_generation_prompt` cannot even find its boundary.
+
+        The produced turn, and only when it carries loss. An earlier assistant turn is history
+        -- `strip_thinking_from_history` decides whether its reasoning survives the render, and
+        the prompt reflects whichever it did -- and a turn nothing is trained on is context
+        rather than a target. `build_supervised_examples` splits a conversation into one example
+        per trained turn, so each turn is checked as the produced turn of its own example.
+        """
+        if not (
+            self.disables_thinking
+            and is_trained
+            and ctx.is_last
+            and message["role"] == "assistant"
+        ):
+            return
+        content = message.get("content")
+        if content and has_thinking(content):
+            raise RendererError(
+                f"{type(self).__name__} disables thinking, so its generation prompt closes the "
+                "think block -- but this turn carries reasoning, which would train the model to "
+                "produce reasoning after being told not to. Render it with the thinking variant "
+                "of this renderer, or drop the reasoning from the turn."
+            )
 
     def _output_is_trained(
         self, message: Message, ctx: RenderContext, train_on_what: TrainOnWhat

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -5,7 +5,6 @@ Use viz_sft_dataset to visualize the output of different renderers. E.g.,
     python -m tinker_cookbook.supervised.viz_sft_dataset dataset_path=Tulu3Builder renderer_name=role_colon
 """
 
-import functools
 import io
 import json
 import logging
@@ -873,12 +872,6 @@ def has_thinking(content: Content) -> bool:
     return "<think>" in content
 
 
-def marker_token(tokenizer: Tokenizer, marker: str) -> int | None:
-    """The token id for ``marker``, or None if this vocab has no single token for it."""
-    ids = tokenizer.encode(marker, add_special_tokens=False)
-    return ids[0] if len(ids) == 1 else None
-
-
 def remove_thinking(parts: list[ContentPart]) -> list[ContentPart]:
     """Filter out ThinkingPart elements from a content part list.
 
@@ -1342,9 +1335,24 @@ class Renderer(ABC):
 
     tokenizer: Tokenizer
 
-    # How this format writes reasoning markers. Override them if a format uses different ones.
-    think_open: str = "<think>"
-    think_close: str = "</think>"
+    disables_thinking: bool = False
+    """Whether this renderer's generation prompt closes the think block.
+
+    Set it on any renderer that tells the model not to reason, which it does by handing over
+    an already-closed block::
+
+        qwen3                   ...assistant\\n<think>\\n                 open, so False
+        qwen3_disable_thinking  ...assistant\\n<think>\\n\\n</think>\\n\\n  closed, so True
+
+    Declared rather than worked out from the prompt, because it is a fact about the renderer:
+    ``Qwen3DisableThinkingRenderer`` disables thinking whichever tokenizer it is given, and the
+    markers are not a single token in every vocabulary. ``_train_after_the_generation_prompt``
+    reads it, and ``test_a_turn_that_reasoned_is_never_trained_after_a_prompt_it_cannot_follow``
+    fails if a renderer needs it and does not set it.
+
+    Not every renderer named ``disable_thinking``: DeepSeek's strips reasoning out of the
+    content instead, so its render already agrees with its prompt.
+    """
 
     # Pickle metadata — set by get_renderer() via _stamp_pickle_metadata().
     # Class-level defaults ensure these exist even when subclasses bypass super().__init__().
@@ -1374,40 +1382,6 @@ class Renderer(ABC):
             _unpickle_renderer,
             (renderer_name, model_name, has_image_processor),
         )
-
-    @functools.cached_property
-    def _think_marker_tokens(self) -> tuple[int | None, int | None]:
-        """``think_open`` and ``think_close`` as token ids.
-
-        A cached_property rather than __init__ work: some renderers do not call
-        super().__init__(), so this resolves the first time it is used instead.
-        """
-        return (
-            marker_token(self.tokenizer, self.think_open),
-            marker_token(self.tokenizer, self.think_close),
-        )
-
-    def prompt_closes_the_think_block(self, prompt: list[int]) -> bool:
-        """Has this generation prompt already closed the think block?
-
-        An open marker means the model is about to reason. A closed one means it is not.
-        The last marker in the prompt is the one that counts::
-
-            qwen3                   ...assistant\\n<think>\\n                 open      -> False
-            qwen3_disable_thinking  ...assistant\\n<think>\\n\\n</think>\\n\\n  closed    -> True
-            deepseekv3              ...<|Assistant|></think>                closed    -> True
-            role_colon              ...\\n\\nAssistant:                       no marker -> False
-
-        This compares token ids, not text, so a user message that quotes "</think>" cannot
-        change the answer.
-        """
-        opened, closed = self._think_marker_tokens
-        for token in reversed(prompt):
-            if token == closed:
-                return True
-            if token == opened:
-                return False
-        return False
 
     @property
     def has_extension_property(self) -> bool:
@@ -1910,8 +1884,8 @@ class Renderer(ABC):
         model on a sequence the model is never given. There are two reasons that happens, and
         only one of them is fixable by whoever called us.
 
-        1. The prompt closed the think block, so this turn was told not to reason -- but it
-           reasoned anyway. For example, feeding a turn with reasoning to
+        1. The renderer sets ``disables_thinking``, so this turn was told not to reason -- but
+           it reasoned anyway. For example, feeding a turn with reasoning to
            ``qwen3_disable_thinking``::
 
                prompt  ...assistant\\n<think>\\n\\n</think>\\n\\n
@@ -1926,9 +1900,9 @@ class Renderer(ABC):
            silently. The conversation and the renderer disagree, and only the caller knows
            which one is wrong, so we say so instead of guessing.
 
-        2. The prompt left the block open, and the template disagrees with itself. nemotron3
-           does this (#860): its prompt ends ``<think>\\n`` but it writes ``<think></think>``
-           for a turn with no reasoning.
+        2. The renderer does not disable thinking, so the template disagrees with itself.
+           nemotron3 does this (#860): its prompt ends ``<think>\\n`` but it writes
+           ``<think></think>`` for a turn with no reasoning.
 
            We stay quiet, as before. Raising would reject training a thinking renderer on data
            with no reasoning, which is a normal thing to do, and the caller cannot fix someone
@@ -1942,7 +1916,7 @@ class Renderer(ABC):
 
         prompt = self.build_generation_prompt(messages[:boundary]).to_ints()
         if model_input.to_ints()[: len(prompt)] != prompt:
-            if self.prompt_closes_the_think_block(prompt):
+            if self.disables_thinking:
                 raise RendererError(
                     f"{type(self).__name__} has thinking turned off: its generation prompt "
                     "closes the think block, which tells the model not to reason. This turn "

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -5,6 +5,7 @@ Use viz_sft_dataset to visualize the output of different renderers. E.g.,
     python -m tinker_cookbook.supervised.viz_sft_dataset dataset_path=Tulu3Builder renderer_name=role_colon
 """
 
+import functools
 import io
 import json
 import logging
@@ -872,30 +873,14 @@ def has_thinking(content: Content) -> bool:
     return "<think>" in content
 
 
-_CLOSED_THINK_BLOCK = re.compile(r"</think>\s*$")
+def marker_token(tokenizer: Tokenizer, marker: str) -> int | None:
+    """The id of ``marker`` where the vocab spells it as one token, else None.
 
-# Enough to cover the longest closing marker a generation prompt ends with -- Qwen3's
-# `<think>\n\n</think>\n\n` is six -- without decoding a whole conversation to look at its tail.
-_MARKER_TOKENS = 16
-
-
-def prompt_closes_the_think_block(tokenizer: Tokenizer, prompt: list[int]) -> bool:
-    """Whether a generation prompt ends having already closed the think block.
-
-    A closed block is a statement about the tokens after it: whatever the model produces from
-    here is not reasoning. An open ``<think>`` says the opposite, and a prompt mentioning
-    neither says nothing. Read off the prompt rather than declared per renderer, so a format
-    that spells the marker the usual way is covered the first time it appears::
-
-        qwen3                     ...<|im_start|>assistant\\n<think>\\n           open
-        qwen3_disable_thinking    ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n   closed
-        deepseekv3                ...<|Assistant|></think>                     closed
-        role_colon                ...\\n\\nAssistant:                            neither
-
-    Formats that mark reasoning some other way -- gpt_oss and its channels -- read as neither,
-    which is the same silence they had before anything asked.
+    A format whose vocab has no single token for it -- llama3, role_colon -- yields None, and
+    no token id ever equals None, so it simply matches nothing.
     """
-    return bool(_CLOSED_THINK_BLOCK.search(tokenizer.decode(prompt[-_MARKER_TOKENS:])))
+    ids = tokenizer.encode(marker, add_special_tokens=False)
+    return ids[0] if len(ids) == 1 else None
 
 
 def remove_thinking(parts: list[ContentPart]) -> list[ContentPart]:
@@ -1361,6 +1346,12 @@ class Renderer(ABC):
 
     tokenizer: Tokenizer
 
+    # How this format spells its reasoning markers. Nearly every template that has them agrees
+    # on these two; a format marking reasoning some other way -- gpt_oss and its channels --
+    # overrides them, and a vocab holding no single token for either never matches.
+    think_open: str = "<think>"
+    think_close: str = "</think>"
+
     # Pickle metadata — set by get_renderer() via _stamp_pickle_metadata().
     # Class-level defaults ensure these exist even when subclasses bypass super().__init__().
     _renderer_name: str | None = None
@@ -1389,6 +1380,42 @@ class Renderer(ABC):
             _unpickle_renderer,
             (renderer_name, model_name, has_image_processor),
         )
+
+    @functools.cached_property
+    def _think_marker_tokens(self) -> tuple[int | None, int | None]:
+        """This format's markers as ids, resolved against the tokenizer once.
+
+        A `cached_property` rather than `__init__` work because several renderers build without
+        calling `super().__init__()`; this resolves the first time something asks.
+        """
+        return (
+            marker_token(self.tokenizer, self.think_open),
+            marker_token(self.tokenizer, self.think_close),
+        )
+
+    def prompt_closes_the_think_block(self, prompt: list[int]) -> bool:
+        """Whether a generation prompt leaves the think block closed.
+
+        A closed block is a statement about the tokens after it: whatever the model produces
+        from here is not reasoning. An open marker says the opposite, and a prompt spelling
+        neither says nothing::
+
+            qwen3                     ...<|im_start|>assistant\\n<think>\\n                  open
+            qwen3_disable_thinking    ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n  closed
+            deepseekv3                ...<|Assistant|></think>                            closed
+            role_colon                ...\\n\\nAssistant:                                   neither
+
+        The last marker decides, and reading ids rather than decoded text is what makes that
+        safe: message content is rendered before the generation suffix, so a conversation
+        quoting ``</think>`` at the model cannot talk this into the wrong answer.
+        """
+        opened, closed = self._think_marker_tokens
+        for token in reversed(prompt):
+            if token == closed:
+                return True
+            if token == opened:
+                return False
+        return False
 
     @property
     def has_extension_property(self) -> bool:
@@ -1902,7 +1929,7 @@ class Renderer(ABC):
 
         prompt = self.build_generation_prompt(messages[:boundary]).to_ints()
         if model_input.to_ints()[: len(prompt)] != prompt:
-            if prompt_closes_the_think_block(self.tokenizer, prompt):
+            if self.prompt_closes_the_think_block(prompt):
                 raise RendererError(
                     f"{type(self).__name__} closes the think block in its generation prompt, so "
                     "what follows cannot be reasoning -- but this turn's render does not begin "

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1338,20 +1338,16 @@ class Renderer(ABC):
     disables_thinking: bool = False
     """Whether this renderer's generation prompt closes the think block.
 
-    Set it on any renderer that tells the model not to reason, which it does by handing over
-    an already-closed block::
+    A closed block tells the model not to reason::
 
         qwen3                   ...assistant\\n<think>\\n                 open, so False
         qwen3_disable_thinking  ...assistant\\n<think>\\n\\n</think>\\n\\n  closed, so True
 
-    Declared rather than worked out from the prompt, because it is a fact about the renderer:
-    ``Qwen3DisableThinkingRenderer`` disables thinking whichever tokenizer it is given, and the
-    markers are not a single token in every vocabulary. ``_train_after_the_generation_prompt``
-    reads it, and ``test_a_turn_that_reasoned_is_never_trained_after_a_prompt_it_cannot_follow``
-    fails if a renderer needs it and does not set it.
+    Set it on any renderer that does that. Forgetting is caught by
+    ``test_a_turn_that_reasoned_is_never_trained_after_a_prompt_it_cannot_follow``.
 
-    Not every renderer named ``disable_thinking``: DeepSeek's strips reasoning out of the
-    content instead, so its render already agrees with its prompt.
+    DeepSeek's non-thinking renderer does not set it and does not need to: it strips reasoning
+    out of the content, so its render already matches its prompt.
     """
 
     # Pickle metadata — set by get_renderer() via _stamp_pickle_metadata().
@@ -1881,32 +1877,22 @@ class Renderer(ABC):
         produce a token it is always given. Only the weights move; the tokens are untouched.
 
         If the render does not start with the prompt, the example is broken: it would train the
-        model on a sequence the model is never given. There are two reasons that happens, and
-        only one of them is fixable by whoever called us.
+        model on a sequence the model is never given. Two things cause that.
 
-        1. The renderer sets ``disables_thinking``, so this turn was told not to reason -- but
-           it reasoned anyway. For example, feeding a turn with reasoning to
-           ``qwen3_disable_thinking``::
+        1. A ``disables_thinking`` renderer was given a turn that reasoned. It was told not to
+           reason, so the empty block the prompt ends on is missing from the render::
 
                prompt  ...assistant\\n<think>\\n\\n</think>\\n\\n
                render  ...assistant\\n<think>\\n2+2 is 4\\n</think>\\n\\n4<|im_end|>
 
-           The render never had the empty block, so it does not start with the prompt.
+           The caller can fix this, by using the thinking renderer or dropping the reasoning,
+           so raise and let them choose.
 
-           We raise. The alternative is to drop the reasoning and train the rest, which is what
-           ``deepseekv3`` does -- and why it never gets here. That is fine for history, which is
-           what ``strip_thinking_from_history`` already does, but this is the turn being
-           trained: dropping its reasoning changes what the model is being taught, and does it
-           silently. The conversation and the renderer disagree, and only the caller knows
-           which one is wrong, so we say so instead of guessing.
-
-        2. The renderer does not disable thinking, so the template disagrees with itself.
-           nemotron3 does this (#860): its prompt ends ``<think>\\n`` but it writes
-           ``<think></think>`` for a turn with no reasoning.
-
-           We stay quiet, as before. Raising would reject training a thinking renderer on data
-           with no reasoning, which is a normal thing to do, and the caller cannot fix someone
-           else's chat template anyway.
+        2. Any other renderer: its own template disagrees with itself. nemotron3 does this
+           (#860) -- its prompt ends ``<think>\\n`` but it writes ``<think></think>`` for a turn
+           with no reasoning. Nobody calling us can fix someone else's chat template, and
+           raising would reject training a thinking renderer on ordinary data with no
+           reasoning, so return the weights unchanged as before.
         """
         boundary = self._first_trained_message_index(messages, train_on_what)
         if boundary is None:

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -872,6 +872,32 @@ def has_thinking(content: Content) -> bool:
     return "<think>" in content
 
 
+_CLOSED_THINK_BLOCK = re.compile(r"</think>\s*$")
+
+# Enough to cover the longest closing marker a generation prompt ends with -- Qwen3's
+# `<think>\n\n</think>\n\n` is six -- without decoding a whole conversation to look at its tail.
+_MARKER_TOKENS = 16
+
+
+def prompt_closes_the_think_block(tokenizer: Tokenizer, prompt: list[int]) -> bool:
+    """Whether a generation prompt ends having already closed the think block.
+
+    A closed block is a statement about the tokens after it: whatever the model produces from
+    here is not reasoning. An open ``<think>`` says the opposite, and a prompt mentioning
+    neither says nothing. Read off the prompt rather than declared per renderer, so a format
+    that spells the marker the usual way is covered the first time it appears::
+
+        qwen3                     ...<|im_start|>assistant\\n<think>\\n           open
+        qwen3_disable_thinking    ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n   closed
+        deepseekv3                ...<|Assistant|></think>                     closed
+        role_colon                ...\\n\\nAssistant:                            neither
+
+    Formats that mark reasoning some other way -- gpt_oss and its channels -- read as neither,
+    which is the same silence they had before anything asked.
+    """
+    return bool(_CLOSED_THINK_BLOCK.search(tokenizer.decode(prompt[-_MARKER_TOKENS:])))
+
+
 def remove_thinking(parts: list[ContentPart]) -> list[ContentPart]:
     """Filter out ThinkingPart elements from a content part list.
 
@@ -1334,26 +1360,6 @@ class Renderer(ABC):
     """
 
     tokenizer: Tokenizer
-
-    disables_thinking: bool = False
-    """Whether this renderer's generation prompt closes the think block.
-
-    A closed block is a statement about the tokens after it, so for these renderers a render
-    that does not begin with its own generation prompt is the conversation's fault rather than
-    the template's, and ``_train_after_the_generation_prompt`` raises rather than reweighting.
-    ``qwen3_disable_thinking`` on the same question, answered two ways::
-
-        prompt  ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n
-        render  ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n4<|im_end|>
-                                         the turn did not reason: the prompt is a prefix
-
-        prompt  ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n
-        render  ...<|im_start|>assistant\\n<think>\\n2+2 is 4\\n</think>\\n\\n4<|im_end|>
-                                         it reasoned: nothing here is what sampling is given
-
-    Not every renderer named ``disable_thinking``: DeepSeek's strips reasoning out of the
-    content, so its render already agrees.
-    """
 
     # Pickle metadata — set by get_renderer() via _stamp_pickle_metadata().
     # Class-level defaults ensure these exist even when subclasses bypass super().__init__().
@@ -1882,9 +1888,11 @@ class Renderer(ABC):
         produce a token it is always given. Only the weights move; the tokens are untouched.
 
         A render that does not begin with the prompt disagrees with it about more than where the
-        boundary falls: there is no sequence sampling can produce that trains this example. A
-        `disables_thinking` renderer says so; anywhere else the weights are returned unchanged,
-        because a template that contradicts itself is not the caller's to fix.
+        boundary falls: there is no sequence sampling can produce that trains this example. When
+        the prompt has closed the think block that is the conversation's doing -- it reasoned
+        where the prompt said it would not -- and this raises. Otherwise the weights are returned
+        unchanged, because a template that contradicts itself is not the caller's to fix: see
+        nemotron3, whose prompt opens a block its own document form writes closed.
         """
         boundary = self._first_trained_message_index(messages, train_on_what)
         if boundary is None:
@@ -1894,7 +1902,7 @@ class Renderer(ABC):
 
         prompt = self.build_generation_prompt(messages[:boundary]).to_ints()
         if model_input.to_ints()[: len(prompt)] != prompt:
-            if self.disables_thinking:
+            if prompt_closes_the_think_block(self.tokenizer, prompt):
                 raise RendererError(
                     f"{type(self).__name__} closes the think block in its generation prompt, so "
                     "what follows cannot be reasoning -- but this turn's render does not begin "

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1336,14 +1336,12 @@ class Renderer(ABC):
     tokenizer: Tokenizer
 
     disables_thinking: bool = False
-    """Whether this renderer's generation prompt asserts the turn did not reason.
+    """Whether this renderer's generation prompt closes the think block.
 
-    A closed ``<think></think>`` in the prompt is a statement about the tokens that follow
-    it, so a turn that reasoned cannot be trained after one. Set this and the assembly
-    refuses that pairing rather than training a sequence sampling never produces.
-
-    Not set by every renderer whose name says ``disable_thinking``: the DeepSeek one strips
-    reasoning out of the content instead, so its render already agrees with its prompt.
+    A closed ``<think></think>`` is a statement about the tokens after it, so a render that
+    disagrees with the prompt is the conversation's fault rather than the template's -- see
+    ``_train_after_the_generation_prompt``. Not every renderer named ``disable_thinking``:
+    DeepSeek's strips reasoning out of the content, so its render already agrees.
     """
 
     # Pickle metadata — set by get_renderer() via _stamp_pickle_metadata().
@@ -1830,9 +1828,6 @@ class Renderer(ABC):
                 last_user_index=last_user_idx,
                 in_last_assistant_turn=in_last_assistant_turn,
             )
-            output_has_weight = self._output_is_trained(message, ctx, train_on_what)
-            self._refuse_reasoning_the_prompt_disables(message, ctx, output_has_weight)
-
             rendered_message = self.render_message(message, ctx)
             header_part = rendered_message.header
             output_parts = rendered_message.output
@@ -1841,6 +1836,8 @@ class Renderer(ABC):
             header_weight = int(train_on_what == TrainOnWhat.ALL_TOKENS)
             if header_part:
                 model_input_chunks_weights += [(header_part, header_weight)]
+
+            output_has_weight = self._output_is_trained(message, ctx, train_on_what)
 
             model_input_chunks_weights += [
                 (output_part, int(output_has_weight)) for output_part in output_parts if output_part
@@ -1873,8 +1870,10 @@ class Renderer(ABC):
         that prefill on whichever side its header logic puts it, so the model is trained to
         produce a token it is always given. Only the weights move; the tokens are untouched.
 
-        Returns them unchanged when the render does not begin with the prompt, which means the
-        two disagree about more than where the boundary falls.
+        A render that does not begin with the prompt disagrees with it about more than where the
+        boundary falls: there is no sequence sampling can produce that trains this example. A
+        `disables_thinking` renderer says so; anywhere else the weights are returned unchanged,
+        because a template that contradicts itself is not the caller's to fix.
         """
         boundary = self._first_trained_message_index(messages, train_on_what)
         if boundary is None:
@@ -1884,38 +1883,17 @@ class Renderer(ABC):
 
         prompt = self.build_generation_prompt(messages[:boundary]).to_ints()
         if model_input.to_ints()[: len(prompt)] != prompt:
+            if self.disables_thinking:
+                raise RendererError(
+                    f"{type(self).__name__} closes the think block in its generation prompt, so "
+                    "what follows cannot be reasoning -- but this turn's render does not begin "
+                    "with that prompt, which is what a turn carrying reasoning looks like here. "
+                    "Render it with the thinking variant of this renderer, or drop the reasoning "
+                    "from the turn."
+                )
             return weights
 
         return torch.cat([torch.zeros(len(prompt)), weights[len(prompt) :]])
-
-    def _refuse_reasoning_the_prompt_disables(
-        self, message: Message, ctx: RenderContext, is_trained: bool
-    ) -> None:
-        """Refuse to train reasoning under a prompt that says the turn did not reason.
-
-        `disables_thinking` renderers close the think block in the generation prompt, so the
-        reasoning would have to arrive before a marker the model has already been handed.
-        There is no sequence that does that: the example trains one thing and sampling starts
-        from another, and `_train_after_the_generation_prompt` cannot even find its boundary.
-
-        The produced turn, and only when it carries loss. An earlier assistant turn is history
-        -- `strip_thinking_from_history` decides whether its reasoning survives the render, and
-        the prompt reflects whichever it did -- and a turn nothing is trained on is context
-        rather than a target. `build_supervised_examples` splits a conversation into one example
-        per trained turn, so each turn is checked as the produced turn of its own example.
-        """
-        if not (
-            self.disables_thinking and is_trained and ctx.is_last and message["role"] == "assistant"
-        ):
-            return
-        content = message.get("content")
-        if content and has_thinking(content):
-            raise RendererError(
-                f"{type(self).__name__} disables thinking, so its generation prompt closes the "
-                "think block -- but this turn carries reasoning, which would train the model to "
-                "produce reasoning after being told not to. Render it with the thinking variant "
-                "of this renderer, or drop the reasoning from the turn."
-            )
 
     def _output_is_trained(
         self, message: Message, ctx: RenderContext, train_on_what: TrainOnWhat

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1338,10 +1338,21 @@ class Renderer(ABC):
     disables_thinking: bool = False
     """Whether this renderer's generation prompt closes the think block.
 
-    A closed ``<think></think>`` is a statement about the tokens after it, so a render that
-    disagrees with the prompt is the conversation's fault rather than the template's -- see
-    ``_train_after_the_generation_prompt``. Not every renderer named ``disable_thinking``:
-    DeepSeek's strips reasoning out of the content, so its render already agrees.
+    A closed block is a statement about the tokens after it, so for these renderers a render
+    that does not begin with its own generation prompt is the conversation's fault rather than
+    the template's, and ``_train_after_the_generation_prompt`` raises rather than reweighting.
+    ``qwen3_disable_thinking`` on the same question, answered two ways::
+
+        prompt  ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n
+        render  ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n4<|im_end|>
+                                         the turn did not reason: the prompt is a prefix
+
+        prompt  ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n
+        render  ...<|im_start|>assistant\\n<think>\\n2+2 is 4\\n</think>\\n\\n4<|im_end|>
+                                         it reasoned: nothing here is what sampling is given
+
+    Not every renderer named ``disable_thinking``: DeepSeek's strips reasoning out of the
+    content, so its render already agrees.
     """
 
     # Pickle metadata — set by get_renderer() via _stamp_pickle_metadata().

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1911,18 +1911,28 @@ class Renderer(ABC):
         only one of them is fixable by whoever called us.
 
         1. The prompt closed the think block, so this turn was told not to reason -- but it
-           reasoned anyway. Fix the conversation, so raise. For example, feeding a turn with
-           reasoning to ``qwen3_disable_thinking``::
+           reasoned anyway. For example, feeding a turn with reasoning to
+           ``qwen3_disable_thinking``::
 
                prompt  ...assistant\\n<think>\\n\\n</think>\\n\\n
                render  ...assistant\\n<think>\\n2+2 is 4\\n</think>\\n\\n4<|im_end|>
 
            The render never had the empty block, so it does not start with the prompt.
 
+           We raise. The alternative is to drop the reasoning and train the rest, which is what
+           ``deepseekv3`` does -- and why it never gets here. That is fine for history, which is
+           what ``strip_thinking_from_history`` already does, but this is the turn being
+           trained: dropping its reasoning changes what the model is being taught, and does it
+           silently. The conversation and the renderer disagree, and only the caller knows
+           which one is wrong, so we say so instead of guessing.
+
         2. The prompt left the block open, and the template disagrees with itself. nemotron3
            does this (#860): its prompt ends ``<think>\\n`` but it writes ``<think></think>``
-           for a turn with no reasoning. Nobody calling us can fix that, so leave the weights
-           alone and stay quiet, as before.
+           for a turn with no reasoning.
+
+           We stay quiet, as before. Raising would reject training a thinking renderer on data
+           with no reasoning, which is a normal thing to do, and the caller cannot fix someone
+           else's chat template anyway.
         """
         boundary = self._first_trained_message_index(messages, train_on_what)
         if boundary is None:

--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -874,11 +874,7 @@ def has_thinking(content: Content) -> bool:
 
 
 def marker_token(tokenizer: Tokenizer, marker: str) -> int | None:
-    """The id of ``marker`` where the vocab spells it as one token, else None.
-
-    A format whose vocab has no single token for it -- llama3, role_colon -- yields None, and
-    no token id ever equals None, so it simply matches nothing.
-    """
+    """The token id for ``marker``, or None if this vocab has no single token for it."""
     ids = tokenizer.encode(marker, add_special_tokens=False)
     return ids[0] if len(ids) == 1 else None
 
@@ -1346,9 +1342,7 @@ class Renderer(ABC):
 
     tokenizer: Tokenizer
 
-    # How this format spells its reasoning markers. Nearly every template that has them agrees
-    # on these two; a format marking reasoning some other way -- gpt_oss and its channels --
-    # overrides them, and a vocab holding no single token for either never matches.
+    # How this format writes reasoning markers. Override them if a format uses different ones.
     think_open: str = "<think>"
     think_close: str = "</think>"
 
@@ -1383,10 +1377,10 @@ class Renderer(ABC):
 
     @functools.cached_property
     def _think_marker_tokens(self) -> tuple[int | None, int | None]:
-        """This format's markers as ids, resolved against the tokenizer once.
+        """``think_open`` and ``think_close`` as token ids.
 
-        A `cached_property` rather than `__init__` work because several renderers build without
-        calling `super().__init__()`; this resolves the first time something asks.
+        A cached_property rather than __init__ work: some renderers do not call
+        super().__init__(), so this resolves the first time it is used instead.
         """
         return (
             marker_token(self.tokenizer, self.think_open),
@@ -1394,20 +1388,18 @@ class Renderer(ABC):
         )
 
     def prompt_closes_the_think_block(self, prompt: list[int]) -> bool:
-        """Whether a generation prompt leaves the think block closed.
+        """Has this generation prompt already closed the think block?
 
-        A closed block is a statement about the tokens after it: whatever the model produces
-        from here is not reasoning. An open marker says the opposite, and a prompt spelling
-        neither says nothing::
+        An open marker means the model is about to reason. A closed one means it is not.
+        The last marker in the prompt is the one that counts::
 
-            qwen3                     ...<|im_start|>assistant\\n<think>\\n                  open
-            qwen3_disable_thinking    ...<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n  closed
-            deepseekv3                ...<|Assistant|></think>                            closed
-            role_colon                ...\\n\\nAssistant:                                   neither
+            qwen3                   ...assistant\\n<think>\\n                 open      -> False
+            qwen3_disable_thinking  ...assistant\\n<think>\\n\\n</think>\\n\\n  closed    -> True
+            deepseekv3              ...<|Assistant|></think>                closed    -> True
+            role_colon              ...\\n\\nAssistant:                       no marker -> False
 
-        The last marker decides, and reading ids rather than decoded text is what makes that
-        safe: message content is rendered before the generation suffix, so a conversation
-        quoting ``</think>`` at the model cannot talk this into the wrong answer.
+        This compares token ids, not text, so a user message that quotes "</think>" cannot
+        change the answer.
         """
         opened, closed = self._think_marker_tokens
         for token in reversed(prompt):
@@ -1914,12 +1906,23 @@ class Renderer(ABC):
         that prefill on whichever side its header logic puts it, so the model is trained to
         produce a token it is always given. Only the weights move; the tokens are untouched.
 
-        A render that does not begin with the prompt disagrees with it about more than where the
-        boundary falls: there is no sequence sampling can produce that trains this example. When
-        the prompt has closed the think block that is the conversation's doing -- it reasoned
-        where the prompt said it would not -- and this raises. Otherwise the weights are returned
-        unchanged, because a template that contradicts itself is not the caller's to fix: see
-        nemotron3, whose prompt opens a block its own document form writes closed.
+        If the render does not start with the prompt, the example is broken: it would train the
+        model on a sequence the model is never given. There are two reasons that happens, and
+        only one of them is fixable by whoever called us.
+
+        1. The prompt closed the think block, so this turn was told not to reason -- but it
+           reasoned anyway. Fix the conversation, so raise. For example, feeding a turn with
+           reasoning to ``qwen3_disable_thinking``::
+
+               prompt  ...assistant\\n<think>\\n\\n</think>\\n\\n
+               render  ...assistant\\n<think>\\n2+2 is 4\\n</think>\\n\\n4<|im_end|>
+
+           The render never had the empty block, so it does not start with the prompt.
+
+        2. The prompt left the block open, and the template disagrees with itself. nemotron3
+           does this (#860): its prompt ends ``<think>\\n`` but it writes ``<think></think>``
+           for a turn with no reasoning. Nobody calling us can fix that, so leave the weights
+           alone and stay quiet, as before.
         """
         boundary = self._first_trained_message_index(messages, train_on_what)
         if boundary is None:
@@ -1931,11 +1934,11 @@ class Renderer(ABC):
         if model_input.to_ints()[: len(prompt)] != prompt:
             if self.prompt_closes_the_think_block(prompt):
                 raise RendererError(
-                    f"{type(self).__name__} closes the think block in its generation prompt, so "
-                    "what follows cannot be reasoning -- but this turn's render does not begin "
-                    "with that prompt, which is what a turn carrying reasoning looks like here. "
-                    "Render it with the thinking variant of this renderer, or drop the reasoning "
-                    "from the turn."
+                    f"{type(self).__name__} has thinking turned off: its generation prompt "
+                    "closes the think block, which tells the model not to reason. This turn "
+                    "contains reasoning, so training on it would teach the model to reason "
+                    "anyway, after being told not to. Either use the thinking version of this "
+                    "renderer, or remove the reasoning from this turn."
                 )
             return weights
 

--- a/tinker_cookbook/renderers/kimi_k25.py
+++ b/tinker_cookbook/renderers/kimi_k25.py
@@ -170,6 +170,8 @@ class KimiK25DisableThinkingRenderer(KimiK25Renderer):
         <|im_assistant|>assistant<|im_middle|><think></think>
     """
 
+    disables_thinking = True
+
     def build_generation_prompt(
         self, messages: list[Message], role: Role = "assistant", prefill: str | None = None
     ) -> tinker.ModelInput:

--- a/tinker_cookbook/renderers/kimi_k25.py
+++ b/tinker_cookbook/renderers/kimi_k25.py
@@ -170,8 +170,6 @@ class KimiK25DisableThinkingRenderer(KimiK25Renderer):
         <|im_assistant|>assistant<|im_middle|><think></think>
     """
 
-    disables_thinking = True
-
     def build_generation_prompt(
         self, messages: list[Message], role: Role = "assistant", prefill: str | None = None
     ) -> tinker.ModelInput:

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -510,6 +510,8 @@ class Nemotron3DisableThinkingRenderer(Nemotron3Renderer):
     <think></think> (no trailing newlines) instead of <think>\\n.
     """
 
+    disables_thinking = True
+
     def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
         """Return generation suffix tokens with ``<think></think>`` to disable thinking.
 

--- a/tinker_cookbook/renderers/nemotron3.py
+++ b/tinker_cookbook/renderers/nemotron3.py
@@ -510,8 +510,6 @@ class Nemotron3DisableThinkingRenderer(Nemotron3Renderer):
     <think></think> (no trailing newlines) instead of <think>\\n.
     """
 
-    disables_thinking = True
-
     def _get_generation_suffix(self, role: Role, ctx: RenderContext) -> list[int]:
         """Return generation suffix tokens with ``<think></think>`` to disable thinking.
 

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -178,10 +178,8 @@ def get_multiturn_thinking_conversation() -> list[Message]:
 def get_multiturn_thinking_history_conversation() -> list[Message]:
     """Multi-turn whose history reasoned and whose produced turn did not.
 
-    What a reasoning-off renderer can be given: `strip_thinking_from_history=False` still has
-    history to preserve, while the turn being trained agrees with a prompt that closes the
-    think block. A produced turn that reasoned is refused instead -- there is no sequence that
-    trains reasoning after being told not to reason.
+    What a reasoning-off renderer can be given: history to preserve, and a produced turn that
+    agrees with a prompt closing the think block.
     """
     return [
         *get_multiturn_thinking_conversation()[:4],
@@ -1315,15 +1313,14 @@ def test_preserve_thinking_registered_in_model_info():
 # disable / low-effort / medium-effort modes, which have no named preserve variant.
 
 
-def _assert_mode_preserve_matches_hf(tokenizer, renderer, conversation_fn=None, **hf_kwargs):
+def _assert_mode_preserve_matches_hf(
+    tokenizer, renderer, conversation_fn=get_multiturn_thinking_conversation, **hf_kwargs
+):
     """Renderer (built with strip_thinking_from_history=False) matches HF with
     truncate_history_thinking=False plus the mode flags in ``hf_kwargs``.
 
-    ``conversation_fn`` names the conversation because the reasoning-off renderers need one
-    whose produced turn did not reason -- see
-    ``get_multiturn_thinking_history_conversation``.
+    The reasoning-off renderers pass a conversation whose produced turn did not reason.
     """
-    conversation_fn = conversation_fn or get_multiturn_thinking_conversation
     sup_msgs = conversation_fn()
     cookbook_sup = renderer.build_supervised_example(sup_msgs)[0].to_ints()
     hf_sup = _hf_supervised_tokens(

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -182,7 +182,7 @@ def get_multiturn_thinking_history_conversation() -> list[Message]:
     agrees with a prompt closing the think block.
     """
     return [
-        *get_multiturn_thinking_conversation()[:4],
+        *get_multiturn_thinking_conversation()[:-1],
         Message(role="assistant", content="Second answer."),
     ]
 
@@ -1333,7 +1333,7 @@ def _assert_mode_preserve_matches_hf(
         f"supervised: {tokenizer.decode(cookbook_sup)}\nHF: {tokenizer.decode(hf_sup)}"
     )
 
-    gen_msgs = conversation_fn()[:4]
+    gen_msgs = conversation_fn()[:-1]
     cookbook_gen = renderer.build_generation_prompt(gen_msgs).to_ints()
     hf_gen = _hf_generation_tokens(
         tokenizer,

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -176,10 +176,10 @@ def get_multiturn_thinking_conversation() -> list[Message]:
 
 
 def get_multiturn_thinking_history_conversation() -> list[Message]:
-    """Multi-turn whose history reasoned and whose produced turn did not.
+    """History that reasoned, and a final turn that did not.
 
-    What a reasoning-off renderer can be given: history to preserve, and a produced turn that
-    agrees with a prompt closing the think block.
+    What a reasoning-off renderer can be given: it refuses a final turn that reasoned, and
+    this still leaves history for `strip_thinking_from_history=False` to preserve.
     """
     return [
         *get_multiturn_thinking_conversation()[:-1],
@@ -1319,7 +1319,7 @@ def _assert_mode_preserve_matches_hf(
     """Renderer (built with strip_thinking_from_history=False) matches HF with
     truncate_history_thinking=False plus the mode flags in ``hf_kwargs``.
 
-    The reasoning-off renderers pass a conversation whose produced turn did not reason.
+    The reasoning-off renderers pass a conversation whose final turn did not reason.
     """
     sup_msgs = conversation_fn()
     cookbook_sup = renderer.build_supervised_example(sup_msgs)[0].to_ints()

--- a/tinker_cookbook/renderers/nemotron3_test.py
+++ b/tinker_cookbook/renderers/nemotron3_test.py
@@ -175,6 +175,20 @@ def get_multiturn_thinking_conversation() -> list[Message]:
     ]
 
 
+def get_multiturn_thinking_history_conversation() -> list[Message]:
+    """Multi-turn whose history reasoned and whose produced turn did not.
+
+    What a reasoning-off renderer can be given: `strip_thinking_from_history=False` still has
+    history to preserve, while the turn being trained agrees with a prompt that closes the
+    think block. A produced turn that reasoned is refused instead -- there is no sequence that
+    trains reasoning after being told not to reason.
+    """
+    return [
+        *get_multiturn_thinking_conversation()[:4],
+        Message(role="assistant", content="Second answer."),
+    ]
+
+
 def get_tool_spec() -> ToolSpec:
     return ToolSpec(
         name="get_weather",
@@ -1301,10 +1315,16 @@ def test_preserve_thinking_registered_in_model_info():
 # disable / low-effort / medium-effort modes, which have no named preserve variant.
 
 
-def _assert_mode_preserve_matches_hf(tokenizer, renderer, **hf_kwargs):
+def _assert_mode_preserve_matches_hf(tokenizer, renderer, conversation_fn=None, **hf_kwargs):
     """Renderer (built with strip_thinking_from_history=False) matches HF with
-    truncate_history_thinking=False plus the mode flags in ``hf_kwargs``."""
-    sup_msgs = get_multiturn_thinking_conversation()
+    truncate_history_thinking=False plus the mode flags in ``hf_kwargs``.
+
+    ``conversation_fn`` names the conversation because the reasoning-off renderers need one
+    whose produced turn did not reason -- see
+    ``get_multiturn_thinking_history_conversation``.
+    """
+    conversation_fn = conversation_fn or get_multiturn_thinking_conversation
+    sup_msgs = conversation_fn()
     cookbook_sup = renderer.build_supervised_example(sup_msgs)[0].to_ints()
     hf_sup = _hf_supervised_tokens(
         tokenizer,
@@ -1316,7 +1336,7 @@ def _assert_mode_preserve_matches_hf(tokenizer, renderer, **hf_kwargs):
         f"supervised: {tokenizer.decode(cookbook_sup)}\nHF: {tokenizer.decode(hf_sup)}"
     )
 
-    gen_msgs = get_multiturn_thinking_conversation()[:4]
+    gen_msgs = conversation_fn()[:4]
     cookbook_gen = renderer.build_generation_prompt(gen_msgs).to_ints()
     hf_gen = _hf_generation_tokens(
         tokenizer,
@@ -1334,7 +1354,12 @@ def test_disable_thinking_preserve_matches_hf(nemotron_tokenizer):
     renderer = Nemotron3DisableThinkingRenderer(
         nemotron_tokenizer, strip_thinking_from_history=False
     )
-    _assert_mode_preserve_matches_hf(nemotron_tokenizer, renderer, enable_thinking=False)
+    _assert_mode_preserve_matches_hf(
+        nemotron_tokenizer,
+        renderer,
+        conversation_fn=get_multiturn_thinking_history_conversation,
+        enable_thinking=False,
+    )
 
 
 def test_low_thinking_preserve_matches_hf(nemotron_super_tokenizer):
@@ -1358,4 +1383,9 @@ def test_ultra_disable_thinking_preserve_matches_hf(nemotron_ultra_tokenizer):
     renderer = Nemotron3UltraDisableThinkingRenderer(
         nemotron_ultra_tokenizer, strip_thinking_from_history=False
     )
-    _assert_mode_preserve_matches_hf(nemotron_ultra_tokenizer, renderer, enable_thinking=False)
+    _assert_mode_preserve_matches_hf(
+        nemotron_ultra_tokenizer,
+        renderer,
+        conversation_fn=get_multiturn_thinking_history_conversation,
+        enable_thinking=False,
+    )

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -534,6 +534,8 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
     "non-thinking" mode while maintaining compatibility with the OpenAI endpoint.
     """
 
+    disables_thinking = True
+
     def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
         """Refuse a produced turn in a conversation with no user message.
 

--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -534,8 +534,6 @@ class Qwen3DisableThinkingRenderer(Qwen3Renderer):
     "non-thinking" mode while maintaining compatibility with the OpenAI endpoint.
     """
 
-    disables_thinking = True
-
     def render_message(self, message: Message, ctx: RenderContext) -> RenderedMessage:
         """Refuse a produced turn in a conversation with no user message.
 

--- a/tinker_cookbook/renderers/qwen3_5.py
+++ b/tinker_cookbook/renderers/qwen3_5.py
@@ -320,6 +320,8 @@ class Qwen3_5DisableThinkingRenderer(Qwen3_5Renderer):
     of <think>\\n, signaling to the model to respond directly without reasoning.
     """
 
+    disables_thinking = True
+
     def _generation_suffix_str(self, role: Role, ctx: RenderContext) -> str:
         maybe_newline = "\n" if ctx.idx > 0 else ""
         return f"{maybe_newline}<|im_start|>{role}\n<think>\n\n</think>\n\n"

--- a/tinker_cookbook/renderers/qwen3_5.py
+++ b/tinker_cookbook/renderers/qwen3_5.py
@@ -320,8 +320,6 @@ class Qwen3_5DisableThinkingRenderer(Qwen3_5Renderer):
     of <think>\\n, signaling to the model to respond directly without reasoning.
     """
 
-    disables_thinking = True
-
     def _generation_suffix_str(self, role: Role, ctx: RenderContext) -> str:
         maybe_newline = "\n" if ctx.idx > 0 else ""
         return f"{maybe_newline}<|im_start|>{role}\n<think>\n\n</think>\n\n"

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -997,8 +997,9 @@ _RENDERERS_WITH_THINKING_STRIPPING = {
     "kimi_k2",
 }
 
-# One per class that sets `disables_thinking`: kimi_k25's covers `kimi_k26_disable_thinking` and
-# nemotron3's covers `nemotron3_ultra_disable_thinking`, which subclass them.
+# The renderers whose generation prompt closes the think block, one per family. Nothing declares
+# that -- `prompt_closes_the_think_block` reads it off the prompt -- so this list is the coverage
+# rather than the definition.
 _REASONING_OFF_RENDERERS = [
     ("Qwen/Qwen3-8B", "qwen3_disable_thinking"),
     ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -1030,7 +1030,7 @@ def test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned(model_name: str, 
         },
     ]
 
-    with pytest.raises(RendererError, match="disables thinking"):
+    with pytest.raises(RendererError, match="closes the think block"):
         renderer.build_supervised_example(cast(list[Message], reasoned))
 
     plain = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]
@@ -1516,15 +1516,9 @@ _EXTENSION_PROPERTY_TEST_PARAMS = [
         {"strip_thinking_from_history": False},
         get_multiturn_thinking_conversation,
     ),
-    # Qwen3.5 disable thinking with strip_thinking_from_history=False (preserves thinking).
-    # A reasoning-less conversation, because the check trains each assistant turn in succession
-    # and a reasoning-off renderer refuses a produced turn that reasoned -- so no conversation
-    # carrying reasoning reaches the property here. Which leaves the claim unmet: with nothing
-    # to preserve, `_assistant_header_suffix` gates the empty block on `idx > last_user_index`,
-    # so one assistant turn carries it as the turn being produced and not as history, and the
-    # sequence through it is no longer a prefix of the next prompt. The old thinking
-    # conversation hid this -- every turn reasoned, so `has_think` suppressed the block
-    # everywhere and extension held by never exercising it.
+    # Qwen3.5 disable thinking, on a reasoning-less conversation: the check trains each assistant
+    # turn in succession, and a reasoning-off renderer refuses one that reasoned. The old
+    # thinking conversation hid the failure below by suppressing the empty block everywhere.
     pytest.param(
         "Qwen/Qwen3.6-35B-A3B",
         Qwen3_5DisableThinkingRenderer,
@@ -1532,8 +1526,10 @@ _EXTENSION_PROPERTY_TEST_PARAMS = [
         get_basic_4turn_conversation,
         marks=pytest.mark.xfail(
             strict=True,
-            reason="positional empty-block rule renders a turn one way as the produced turn "
-            "and another as history, so has_extension_property=True is not met",
+            reason="`_assistant_header_suffix` gates the empty block on `idx > last_user_index`, "
+            "so an assistant turn carries it as the produced turn and not as history and the "
+            "sequence through it is not a prefix of the next prompt: has_extension_property "
+            "is claimed but not met",
         ),
     ),
     # DeepSeek non-thinking with basic multi-turn

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -996,8 +996,9 @@ _RENDERERS_WITH_THINKING_STRIPPING = {
     "kimi_k2",
 }
 
-# One renderer per family whose generation prompt closes the think block. No renderer declares
-# that; `prompt_closes_the_think_block` works it out. So this list is test coverage, not config.
+# One renderer per class that sets `disables_thinking`. kimi_k25's covers
+# `kimi_k26_disable_thinking` and nemotron3's covers `nemotron3_ultra_disable_thinking`, which
+# subclass them.
 _REASONING_OFF_RENDERERS = [
     ("Qwen/Qwen3-8B", "qwen3_disable_thinking"),
     ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
@@ -1034,6 +1035,47 @@ def test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned(model_name: str, 
     observation = model_input.to_ints()[: [w > 0 for w in weights.tolist()].index(True)]
     assert (
         observation == renderer.build_generation_prompt(cast(list[Message], plain[:-1])).to_ints()
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name,renderer_name",
+    sorted(set(_CONSISTENCY_RENDERERS) | set(_REASONING_OFF_RENDERERS)),
+)
+def test_a_turn_that_reasoned_is_never_trained_after_a_prompt_it_cannot_follow(
+    model_name: str, renderer_name: str
+):
+    """Whatever a renderer does with reasoning, it must not train it after the wrong prompt.
+
+    Refusing is fine, rendering it is fine, and dropping it is fine. What is not fine is an
+    example whose tokens do not start with the prompt its turn is sampled after, because that
+    trains the model on a sequence it is never given.
+
+    This is the check that catches a reasoning-off renderer added without `disables_thinking`:
+    it would render the reasoning, the example would not start with the generation prompt, and
+    nothing else here would notice.
+    """
+    renderer = get_renderer(renderer_name, get_tokenizer(model_name))
+    reasoned = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": [
+                ThinkingPart(type="thinking", thinking="r"),
+                TextPart(type="text", text="a"),
+            ],
+        },
+    ]
+
+    try:
+        model_input, _ = renderer.build_supervised_example(cast(list[Message], reasoned))
+    except RendererError:
+        return  # declining to render it is one of the acceptable answers
+
+    prompt = renderer.build_generation_prompt(cast(list[Message], reasoned[:-1])).to_ints()
+    assert model_input.to_ints()[: len(prompt)] == prompt, (
+        f"{renderer_name} trains a turn that reasoned after a prompt it cannot follow. If this "
+        "renderer tells the model not to reason, set disables_thinking = True on it."
     )
 
 

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -985,9 +985,8 @@ _RENDERERS_WITHOUT_THINKING_SUPPORT = {"llama3", "role_colon"}
 # Renderers that don't support tool calling
 _RENDERERS_WITHOUT_TOOL_SUPPORT = {"role_colon"}
 
-# Renderers that cannot be handed a produced turn carrying reasoning, so the conversation must
-# have no ThinkingPart. `deepseekv3` and `kimi_k2` strip it out; the rest close the think block
-# in the generation prompt and refuse it -- see
+# These renderers cannot be given a turn that reasoned, so the conversation must have no
+# ThinkingPart. `deepseekv3` and `kimi_k2` drop the reasoning; the other three raise, per
 # `test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned`.
 _RENDERERS_WITH_THINKING_STRIPPING = {
     "qwen3_disable_thinking",
@@ -997,9 +996,8 @@ _RENDERERS_WITH_THINKING_STRIPPING = {
     "kimi_k2",
 }
 
-# The renderers whose generation prompt closes the think block, one per family. Nothing declares
-# that -- `prompt_closes_the_think_block` reads it off the prompt -- so this list is the coverage
-# rather than the definition.
+# One renderer per family whose generation prompt closes the think block. No renderer declares
+# that; `prompt_closes_the_think_block` works it out. So this list is test coverage, not config.
 _REASONING_OFF_RENDERERS = [
     ("Qwen/Qwen3-8B", "qwen3_disable_thinking"),
     ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
@@ -1010,14 +1008,11 @@ _REASONING_OFF_RENDERERS = [
 
 @pytest.mark.parametrize("model_name,renderer_name", _REASONING_OFF_RENDERERS)
 def test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned(model_name: str, renderer_name: str):
-    """A closed think block in the prompt and reasoning in the target cannot both hold.
+    """These renderers tell the model not to reason, so a turn that reasoned cannot be trained.
 
-    These renderers hand the model a closed `<think></think>`, so reasoning would have to
-    arrive after the marker saying there is none. Rendering it anyway trains a sequence
-    sampling cannot produce -- and silently, because both sides are the same renderer, so no
-    comparison against a second implementation sees it.
-
-    The same turn without reasoning renders, and observes the prompt it is sampled after.
+    Drop the reasoning and the same turn renders fine, with its observation equal to the
+    prompt. Nothing but this check catches it: one renderer produces both sides, so comparing
+    against a second implementation sees two copies of the same mistake.
     """
     renderer = get_renderer(renderer_name, get_tokenizer(model_name))
     reasoned = [
@@ -1517,9 +1512,10 @@ _EXTENSION_PROPERTY_TEST_PARAMS = [
         {"strip_thinking_from_history": False},
         get_multiturn_thinking_conversation,
     ),
-    # Qwen3.5 disable thinking, on a reasoning-less conversation: the check trains each assistant
-    # turn in succession, and a reasoning-off renderer refuses one that reasoned. The old
-    # thinking conversation hid the failure below by suppressing the empty block everywhere.
+    # Qwen3.5 disable thinking, on a conversation with no reasoning: this check trains each
+    # assistant turn in turn, and a reasoning-off renderer refuses one that reasoned. The old
+    # thinking conversation hid the failure below, because every turn reasoned and so no turn
+    # ever got the empty block.
     pytest.param(
         "Qwen/Qwen3.6-35B-A3B",
         Qwen3_5DisableThinkingRenderer,
@@ -1527,10 +1523,10 @@ _EXTENSION_PROPERTY_TEST_PARAMS = [
         get_basic_4turn_conversation,
         marks=pytest.mark.xfail(
             strict=True,
-            reason="`_assistant_header_suffix` gates the empty block on `idx > last_user_index`, "
-            "so an assistant turn carries it as the produced turn and not as history and the "
-            "sequence through it is not a prefix of the next prompt: has_extension_property "
-            "is claimed but not met",
+            reason="`_assistant_header_suffix` decides the empty block by position "
+            "(`idx > last_user_index`), so one assistant turn gets it as the turn being "
+            "produced and not as history. The sequence through that turn is then not a prefix "
+            "of the next prompt, so has_extension_property=True does not hold.",
         ),
     ),
     # DeepSeek non-thinking with basic multi-turn

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -985,7 +985,10 @@ _RENDERERS_WITHOUT_THINKING_SUPPORT = {"llama3", "role_colon"}
 # Renderers that don't support tool calling
 _RENDERERS_WITHOUT_TOOL_SUPPORT = {"role_colon"}
 
-# Renderers that strip thinking in non-thinking mode (conversation must not have ThinkingPart)
+# Renderers that cannot be handed a produced turn carrying reasoning, so the conversation must
+# have no ThinkingPart. `deepseekv3` and `kimi_k2` strip it out; the rest close the think block
+# in the generation prompt and refuse it -- see
+# `test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned`.
 _RENDERERS_WITH_THINKING_STRIPPING = {
     "qwen3_disable_thinking",
     "qwen3_5_disable_thinking",
@@ -993,6 +996,50 @@ _RENDERERS_WITH_THINKING_STRIPPING = {
     "deepseekv3",
     "kimi_k2",
 }
+
+# One per class that sets `disables_thinking`: kimi_k25's covers `kimi_k26_disable_thinking` and
+# nemotron3's covers `nemotron3_ultra_disable_thinking`, which subclass them.
+_REASONING_OFF_RENDERERS = [
+    ("Qwen/Qwen3-8B", "qwen3_disable_thinking"),
+    ("Qwen/Qwen3.6-35B-A3B", "qwen3_5_disable_thinking"),
+    ("moonshotai/Kimi-K2.5", "kimi_k25_disable_thinking"),
+    ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "nemotron3_disable_thinking"),
+]
+
+
+@pytest.mark.parametrize("model_name,renderer_name", _REASONING_OFF_RENDERERS)
+def test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned(model_name: str, renderer_name: str):
+    """A closed think block in the prompt and reasoning in the target cannot both hold.
+
+    These renderers hand the model a closed `<think></think>`, so reasoning would have to
+    arrive after the marker saying there is none. Rendering it anyway trains a sequence
+    sampling cannot produce -- and silently, because both sides are the same renderer, so no
+    comparison against a second implementation sees it.
+
+    The same turn without reasoning renders, and observes the prompt it is sampled after.
+    """
+    renderer = get_renderer(renderer_name, get_tokenizer(model_name))
+    reasoned = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": [
+                ThinkingPart(type="thinking", thinking="r"),
+                TextPart(type="text", text="a"),
+            ],
+        },
+    ]
+
+    with pytest.raises(RendererError, match="disables thinking"):
+        renderer.build_supervised_example(cast(list[Message], reasoned))
+
+    plain = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]
+    model_input, weights = renderer.build_supervised_example(cast(list[Message], plain))
+    observation = model_input.to_ints()[: [w > 0 for w in weights.tolist()].index(True)]
+    assert (
+        observation == renderer.build_generation_prompt(cast(list[Message], plain[:-1])).to_ints()
+    )
+
 
 # Renderers whose supervised target is rendered the way sampling produces it rather than the
 # way the template renders history. HF writes a finished turn as history -- deepseek as a bare
@@ -1469,12 +1516,25 @@ _EXTENSION_PROPERTY_TEST_PARAMS = [
         {"strip_thinking_from_history": False},
         get_multiturn_thinking_conversation,
     ),
-    # Qwen3.5 disable thinking with strip_thinking_from_history=False (preserves thinking)
-    (
+    # Qwen3.5 disable thinking with strip_thinking_from_history=False (preserves thinking).
+    # A reasoning-less conversation, because the check trains each assistant turn in succession
+    # and a reasoning-off renderer refuses a produced turn that reasoned -- so no conversation
+    # carrying reasoning reaches the property here. Which leaves the claim unmet: with nothing
+    # to preserve, `_assistant_header_suffix` gates the empty block on `idx > last_user_index`,
+    # so one assistant turn carries it as the turn being produced and not as history, and the
+    # sequence through it is no longer a prefix of the next prompt. The old thinking
+    # conversation hid this -- every turn reasoned, so `has_think` suppressed the block
+    # everywhere and extension held by never exercising it.
+    pytest.param(
         "Qwen/Qwen3.6-35B-A3B",
         Qwen3_5DisableThinkingRenderer,
         {"strip_thinking_from_history": False},
-        get_multiturn_thinking_conversation,
+        get_basic_4turn_conversation,
+        marks=pytest.mark.xfail(
+            strict=True,
+            reason="positional empty-block rule renders a turn one way as the produced turn "
+            "and another as history, so has_extension_property=True is not met",
+        ),
     ),
     # DeepSeek non-thinking with basic multi-turn
     ("deepseek-ai/DeepSeek-V3.1", "deepseekv3", {}, get_basic_4turn_conversation),

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -1011,9 +1011,7 @@ _REASONING_OFF_RENDERERS = [
 def test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned(model_name: str, renderer_name: str):
     """These renderers tell the model not to reason, so a turn that reasoned cannot be trained.
 
-    Drop the reasoning and the same turn renders fine, with its observation equal to the
-    prompt. Nothing but this check catches it: one renderer produces both sides, so comparing
-    against a second implementation sees two copies of the same mistake.
+    Without the reasoning the same turn renders fine, and its observation equals the prompt.
     """
     renderer = get_renderer(renderer_name, get_tokenizer(model_name))
     reasoned = [
@@ -1045,15 +1043,14 @@ def test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned(model_name: str, 
 def test_a_turn_that_reasoned_is_never_trained_after_a_prompt_it_cannot_follow(
     model_name: str, renderer_name: str
 ):
-    """Whatever a renderer does with reasoning, it must not train it after the wrong prompt.
+    """A turn that reasoned is refused, or it is trained after the prompt it is sampled from.
 
-    Refusing is fine, rendering it is fine, and dropping it is fine. What is not fine is an
-    example whose tokens do not start with the prompt its turn is sampled after, because that
-    trains the model on a sequence it is never given.
+    Refusing, rendering and dropping the reasoning are all fine. Training an example that does
+    not start with its own generation prompt is not, because the model is never given that
+    sequence.
 
-    This is the check that catches a reasoning-off renderer added without `disables_thinking`:
-    it would render the reasoning, the example would not start with the generation prompt, and
-    nothing else here would notice.
+    Catches a reasoning-off renderer added without `disables_thinking`: it would render the
+    reasoning, and nothing else here would notice.
     """
     renderer = get_renderer(renderer_name, get_tokenizer(model_name))
     reasoned = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #885

## The bug

Six `*_disable_thinking` renderers trained the model to reason after telling it not to.

Their generation prompt closes the think block — that is how they say "do not reason". But
`build_supervised_example`, given a turn that reasoned, wrote the reasoning out anyway and
dropped the closed block:

```
qwen3_disable_thinking, [user, assistant(thinking, "4")]

what sampling is given   ...assistant\n<think>\n\n</think>\n\n
what the example trains  ...assistant\n<think>\n2+2 is 4\n</think>\n\n4<|im_end|>
```

The example trains on a sequence the model is never given, and what it trains is reasoning —
the one thing this mode exists to switch off.

Affects the disable-thinking renderers for qwen3, qwen3_5, kimi_k25, kimi_k26, nemotron3 and
nemotron3_ultra.

## The template says we are wrong

Qwen3's template with `enable_thinking=False` writes the empty block in both modes, so its
generation prompt is an exact prefix of its document form. We were contradicting the template,
not copying it.

## The fix

`_train_after_the_generation_prompt` already checks whether the render starts with the
generation prompt. It quietly returned the weights unchanged when it did not. That silence is
the bug, so the only new decision is what to do instead.

Two things make that check fail, and only one is the caller's fault. The renderer says which:

| renderer | what the failure means | what we do |
|---|---|---|
| sets `disables_thinking` | the turn was told not to reason, and reasoned anyway | raise |
| anything else | the template disagrees with itself | stay quiet, as before |

Row one is the bug above. Row two is nemotron3 (#860): NVIDIA's template ends its prompt with
`<think>\n` but writes `<think></think>` for a turn with no reasoning. No caller can fix that,
so it keeps the old behaviour.

### Why raise, rather than drop the reasoning?

Dropping it and training the rest is a real option — `deepseekv3` already does exactly that,
which is why it never reaches this check. Cookbook is also happy to drop reasoning from
*history*, which is what `strip_thinking_from_history` is for.

The difference is that this is the turn being **trained**. Dropping its reasoning changes what
the model is taught, and does it silently: you asked to train on reasoning and got a model
trained not to. The conversation and the renderer contradict each other, and only the caller
knows which of the two is the mistake, so we say so rather than pick one.

The other options and why not:

| option | why not |
|---|---|
| train it anyway | the bug being fixed — silently trains an unreachable sequence |
| warn and train anyway | a log line does not stop a bad training run, and the damage is invisible |
| render as if thinking were on | silently switches the mode the caller chose |

For row one the same reasoning runs the other way: raising there would reject training a
thinking renderer on data with no reasoning, which is a perfectly normal thing to do.

## Where the check lives, and what else was tried

| implementation | why not |
|---|---|
| `render_message` override, per renderer — #882's shape, in this same file | it sees one message, not the assembled example, so it has to predict the failure from position and content rather than observe it; and four renderer classes each repeat that logic |
| a check in the `build_supervised_example` loop | same prediction problem: it needs `has_thinking` plus is-last plus is-trained guards to avoid firing when the render drops the reasoning anyway, which `deepseekv3` and history-stripping both do |
| work the mode out from the prompt at runtime | see below |
| **a `disables_thinking` flag, read by the existing prefix check** (this PR) | the invariant is already computed there, and the flag is a fact the renderer already knows |

#882 is the closest precedent and worth spelling out: it refuses on a property of the
**conversation** — no user message — which you can tell while rendering a single message. This
is a property of the **assembled example**: does it start with the generation prompt.
`render_message` cannot see that.

### Why not work it out from the prompt?

Tempting, because it cannot be forgotten. But the mode is a fact about the *renderer*, and
deriving it means reading it back through the tokenizer, which is not reliable:
`Qwen3DisableThinkingRenderer` disables thinking whichever tokenizer you hand it, and
`get_renderer` takes any tokenizer — `warn_if_renderer_not_recommended` exists precisely
because mismatches happen. With a Llama tokenizer:

```
qwen3_disable_thinking, Llama-3.1 tokenizer
  prompt ends  ...assistant\n<think>\n\n</think>\n\n   the block is plainly closed
  </think> as a single token?  no
```

Detection by token id then answers "not closed" and the bug comes back, silently. Detecting on
decoded text instead avoids that, but keeps the same tokenizer round-trip and adds a
how-many-tokens-to-decode constant, on a path that a self-contradicting template hits for every
example.

So the mode is declared, and the cost of declaring it — someone forgets on the next model
family — is paid by a test rather than by runtime cleverness.
`test_a_turn_that_reasoned_is_never_trained_after_a_prompt_it_cannot_follow` runs over every
renderer in `_CONSISTENCY_RENDERERS`: a turn that reasoned must either be refused, or produce
an example that still starts with its generation prompt. Removing `disables_thinking` from
`qwen3_disable_thinking` fails it, and the message says what to set.

`deepseekv3` does not set the flag and does not need it: it strips reasoning out of content, so
its render already starts with its prompt, and it passes the test by the second branch.

## Why nobody noticed

`_RENDERERS_WITH_THINKING_STRIPPING` excluded reasoning conversations from precisely these
renderers, so the tests never gave them the input that shows the bug. Its comment said they
strip reasoning; only `deepseekv3` and `kimi_k2` do. Same shape as #862.

## A second bug, recorded but not fixed

Putting a reasoning-free conversation into the extension-property test exposed an unrelated,
pre-existing defect. `Qwen3_5DisableThinkingRenderer` decides the empty block by position
(`idx > last_user_index`), so one assistant turn gets it as the turn being produced and not as
history, and `has_extension_property=True` does not hold. The old fixture hid this because
every turn reasoned, so no turn ever got the block. Marked `xfail(strict=True)`, which goes red
when someone fixes it.

## Test plan

`test_a_reasoning_off_renderer_refuses_a_turn_that_reasoned` covers one renderer per family:
the turn that reasoned raises, and the same turn without reasoning renders with
`observation == build_generation_prompt(...)`.

The two nemotron HF-parity tests keep their subject and move to a conversation whose history
reasoned and whose final turn did not, so `truncate_history_thinking=False` still has history
to preserve.

- `pytest tinker_cookbook/renderers tinker_cookbook/supervised tinker_cookbook/model_info_test.py`
  — 720 passed, 132 skipped, 1 xfailed
- `ruff check`, `ruff format --check`, `pyright` clean on the touched files

Checked against the monorepo's `lib/chat_conformance`, which runs this same train/serve check
over all 26 cookbook renderers that pair with a model: 30 disagreements before, 18 after, and
all 18 remaining are the nemotron3 thinking variants described above. Over five reasoning-free
conversations on all 26 renderers, the new error never fires. No renderer that already agreed
changed.
