### PR TITLE
mmlu_redux make per-subject accuracy no longer collapse to unknown

### DIFF
--- a/tinker_cookbook/eval/benchmarks/benchmark_test.py
+++ b/tinker_cookbook/eval/benchmarks/benchmark_test.py
@@ -396,6 +396,40 @@ class TestGradingConsistency:
             assert old(resp) == new(resp), f"Mismatch on: {resp}"
 
 
+class TestMMLUReduxAggregate:
+    def test_per_subject_breakdown(self):
+        from tinker_cookbook.eval.benchmarks.mmlu_redux import (
+            _SUBJECTS,
+            MMLUReduxBenchmarkBuilder,
+        )
+
+        builder = MMLUReduxBenchmarkBuilder()
+        s0, s1 = _SUBJECTS[0], _SUBJECTS[1]
+        i0 = float(_SUBJECTS.index(s0))
+        i1 = float(_SUBJECTS.index(s1))
+        rewards = [1.0, 0.0, 1.0, 1.0]
+        metrics_list = [
+            {"correct": 1.0, "subject_idx": i0},
+            {"correct": 0.0, "subject_idx": i0},
+            {"correct": 1.0, "subject_idx": i1},
+            {"correct": 1.0, "subject_idx": i1},
+        ]
+        result = builder.aggregate(rewards, metrics_list)
+        assert abs(result.score - 0.75) < 1e-9
+        assert abs(result.metrics[f"mmlu_redux/{s0}/accuracy"] - 0.5) < 1e-9
+        assert abs(result.metrics[f"mmlu_redux/{s1}/accuracy"] - 1.0) < 1e-9
+        assert "mmlu_redux/unknown/accuracy" not in result.metrics
+
+    def test_missing_subject_idx_falls_to_unknown(self):
+        from tinker_cookbook.eval.benchmarks.mmlu_redux import MMLUReduxBenchmarkBuilder
+
+        builder = MMLUReduxBenchmarkBuilder()
+        rewards = [1.0, 0.0]
+        metrics_list = [{"correct": 1.0}, {"correct": 0.0}]
+        result = builder.aggregate(rewards, metrics_list)
+        assert abs(result.metrics["mmlu_redux/unknown/accuracy"] - 0.5) < 1e-9
+
+
 class TestEvalStore:
     def test_create_and_list_runs(self, tmp_path):
         from tinker_cookbook.stores.eval_store import EvalStore

--- a/tinker_cookbook/eval/benchmarks/mmlu_redux.py
+++ b/tinker_cookbook/eval/benchmarks/mmlu_redux.py
@@ -128,11 +128,14 @@ class MMLUReduxMessageEnv(MessageEnv):
         response = get_text_content(message)
         extracted = extract_mcq_answer(response)
         correct = extracted == self.expected
+        subject_idx = (
+            float(_SUBJECTS.index(self.subject)) if self.subject in _SUBJECTS else -1.0
+        )
         return MessageStepResult(
             reward=1.0 if correct else 0.0,
             episode_done=True,
             next_messages=[],
-            metrics={"correct": float(correct)},
+            metrics={"correct": float(correct), "subject_idx": subject_idx},
             logs={
                 "example_id": self.example_id,
                 "input": self.prompt[:200],
@@ -191,15 +194,23 @@ class MMLUReduxBenchmarkBuilder(BenchmarkBuilder):
         return envs
 
     def aggregate(self, rewards: list[float], metrics_list: list[Metrics]) -> BenchmarkResult:
-        """Aggregate with per-subject breakdown."""
+        """Aggregate accuracy with a per-subject breakdown.
+
+        The subject is carried in ``metrics["subject_idx"]`` as an int index
+        into the module-level ``_SUBJECTS`` list (see
+        ``MMLUReduxMessageEnv.step``). ``Metrics`` is typed
+        ``dict[str, float | int]`` and cannot hold the subject string directly,
+        so an index is used instead. A missing or out-of-range index falls back
+        to the ``"unknown"`` bucket.
+        """
         num_correct = sum(1 for r in rewards if r > 0)
         accuracy = num_correct / len(rewards) if rewards else 0.0
 
         subject_results: dict[str, list[bool]] = {}
         for r, m in zip(rewards, metrics_list):
-            subj = m.get("subject", "unknown")
-            if isinstance(subj, str):
-                subject_results.setdefault(subj, []).append(r > 0)
+            idx = m.get("subject_idx", -1.0)
+            subj = _SUBJECTS[int(idx)] if 0 <= idx < len(_SUBJECTS) else "unknown"
+            subject_results.setdefault(subj, []).append(r > 0)
 
         metrics: dict[str, float] = {"mmlu_redux/accuracy": accuracy}
         for subj, subj_res in sorted(subject_results.items()):


### PR DESCRIPTION
Fixes Issue #896.

aggregate() advertises a per-subject breakdown, but step() wrote subject only to logs while aggregate() read it from metrics_list — so every example landed in one unknown bucket that just restated the headline accuracy.
