### PR TITLE
Fix IFEval free credit: repeat_prompt branch, english_capital, fail closed on unhandled ids

### DIFF
--- a/tinker_cookbook/eval/benchmarks/_ifeval_verify.py
+++ b/tinker_cookbook/eval/benchmarks/_ifeval_verify.py
@@ -212,8 +212,9 @@ def verify_instruction(instruction_id: str, response: str, kwargs: dict) -> bool
 
         # --- change_case ---
         elif iid == "change_case:english_capital":
-            words = response.split()
-            return all(w[0].isupper() for w in words if w and w[0].isalpha())
+            # Reference: instructions.py CapitalLettersEnglishChecker, value.isupper().
+            # First-letter-per-word checking accepted title case as "all capital letters".
+            return response.isupper()
 
         elif iid == "change_case:english_lowercase":
             alpha = [c for c in response if c.isalpha()]
@@ -311,9 +312,19 @@ def verify_instruction(instruction_id: str, response: str, kwargs: dict) -> bool
             separators = ["***", "---", "===", "Response 1", "Response 2"]
             return any(sep in response for sep in separators)
 
+        elif iid == "combination:repeat_prompt":
+            # Reference: instructions.py RepeatPromptThenAnswer.check_following.
+            prompt_to_repeat = kwargs.get("prompt_to_repeat", "")
+            if not prompt_to_repeat:
+                return False
+            return response.strip().lower().startswith(prompt_to_repeat.strip().lower())
+
         else:
-            logger.debug(f"Unhandled instruction type: {instruction_id}")
-            return True
+            # Fail closed, matching ifbench.py's unknown-id handling. Returning True
+            # here silently paid full credit for any constraint this chain does not
+            # implement, invisibly at default log levels.
+            logger.warning(f"Unhandled instruction type: {instruction_id}")
+            return False
 
     except Exception as e:
         logger.warning(f"Error verifying instruction {instruction_id}: {e}")

--- a/tinker_cookbook/eval/benchmarks/_ifeval_verify_test.py
+++ b/tinker_cookbook/eval/benchmarks/_ifeval_verify_test.py
@@ -62,9 +62,7 @@ class TestEnglishCapital:
         )
 
     def test_mixed_case_fails(self):
-        assert not verify_instruction(
-            "change_case:english_capital", "THIS IS MOSTLY caps", {}
-        )
+        assert not verify_instruction("change_case:english_capital", "THIS IS MOSTLY caps", {})
 
 
 class TestUnhandledInstructionId:

--- a/tinker_cookbook/eval/benchmarks/_ifeval_verify_test.py
+++ b/tinker_cookbook/eval/benchmarks/_ifeval_verify_test.py
@@ -1,0 +1,79 @@
+"""Tests for the IFEval instruction verifier.
+
+Covers the silent free-credit paths reported in the repeat_prompt and
+english_capital issues: an instruction id with no branch fell through to
+``return True`` at DEBUG, and the all-capital check accepted title case.
+"""
+
+import pytest
+
+from tinker_cookbook.eval.benchmarks._ifeval_verify import (
+    verify_all_instructions,
+    verify_instruction,
+)
+
+PROMPT = (
+    "Write a blog post about the most interesting things you have seen or "
+    "ridden on public transportation."
+)
+
+
+class TestRepeatPrompt:
+    def test_violating_response_fails(self):
+        assert not verify_instruction(
+            "combination:repeat_prompt",
+            "i will not repeat anything",
+            {"prompt_to_repeat": PROMPT},
+        )
+
+    def test_complying_response_passes(self):
+        response = PROMPT + " Here is the post: trams are underrated."
+        assert verify_instruction(
+            "combination:repeat_prompt", response, {"prompt_to_repeat": PROMPT}
+        )
+
+    def test_case_and_whitespace_insensitive_like_reference(self):
+        response = "  " + PROMPT.upper() + " and now the answer."
+        assert verify_instruction(
+            "combination:repeat_prompt", response, {"prompt_to_repeat": PROMPT}
+        )
+
+    def test_missing_kwargs_fails_closed(self):
+        assert not verify_instruction("combination:repeat_prompt", "anything", {})
+
+    def test_solo_constraint_prompt_no_longer_scores_any_response_correct(self):
+        # google/IFEval key=1480: repeat_prompt is the only constraint.
+        fraction, results = verify_all_instructions(
+            "garbage response",
+            ["combination:repeat_prompt"],
+            [{"prompt_to_repeat": PROMPT}],
+        )
+        assert fraction < 1.0
+        assert results["combination:repeat_prompt"] is False
+
+
+class TestEnglishCapital:
+    def test_all_caps_passes(self):
+        assert verify_instruction("change_case:english_capital", "THIS IS ALL CAPS.", {})
+
+    def test_title_case_fails(self):
+        assert not verify_instruction(
+            "change_case:english_capital", "This Response Is Title Case", {}
+        )
+
+    def test_mixed_case_fails(self):
+        assert not verify_instruction(
+            "change_case:english_capital", "THIS IS MOSTLY caps", {}
+        )
+
+
+class TestUnhandledInstructionId:
+    def test_unknown_id_fails_closed(self):
+        assert not verify_instruction("no_such:instruction", "any response", {})
+
+    @pytest.mark.parametrize(
+        "iid",
+        ["detectable_format:constrained_response", "count:counting_composition"],
+    )
+    def test_documented_approximations_still_pass(self, iid):
+        assert verify_instruction(iid, "any response", {})


### PR DESCRIPTION
Fixes #897, fixes #898.

Three changes in `_ifeval_verify.py`, all aligning with the reference `instruction_following_eval/instructions.py`:

1. **Add the missing `combination:repeat_prompt` branch** (reference: `RepeatPromptThenAnswer.check_following`, case- and whitespace-insensitive prefix match). Missing `prompt_to_repeat` kwargs fail closed. This constraint is on 41 of the 541 dataset prompts and was scoring as satisfied for any response; on the 18 prompts where it is the sole constraint, any response at all scored strict-correct (#897).
2. **`change_case:english_capital` uses `response.isupper()`** instead of first-letter-per-word, which accepted title case (#898).
3. **The unhandled-id fallthrough fails closed with a WARNING** instead of returning True at DEBUG, matching `ifbench.py`'s unknown-id handling. Verified against the official dataset that every instruction id present has an explicit branch, so on google/IFEval this changes nothing beyond the two fixes above; the two documented approximations (`constrained_response`, `counting_composition`) keep returning True in their own branches.

Tests in `tinker_cookbook/eval/benchmarks/_ifeval_verify_test.py` (unit-test convention, no API key): violating and complying repeat_prompt responses, reference-style case/whitespace insensitivity, missing-kwargs fail-closed, the key=1480 solo-constraint row no longer scoring any response correct, english_capital all-caps/title-case/mixed, unknown-id fail-closed, and the two documented approximations still passing. 11 pass with the fix; the bug-catching ones fail on current main (verified both ways before pushing).

Direction of the error before this fix: both `ifeval/strict_accuracy` and `ifeval/loose_accuracy` too high.
