### PR TITLE
[rl] per-tag metrics follow their own groups when uniform ones are dropped

### DIFF
--- a/tinker_cookbook/rl/data_processing.py
+++ b/tinker_cookbook/rl/data_processing.py
@@ -232,6 +232,38 @@ def assemble_training_data(
     return data_D, metadata_D
 
 
+def nonconstant_reward_group_indices(
+    trajectory_groups_P: list[TrajectoryGroup],
+) -> list[int]:
+    """Indices of the groups that :func:`remove_constant_reward_groups` keeps.
+
+    Callers that hold lists running parallel to *trajectory_groups_P* -- the
+    ``EnvGroupBuilder`` each group came from, for instance -- must filter those
+    by the same indices. Dropping groups from one list alone silently shifts
+    the correspondence, so a builder ends up paired with another problem's
+    trajectories.
+
+    Args:
+        trajectory_groups_P (list[TrajectoryGroup]): Groups of trajectories
+            to filter.
+
+    Returns:
+        list[int]: Indices, ascending, of the groups containing at least two
+            distinct reward values; ``[0]`` if every group was uniform (see
+            :func:`remove_constant_reward_groups`); ``[]`` if there were no
+            groups at all.
+    """
+    kept = [
+        i for i, group in enumerate(trajectory_groups_P) if not all_same(group.get_total_rewards())
+    ]
+    if not kept:
+        logger.warning("All rewards are uniform. There will be no gradient")
+        # Keep one group rather than returning an empty batch, which breaks
+        # downstream code that assumes at least one group.
+        return [0] if trajectory_groups_P else []
+    return kept
+
+
 def remove_constant_reward_groups(
     trajectory_groups_P: list[TrajectoryGroup],
 ) -> list[TrajectoryGroup]:
@@ -242,6 +274,9 @@ def remove_constant_reward_groups(
     If *all* groups are uniform, a single group is returned so downstream code
     that expects a non-empty list does not break.
 
+    Use :func:`nonconstant_reward_group_indices` instead when any list runs
+    parallel to *trajectory_groups_P* and has to be filtered along with it.
+
     Args:
         trajectory_groups_P (list[TrajectoryGroup]): Groups of trajectories
             to filter.
@@ -251,12 +286,4 @@ def remove_constant_reward_groups(
             distinct reward values, or a singleton list if every group was
             uniform.
     """
-    new_groups: list[TrajectoryGroup] = []
-    for group in trajectory_groups_P:
-        if not all_same(group.get_total_rewards()):
-            new_groups.append(group)
-    if not new_groups:
-        logger.warning("All rewards are uniform. There will be no gradient")
-        return trajectory_groups_P[0:1]  # return singleton list in case empty
-        # list will cause problems
-    return new_groups
+    return [trajectory_groups_P[i] for i in nonconstant_reward_group_indices(trajectory_groups_P)]

--- a/tinker_cookbook/rl/data_processing_test.py
+++ b/tinker_cookbook/rl/data_processing_test.py
@@ -1,0 +1,130 @@
+"""Tests for RL data processing helpers."""
+
+from __future__ import annotations
+
+import tinker
+
+from tinker_cookbook.completers import TokensWithLogprobs
+from tinker_cookbook.rl.data_processing import (
+    nonconstant_reward_group_indices,
+    remove_constant_reward_groups,
+)
+from tinker_cookbook.rl.metric_util import compute_trajectory_metrics
+from tinker_cookbook.rl.types import Trajectory, TrajectoryGroup, Transition
+
+
+def _make_trajectory(reward: float, num_action_tokens: int = 2) -> Trajectory:
+    return Trajectory(
+        transitions=[
+            Transition(
+                ob=tinker.ModelInput.from_ints([1, 2, 3]),
+                ac=TokensWithLogprobs(
+                    tokens=[4] * num_action_tokens,
+                    maybe_logprobs=[0.0] * num_action_tokens,
+                ),
+                reward=reward,
+                episode_done=True,
+            )
+        ],
+        final_ob=tinker.ModelInput.from_ints([]),
+    )
+
+
+def _make_trajectory_group(rewards: list[float], num_action_tokens: int = 2) -> TrajectoryGroup:
+    return TrajectoryGroup(
+        trajectories_G=[_make_trajectory(r, num_action_tokens) for r in rewards],
+        final_rewards_G=[0.0] * len(rewards),
+        metrics_G=[{} for _ in rewards],
+    )
+
+
+class TestNonconstantRewardGroupIndices:
+    def test_keeps_mixed_drops_uniform(self):
+        groups_P = [
+            _make_trajectory_group([1.0, 1.0]),  # uniform
+            _make_trajectory_group([1.0, 0.0]),  # mixed
+            _make_trajectory_group([0.0, 0.0]),  # uniform
+            _make_trajectory_group([0.5, 0.25]),  # mixed
+        ]
+        assert nonconstant_reward_group_indices(groups_P) == [1, 3]
+
+    def test_all_uniform_keeps_first_group(self):
+        groups_P = [
+            _make_trajectory_group([1.0, 1.0]),
+            _make_trajectory_group([0.0, 0.0]),
+        ]
+        assert nonconstant_reward_group_indices(groups_P) == [0]
+
+    def test_no_groups(self):
+        assert nonconstant_reward_group_indices([]) == []
+
+    def test_agrees_with_remove_constant_reward_groups(self):
+        groups_P = [
+            _make_trajectory_group([1.0, 1.0]),
+            _make_trajectory_group([1.0, 0.0]),
+            _make_trajectory_group([0.5, 0.25]),
+        ]
+        by_index = [groups_P[i] for i in nonconstant_reward_group_indices(groups_P)]
+        assert by_index == remove_constant_reward_groups(groups_P)
+
+    def test_agrees_with_remove_constant_reward_groups_when_all_uniform(self):
+        groups_P = [
+            _make_trajectory_group([1.0, 1.0]),
+            _make_trajectory_group([0.0, 0.0]),
+        ]
+        by_index = [groups_P[i] for i in nonconstant_reward_group_indices(groups_P)]
+        assert by_index == remove_constant_reward_groups(groups_P)
+
+
+class TestFilteringKeepsParallelListsAligned:
+    """Lists running parallel to the trajectory groups must be filtered in step.
+
+    ``do_sync_training`` drops constant-reward groups and then hands both the
+    groups and their ``EnvGroupBuilder`` list to ``prepare_minibatch``, which
+    zips the two to tag metrics. Filtering only the groups shifts every tag
+    onto a later problem's rollouts, so per-tag reward curves report another
+    dataset's numbers.
+    """
+
+    def test_tags_follow_their_own_groups(self):
+        # Distinct action-token counts make each group identifiable in the metrics.
+        groups_P = [
+            _make_trajectory_group([1.0, 1.0], num_action_tokens=100),  # uniform
+            _make_trajectory_group([1.0, 0.6], num_action_tokens=200),
+            _make_trajectory_group([0.2, 0.0], num_action_tokens=300),
+        ]
+        taglist_P = [["math"], ["code"], ["chat"]]
+
+        keep_P = nonconstant_reward_group_indices(groups_P)
+        assert keep_P == [1, 2]
+
+        metrics = compute_trajectory_metrics(
+            [groups_P[i] for i in keep_P],
+            [taglist_P[i] for i in keep_P],
+        )
+
+        # "code" is the 200-token group with mean reward 0.8; "chat" is the
+        # 300-token group with mean reward 0.1. "math" was dropped entirely.
+        assert metrics["env/code/ac_tokens_per_turn"] == 200.0
+        assert metrics["env/chat/ac_tokens_per_turn"] == 300.0
+        assert metrics["env/code/reward/total"] == 0.8
+        assert metrics["env/chat/reward/total"] == 0.1
+        assert not any(key.startswith("env/math/") for key in metrics)
+
+    def test_filtering_groups_alone_misattributes_tags(self):
+        """Pin the failure mode, so a regression is unmistakable."""
+        groups_P = [
+            _make_trajectory_group([1.0, 1.0], num_action_tokens=100),  # uniform
+            _make_trajectory_group([1.0, 0.6], num_action_tokens=200),
+            _make_trajectory_group([0.2, 0.0], num_action_tokens=300),
+        ]
+        taglist_P = [["math"], ["code"], ["chat"]]
+
+        # What the old call site did: groups filtered, parallel list left whole.
+        metrics = compute_trajectory_metrics(remove_constant_reward_groups(groups_P), taglist_P)
+
+        # Every tag slides onto the next group: "math" reports "code"'s rollouts,
+        # "code" reports "chat"'s, and "chat" disappears.
+        assert metrics["env/math/ac_tokens_per_turn"] == 200.0
+        assert metrics["env/code/ac_tokens_per_turn"] == 300.0
+        assert "env/chat/ac_tokens_per_turn" not in metrics

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -33,7 +33,7 @@ from tinker_cookbook.exceptions import ConfigurationError
 from tinker_cookbook.rl.data_processing import (
     assemble_training_data,
     compute_advantages,
-    remove_constant_reward_groups,
+    nonconstant_reward_group_indices,
 )
 from tinker_cookbook.rl.metric_util import RLTestSetEvaluator, compute_trajectory_metrics
 from tinker_cookbook.rl.metrics import (
@@ -1819,7 +1819,13 @@ async def do_sync_training(
                 )
 
                 if config.remove_constant_reward_groups:
-                    trajectory_groups_P = remove_constant_reward_groups(trajectory_groups_P)
+                    # Filter the builders by the same indices. They run parallel to
+                    # the trajectory groups and are zipped against them downstream to
+                    # tag metrics, so dropping groups alone shifts every tag onto a
+                    # later problem's rollouts.
+                    keep_P = nonconstant_reward_group_indices(trajectory_groups_P)
+                    trajectory_groups_P = [trajectory_groups_P[i] for i in keep_P]
+                    env_group_builders_P = [env_group_builders_P[i] for i in keep_P]
 
                 # Train step
                 sampling_client, train_step_metrics = await do_train_step_and_get_sampling_client(


### PR DESCRIPTION
`do_sync_training` filters constant-reward groups out of `trajectory_groups_P`, then passes the *unfiltered* `env_group_builders_P` alongside them:

```python
if config.remove_constant_reward_groups:
    trajectory_groups_P = remove_constant_reward_groups(trajectory_groups_P)

sampling_client, train_step_metrics = await do_train_step_and_get_sampling_client(
    ...,
    env_group_builders_P,   # full batch
    trajectory_groups_P,    # filtered
)
```

`prepare_minibatch` derives the tag list from the builders and zips it against the groups:

```python
taglist_P = [b.logging_tags() for b in env_group_builders_P]
metrics.update(compute_trajectory_metrics(trajectory_groups_P, taglist_P))
```

`compute_trajectory_metrics` uses a plain `zip`, not `safezip`, so the length mismatch is silent. Each tag slides onto a later problem's rollouts and the trailing tags fall off the end.

## What it looks like

Three tagged problems, the first with uniform reward so it gets dropped:

| tag | reported | actual |
| --- | --- | --- |
| `env/math/reward/total` | 0.8 | — (dropped) |
| `env/code/reward/total` | 0.1 | 0.8 |
| `env/chat/reward/total` | absent | 0.1 |

Every tag reports the next dataset's numbers, and the last one disappears. Which groups get dropped changes step to step, so the curves don't shift by a constant — they wander, and the size of the error tracks how often each dataset saturates.

## Scope

Metrics only. Advantages and datums are built from `trajectory_groups_P` alone (`compute_advantages`, `assemble_training_data`), so gradients are correct — but for a mixture run these per-tag curves are exactly what you'd read to decide whether to reweight a dataset or stop training.

Requires `remove_constant_reward_groups=True`, which is not the default, and hits only `do_sync_training`. The async and stream-minibatch loops carry the builder next to its group inside `WrappedTrajectoryGroup`, so they cannot desync; they are unchanged here.

`env/all/*` is also unaffected — it aggregates the groups without consulting the tags.

## What changed

`nonconstant_reward_group_indices` returns the surviving indices rather than the filtered list, so the call site filters both lists by the same ones. `remove_constant_reward_groups` now delegates to it and is otherwise untouched: same signature, same singleton fallback when every group is uniform, same warning.

## Tests

New `tinker_cookbook/rl/data_processing_test.py`. Alongside the filtering itself and its agreement with `remove_constant_reward_groups`, `TestFilteringKeepsParallelListsAligned` covers both directions — that tags follow their own groups once both lists are filtered, and, in `test_filtering_groups_alone_misattributes_tags`, exactly how the numbers come out wrong when only one is. The second test asserts the old behaviour deliberately, so the failure mode is written down rather than merely fixed.

`ruff check`, `ruff format --check` and `pyright` are clean locally, as is `pytest tinker_cookbook/rl tinker_cookbook/distillation` apart from `rollout_logging_test.py::test_write_rollout_summaries_jsonl_handles_numpy_scalars`, which is unrelated to this change and left alone.

That one is worth a note, because it fails on `main` for me but passes in CI here. It calls `write_rollout_summaries_jsonl`, whose deprecation carries `removal_version="0.4.0"`, and `utils/deprecation.py` raises once the installed version reaches that. The version comes from `hatch-vcs`, so it depends on whether the checkout has the release tags: locally it resolves to `0.5.5.dev3` and the tripwire fires, while CI checks out with `--no-tags --depth=1` and resolves to `0.1.dev1`, leaving it dormant. So no removal tripwire in this repo can fire in CI, which seems worth its own issue -- happy to open one.

## Notes

A `safezip` in `compute_trajectory_metrics` would have turned this into a crash rather than silent misattribution. I left it as a plain `zip` to keep this change to the bug itself — happy to tighten it here or separately if you'd like.

Touches `rl/data_processing.py` alongside #904, which fixes the same class of bug in the distillation loops. The two are independent; whichever lands second needs a trivial rebase of that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
