### PR TITLE
Fix 404 link to the loss functions docs

### DIFF
--- a/tinker_cookbook/distillation/train_on_policy.py
+++ b/tinker_cookbook/distillation/train_on_policy.py
@@ -147,7 +147,7 @@ class Config:
     kl_discount_factor: float = 0.0
 
     # Loss function and configuration.
-    # See https://tinker-docs.thinkingmachines.ai/losses
+    # See https://tinker-docs.thinkingmachines.ai/tinker/losses
     loss_fn: LossFnType = "importance_sampling"
     loss_fn_config: dict[str, Any] | None = None
 

--- a/tinker_cookbook/recipes/distillation/on_policy_distillation.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_distillation.py
@@ -77,7 +77,7 @@ class CLIConfig:
     num_substeps: int = 1
 
     # Loss function and configuration.
-    # See https://tinker-docs.thinkingmachines.ai/losses
+    # See https://tinker-docs.thinkingmachines.ai/tinker/losses
     loss_fn: LossFnType = "importance_sampling"
     loss_fn_config: dict[str, Any] | None = None
 

--- a/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
+++ b/tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py
@@ -69,7 +69,7 @@ class CLIConfig:
     num_substeps: int = 1
 
     # Loss function and configuration.
-    # See https://tinker-docs.thinkingmachines.ai/losses
+    # See https://tinker-docs.thinkingmachines.ai/tinker/losses
     loss_fn: LossFnType = "importance_sampling"
     loss_fn_config: dict[str, Any] | None = None
 

--- a/tinker_cookbook/recipes/math_rl/train.py
+++ b/tinker_cookbook/recipes/math_rl/train.py
@@ -67,7 +67,7 @@ class CLIConfig:
     stream_minibatch_config: StreamMinibatchConfig | None = None
 
     # Loss function and configuration.
-    # See https://tinker-docs.thinkingmachines.ai/losses
+    # See https://tinker-docs.thinkingmachines.ai/tinker/losses
     loss_fn: LossFnType = "importance_sampling"
     loss_fn_config: dict[str, Any] | None = None
 

--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -473,7 +473,7 @@ class Config:
     # Loss and optimizer behavior (advanced)
     # -------------------------------------------------------------------------
     # Loss function and configuration.
-    # See https://tinker-docs.thinkingmachines.ai/losses
+    # See https://tinker-docs.thinkingmachines.ai/tinker/losses
     loss_fn: LossFnType = "importance_sampling"
     loss_fn_config: dict[str, Any] | None = None
 


### PR DESCRIPTION
`https://tinker-docs.thinkingmachines.ai/losses` returns 404. The loss functions page is at `https://tinker-docs.thinkingmachines.ai/tinker/losses`.

Five `loss_fn` config comments used the bare path:

- `tinker_cookbook/rl/train.py`
- `tinker_cookbook/distillation/train_on_policy.py`
- `tinker_cookbook/recipes/distillation/on_policy_distillation.py`
- `tinker_cookbook/recipes/distillation/on_policy_multi_teacher.py`
- `tinker_cookbook/recipes/math_rl/train.py`

This points them at the working URL, matching `tinker_cookbook/distillation/sdft.py` and `tinker_cookbook/recipes/sdft/README.md`, which already link to `/tinker/losses`. Comments only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)