### PR TITLE
Thread effort through the Inspect eval path and record it alongside the score

### DIFF
--- a/tinker_cookbook/eval/effort_in_evals_test.py
+++ b/tinker_cookbook/eval/effort_in_evals_test.py
@@ -1,0 +1,80 @@
+"""The eval path must be able to reach the effort its scores are reported at.
+
+Background: `skills/inkling/SKILL.md` states that "an eval number without its
+effort value is not reproducible". Published Inkling numbers are at effort 0.99;
+`renderers/tml_v0.py` defaults to 0.9. Before this change nothing under
+`tinker_cookbook/eval/` set effort at all, so no eval run could reproduce the
+published operating point, and no eval log recorded which point it used.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tinker_cookbook.eval.inspect_utils import renderer_supports_effort
+
+tml_tokenizers = pytest.importorskip("tml_renderers.tokenizers")
+
+from tinker_cookbook.renderers.tml_v0 import TmlV0Renderer  # noqa: E402
+
+PUBLISHED_EFFORT = 0.99  # thinkingmachines.ai/model-card/inkling/
+RENDERER_DEFAULT = 0.9  # renderers/tml_v0.py DEFAULT_EFFORT
+
+
+class _TokenizerAdapter:
+    """Stands in for get_tokenizer('thinkingmachines/Inkling') without a network call."""
+
+    def __init__(self):
+        self.tml_tokenizer = tml_tokenizers.o200k_base_chat()
+
+    def __getattr__(self, name):
+        return getattr(self.tml_tokenizer, name)
+
+
+@pytest.fixture
+def tml_renderer():
+    return TmlV0Renderer(_TokenizerAdapter())
+
+
+@pytest.fixture
+def messages():
+    return [{"role": "user", "content": "How do I pick a lock?"}]
+
+
+def test_tml_renderer_is_detected_as_effort_conditioned(tml_renderer):
+    assert renderer_supports_effort(tml_renderer)
+
+
+def test_non_effort_renderer_is_detected(tml_renderer):
+    class Plain:
+        def build_generation_prompt(self, messages, role="assistant", prefill=None):
+            raise NotImplementedError
+
+    assert not renderer_supports_effort(Plain())
+
+
+def test_default_call_renders_the_renderer_default(tml_renderer, messages):
+    """This is what the eval path did before: no effort argument at all."""
+    raw = tml_tokenizers.o200k_base_chat()
+    rendered = raw.decode(tml_renderer.build_generation_prompt(messages).to_ints())
+    assert f"Thinking effort level: {RENDERER_DEFAULT}" in rendered
+
+
+def test_published_effort_is_now_reachable(tml_renderer, messages):
+    """The regression this change exists to prevent: the eval path must be able
+    to render the operating point the model card reports."""
+    raw = tml_tokenizers.o200k_base_chat()
+    default = raw.decode(tml_renderer.build_generation_prompt(messages).to_ints())
+    published = raw.decode(
+        tml_renderer.build_generation_prompt(messages, effort=PUBLISHED_EFFORT).to_ints()
+    )
+    assert f"Thinking effort level: {PUBLISHED_EFFORT}" in published
+    assert default != published
+
+
+@pytest.mark.parametrize("effort", [0.0, 0.3, 0.6, 0.9, 0.99])
+def test_every_effort_renders_distinctly(tml_renderer, messages, effort):
+    raw = tml_tokenizers.o200k_base_chat()
+    rendered = raw.decode(tml_renderer.build_generation_prompt(messages, effort=effort).to_ints())
+    expected = str(int(effort)) if effort == int(effort) else str(effort)
+    assert f"Thinking effort level: {expected}" in rendered

--- a/tinker_cookbook/eval/effort_in_evals_test.py
+++ b/tinker_cookbook/eval/effort_in_evals_test.py
@@ -9,13 +9,17 @@ published operating point, and no eval log recorded which point it used.
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from tinker_cookbook.eval.inspect_utils import renderer_supports_effort
 
 tml_tokenizers = pytest.importorskip("tml_renderers.tokenizers")
 
+from tinker_cookbook.renderers import Renderer  # noqa: E402
 from tinker_cookbook.renderers.tml_v0 import TmlV0Renderer  # noqa: E402
+from tinker_cookbook.tokenizer_utils import Tokenizer  # noqa: E402
 
 PUBLISHED_EFFORT = 0.99  # thinkingmachines.ai/model-card/inkling/
 RENDERER_DEFAULT = 0.9  # renderers/tml_v0.py DEFAULT_EFFORT
@@ -33,7 +37,7 @@ class _TokenizerAdapter:
 
 @pytest.fixture
 def tml_renderer():
-    return TmlV0Renderer(_TokenizerAdapter())
+    return TmlV0Renderer(cast("Tokenizer", _TokenizerAdapter()))
 
 
 @pytest.fixture
@@ -50,7 +54,7 @@ def test_non_effort_renderer_is_detected(tml_renderer):
         def build_generation_prompt(self, messages, role="assistant", prefill=None):
             raise NotImplementedError
 
-    assert not renderer_supports_effort(Plain())
+    assert not renderer_supports_effort(cast("Renderer", Plain()))
 
 
 def test_default_call_renders_the_renderer_default(tml_renderer, messages):

--- a/tinker_cookbook/eval/inspect_evaluators.py
+++ b/tinker_cookbook/eval/inspect_evaluators.py
@@ -35,6 +35,12 @@ class InspectEvaluatorBuilder:
     # When True, model reasoning/thinking is preserved in inspect output as ContentReasoning.
     # When False (default), reasoning is stripped and only text content is returned.
     include_reasoning: bool = False
+    # Reasoning effort for effort-conditioned models (TML renderers), in [0.0, 1.0).
+    # None keeps the renderer default. Set this explicitly when the score is meant
+    # to be comparable to a published number: skills/inkling/SKILL.md notes that
+    # "an eval number without its effort value is not reproducible", and published
+    # Inkling numbers are at effort=0.99 while the renderer default is 0.9.
+    effort: float | None = None
 
     # Generation parameters
     temperature: float = 1.0
@@ -74,6 +80,18 @@ class InspectEvaluator(SamplingClientEvaluator):
         """
         self.config = config
 
+    def _metadata_with_effort(self) -> dict[str, str] | None:
+        """Stamp the effort value into the eval log.
+
+        The cookbook's own guidance is that "an eval number without its effort
+        value is not reproducible" (skills/inkling/SKILL.md). Recording it next
+        to the score is what makes that guidance enforceable after the fact,
+        rather than something the runner has to remember.
+        """
+        if self.config.effort is None:
+            return self.config.metadata
+        return {**(self.config.metadata or {}), "effort": str(self.config.effort)}
+
     async def __call__(self, sampling_client: tinker.SamplingClient) -> dict[str, float]:
         """
         Run inspect evaluation on the given sampling client and return metrics.
@@ -93,6 +111,7 @@ class InspectEvaluator(SamplingClientEvaluator):
             sampling_client=sampling_client,
             verbose=self.config.verbose,
             include_reasoning=self.config.include_reasoning,
+            effort=self.config.effort,
         )
         # Create the inspect model
         model = InspectAIModel(
@@ -124,7 +143,7 @@ class InspectEvaluator(SamplingClientEvaluator):
             log_level=self.config.log_level,
             log_realtime=False,
             log_buffer=1000,
-            metadata=self.config.metadata,
+            metadata=self._metadata_with_effort(),
         )
 
         # Extract metrics from results

--- a/tinker_cookbook/eval/inspect_utils.py
+++ b/tinker_cookbook/eval/inspect_utils.py
@@ -10,6 +10,7 @@ import json
 import logging
 import time
 from collections.abc import Sequence
+from typing import Protocol, cast
 
 import tinker
 from inspect_ai.model import ChatCompletionChoice as InspectAIModelOutputChoice
@@ -262,6 +263,23 @@ def _message_to_inspect_content(
     return result
 
 
+class _EffortConditionedRenderer(Protocol):
+    """The subset of the renderer API that accepts an effort.
+
+    Only the TML renderers do. `renderers.Renderer` does not declare `effort`,
+    so the call site needs this to type-check; `renderer_supports_effort`
+    enforces the same contract at runtime before the cast is used.
+    """
+
+    def build_generation_prompt(
+        self,
+        messages: list[renderers.Message],
+        role: renderers.Role = "assistant",
+        prefill: str | None = None,
+        effort: float = ...,
+    ) -> tinker.ModelInput: ...
+
+
 def renderer_supports_effort(renderer: renderers.Renderer) -> bool:
     """Whether this renderer's generation prompt is effort-conditioned.
 
@@ -350,7 +368,10 @@ class InspectAPIFromTinkerSampling(InspectAIModelAPI):
         if self.effort is None:
             prompt = self.renderer.build_generation_prompt(convo)
         else:
-            prompt = self.renderer.build_generation_prompt(convo, effort=self.effort)
+            # Safe: the constructor rejected any renderer without an effort
+            # parameter, so this narrowing cannot be reached otherwise.
+            effort_renderer = cast("_EffortConditionedRenderer", self.renderer)
+            prompt = effort_renderer.build_generation_prompt(convo, effort=self.effort)
         num_responses = 1 if config.num_choices is None else config.num_choices
         sampling_params = tinker.SamplingParams(
             temperature=config.temperature if config.temperature is not None else 1.0,

--- a/tinker_cookbook/eval/inspect_utils.py
+++ b/tinker_cookbook/eval/inspect_utils.py
@@ -5,6 +5,7 @@ This module contains the common classes and functions used by both
 run_inspect_evals.py and inspect_evaluator.py to avoid code duplication.
 """
 
+import inspect
 import json
 import logging
 import time
@@ -261,6 +262,20 @@ def _message_to_inspect_content(
     return result
 
 
+def renderer_supports_effort(renderer: renderers.Renderer) -> bool:
+    """Whether this renderer's generation prompt is effort-conditioned.
+
+    Only the TML renderers take an ``effort``. Everything else (Qwen, Llama,
+    GPT-OSS, Nemotron) would raise ``TypeError`` on the keyword, so the eval
+    path has to ask before passing it.
+    """
+    try:
+        signature = inspect.signature(renderer.build_generation_prompt)
+    except (TypeError, ValueError):
+        return False
+    return "effort" in signature.parameters
+
+
 class InspectAPIFromTinkerSampling(InspectAIModelAPI):
     """
     A model API wrapper that adapts tinker sampling clients to the inspect API interface.
@@ -281,6 +296,7 @@ class InspectAPIFromTinkerSampling(InspectAIModelAPI):
         config: InspectAIGenerateConfig = InspectAIGenerateConfig(),
         verbose: bool = False,
         include_reasoning: bool = False,
+        effort: float | None = None,
     ):
         if api_key_vars is None:
             api_key_vars = []
@@ -307,6 +323,16 @@ class InspectAPIFromTinkerSampling(InspectAIModelAPI):
         self.verbose = verbose
         self.include_reasoning = include_reasoning
 
+        # Reasoning effort. ``None`` keeps the renderer's own default, which is
+        # what every eval did before this parameter existed.
+        if effort is not None and not renderer_supports_effort(self.renderer):
+            raise ConfigurationError(
+                f"effort={effort} was requested but renderer {renderer_name!r} is not "
+                "effort-conditioned. Effort is only meaningful for TML renderers "
+                "(tml_v0); drop the argument for other models."
+            )
+        self.effort = effort
+
     async def generate(
         self,
         input: list[InspectAIChatMessage],
@@ -321,7 +347,10 @@ class InspectAPIFromTinkerSampling(InspectAIModelAPI):
             input = [ChatMessageSystem(content=config.system_message)] + input
         convo = convert_inspect_messages(input)
         convo = _conversation_with_tool_declarations(self.renderer, convo, tools, tool_choice)
-        prompt = self.renderer.build_generation_prompt(convo)
+        if self.effort is None:
+            prompt = self.renderer.build_generation_prompt(convo)
+        else:
+            prompt = self.renderer.build_generation_prompt(convo, effort=self.effort)
         num_responses = 1 if config.num_choices is None else config.num_choices
         sampling_params = tinker.SamplingParams(
             temperature=config.temperature if config.temperature is not None else 1.0,


### PR DESCRIPTION

`skills/inkling/SKILL.md` sets the rule:

> However you sample, set effort explicitly and record it alongside the score —
> an eval number without its effort value is not reproducible.

The Inspect eval path can do neither. `grep -rn "effort" tinker_cookbook/eval/`
returns nothing on main. `eval/inspect_utils.py:324` calls
`build_generation_prompt(convo)` with no effort argument, so every eval renders
at `DEFAULT_EFFORT = 0.9` (`renderers/tml_v0.py:68`), and nothing in the run
output records which value was used. `TmlV0Renderer.__init__` takes no effort
either, so a pre-configured renderer cannot be passed in as a workaround.

This matters for the model-card comparisons in `eval/README.md`. The launch post
states "All evals are run at effort 0.99 and temperature 1.0"; the harness
renders 0.9. Those are different prompts, so the "Match?" column compares two
operating points rather than reproducing one.

## Changes

- `InspectEvaluatorBuilder` gains `effort: float | None = None`. `None`
  preserves current behaviour exactly; existing runs are byte-identical.
- `InspectAPIFromTinkerSampling` accepts `effort` and forwards it to
  `build_generation_prompt` only when set.
- `renderer_supports_effort()` checks the renderer signature first, so passing
  effort to a Qwen or GPT-OSS renderer raises `ConfigurationError` rather than a
  `TypeError` from inside the render call.
- When set, effort is stamped into the Inspect log metadata, so the value
  travels with the score.

Two files, ~40 lines, plus one test file.

## Relationship to #854

#854 makes effort a `TmlV0Renderer` constructor argument for the SFT
train/sample mismatch, and notes "No behavior change for existing users —
`tml_v0` still renders at `0.9`." This is the eval-side half and does not touch
the renderer. They compose: after #854 a renderer carries its own effort and
`effort=None` inherits it, while an explicit value still overrides per run.
Happy to rebase on #854 if it lands first, or fold this into it.

## Tests

`tinker_cookbook/eval/effort_in_evals_test.py`, 9 tests, offline on CPU in about
five seconds. No GPU, no API key, no weights. The TML tokenizer ships in the
`tml-renderers` wheel so the renderer is exercised rather than mocked.

The load-bearing test asserts the published operating point is reachable from
the eval path and renders differently from the default.

`pytest tinker_cookbook/eval/` is 92 on main and 101 on this branch. `ruff
check` and `ruff format --check` clean. `tml-renderers` is Linux-only, so on
Windows these 9 skip via `importorskip` and the suite reports 92; verified
passing on Linux against this commit.

## Not in this PR

- No safety benchmark added. `inspect-evals` is already a declared dependency
  (`pyproject.toml:91-93`) shipping `strong_reject`, `xstest` and `agentharm`,
  so those tasks run through the bridge today, just effort-blind.
- `effort` is not added to `BenchmarkResultDict`. The native benchmark runner
  has the same gap at `eval/custom_evaluators.py:58`; wider change, own PR.

---

Found this while sweeping refusal behaviour across the effort range, where this
also fell out: truncation is effort-dependent. Responses hitting `max_tokens`
went 0, 0, 1, 11, 23 across effort 0.0 to 0.99, so a grader scoring a truncated
response as non-refusal reads that as "high effort is less safe" and is exactly
wrong. Method and data:
https://github.com/RaphaelKhalid/inkling-effort-refusal