### PR TITLE
Fix IFEval dropping a constraint when a prompt repeats an instruction id

### DIFF
--- a/tinker_cookbook/eval/benchmarks/_ifeval_verify.py
+++ b/tinker_cookbook/eval/benchmarks/_ifeval_verify.py
@@ -329,7 +329,7 @@ def verify_all_instructions(
     response: str,
     instruction_id_list: list[str],
     kwargs_list: list[dict],
-) -> tuple[float, dict[str, bool]]:
+) -> tuple[float, list[bool]]:
     """Verify all instructions for a prompt.
 
     Args:
@@ -338,15 +338,19 @@ def verify_all_instructions(
         kwargs_list: Per-instruction kwargs (e.g. ``{"keywords": ["hello"]}``)
 
     Returns:
-        Tuple of (fraction_correct, per_instruction_results).
+        Tuple of (fraction_correct, per_instruction_results), where the results
+        are in the same order as ``instruction_id_list``.
     """
     if not instruction_id_list:
-        return 1.0, {}
+        return 1.0, []
 
-    results = {}
+    # A prompt can repeat an instruction id with different kwargs (17 of the 541
+    # google/IFEval prompts do), so results are kept positionally — keying them
+    # by id would drop all but the last constraint of each repeated id.
+    results = []
     for inst_id, kw in zip(instruction_id_list, kwargs_list):
-        results[inst_id] = verify_instruction(inst_id, response, kw)
+        results.append(verify_instruction(inst_id, response, kw))
 
-    n_correct = sum(results.values())
+    n_correct = sum(results)
     fraction = n_correct / len(results)
     return fraction, results

--- a/tinker_cookbook/eval/benchmarks/benchmark_test.py
+++ b/tinker_cookbook/eval/benchmarks/benchmark_test.py
@@ -619,3 +619,144 @@ class TestTokenTurnSummary:
         )
         assert result["total_turns"] == 0
         assert "ac_tokens_per_turn" not in result
+
+
+class TestIFEvalDuplicateInstructions:
+    """Grading a prompt that carries the same instruction id more than once.
+
+    17 of the 541 google/IFEval prompts repeat an id with different kwargs
+    (e.g. key 19 has two ``length_constraints:number_words`` constraints), so
+    every constraint has to be scored on its own, not folded together.
+    """
+
+    def test_first_of_duplicate_pair_violated(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        # Only 3 words: the "at least 20" constraint fails, "at least 2" passes.
+        fraction, results = verify_all_instructions(
+            "one two three",
+            ["length_constraints:number_words", "length_constraints:number_words"],
+            [
+                {"relation": "at least", "num_words": 20},
+                {"relation": "at least", "num_words": 2},
+            ],
+        )
+        assert fraction == 0.5
+        assert list(results) == [False, True]
+
+    def test_second_of_duplicate_pair_violated(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        fraction, results = verify_all_instructions(
+            "one two three",
+            ["length_constraints:number_words", "length_constraints:number_words"],
+            [
+                {"relation": "at least", "num_words": 2},
+                {"relation": "at least", "num_words": 20},
+            ],
+        )
+        assert fraction == 0.5
+        assert list(results) == [True, False]
+
+    def test_both_of_duplicate_pair_satisfied(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        fraction, results = verify_all_instructions(
+            "one two three",
+            ["length_constraints:number_words", "length_constraints:number_words"],
+            [
+                {"relation": "at least", "num_words": 2},
+                {"relation": "at least", "num_words": 3},
+            ],
+        )
+        assert fraction == 1.0
+        assert list(results) == [True, True]
+
+    def test_both_of_duplicate_pair_violated(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        fraction, results = verify_all_instructions(
+            "one two three",
+            ["length_constraints:number_words", "length_constraints:number_words"],
+            [
+                {"relation": "at least", "num_words": 20},
+                {"relation": "at least", "num_words": 30},
+            ],
+        )
+        assert fraction == 0.0
+        assert list(results) == [False, False]
+
+    def test_duplicate_pair_counts_twice_in_denominator(self):
+        """Two constraints sharing an id must divide by 2, not by 1."""
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        fraction, results = verify_all_instructions(
+            "one two three",
+            ["length_constraints:number_words", "length_constraints:number_words"],
+            [
+                {"relation": "at least", "num_words": 20},
+                {"relation": "at least", "num_words": 2},
+            ],
+        )
+        assert len(results) == 2
+        assert fraction == 0.5
+
+    def test_ifeval_key_19_shape(self):
+        """Mirrors IFEval key 19: two word-count bounds, only one of them met."""
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        response = " ".join(["word"] * 40)
+        fraction, _ = verify_all_instructions(
+            response,
+            ["length_constraints:number_words", "length_constraints:number_words"],
+            [
+                {"relation": "at least", "num_words": 30},
+                {"relation": "at least", "num_words": 100},
+            ],
+        )
+        # A response that misses one of the two bounds isn't a correct answer.
+        assert fraction == 0.5
+        assert fraction != 1.0
+
+    def test_duplicate_ids_with_a_third_constraint(self):
+        """Shaped like key 1418: a repeated id alongside an unrelated one."""
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        fraction, results = verify_all_instructions(
+            "One. Two. Three.",
+            [
+                "punctuation:no_comma",
+                "length_constraints:number_sentences",
+                "length_constraints:number_sentences",
+            ],
+            [
+                {},
+                {"relation": "at least", "num_sentences": 2},
+                {"relation": "at least", "num_sentences": 10},
+            ],
+        )
+        assert len(results) == 3
+        assert fraction == pytest.approx(2 / 3)
+
+    def test_distinct_ids_unchanged(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        fraction, results = verify_all_instructions(
+            "hello world",
+            ["keywords:existence", "punctuation:no_comma", "keywords:forbidden_words"],
+            [
+                {"keywords": ["hello"]},
+                {},
+                {"forbidden_words": ["world"]},
+            ],
+        )
+        assert len(results) == 3
+        assert fraction == pytest.approx(2 / 3)
+        assert list(results) == [True, True, False]
+
+    def test_no_instructions(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_all_instructions
+
+        fraction, results = verify_all_instructions("anything", [], [])
+        assert fraction == 1.0
+        assert len(results) == 0


### PR DESCRIPTION
Fixes #893.

`verify_all_instructions` keyed its results by instruction id, so a prompt that repeats an id lost every result but the last — and the denominator shrank with it. Results are now kept positionally, matching what `ifbench.py::_verify_constraints` already does in the same directory.

```diff
-    results = {}
+    results = []
     for inst_id, kw in zip(instruction_id_list, kwargs_list):
-        results[inst_id] = verify_instruction(inst_id, response, kw)
+        results.append(verify_instruction(inst_id, response, kw))

-    n_correct = sum(results.values())
+    n_correct = sum(results)
     fraction = n_correct / len(results)
```

17 of the 541 `google/IFEval` prompts repeat an instruction id, so 17 constraints were never scored. Since `ifeval.py` derives `correct = fraction == 1.0`, a response violating the first of a repeated pair scored as fully correct — `("one two three", at least 20 words, at least 2 words)` returned `1.0` instead of `0.5`.

The second element of the return value changes from `dict[str, bool]` to `list[bool]`, and the empty-input early return from `1.0, {}` to `1.0, []`. That's safe: `verify_all_instructions` has exactly two references in the tree — its definition and `ifeval.py:64`, which discards the second element via `fraction, _ = ...`. Nothing reads it as a mapping.

## Tests

Added `TestIFEvalDuplicateInstructions` to `benchmark_test.py`:

- first of a repeated pair violated → `0.5`, not `1.0` (**fails on `main`**)
- both satisfied → `1.0`; both violated → `0.0`
- the denominator itself, asserted on the fraction rather than on a boolean
- a case mirroring dataset key 19 (two `number_words` bounds, only one satisfied)
- non-repeating prompts unchanged, and the empty-instruction case still returns `1.0`

`uv run pytest tinker_cookbook/eval/` goes from 72 to 81 passed (+9, no regressions). The wider unit suite is unchanged against a stashed baseline — `5 failed, 2009 passed` with the fix vs `5 failed, 2000 passed` without, the same five pre-existing failures in unrelated modules. `ruff check`, `ruff format --check` clean; `pyright` reports the same 98 package-wide errors before and after, so the type change adds none.

## Note

#892 also touches `benchmark_test.py` (a different bug in the same file — `less than` never matching). The two are independent; this adds a separate test class to keep the overlap minimal, and I'll rebase whichever lands second.
