### PR TITLE
[harbor_rl] Upload test fixtures as bytes so binary graders work

### DIFF
--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools.py
@@ -93,12 +93,18 @@ class HarborReward:
         Walks ``tests_dir`` recursively so nested fixture trees (e.g. a
         ``tests/repo_overlay/`` directory copied into the workspace by
         ``test.sh``) are preserved. ``Path.iterdir`` would silently drop them.
+
+        Files are read as bytes because test fixtures are not always text:
+        several Terminal-Bench tasks ship reference images, serialized model
+        weights, or tarballs that their graders compare against. ``read_text``
+        raises ``UnicodeDecodeError`` on those, which ``__call__`` swallows
+        into a zero reward, making the task permanently unsolvable.
         """
         await self.sandbox.run_command("mkdir -p /tests", workdir="/")
         for file_path in self.tests_dir.rglob("*"):
             if not file_path.is_file():
                 continue
-            content = file_path.read_text()
+            content = file_path.read_bytes()
             target = f"/tests/{file_path.relative_to(self.tests_dir)}"
             await self.sandbox.write_file(target, content, executable=(file_path.suffix == ".sh"))
 

--- a/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
+++ b/tinker_cookbook/recipes/harbor_rl/harbor_tools_test.py
@@ -19,7 +19,9 @@ class FakeSandbox:
     """In-memory sandbox for testing."""
 
     def __init__(self) -> None:
-        self.files: dict[str, str] = {}
+        # Values are stored exactly as written so binary fixtures round-trip,
+        # matching ModalSandbox.write_file, which streams raw bytes.
+        self.files: dict[str, str | bytes] = {}
         self.executable_files: set[str] = set()
         self.commands_run: list[str] = []
         self._command_results: dict[str, SandboxResult] = {}
@@ -51,13 +53,15 @@ class FakeSandbox:
         self, path: str, max_bytes: int | None = None, timeout: int = 60
     ) -> SandboxResult:
         if path in self.files:
-            return SandboxResult(stdout=self.files[path], stderr="", exit_code=0)
+            content = self.files[path]
+            stdout = content if isinstance(content, str) else content.decode(errors="replace")
+            return SandboxResult(stdout=stdout, stderr="", exit_code=0)
         return SandboxResult(stdout="", stderr=f"No such file: {path}", exit_code=1)
 
     async def write_file(
         self, path: str, content: str | bytes, executable: bool = False, timeout: int = 60
     ) -> SandboxResult:
-        self.files[path] = content if isinstance(content, str) else content.decode()
+        self.files[path] = content
         if executable:
             self.executable_files.add(path)
         return SandboxResult(stdout="", stderr="", exit_code=0)
@@ -152,6 +156,28 @@ class TestHarborReward:
         assert "/tests/test.sh" in sandbox.executable_files
         assert "/tests/helper.py" not in sandbox.executable_files
         assert "/tests/fixtures/expected.txt" not in sandbox.executable_files
+
+    def test_upload_tests_with_binary_fixture(self, tmp_path: Path) -> None:
+        """Non-UTF-8 fixtures upload byte-for-byte instead of failing the grade.
+
+        Terminal-Bench tasks such as sam-cell-seg (tests/test_img.png) and
+        pytorch-model-recovery (tests/weights_gtruth.pt) ship binary ground
+        truth that their graders read back, so reading the tree as text makes
+        those tasks unsolvable regardless of what the agent did.
+        """
+        png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\xff\xfe"
+        (tmp_path / "test.sh").write_text("#!/bin/bash\necho ok")
+        (tmp_path / "reference.png").write_bytes(png_bytes)
+
+        sandbox = FakeSandbox()
+        sandbox.files["/logs/verifier/reward.txt"] = "1.0"
+        reward_fn = self._make_reward(tmp_path, sandbox)
+
+        reward, info = asyncio.run(reward_fn([]))
+
+        assert sandbox.files["/tests/reference.png"] == png_bytes
+        assert reward == 1.0
+        assert "grading_error" not in info
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #889.

### Problem

`HarborReward._upload_tests` read every file under a task's `tests/` directory with `Path.read_text()`. Terminal-Bench tasks whose graders compare against binary ground truth raise `UnicodeDecodeError` there, and `__call__` catches it and returns `reward=0.0, grading_error=1.0` — so those tasks score zero regardless of what the agent did.

7 of the 89 tasks in `terminal-bench@2.0` are affected: `build-pov-ray`, `make-doom-for-mips`, `make-mips-interpreter`, `pytorch-model-recovery`, `sam-cell-seg`, `train-fasttext`, `video-processing`. Their fixtures are load-bearing — `sam-cell-seg/tests/test.sh:25` does `cp /tests/test_img.png .`, and `make-mips-interpreter/tests/test_outputs.py:71` reads `/tests/reference.jpg` for an L2 image comparison.

Because the failure is swallowed rather than raised, `eval.py` classifies the returned `0.0` as `FAIL` rather than `ERROR`, so it is indistinguishable from a genuine miss. In RL the group's reward is constant zero, so advantages center to zero and the group yields no gradient.

### Change

- `_upload_tests` reads with `read_bytes()` instead of `read_text()`. `SandboxInterface.write_file` already accepts `str | bytes`, and `ModalSandbox.write_file` encodes `str` to bytes before streaming to stdin, so this is the path it was already built for — no sandbox-layer change needed.
- `FakeSandbox` now stores written content verbatim instead of eagerly `.decode()`-ing it, so the test double round-trips binary the way the real sandbox does. `read_file` decodes on the way out to keep returning `str`.
- New regression test `test_upload_tests_with_binary_fixture`.

### Verification

The new test fails on `main` with the same error seen in training logs:

```
E       KeyError: '/tests/reference.png'
ERROR   Harbor grading failed: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
1 failed, 10 passed
```

and passes with the fix:

```
11 passed in 2.27s
```

Wider suite: `pytest tinker_cookbook/recipes/ tinker_cookbook/tool_use/` gives 194 passed, 10 skipped. The remaining failures in my environment are pre-existing and unrelated to these files (`sdft_test.py` needs `pytest-asyncio`; `math_rl` needs the `math-rl` extra). `ruff format --check` and `ruff check` are clean on both files.

### Note

#673 (draft) also touches `harbor_tools.py` and `harbor_tools_test.py`. It does not modify `_upload_tests`, but it does add its own `FakeSandbox` usage, so there may be a textual conflict to resolve depending on merge order.
