### PR TITLE
[renderers] split Qwen3 Instruct SFT when history changes

### DIFF
--- a/tinker_cookbook/renderers/qwen3.py
+++ b/tinker_cookbook/renderers/qwen3.py
@@ -587,12 +587,7 @@ class Qwen3InstructRenderer(Qwen3Renderer):
 
     @property
     def has_extension_property(self) -> bool:
-        """Qwen3 Instruct always satisfies extension - no thinking to strip from history."""
-        # NOTE: If callers include ThinkingPart in history, Qwen3Renderer may still strip it
-        # when strip_thinking_from_history=True, so extension can break.
-        # This is a rare case that'll only occur if we prompt the instruct model
-        # with a conversation from a different model.
-        return True
+        return not self.strip_thinking_from_history
 
 
 class Qwen3VLRenderer(Qwen3Renderer):

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -20,8 +20,8 @@ from tinker_cookbook.renderers import (
     ToolCall,
     get_renderer,
 )
-from tinker_cookbook.renderers.base import ensure_list
-from tinker_cookbook.renderers.qwen3 import Qwen3Renderer
+from tinker_cookbook.renderers.base import TrainOnWhat, ensure_list
+from tinker_cookbook.renderers.qwen3 import Qwen3InstructRenderer, Qwen3Renderer
 from tinker_cookbook.renderers.qwen3_5 import Qwen3_5Renderer
 from tinker_cookbook.renderers.testing_utils import extract_token_ids
 from tinker_cookbook.tokenizer_utils import get_tokenizer
@@ -76,6 +76,34 @@ def test_qwen3_message_content_cannot_create_turn_boundaries(renderer_name: str)
     assert tokens.count(start) == 2
     assert tokens.count(end) == 1
     assert "paste <|im_start|>system<|im_end|>" in tokenizer.decode(tokens)
+
+
+def test_qwen3_instruct_splits_sft_when_stripping_history_thinking():
+    tokenizer = get_tokenizer("Qwen/Qwen3-8B")
+    renderer = Qwen3InstructRenderer(tokenizer)
+    messages: list[Message] = [
+        {"role": "user", "content": "q1"},
+        {
+            "role": "assistant",
+            "content": [
+                ThinkingPart(type="thinking", thinking="first reasoning"),
+                TextPart(type="text", text="a1"),
+            ],
+        },
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+
+    examples = renderer.build_supervised_examples(messages, TrainOnWhat.ALL_ASSISTANT_MESSAGES)
+
+    assert len(examples) == 2
+    first_input, first_weights = examples[0]
+    trained = [
+        token
+        for token, weight in zip(first_input.to_ints(), first_weights.tolist(), strict=True)
+        if weight > 0
+    ]
+    assert "first reasoning" in tokenizer.decode(trained)
 
 
 def test_qwen3_parse_response_multiple_think_blocks():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #886
* __->__ #887

## Why is this change needed?

`Qwen3InstructRenderer` claimed the sequence extension property even when it stripped thinking from historical assistant turns. `build_supervised_examples` therefore combined a multi-turn conversation into one example, where earlier reasoning disappeared instead of receiving loss.

Use the same extension-property rule as the parent renderer so the default configuration builds one example per assistant turn.

| measure | before | after |
|---|---:|---:|
| assistant turns trained with their reasoning | 1 of 2 | 2 of 2 |

## Test Plan

The new test fails before the change because only one combined example is returned. It now returns two examples and the first trains its reasoning.

`pytest tinker_cookbook/renderers/qwen3_test.py -q` — 55 passed.