### PR TITLE
[eval] extract_boxed takes the last box, matching math_rl

### DIFF
--- a/tinker_cookbook/eval/benchmarks/_common.py
+++ b/tinker_cookbook/eval/benchmarks/_common.py
@@ -324,24 +324,42 @@ class SandboxMixin:
 
 
 def extract_boxed(text: str) -> str | None:
-    r"""Extract content from ``\boxed{...}`` handling nested braces.
+    r"""Extract content from the last ``\boxed{...}`` handling nested braces.
+
+    When a response contains several ``\boxed{}`` spans -- e.g. a model boxes an
+    intermediate result, or a self-corrected value, before its final answer --
+    the last one is the answer. This matches the convention used by
+    ``recipes.math_rl.math_grading.extract_boxed`` and by the other extractors
+    in this module, which all take the last match.
+
+    Nested spans resolve to the outermost: ``\boxed{\boxed{3}}`` yields
+    ``\boxed{3}``. An unclosed span is skipped, so a well-formed earlier span is
+    still found.
 
     Returns:
-        The content inside the outermost ``\boxed{}``, or ``None`` if not found.
+        The content inside the last closed ``\boxed{}``, or ``None`` if there is none.
     """
-    idx = text.find("\\boxed{")
-    if idx == -1:
-        return None
-    start = idx + len("\\boxed{")
-    depth = 1
-    i = start
-    while i < len(text) and depth > 0:
-        if text[i] == "{":
-            depth += 1
-        elif text[i] == "}":
-            depth -= 1
-        i += 1
-    return text[start : i - 1] if depth == 0 else None
+    marker = "\\boxed{"
+    result: str | None = None
+    idx = text.find(marker)
+    while idx != -1:
+        start = idx + len(marker)
+        depth = 1
+        i = start
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        if depth == 0:
+            # Closed span: record it and resume past it so nesting keeps the outermost.
+            result = text[start : i - 1]
+            idx = text.find(marker, i)
+        else:
+            # Unclosed span: resume just inside it, in case a later span is well-formed.
+            idx = text.find(marker, start)
+    return result
 
 
 def extract_number(text: str) -> str:

--- a/tinker_cookbook/eval/benchmarks/benchmark_test.py
+++ b/tinker_cookbook/eval/benchmarks/benchmark_test.py
@@ -63,6 +63,60 @@ class TestBenchmarkConfig:
         assert c.judge_sampling_client is None
 
 
+class TestExtractBoxed:
+    """Test \\boxed{} extraction shared by the math and MCQ benchmarks."""
+
+    def test_single_box(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        assert extract_boxed("The answer is \\boxed{42}") == "42"
+
+    def test_multiple_boxes_returns_last(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        assert extract_boxed("\\boxed{1} then \\boxed{2}") == "2"
+
+    def test_self_correction_returns_final_answer(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        response = "Try \\boxed{7}. That is wrong; the answer is \\boxed{42}."
+        assert extract_boxed(response) == "42"
+
+    def test_nested_braces(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        assert extract_boxed("\\boxed{\\frac{1}{2}}") == "\\frac{1}{2}"
+        assert extract_boxed("\\boxed{\\sqrt{\\frac{3}{4}}}") == "\\sqrt{\\frac{3}{4}}"
+
+    def test_nested_boxed_returns_outermost(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        assert extract_boxed("\\boxed{\\boxed{3}}") == "\\boxed{3}"
+
+    def test_empty_box(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        assert extract_boxed("\\boxed{}") == ""
+
+    def test_no_box_returns_none(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        assert extract_boxed("no answer here") is None
+
+    def test_unclosed_box_returns_none(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        assert extract_boxed("\\boxed{unclosed") is None
+
+    def test_unclosed_box_falls_back_to_closed_span(self):
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed
+
+        # A trailing truncated span must not hide a well-formed earlier answer,
+        # and a leading truncated span must not swallow a later one.
+        assert extract_boxed("\\boxed{42} and \\boxed{unclosed") == "42"
+        assert extract_boxed("\\boxed{unclosed and \\boxed{42}") == "42"
+
+
 class TestGSM8KImport:
     def test_gsm8k_registered(self):
         # Importing the module triggers registration
@@ -391,6 +445,33 @@ class TestGradingConsistency:
             "\\boxed{C}",
             "I believe A is correct.",
             "D",
+        ]
+        for resp in cases:
+            assert old(resp) == new(resp), f"Mismatch on: {resp}"
+
+    def test_extract_boxed_matches_math_rl(self):
+        """Regression guard for #895: eval and math-RL must pick the same box.
+
+        The eval path and the math-RL training path both grade \\boxed{} answers.
+        They previously disagreed -- eval took the first span, math_rl the last --
+        so a self-correcting model was graded on its discarded first attempt.
+        """
+        # math_grading raises a bare ImportError (not ModuleNotFoundError) when the
+        # math-rl extras are absent, which pytest.importorskip does not catch.
+        try:
+            from tinker_cookbook.recipes.math_rl.math_grading import extract_boxed as old
+        except ImportError:
+            pytest.skip("math-rl extras (sympy, pylatexenc, math-verify) not installed")
+        from tinker_cookbook.eval.benchmarks._common import extract_boxed as new
+
+        cases = [
+            "The answer is \\boxed{42}",
+            "\\boxed{1} then \\boxed{2}",
+            "Try \\boxed{7}. That is wrong; the answer is \\boxed{42}.",
+            "\\boxed{\\frac{1}{2}}",
+            "\\boxed{\\sqrt{\\frac{3}{4}}}",
+            "\\boxed{x^2 + 1}",
+            "\\boxed{}",
         ]
         for resp in cases:
             assert old(resp) == new(resp), f"Mismatch on: {resp}"


### PR DESCRIPTION
Addresses #895.

`tinker_cookbook/eval/benchmarks/_common.py` and `tinker_cookbook/recipes/math_rl/math_grading.py` both grade `\boxed{}` answers, and they disagreed on which span wins: `_common.extract_boxed` scanned with `text.find` and returned the **first** box, while `math_grading.extract_boxed` returns the **last**. A model that boxes an intermediate or self-corrected value before its final answer was graded on the attempt it had discarded.

```python
text = r"First attempt gives \boxed{5}. That is wrong; correcting, the answer is \boxed{7}."
eval._common.extract_boxed(text)     # '5'
math_rl.extract_boxed(text)          # '7'
```

## Why last-wins

- It is already the convention in this module: `extract_number`, `extract_gsm8k_answer` and `extract_mcq_answer` all take the last match. `extract_boxed` was the only exception.
- It is what the training path does, so eval and RL now grade identically.
- The docstring said "outermost", which describes nesting rather than position, so the first-box scan reads as an oversight rather than a decision. The new docstring states position and nesting separately.

This reaches past the math benchmarks: `extract_mcq_answer` calls `extract_boxed` (`_common.py:437`), so `mmlu_pro`, `gpqa`, `mmlu_redux`, `ceval` and `supergpqa` were subject to the same first-vs-last choice.

## What changed

`extract_boxed` scans for the last *closed* span. Nesting still resolves to the outermost (`\boxed{\boxed{3}}` → `\boxed{3}`), because a closed span resumes the scan past its own end. An unclosed span resumes just inside itself, so it no longer hides a well-formed span on either side of it — `\boxed{42} and \boxed{unclosed` and `\boxed{unclosed and \boxed{42}` both yield `42`, where the second returned `None` before.

This shifts grading output for any response that contains more than one box, so cached eval results produced before this change would move.

## Tests

- New `TestExtractBoxed`: single, multiple, self-correction, nested braces, nested boxes, empty, absent, unclosed, and unclosed-alongside-closed.
- New `test_extract_boxed_matches_math_rl` in `TestGradingConsistency`, asserting the two implementations agree on the same inputs.

The three existing `TestGradingConsistency` tests all `importorskip` `recipes.nemotron_cascade`, which is no longer in the repo, so the class skipped in full and guarded nothing. The new test runs whenever the math-rl extras are installed. It catches the bare `ImportError` that `math_grading` raises when those extras are absent, which `pytest.importorskip` does not intercept, and skips instead.

Every existing boxed assertion in `benchmark_test.py` and `math_env_test.py` still passes; `ruff check`, `ruff format --check` and `pytest tinker_cookbook/eval/benchmarks/` are clean locally.

## Note

#895 asked which behaviour is authoritative and that question is still open. This is the branch I offered there — if first-wins was in fact intended, close this and the fix is a docstring on each side saying so. Happy for @winklemad to take it over or for a maintainer to reshape it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

