### PR TITLE
[distillation] a failed rollout no longer renumbers the teacher lookup

### DIFF
--- a/tinker_cookbook/distillation/sdft.py
+++ b/tinker_cookbook/distillation/sdft.py
@@ -57,6 +57,7 @@ from tinker_cookbook.eval.evaluators import SamplingClientEvaluator, SamplingCli
 from tinker_cookbook.rl.data_processing import (
     assemble_training_data,
     compute_advantages,
+    successful_rollout_indices,
 )
 from tinker_cookbook.rl.metric_util import RLTestSetEvaluator, compute_trajectory_metrics
 from tinker_cookbook.rl.rollouts import do_group_rollout_and_filter_constant_reward
@@ -96,6 +97,44 @@ class SDFTBatchProvider(Protocol):
         ...
 
     def __len__(self) -> int: ...
+
+
+def drop_failed_rollouts(
+    trajectory_groups_raw: Sequence[TrajectoryGroup | None],
+    builders_P: Sequence[EnvGroupBuilder],
+    questions_P: Sequence[str],
+    golden_answers_P: Sequence[str],
+) -> tuple[list[TrajectoryGroup], list[EnvGroupBuilder], list[str], list[str]]:
+    """Drop the problems whose rollout failed, keeping the parallel lists in step.
+
+    A group rollout returns ``None`` when every trajectory in it errored out.
+    Those problems have nothing to train on, but the builders, questions and
+    golden answers still run parallel to the full batch, and each surviving
+    datum is stamped with the *index* of its trajectory group -- the index the
+    teacher prompt is later looked up by. Filtering the groups alone renumbers
+    them, so every problem after the first failure is teacher-forced against an
+    earlier problem's prompt and the student learns against a distribution
+    conditioned on the wrong question.
+
+    Args:
+        trajectory_groups_raw (Sequence[TrajectoryGroup | None]): Rollout
+            results, one per problem, ``None`` where the rollout failed.
+        builders_P (Sequence[EnvGroupBuilder]): Builders for the batch.
+        questions_P (Sequence[str]): Questions for the batch.
+        golden_answers_P (Sequence[str]): Golden answers for the batch.
+
+    Returns:
+        tuple[list[TrajectoryGroup], list[EnvGroupBuilder], list[str], list[str]]:
+        The four lists restricted to the problems that produced a trajectory
+        group, still index-aligned with one another.
+    """
+    kept_P = successful_rollout_indices(trajectory_groups_raw)
+    return (
+        [cast(TrajectoryGroup, trajectory_groups_raw[i]) for i in kept_P],
+        [builders_P[i] for i in kept_P],
+        [questions_P[i] for i in kept_P],
+        [golden_answers_P[i] for i in kept_P],
+    )
 
 
 def build_sdft_teacher_prompt(
@@ -948,9 +987,9 @@ async def main(
                         for i, builder in enumerate(builders_P)
                     ],
                 )
-            trajectory_groups_P: list[TrajectoryGroup] = [
-                tg for tg in trajectory_groups_raw if tg is not None
-            ]
+            trajectory_groups_P, builders_P, questions_P, golden_answers_P = drop_failed_rollouts(
+                trajectory_groups_raw, builders_P, questions_P, golden_answers_P
+            )
 
             # Compute trajectory metrics
             taglist_P = [b.logging_tags() for b in builders_P]

--- a/tinker_cookbook/distillation/sdft_test.py
+++ b/tinker_cookbook/distillation/sdft_test.py
@@ -63,7 +63,7 @@ class TestDropFailedRollouts:
         )
 
         assert len(groups) == 2
-        assert [b.tag for b in builders] == ["b", "c"]
+        assert [b.logging_tags() for b in builders] == [["b"], ["c"]]
         assert questions == ["qb", "qc"]
         assert goldens == ["gb", "gc"]
 
@@ -76,7 +76,7 @@ class TestDropFailedRollouts:
         )
 
         assert groups == raw
-        assert [b.tag for b in builders] == ["a", "b"]
+        assert [b.logging_tags() for b in builders] == [["a"], ["b"]]
         assert questions == ["qa", "qb"]
         assert goldens == ["ga", "gb"]
 

--- a/tinker_cookbook/distillation/sdft_test.py
+++ b/tinker_cookbook/distillation/sdft_test.py
@@ -1,0 +1,123 @@
+"""Tests for SDFT batch bookkeeping."""
+
+from __future__ import annotations
+
+import tinker
+
+from tinker_cookbook.completers import TokensWithLogprobs
+from tinker_cookbook.distillation.sdft import drop_failed_rollouts
+from tinker_cookbook.rl.data_processing import assemble_training_data, compute_advantages
+from tinker_cookbook.rl.types import (
+    EnvGroupBuilder,
+    Trajectory,
+    TrajectoryGroup,
+    Transition,
+)
+
+
+class _FakeBuilder(EnvGroupBuilder):
+    def __init__(self, tag: str):
+        self.tag = tag
+
+    async def make_envs(self):  # type: ignore[override]
+        return []
+
+    def logging_tags(self) -> list[str]:
+        return [self.tag]
+
+
+def _make_trajectory_group(marker_token: int) -> TrajectoryGroup:
+    """A one-trajectory group whose action tokens identify which problem it is."""
+    return TrajectoryGroup(
+        trajectories_G=[
+            Trajectory(
+                transitions=[
+                    Transition(
+                        ob=tinker.ModelInput.from_ints([1, 2, 3]),
+                        ac=TokensWithLogprobs(
+                            tokens=[marker_token, marker_token],
+                            maybe_logprobs=[0.0, 0.0],
+                        ),
+                        reward=0.0,
+                        episode_done=True,
+                    )
+                ],
+                final_ob=tinker.ModelInput.from_ints([]),
+            )
+        ],
+        final_rewards_G=[0.0],
+        metrics_G=[{}],
+    )
+
+
+class TestDropFailedRollouts:
+    def test_keeps_lists_aligned(self):
+        builders_P = [_FakeBuilder("a"), _FakeBuilder("b"), _FakeBuilder("c")]
+        questions_P = ["qa", "qb", "qc"]
+        golden_answers_P = ["ga", "gb", "gc"]
+        # The first problem's rollout failed.
+        raw = [None, _make_trajectory_group(20), _make_trajectory_group(30)]
+
+        groups, builders, questions, goldens = drop_failed_rollouts(
+            raw, builders_P, questions_P, golden_answers_P
+        )
+
+        assert len(groups) == 2
+        assert [b.tag for b in builders] == ["b", "c"]
+        assert questions == ["qb", "qc"]
+        assert goldens == ["gb", "gc"]
+
+    def test_no_failures_is_identity(self):
+        builders_P = [_FakeBuilder("a"), _FakeBuilder("b")]
+        raw = [_make_trajectory_group(10), _make_trajectory_group(20)]
+
+        groups, builders, questions, goldens = drop_failed_rollouts(
+            raw, builders_P, ["qa", "qb"], ["ga", "gb"]
+        )
+
+        assert groups == raw
+        assert [b.tag for b in builders] == ["a", "b"]
+        assert questions == ["qa", "qb"]
+        assert goldens == ["ga", "gb"]
+
+    def test_all_failed(self):
+        groups, builders, questions, goldens = drop_failed_rollouts(
+            [None, None], [_FakeBuilder("a"), _FakeBuilder("b")], ["qa", "qb"], ["ga", "gb"]
+        )
+        assert groups == []
+        assert builders == []
+        assert questions == []
+        assert goldens == []
+
+    def test_group_idx_selects_the_datums_own_question(self):
+        """The teacher prompt is looked up by ``metadata_D["group_idx"]``.
+
+        That index points into the *filtered* group list, so the questions must
+        be filtered alongside it -- otherwise a student completion is teacher-
+        forced against another problem's prompt.
+        """
+        builders_P = [_FakeBuilder("a"), _FakeBuilder("b"), _FakeBuilder("c")]
+        questions_P = ["qa", "qb", "qc"]
+        # Marker tokens tie each trajectory back to the problem it came from.
+        marker_by_question = {"qa": 10, "qb": 20, "qc": 30}
+        raw = [None, _make_trajectory_group(20), _make_trajectory_group(30)]
+
+        groups, _builders, questions, _goldens = drop_failed_rollouts(
+            raw, builders_P, questions_P, ["ga", "gb", "gc"]
+        )
+
+        data_D, metadata_D = assemble_training_data(groups, compute_advantages(groups))
+        assert data_D
+
+        for datum, metadata in zip(data_D, metadata_D, strict=True):
+            question = questions[metadata["group_idx"]]
+            expected_marker = marker_by_question[question]
+            # Every action token in this datum came from that question's rollout.
+            assert expected_marker in datum.model_input.to_ints()
+
+        # The hazard this guards against: the same index into the *unfiltered*
+        # questions picks a different problem for every surviving datum.
+        assert all(
+            questions_P[metadata["group_idx"]] != questions[metadata["group_idx"]]
+            for metadata in metadata_D
+        )

--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -29,6 +29,7 @@ from tinker_cookbook.eval.evaluators import SamplingClientEvaluator, SamplingCli
 from tinker_cookbook.rl.data_processing import (
     assemble_training_data,
     compute_advantages,
+    successful_rollout_indices,
 )
 from tinker_cookbook.rl.metric_util import RLTestSetEvaluator, compute_trajectory_metrics
 from tinker_cookbook.rl.metrics import discounted_future_sum_vectorized
@@ -336,11 +337,14 @@ async def do_sync_training(
                         for i, builder in enumerate(env_group_builders_P)
                     ],
                 )
-            trajectory_groups_P = [
-                trajectory_group
-                for trajectory_group in trajectory_groups_P
-                if trajectory_group is not None
-            ]
+            # Drop the groups that failed to roll out, and filter the builders and
+            # dataset indices by the same indices. Both run parallel to the batch and
+            # are looked up downstream by the group index stamped onto each datum, so
+            # dropping groups alone would pick another problem's teacher client.
+            keep_P = successful_rollout_indices(trajectory_groups_P)
+            trajectory_groups_P = [cast(TrajectoryGroup, trajectory_groups_P[i]) for i in keep_P]
+            env_group_builders_P = [env_group_builders_P[i] for i in keep_P]
+            dataset_indices_P = [dataset_indices_P[i] for i in keep_P]
 
             # Train step
             sampling_client, train_step_metrics = await do_train_step_and_get_sampling_client(

--- a/tinker_cookbook/rl/data_processing.py
+++ b/tinker_cookbook/rl/data_processing.py
@@ -6,6 +6,7 @@ and assembling training batches.
 """
 
 import logging
+from collections.abc import Sequence
 
 import tinker
 import torch
@@ -230,6 +231,30 @@ def assemble_training_data(
             metadata_D.extend([{"group_idx": i_group, "traj_idx": i_traj} for _ in new_data])
 
     return data_D, metadata_D
+
+
+def successful_rollout_indices(
+    trajectory_groups_raw: Sequence[TrajectoryGroup | None],
+) -> list[int]:
+    """Indices of the rollouts that produced a trajectory group.
+
+    ``do_group_rollout_and_filter_constant_reward`` returns ``None`` for a group
+    it could not roll out. Dropping those from the group list alone renumbers
+    every group after the first failure, and the group index is what
+    :func:`assemble_training_data` stamps onto each datum -- so anything looked
+    up by that index afterwards (the teacher client for the datum, its dataset,
+    its prompt) silently comes from a different problem. Filter every list that
+    runs parallel to the batch by these indices.
+
+    Args:
+        trajectory_groups_raw (Sequence[TrajectoryGroup | None]): Rollout
+            results, one per problem in the batch, ``None`` where the rollout
+            failed.
+
+    Returns:
+        list[int]: Indices, ascending, of the non-``None`` entries.
+    """
+    return [i for i, group in enumerate(trajectory_groups_raw) if group is not None]
 
 
 def remove_constant_reward_groups(

--- a/tinker_cookbook/rl/data_processing_test.py
+++ b/tinker_cookbook/rl/data_processing_test.py
@@ -1,0 +1,81 @@
+"""Tests for RL data processing helpers."""
+
+from __future__ import annotations
+
+import tinker
+
+from tinker_cookbook.completers import TokensWithLogprobs
+from tinker_cookbook.rl.data_processing import (
+    assemble_training_data,
+    compute_advantages,
+    successful_rollout_indices,
+)
+from tinker_cookbook.rl.types import Trajectory, TrajectoryGroup, Transition
+
+
+def _make_trajectory(reward: float, num_action_tokens: int = 2) -> Trajectory:
+    return Trajectory(
+        transitions=[
+            Transition(
+                ob=tinker.ModelInput.from_ints([1, 2, 3]),
+                ac=TokensWithLogprobs(
+                    tokens=[4] * num_action_tokens,
+                    maybe_logprobs=[0.0] * num_action_tokens,
+                ),
+                reward=reward,
+                episode_done=True,
+            )
+        ],
+        final_ob=tinker.ModelInput.from_ints([]),
+    )
+
+
+def _make_trajectory_group(rewards: list[float], num_action_tokens: int = 2) -> TrajectoryGroup:
+    return TrajectoryGroup(
+        trajectories_G=[_make_trajectory(r, num_action_tokens) for r in rewards],
+        final_rewards_G=[0.0] * len(rewards),
+        metrics_G=[{} for _ in rewards],
+    )
+
+
+class TestSuccessfulRolloutIndices:
+    def test_skips_failed_rollouts(self):
+        groups_raw = [
+            None,
+            _make_trajectory_group([1.0, 0.0]),
+            None,
+            _make_trajectory_group([0.5, 0.25]),
+        ]
+        assert successful_rollout_indices(groups_raw) == [1, 3]
+
+    def test_all_succeeded(self):
+        groups_raw = [_make_trajectory_group([1.0, 0.0]) for _ in range(3)]
+        assert successful_rollout_indices(groups_raw) == [0, 1, 2]
+
+    def test_all_failed(self):
+        assert successful_rollout_indices([None, None]) == []
+
+    def test_no_rollouts(self):
+        assert successful_rollout_indices([]) == []
+
+    def test_group_index_stamped_on_datums_matches_the_filtered_list(self):
+        """``assemble_training_data`` numbers groups by position in the list it is given.
+
+        Anything the caller looks up by that index -- a teacher client, a
+        dataset index, a prompt -- must come from a list filtered by these same
+        indices, or it belongs to a different problem.
+        """
+        groups_raw = [None, _make_trajectory_group([1.0, 0.0]), _make_trajectory_group([0.5, 0.25])]
+        dataset_indices_P = [7, 8, 9]
+
+        keep_P = successful_rollout_indices(groups_raw)
+        groups_P = [groups_raw[i] for i in keep_P]
+        kept_dataset_indices_P = [dataset_indices_P[i] for i in keep_P]
+
+        _data_D, metadata_D = assemble_training_data(groups_P, compute_advantages(groups_P))
+        stamped = sorted({m["group_idx"] for m in metadata_D})
+        assert stamped == [0, 1]
+        assert [kept_dataset_indices_P[i] for i in stamped] == [8, 9]
+
+        # The hazard: the same indices into the unfiltered list name other problems.
+        assert [dataset_indices_P[i] for i in stamped] == [7, 8]


### PR DESCRIPTION
Both distillation training loops drop the trajectory groups whose rollout failed, but leave the lists running parallel to the batch at full length. Because a datum is identified downstream by the *position* of its group, everything after the first failure is looked up against another problem's data.

`assemble_training_data` stamps each datum with `metadata_D["group_idx"]`, an index into the list of groups it was given. Filter that list alone and every later group is renumbered:

```
problem       0        1        2
rollout     FAILED    ok       ok
groups_P              [0]      [1]      <- renumbered
parallel     [0]      [1]      [2]      <- not
```

so `group_idx=0` now selects problem 0's teacher while carrying problem 1's tokens.

## What breaks

**`train_on_policy.py` — wrong teacher model.** `env_group_builders_P` and `dataset_indices_P` stay whole, and `prepare_minibatch` builds the per-datum teacher list as

```python
teacher_clients_D = [
    teacher_clients[dataset_indices_P[metadata["group_idx"]]] for metadata in metadata_D
]
```

In a multi-dataset run, one failed rollout is enough to distill a student against another dataset's teacher for the rest of the batch. The comment directly above that line states the invariant the filter breaks: "metadata_D contains group_idx which indexes into trajectory_groups_P".

**`sdft.py` — wrong teacher prompt.** `questions_P` and `golden_answers_P` stay whole, and `teacher_prompts_P[group_idx]` is what each student completion is teacher-forced through. The completion is then scored against a teacher conditioned on a different question. This reaches all three modes — `build_reverse_kl_datums`, `build_topk_distillation_datums`, and the per-token importance-sampling path — since each indexes `teacher_prompts_P` the same way. The `SDFTBatchProvider.get_batch` docstring already promises these lists are parallel ("Each list has the same length (one per problem in the batch)").

Neither raises. The rollouts are valid, the shapes all match, and the loss is computed against a target for the wrong problem.

## Trigger

A group rollout returns `None` when `AllTrajectoriesFailedError` is raised or, under an error-tolerant strategy, when the group itself errors. No config flag gates this — both loops call `do_group_rollout_and_filter_constant_reward` with `do_remove_constant_reward_groups=False`, so `None` means failure only. A clean batch is unaffected, which is why this survives short runs and shows up as unexplained noise in long ones.

## What changed

`successful_rollout_indices` in `rl/data_processing.py` returns the indices rather than the filtered list, so callers can filter every parallel list in step:

- `train_on_policy.do_sync_training` filters `env_group_builders_P` and `dataset_indices_P` alongside the groups.
- `sdft.drop_failed_rollouts` does the same for `builders_P`, `questions_P` and `golden_answers_P`, and is exported so the invariant has one documented home.

The `rl/train.py` sync RL loop already pairs builders with groups before filtering `None`, so it needs no change here.

## Tests

New `tinker_cookbook/rl/data_processing_test.py::TestSuccessfulRolloutIndices` and `tinker_cookbook/distillation/sdft_test.py`. Beyond the filtering itself, both pin the property that actually matters: that `metadata_D["group_idx"]` indexes a *filtered* parallel list to the datum's own problem, and that the same index into the unfiltered list names a different one.

`ruff check`, `ruff format --check` and `pyright` are clean locally, as is `pytest tinker_cookbook/rl tinker_cookbook/distillation` apart from `rollout_logging_test.py::test_write_rollout_summaries_jsonl_handles_numpy_scalars`, which is unrelated to this change and left alone.

That one is worth a note, because it fails on `main` for me but passes in CI here. It calls `write_rollout_summaries_jsonl`, whose deprecation carries `removal_version="0.4.0"`, and `utils/deprecation.py` raises once the installed version reaches that. The version comes from `hatch-vcs`, so it depends on whether the checkout has the release tags: locally it resolves to `0.5.5.dev3` and the tripwire fires, while CI checks out with `--no-tags --depth=1` and resolves to `0.1.dev1`, leaving it dormant. So no removal tripwire in this repo can fire in CI, which seems worth its own issue -- happy to open one.

## Note

Touches `rl/data_processing.py` alongside #905, which fixes the same class of bug in the sync RL loop's metrics. The two are independent; whichever lands second needs a trivial rebase of that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
