### PR TITLE
make ifeval number_bullet_lists require exactly N bullets

### DIFF
--- a/tinker_cookbook/eval/benchmarks/_ifeval_verify.py
+++ b/tinker_cookbook/eval/benchmarks/_ifeval_verify.py
@@ -162,7 +162,7 @@ def verify_instruction(instruction_id: str, response: str, kwargs: dict) -> bool
         elif iid == "detectable_format:number_bullet_lists":
             bullets = re.findall(r"^\s*[\*\-\•]\s", response, re.MULTILINE)
             num_bullets = kwargs.get("num_bullets", 1)
-            return len(bullets) >= num_bullets
+            return len(bullets) == num_bullets
 
         elif iid == "detectable_format:number_highlighted_sections":
             highlights = re.findall(r"\*[^*]+\*", response)

--- a/tinker_cookbook/eval/benchmarks/benchmark_test.py
+++ b/tinker_cookbook/eval/benchmarks/benchmark_test.py
@@ -396,6 +396,26 @@ class TestGradingConsistency:
             assert old(resp) == new(resp), f"Mismatch on: {resp}"
 
 
+class TestIFEvalBulletList:
+    def test_exact_count_satisfied(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_instruction
+
+        assert verify_instruction(
+            "detectable_format:number_bullet_lists",
+            "* a\n* b\n* c",
+            {"num_bullets": 3},
+        )
+
+    def test_too_many_bullets_fails(self):
+        from tinker_cookbook.eval.benchmarks._ifeval_verify import verify_instruction
+
+        assert not verify_instruction(
+            "detectable_format:number_bullet_lists",
+            "* a\n* b\n* c\n* d\n* e",
+            {"num_bullets": 3},
+        )
+
+
 class TestEvalStore:
     def test_create_and_list_runs(self, tmp_path):
         from tinker_cookbook.stores.eval_store import EvalStore


### PR DESCRIPTION
The detectable_format:number_bullet_lists instruction asks for "exactly N bullet points," but the verifier used >=, so extra bullets still passed.

Dataset source (google/IFEval, the prompts the model is graded against):

["…exactly 3 bullet points in the markdown format…" (`num_bullets=3`)](https://datasets-server.huggingface.co/rows?dataset=google/IFEval&config=default&split=train&offset=5&length=1)
["…exactly 6 bullet point in Markdown…" (`num_bullets=6`)](https://datasets-server.huggingface.co/rows?dataset=google/IFEval&config=default&split=train&offset=56&length=1)