### PR TITLE
[renderers] train the full RoleColon stop on every turn

### DIFF
--- a/tinker_cookbook/renderers/base.py
+++ b/tinker_cookbook/renderers/base.py
@@ -1253,8 +1253,9 @@ class RenderedMessage:
 
             Only RoleColonRenderer uses this. Its stop sequence is "\\\\n\\\\nUser:", where "\\\\n\\\\n"
             ends the output but "User:" would duplicate the next message's header. To avoid
-            duplication, "User:" is stored here and only appended for the last message in
-            supervised training. The name "stop_overlap" reflects that these tokens are the
+            duplication, "User:" is stored here. In supervised training, the matching next
+            header receives the preceding output's weight; when there is no next header, the
+            overlap is appended. The name "stop_overlap" reflects that these tokens are the
             overlap between the stop sequence and the next message's header.
     """
 
@@ -1812,6 +1813,7 @@ class Renderer(ABC):
         )
 
         turn_start = self._last_assistant_turn_start_index(messages[:-1])
+        pending_stop_overlap: tuple[tinker.types.EncodedTextChunk, bool] | None = None
 
         for idx, message in enumerate(messages):
             if train_on_what == TrainOnWhat.CUSTOMIZED:
@@ -1840,6 +1842,11 @@ class Renderer(ABC):
             stop_overlap_part = rendered_message.stop_overlap
 
             header_weight = int(train_on_what == TrainOnWhat.ALL_TOKENS)
+            if pending_stop_overlap is not None:
+                overlap, overlap_has_weight = pending_stop_overlap
+                if header_part and header_part.tokens == overlap.tokens:
+                    header_weight = max(header_weight, int(overlap_has_weight))
+                pending_stop_overlap = None
             if header_part:
                 model_input_chunks_weights += [(header_part, header_weight)]
 
@@ -1849,10 +1856,12 @@ class Renderer(ABC):
                 (output_part, int(output_has_weight)) for output_part in output_parts if output_part
             ]
 
-            # stop_overlap completes the stop sequence for formats like RoleColon (e.g., "User:")
-            # Only included for the last message.
             if is_last_message and stop_overlap_part:
                 model_input_chunks_weights += [(stop_overlap_part, int(output_has_weight))]
+            elif stop_overlap_part:
+                # The next message already renders these tokens as its header. Give that header
+                # the preceding output's weight instead of duplicating the stop sequence.
+                pending_stop_overlap = (stop_overlap_part, output_has_weight)
 
         weights_data = [w for chunk, w in model_input_chunks_weights for _ in range(chunk.length)]
         weights_tensor = torch.tensor(weights_data)

--- a/tinker_cookbook/renderers/role_colon_test.py
+++ b/tinker_cookbook/renderers/role_colon_test.py
@@ -1,4 +1,4 @@
-"""Tests for RoleColonRenderer.parse_response.
+"""Tests for RoleColon rendering and parsing.
 
 Regression tests for issue #685: base models that terminate single-turn
 responses with EOS (no "\\n\\nUser:" delimiter) must report ``ParseTermination.EOS``
@@ -8,7 +8,7 @@ failed_parse_reward=0 and never grades the answer.
 
 import pytest
 
-from tinker_cookbook.renderers.base import ParseTermination
+from tinker_cookbook.renderers.base import Message, ParseTermination, TrainOnWhat
 from tinker_cookbook.renderers.role_colon import RoleColonRenderer
 from tinker_cookbook.tokenizer_utils import get_tokenizer
 
@@ -91,6 +91,36 @@ def test_parse_response_multiple_user_delimiters_is_malformed(renderer: RoleColo
 
     assert termination == ParseTermination.MALFORMED
     assert message["content"] == "Answer."
+
+
+def test_supervised_trains_the_full_stop_on_intermediate_turns(renderer: RoleColonRenderer):
+    messages: list[Message] = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+
+    model_input, weights = renderer.build_supervised_example(
+        messages, TrainOnWhat.ALL_ASSISTANT_MESSAGES
+    )
+    trained = [
+        token
+        for token, weight in zip(model_input.to_ints(), weights.tolist(), strict=True)
+        if weight > 0
+    ]
+
+    assert renderer.tokenizer.decode(trained) == " a1\n\nUser: a2\n\nUser:"
+
+    last_input, last_weights = renderer.build_supervised_example(
+        messages, TrainOnWhat.LAST_ASSISTANT_MESSAGE
+    )
+    last_trained = [
+        token
+        for token, weight in zip(last_input.to_ints(), last_weights.tolist(), strict=True)
+        if weight > 0
+    ]
+    assert renderer.tokenizer.decode(last_trained) == " a2\n\nUser:"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #886
* #887
* __->__ #888

RoleColon stores User: as the part of its stop sequence that overlaps the next user header. Give that existing header the preceding assistant output's weight, so intermediate turns learn the same full stop as the final turn without duplicating tokens.\n\nTests: uv run pytest -q tinker_cookbook/renderers/role_colon_test.py (10 passed)