### PR TITLE
[rl] Skip fully filtered streaming batches

### DIFF
--- a/tinker_cookbook/rl/train.py
+++ b/tinker_cookbook/rl/train.py
@@ -1569,6 +1569,13 @@ async def do_train_step_streaming_and_get_sampling_client(
             i_minibatch += 1
             wrapped_trajectory_groups = []
 
+        if not forward_backward_futures:
+            logger.info(
+                f"[stream_minibatch] Step {i_batch}, Substep {i_substep}/{config.num_substeps}: "
+                "No valid trajectory groups; skipping optimizer substep"
+            )
+            continue
+
         # Enqueue optim_step before awaiting results (so they land on same clock cycle)
         adam_params = tinker.AdamParams(
             learning_rate=config.learning_rate, beta1=0.9, beta2=0.95, eps=1e-8
@@ -1587,6 +1594,16 @@ async def do_train_step_streaming_and_get_sampling_client(
 
         if optim_result.metrics:
             metrics.update(optim_result.metrics)
+
+    if not all_data_D:
+        logger.info(
+            f"[stream_minibatch] Step {i_batch}: No valid trajectory groups; skipping training step"
+        )
+        sampling_client, checkpoint_metrics = await save_checkpoint_and_get_sampling_client(
+            training_client, checkpoint_mgr, i_batch + 1
+        )
+        metrics.update(checkpoint_metrics)
+        return sampling_client, metrics, all_wrapped_trajectory_groups
 
     # Aggregate metrics across the entire batch
     metrics.update(compute_sampling_client_metrics(all_wrapped_trajectory_groups))

--- a/tinker_cookbook/rl/train_streaming_test.py
+++ b/tinker_cookbook/rl/train_streaming_test.py
@@ -1,0 +1,57 @@
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import tinker
+
+from tinker_cookbook import checkpoint_utils
+from tinker_cookbook.rl import train
+from tinker_cookbook.tokenizer_utils import Tokenizer
+
+
+@pytest.mark.asyncio
+async def test_streaming_step_skips_update_when_all_minibatches_are_filtered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = cast(
+        train.Config,
+        SimpleNamespace(
+            stream_minibatch_config=train.StreamMinibatchConfig(
+                groups_per_batch=4,
+                num_minibatches=2,
+            ),
+            num_substeps=1,
+            learning_rate=1e-5,
+        ),
+    )
+    trajectory_groups_queue: asyncio.Queue[
+        train.WrappedTrajectoryGroup | train._Shutdown | None
+    ] = asyncio.Queue()
+    for _ in range(4):
+        trajectory_groups_queue.put_nowait(None)
+
+    training_client_mock = MagicMock()
+    training_client_mock.forward_backward_async = AsyncMock()
+    training_client_mock.optim_step_async = AsyncMock()
+    training_client = cast(tinker.TrainingClient, training_client_mock)
+    checkpoint_mgr = cast(checkpoint_utils.CheckpointManager, MagicMock())
+    sampling_client = cast(tinker.SamplingClient, MagicMock())
+    save_checkpoint = AsyncMock(return_value=(sampling_client, {"checkpoint/skipped_step": 1}))
+    monkeypatch.setattr(train, "save_checkpoint_and_get_sampling_client", save_checkpoint)
+
+    result = await train.do_train_step_streaming_and_get_sampling_client(
+        config=config,
+        i_batch=7,
+        trajectory_groups_queue=trajectory_groups_queue,
+        training_client=training_client,
+        checkpoint_mgr=checkpoint_mgr,
+        kl_reference_client=None,
+        tokenizer=cast(Tokenizer, MagicMock()),
+    )
+
+    assert result == (sampling_client, {"checkpoint/skipped_step": 1}, [])
+    training_client_mock.forward_backward_async.assert_not_awaited()
+    training_client_mock.optim_step_async.assert_not_awaited()
+    save_checkpoint.assert_awaited_once_with(training_client, checkpoint_mgr, 8)


### PR DESCRIPTION
## Summary
- skip optimizer substeps when constant-reward filtering leaves no valid minibatches
- refresh the sampling client without computing empty-batch KL metrics
- add a no-network regression test for a fully filtered streaming batch

## Motivation
With `remove_constant_reward_groups=True`, every group in a streaming batch can be filtered. The loop currently advances past those empty minibatches, issues an optimizer step with no forward/backward calls, and then computes full-batch metrics from empty inputs. This fails in `compute_kl_sample_train` instead of safely skipping the update.

## Test plan
- `uv run pytest tinker_cookbook/rl/train_streaming_test.py -q`
- `uv run pyright tinker_cookbook/rl/train.py tinker_cookbook/rl/train_streaming_test.py`
- `uv run pre-commit run --all-files`

Made with [Cursor](https://cursor.com)