### PR TITLE
[Recipe] Add a forecasting recipe

### DIFF
--- a/tests/recipes/test_recipe_forecasting.py
+++ b/tests/recipes/test_recipe_forecasting.py
@@ -1,0 +1,21 @@
+import pytest
+
+from tests.helpers import run_recipe
+
+MODULE = "tinker_cookbook.recipes.forecasting.train"
+
+
+@pytest.mark.integration
+def test_forecasting():
+    run_recipe(
+        MODULE,
+        [
+            "model_name=Qwen/Qwen3.5-4B",
+            "renderer_name=qwen3_5",
+            "groups_per_batch=8",
+            "group_size=4",
+            "max_tokens=5",
+            "max_steps=1",
+            "behavior_if_log_dir_exists=delete",
+        ],
+    )

--- a/tinker_cookbook/recipes/README.md
+++ b/tinker_cookbook/recipes/README.md
@@ -25,6 +25,7 @@ We provide the following examples:
 - **[Code reasoning](./code_rl/)**: train LLMs on competitive programming problems with sandboxed code execution (DeepCoder replication).
 - **[Preference learning](./preference/)**: showcase a three-stage RLHF pipeline: 1) supervised fine-tuning, 2) learning a reward model, 3) RL against the reward model.
 - **[Tool use](./search_tool/)**: train LLMs to better use retrieval tools to answer questions more accurately.
+- **[Forecasting](./forecasting/)**: train LLMs to make calibrated probability forecasts about real-world events, scored with a Brier reward.
 - **[Prompt distillation](./prompt_distillation/)**: internalize long and complex instructions into LLMs.
 - **[Multi-Agent](./multiplayer_rl/)**: optimize LLMs to play against another LLM or themselves.
 - **[Model distillation](./distillation/)**: use on-policy distillation or SFT to distill intelligence from a teacher model.

--- a/tinker_cookbook/recipes/forecasting/README.md
+++ b/tinker_cookbook/recipes/forecasting/README.md
@@ -1,20 +1,27 @@
 # Forecasting with RL
 
-Fine-tune Qwen3.8-27B with Tinker on binary markets from the
+Fine-tune a model (Qwen3.8-27B in this example) with Tinker on binary markets from the
 [Prophet Arena subset](https://huggingface.co/datasets/prophetarena/Prophet-Arena-Subset-1200)
 using a chronological split and Brier reward.
+
 
 ## Run
 
 ```bash
 export TINKER_API_KEY=...
 
+# optionally download, verify, and inspect the data split
 python -m tinker_cookbook.recipes.forecasting.data
+
+# train forecasting model
 python -m tinker_cookbook.recipes.forecasting.train
 ```
 
 ## Prompt
 
+Task: Given a binary prediction-market question and information available at a historical snapshot, forecast the probability that the market will resolve YES. The model does not use tools or live search in this recipe.
+
+Here is the exact prompt template we use:
 ```text
 Forecast whether this market will resolve YES using information available through {snapshot time}.
 
@@ -95,12 +102,37 @@ and 1,180 questions, which the default caps trim to 1,024 and 256.
 The recipe downloads a fixed published version and verifies the CSV contents,
 so later dataset updates do not change a rerun.
 
+
+### Temporal split methodology
+This cookbook specifically uses a cutoff of October 20, 2025 UTC, but feel free to adjust based on the model you are using.
+
+* Knowledge cutoff: Try to find the knowledge cutoff for the model you are post-training. Ideally its pretraining cutoff predates the forecasting questions. Qwen3.8 has been reported to self-identify an [early-2025 cutoff](https://huggingface.co/Qwen/Qwen3.8-27B-FP8/discussions/8), although this is not publisher-verified. Adjust the model or split date to reduce outcome contamination.
+* Training split: Events whose markets all closed before the cutoff.
+* Validation split: Events first observed on or after the cutoff.
+
+We further refine our data via:
+* Boundary events: Events open across the cutoff are excluded.
+* Deduplication: Each event-market pair becomes one question using its earliest snapshot, and all markets from the same event remain in the same split.
+
 ## Configuration
 
-The default run uses the Qwen3.8 low-reasoning renderer, LoRA rank 32, 16
-questions per step, 32 forecasts per question, and a learning rate of `8e-5`. It
-trains for 100 steps. Validation runs every 20 steps and after the final update,
-with eight forecasts per question.
+**Model**
+* Qwen3.8-27B, using the Tinker [`qwen3_8_low_reasoning`](../../renderers/qwen3_8.py) renderer
+* LoRA rank 32
+* learning rate `8e-5`
+
+When switching models, use that model's recommended renderer and rerun the relevant hyperparameter ablations.
+
+**Training loop**
+
+* 16 questions per step
+* 32 forecasts per question
+* 100 training steps
+
+**Validation**
+
+* every 20 steps and after the final update
+* 8 forecasts per question
 
 ## Reward
 
@@ -116,7 +148,7 @@ for the outcome-based forecasting setup.
 
 ## Result
 
-A default run produced:
+With Qwen3.8-27B, we produced the following for reference:
 
 | Step | Validation Brier reward | Validation accuracy | Valid format |
 |---:|---:|---:|---:|
@@ -126,6 +158,8 @@ A default run produced:
 | 60 | 0.8198 | 74.49% | 99.95% |
 | 80 | 0.8223 | 74.24% | 100.00% |
 | 100 | 0.8252 | 74.15% | 100.00% |
+
+This shows consistent improvement on temporally **held-out** validation questions and suggests that the learned forecasting behavior generalizes beyond the training events.
 
 For scale, always answering `0.5` scores `0.7500` on this validation split and
 always answering the training base rate scores `0.7709`.

--- a/tinker_cookbook/recipes/forecasting/README.md
+++ b/tinker_cookbook/recipes/forecasting/README.md
@@ -1,0 +1,137 @@
+# Forecasting with RL
+
+Fine-tune Qwen3.8-27B with Tinker on binary markets from the
+[Prophet Arena subset](https://huggingface.co/datasets/prophetarena/Prophet-Arena-Subset-1200)
+using a chronological split and Brier reward.
+
+## Run
+
+```bash
+export TINKER_API_KEY=...
+
+python -m tinker_cookbook.recipes.forecasting.data
+python -m tinker_cookbook.recipes.forecasting.train
+```
+
+## Prompt
+
+```text
+Forecast whether this market will resolve YES using information available through {snapshot time}.
+
+Event:
+{event title}
+
+Market:
+{market}
+
+Reference material:
+{reference material available at the snapshot}
+
+Resolution criteria:
+{resolution criteria}
+
+Market close time: {close time}
+
+Output only the probability of YES as a number between 0 and 1.
+```
+
+An example from the pinned dataset is below. Note that this event bundles the
+markets `PSG`, `Real Madrid`, and `Tie`, so it becomes three questions. Below is
+the `Real Madrid` one, which resolved NO.
+
+```text
+Forecast whether this market will resolve YES using information available through 2025-07-08T12:01:09.330143+00:00.
+
+Event:
+PSG vs Real Madrid
+
+Market:
+Real Madrid
+
+Reference material:
+1. 2024–25 Paris Saint-Germain FC season
+This article details PSG's 2024–25 season, highlighting their achievements including winning Ligue 1, the Coupe de France, and the UEFA Champions League, marking their first continental treble. It emphasizes the team's strong performance under manager Luis Enrique and the significant contributions of key players like Ousmane Dembélé, who was the season's top scorer with 33 goals. This information is relevant as it showcases PSG's recent form and success leading up to their match against Real Madrid.
+
+2. 2025 FIFA Club World Cup Group H
+This article outlines the structure and participants of Group H in the 2025 FIFA Club World Cup, which includes Real Madrid. It provides insights into Real Madrid's recent international competition schedule and performance. Understanding their participation and results in this tournament can offer context for their preparedness and form ahead of the match against PSG.
+
+3. Ousmane Dembélé
+This article provides an overview of Ousmane Dembélé's career, focusing on his impactful tenure at PSG since joining in August 2023. It highlights his contributions, including scoring 33 goals in the 2024–25 season and playing a pivotal role in PSG's treble-winning campaign. Dembélé's form and performance are crucial factors to consider when predicting the outcome of the upcoming match against Real Madrid.
+
+...three more sources...
+
+Resolution criteria:
+The market resolves YES if this condition occurs: Real Madrid.
+
+Market close time: 2025-07-09T21:06:41.016512+00:00
+
+Output only the probability of YES as a number between 0 and 1.
+```
+
+Prompts use the event, named market, reference material, and timestamp from its
+earliest snapshot, together with the market close time. Market prices and
+outcome fields are omitted.
+
+## Data
+
+One CSV of 1,200 snapshots covering 869 events.
+
+An event bundles one or more markets (median of 2 markets but occasionally over
+100), and each market becomes its own binary question, with resolution criteria
+derived from the market name. The 1,200 rows expand to 5,232 questions.
+
+Each row is one snapshot, and the loader keeps the earliest snapshot for each
+market. Note that the question never changes between snapshots, only the
+attached news and the market price, so the earliest snapshot is the
+longest-horizon and least informed version of the question.
+
+Events that closed before October 20, 2025 form the training set. Events that
+were first observed on that cutoff date or later form the validation set, with
+every market of an event kept on the same side. Events that started before the
+cutoff and had not closed by it are excluded. That splits 869 events into 613
+training and 207 validation, dropping 49 at the boundary. This produces 3,587
+and 1,180 questions, which the default caps trim to 1,024 and 256.
+
+The recipe downloads a fixed published version and verifies the CSV contents,
+so later dataset updates do not change a rerun.
+
+## Configuration
+
+The default run uses the Qwen3.8 low-reasoning renderer, LoRA rank 32, 16
+questions per step, 32 forecasts per question, and a learning rate of `8e-5`. It
+trains for 100 steps. Validation runs every 20 steps and after the final update,
+with eight forecasts per question.
+
+## Reward
+
+For probability `p` and outcome `y`:
+
+```text
+Brier reward = 1 - (p - y)^2
+```
+
+This is a strictly proper scoring rule; malformed answers receive `0`. See
+[Outcome-based Reinforcement Learning to Predict the Future](https://arxiv.org/abs/2507.16806)
+for the outcome-based forecasting setup.
+
+## Result
+
+A default run produced:
+
+| Step | Validation Brier reward | Validation accuracy | Valid format |
+|---:|---:|---:|---:|
+| 0 | 0.8013 | 73.10% | 99.90% |
+| 20 | 0.8076 | 73.75% | 100.00% |
+| 40 | 0.8132 | 73.36% | 100.00% |
+| 60 | 0.8198 | 74.49% | 99.95% |
+| 80 | 0.8223 | 74.24% | 100.00% |
+| 100 | 0.8252 | 74.15% | 100.00% |
+
+For scale, always answering `0.5` scores `0.7500` on this validation split and
+always answering the training base rate scores `0.7709`.
+
+## License
+
+Prophet Arena data is distributed under the MIT license; see the
+[dataset card](https://huggingface.co/datasets/prophetarena/Prophet-Arena-Subset-1200)
+for terms.

--- a/tinker_cookbook/recipes/forecasting/__init__.py
+++ b/tinker_cookbook/recipes/forecasting/__init__.py
@@ -1,0 +1,1 @@
+"""A small Prophet Arena reinforcement-learning recipe for Tinker."""

--- a/tinker_cookbook/recipes/forecasting/data.py
+++ b/tinker_cookbook/recipes/forecasting/data.py
@@ -118,13 +118,18 @@ def _required_text(row: Mapping[str, str], key: str, context: str) -> str:
     return value
 
 
-def _parse_datetime(value: str, context: str) -> datetime:
+def parse_utc_datetime(value: str, context: str = "datetime") -> datetime:
+    """Parse an ISO datetime and normalize it to UTC.
+
+    Values without an explicit timezone are interpreted as UTC. Values with
+    an offset are converted to UTC without changing the instant they represent.
+    """
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
         raise ValueError(f"invalid ISO datetime for {context}: {value!r}") from exc
     if parsed.tzinfo is None:
-        raise ValueError(f"expected timezone-aware datetime for {context}: {value!r}")
+        parsed = parsed.replace(tzinfo=UTC)
     return parsed.astimezone(UTC)
 
 
@@ -193,10 +198,10 @@ def _row_to_examples(row: Mapping[str, str], row_number: int) -> list[ForecastEx
     reference_material = _format_sources(raw_sources, context)
     if not reference_material:
         raise ValueError(f"expected at least one source in {context}")
-    snapshot_time = _parse_datetime(
+    snapshot_time = parse_utc_datetime(
         _required_text(row, "snapshot_time", context), f"{context}.snapshot_time"
     )
-    close_time = _parse_datetime(
+    close_time = parse_utc_datetime(
         _required_text(row, "close_time", context), f"{context}.close_time"
     )
     if snapshot_time >= close_time:
@@ -353,8 +358,8 @@ def main() -> None:
     parser.add_argument("--cache-dir", default=DEFAULT_CACHE_DIR)
     parser.add_argument(
         "--split-date",
-        type=datetime.fromisoformat,
-        default=datetime.fromisoformat(DEFAULT_SPLIT_DATE).replace(tzinfo=UTC),
+        type=parse_utc_datetime,
+        default=parse_utc_datetime(DEFAULT_SPLIT_DATE, "default split date"),
     )
     parser.add_argument("--max-train-questions", type=int, default=DEFAULT_MAX_TRAIN_QUESTIONS)
     parser.add_argument(

--- a/tinker_cookbook/recipes/forecasting/data.py
+++ b/tinker_cookbook/recipes/forecasting/data.py
@@ -1,0 +1,388 @@
+"""Download Prophet Arena and build a leakage-resistant temporal split."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import hashlib
+import json
+import logging
+import os
+import random
+import shutil
+import tempfile
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+DATASET_REPOSITORY = "prophetarena/Prophet-Arena-Subset-1200"
+DEFAULT_DATASET_REVISION = "c94b6f450d7fe3b03688799cce1c8b29838b5d96"
+DEFAULT_DATASET_SHA256 = "1e34a5970e515cd06a2e57a955074561308cb8734c8c5712adb1452b977b3984"
+DEFAULT_CACHE_DIR = "~/.cache/tinker-cookbook/prophet-arena"
+DEFAULT_SPLIT_DATE = "2025-10-20"
+DEFAULT_MAX_TRAIN_QUESTIONS = 1024
+DEFAULT_MAX_VALIDATION_QUESTIONS = 256
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ForecastExample:
+    """One binary market forecast at its earliest recorded snapshot."""
+
+    submission_id: str
+    event_ticker: str
+    event_title: str
+    market: str
+    reference_material: str
+    resolution_criteria: str
+    snapshot_time: datetime
+    close_time: datetime
+    category: str
+    outcome: int
+
+
+@dataclass(frozen=True)
+class ForecastSplit:
+    """Training and validation examples separated by an outcome-availability gap."""
+
+    train: tuple[ForecastExample, ...]
+    validation: tuple[ForecastExample, ...]
+    split_time: datetime
+    excluded_crossing_events: int
+
+
+def _safe_revision(revision: str) -> str:
+    if not revision or revision in {".", ".."}:
+        raise ValueError("dataset revision must be a non-empty Git revision")
+    if any(
+        character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/"
+        for character in revision
+    ):
+        raise ValueError(f"unsafe dataset revision: {revision!r}")
+    return revision
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fetch_prophet_arena(
+    revision: str = DEFAULT_DATASET_REVISION,
+    cache_dir: str = DEFAULT_CACHE_DIR,
+) -> Path:
+    """Download a commit-pinned Prophet Arena CSV and return its path."""
+    revision = _safe_revision(revision)
+    expected_sha256 = DEFAULT_DATASET_SHA256 if revision == DEFAULT_DATASET_REVISION else None
+    target = Path(cache_dir).expanduser() / revision.replace("/", "--") / "subset_data_1200.csv"
+    if target.exists():
+        if expected_sha256 is not None and _sha256(target) != expected_sha256:
+            raise ValueError(f"cached Prophet Arena file has an unexpected checksum: {target}")
+        return target
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    quoted_revision = urllib.parse.quote(revision, safe="")
+    url = f"https://huggingface.co/datasets/{DATASET_REPOSITORY}/resolve/{quoted_revision}/subset_data_1200.csv"
+    request = urllib.request.Request(url, headers={"User-Agent": "tinker-forecast-cookbook/1"})
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{target.name}-", dir=target.parent, delete=False
+        ) as output:
+            temporary_path = Path(output.name)
+            logger.info("Downloading Prophet Arena revision %s", revision)
+            with urllib.request.urlopen(request, timeout=120) as response:
+                shutil.copyfileobj(response, output)
+        if expected_sha256 is not None and _sha256(temporary_path) != expected_sha256:
+            raise ValueError("downloaded Prophet Arena file has an unexpected checksum")
+        os.replace(temporary_path, target)
+        return target
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _required_text(row: Mapping[str, str], key: str, context: str) -> str:
+    value = row.get(key, "").strip()
+    if not value:
+        raise ValueError(f"expected non-empty {key!r} in {context}")
+    return value
+
+
+def _parse_datetime(value: str, context: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"invalid ISO datetime for {context}: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"expected timezone-aware datetime for {context}: {value!r}")
+    return parsed.astimezone(UTC)
+
+
+def _parse_structured(value: str, context: str) -> object:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        try:
+            return ast.literal_eval(value)
+        except (SyntaxError, ValueError) as exc:
+            raise ValueError(f"invalid structured value for {context}") from exc
+
+
+def _parse_json_list(value: str, context: str) -> list[object]:
+    parsed = _parse_structured(value, context)
+    if not isinstance(parsed, list):
+        raise ValueError(f"expected a JSON list for {context}")
+    return parsed
+
+
+def _parse_json_object(value: str, context: str) -> Mapping[str, object]:
+    parsed = _parse_structured(value, context)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"expected a JSON object for {context}")
+    return parsed
+
+
+def _format_sources(raw_sources: Sequence[object], context: str) -> str:
+    sources: list[tuple[int, str, str]] = []
+    for index, raw_source in enumerate(raw_sources):
+        if not isinstance(raw_source, dict):
+            raise ValueError(f"expected {context}.sources[{index}] to be an object")
+        title = raw_source.get("title")
+        summary = raw_source.get("summary")
+        ranking = raw_source.get("ranking", index + 1)
+        if not isinstance(title, str) or not isinstance(summary, str):
+            raise ValueError(f"expected source title and summary strings in {context}")
+        if isinstance(ranking, bool) or not isinstance(ranking, int):
+            ranking = index + 1
+        if title.strip() or summary.strip():
+            sources.append((ranking, title.strip(), summary.strip()))
+    sources.sort(key=lambda item: (item[0], item[1]))
+    return "\n\n".join(
+        f"{position}. {title}\n{summary}"
+        for position, (_, title, summary) in enumerate(sources, start=1)
+    )
+
+
+def _row_to_examples(row: Mapping[str, str], row_number: int) -> list[ForecastExample]:
+    context = f"row {row_number}"
+    submission_id = _required_text(row, "submission_id", context)
+    event_ticker = _required_text(row, "event_ticker", context)
+    category = _required_text(row, "category", context)
+    markets = _parse_json_list(_required_text(row, "markets", context), f"{context}.markets")
+    outcomes = _parse_json_object(
+        _required_text(row, "market_outcome", context), f"{context}.market_outcome"
+    )
+    if not markets or not all(isinstance(market, str) and market.strip() for market in markets):
+        raise ValueError(f"expected non-empty string markets in {context}")
+    market_names = [market for market in markets if isinstance(market, str)]
+    if set(market_names) != set(outcomes):
+        raise ValueError(f"markets and market_outcome disagree in {context}")
+
+    title = _required_text(row, "title", context)
+    raw_sources = _parse_json_list(_required_text(row, "sources", context), f"{context}.sources")
+    reference_material = _format_sources(raw_sources, context)
+    if not reference_material:
+        raise ValueError(f"expected at least one source in {context}")
+    snapshot_time = _parse_datetime(
+        _required_text(row, "snapshot_time", context), f"{context}.snapshot_time"
+    )
+    close_time = _parse_datetime(
+        _required_text(row, "close_time", context), f"{context}.close_time"
+    )
+    if snapshot_time >= close_time:
+        raise ValueError(f"snapshot_time must precede close_time in {context}")
+
+    examples: list[ForecastExample] = []
+    for market in market_names:
+        raw_outcome = outcomes[market]
+        if isinstance(raw_outcome, bool) or raw_outcome not in (0, 1):
+            raise ValueError(f"expected a binary outcome for {market!r} in {context}")
+        examples.append(
+            ForecastExample(
+                submission_id=submission_id,
+                event_ticker=event_ticker,
+                event_title=title,
+                market=market,
+                reference_material=reference_material,
+                resolution_criteria=(
+                    f"The market resolves YES if this condition occurs: {market}."
+                ),
+                snapshot_time=snapshot_time,
+                close_time=close_time,
+                category=category,
+                outcome=int(raw_outcome),
+            )
+        )
+    return examples
+
+
+def load_prophet_arena_examples(csv_path: str | Path) -> list[ForecastExample]:
+    """Load the earliest snapshot of each binary market."""
+    path = Path(csv_path).expanduser()
+    by_market: dict[tuple[str, str], list[ForecastExample]] = defaultdict(list)
+    with path.open(newline="", encoding="utf-8") as source:
+        reader = csv.DictReader(source)
+        required_columns = {
+            "submission_id",
+            "event_ticker",
+            "title",
+            "snapshot_time",
+            "close_time",
+            "market_outcome",
+            "category",
+            "markets",
+            "sources",
+        }
+        if reader.fieldnames is None or not required_columns.issubset(reader.fieldnames):
+            missing = sorted(required_columns.difference(reader.fieldnames or ()))
+            raise ValueError(f"Prophet Arena CSV is missing columns: {missing}")
+        for row_number, row in enumerate(reader, start=2):
+            for example in _row_to_examples(row, row_number):
+                by_market[(example.event_ticker, example.market)].append(example)
+
+    if not by_market:
+        raise ValueError(f"no Prophet Arena examples found in {path}")
+
+    examples: list[ForecastExample] = []
+    for (event_ticker, market), snapshots in by_market.items():
+        stable_fields = {
+            (
+                example.event_title,
+                example.market,
+                example.resolution_criteria,
+                example.close_time,
+                example.category,
+                example.outcome,
+            )
+            for example in snapshots
+        }
+        if len(stable_fields) != 1:
+            raise ValueError(f"market {event_ticker}:{market} changes across snapshots")
+        examples.append(min(snapshots, key=lambda item: (item.snapshot_time, item.submission_id)))
+    examples.sort(key=lambda item: (item.snapshot_time, item.event_ticker, item.market))
+    return examples
+
+
+def _sample(examples: list[ForecastExample], cap: int | None, seed: int) -> list[ForecastExample]:
+    if cap is not None and cap <= 0:
+        raise ValueError("question caps must be positive or None")
+    if cap is None or len(examples) <= cap:
+        return list(examples)
+    return random.Random(seed).sample(examples, cap)
+
+
+def load_prophet_arena_split(
+    csv_path: str | Path,
+    *,
+    split_time: datetime,
+    max_train_questions: int | None = DEFAULT_MAX_TRAIN_QUESTIONS,
+    max_validation_questions: int | None = DEFAULT_MAX_VALIDATION_QUESTIONS,
+    seed: int = 0,
+) -> ForecastSplit:
+    """Split events around a boundary without sharing events or future labels."""
+    if split_time.tzinfo is None:
+        raise ValueError("split_time must be timezone-aware")
+    split_time = split_time.astimezone(UTC)
+    examples = load_prophet_arena_examples(csv_path)
+
+    # Keep every market from an event on the same side of the split. Training
+    # labels come only from events whose markets all closed before validation
+    # begins; events already open at the boundary form a gap.
+    event_starts: dict[str, datetime] = {}
+    event_closes: dict[str, datetime] = {}
+    for example in examples:
+        event_starts[example.event_ticker] = min(
+            event_starts.get(example.event_ticker, example.snapshot_time),
+            example.snapshot_time,
+        )
+        event_closes[example.event_ticker] = max(
+            event_closes.get(example.event_ticker, example.close_time),
+            example.close_time,
+        )
+
+    train_event_tickers = {
+        event_ticker for event_ticker, close_time in event_closes.items() if close_time < split_time
+    }
+    validation_event_tickers = {
+        event_ticker
+        for event_ticker, snapshot_time in event_starts.items()
+        if snapshot_time >= split_time
+    }
+    crossing_event_tickers = set(event_starts) - train_event_tickers - validation_event_tickers
+    train_candidates = [
+        example for example in examples if example.event_ticker in train_event_tickers
+    ]
+    validation_candidates = [
+        example for example in examples if example.event_ticker in validation_event_tickers
+    ]
+    excluded = len(crossing_event_tickers)
+    train_events = {example.event_ticker for example in train_candidates}
+    validation_events = {example.event_ticker for example in validation_candidates}
+    if train_events & validation_events:
+        raise ValueError("an event appears in both training and validation")
+
+    train = _sample(train_candidates, max_train_questions, seed)
+    random.Random(seed).shuffle(train)
+    validation = _sample(validation_candidates, max_validation_questions, seed + 1)
+    validation.sort(key=lambda item: (item.snapshot_time, item.event_ticker, item.market))
+    if not train or not validation:
+        raise ValueError(
+            f"empty temporal split: {len(train)} train and {len(validation)} validation"
+        )
+    return ForecastSplit(tuple(train), tuple(validation), split_time, excluded)
+
+
+def _yes_rate(examples: Sequence[ForecastExample]) -> float:
+    return sum(example.outcome for example in examples) / len(examples)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-path", default=None)
+    parser.add_argument("--revision", default=DEFAULT_DATASET_REVISION)
+    parser.add_argument("--cache-dir", default=DEFAULT_CACHE_DIR)
+    parser.add_argument(
+        "--split-date",
+        type=datetime.fromisoformat,
+        default=datetime.fromisoformat(DEFAULT_SPLIT_DATE).replace(tzinfo=UTC),
+    )
+    parser.add_argument("--max-train-questions", type=int, default=DEFAULT_MAX_TRAIN_QUESTIONS)
+    parser.add_argument(
+        "--max-validation-questions", type=int, default=DEFAULT_MAX_VALIDATION_QUESTIONS
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    csv_path = (
+        Path(args.data_path).expanduser()
+        if args.data_path is not None
+        else fetch_prophet_arena(args.revision, args.cache_dir)
+    )
+    split = load_prophet_arena_split(
+        csv_path,
+        split_time=args.split_date,
+        max_train_questions=args.max_train_questions,
+        max_validation_questions=args.max_validation_questions,
+        seed=args.seed,
+    )
+    print(f"dataset: {csv_path}")
+    print(f"split date: {split.split_time.date().isoformat()}")
+    print(f"train: {len(split.train)} examples, yes rate {_yes_rate(split.train):.3f}")
+    print(
+        f"validation: {len(split.validation)} examples, yes rate {_yes_rate(split.validation):.3f}"
+    )
+    print(f"excluded crossing events: {split.excluded_crossing_events}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tinker_cookbook/recipes/forecasting/data_test.py
+++ b/tinker_cookbook/recipes/forecasting/data_test.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from .data import load_prophet_arena_examples, load_prophet_arena_split
+
+
+def _row(
+    event_ticker: str,
+    submission_id: str,
+    snapshot_time: str,
+    close_time: str,
+    *,
+    markets: list[str] | None = None,
+    target: str | None = None,
+    outcome: int = 1,
+    source_summary: str = "Information available before the forecast.",
+) -> dict[str, str]:
+    markets = markets or ["Alpha", "Beta"]
+    target = target or markets[0]
+    outcomes = {market: int(market == target and outcome == 1) for market in markets}
+    return {
+        "submission_id": submission_id,
+        "event_ticker": event_ticker,
+        "title": f"What will happen in {event_ticker}?",
+        "snapshot_time": snapshot_time,
+        "close_time": close_time,
+        "market_data": json.dumps({market: {"yes_ask": 50} for market in markets}),
+        "market_outcome": json.dumps(outcomes),
+        "category": "Other",
+        # The published file mixes JSON objects with Python-style lists.
+        "markets": repr(markets),
+        "augmented_title": f"Will {target} happen?",
+        "rules": f"If the host says {target}, then the market resolves to Yes.",
+        "sources": repr(
+            [
+                {
+                    "ranking": 1,
+                    "title": "Reference",
+                    "summary": source_summary,
+                    "url": "https://example.test/reference",
+                }
+            ]
+        ),
+    }
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as output:
+        writer = csv.DictWriter(output, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_loader_uses_every_market_and_its_earliest_snapshot(tmp_path: Path) -> None:
+    path = tmp_path / "prophet.csv"
+    _write_csv(
+        path,
+        [
+            _row(
+                "event",
+                "later",
+                "2025-09-02T00:00:00+00:00",
+                "2025-09-03T00:00:00+00:00",
+                markets=["Speaker", "Target phrase"],
+                target="Target phrase",
+                source_summary="Later material.",
+            ),
+            _row(
+                "event",
+                "earlier",
+                "2025-09-01T00:00:00+00:00",
+                "2025-09-03T00:00:00+00:00",
+                markets=["Speaker", "Target phrase"],
+                target="Target phrase",
+                source_summary="Earlier material.",
+            ),
+        ],
+    )
+
+    examples = load_prophet_arena_examples(path)
+
+    assert [example.market for example in examples] == ["Speaker", "Target phrase"]
+    assert [example.outcome for example in examples] == [0, 1]
+    assert {example.submission_id for example in examples} == {"earlier"}
+    assert {example.event_title for example in examples} == {"What will happen in event?"}
+    assert all("Earlier material." in example.reference_material for example in examples)
+    assert all("Later material." not in example.reference_material for example in examples)
+    assert examples[0].resolution_criteria == (
+        "The market resolves YES if this condition occurs: Speaker."
+    )
+    assert "host says Target phrase" not in examples[0].resolution_criteria
+
+
+def test_split_requires_closed_training_events_and_later_validation_snapshots(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "prophet.csv"
+    _write_csv(
+        path,
+        [
+            _row(
+                "train",
+                "train-id",
+                "2025-10-01T00:00:00+00:00",
+                "2025-10-19T00:00:00+00:00",
+            ),
+            _row(
+                "crossing",
+                "crossing-id",
+                "2025-10-01T00:00:00+00:00",
+                "2025-10-21T00:00:00+00:00",
+            ),
+            _row(
+                "validation",
+                "validation-later",
+                "2025-10-22T00:00:00+00:00",
+                "2025-10-23T00:00:00+00:00",
+            ),
+            _row(
+                "validation",
+                "validation-first",
+                "2025-10-20T00:00:00+00:00",
+                "2025-10-23T00:00:00+00:00",
+            ),
+        ],
+    )
+
+    split = load_prophet_arena_split(
+        path,
+        split_time=datetime(2025, 10, 20, tzinfo=UTC),
+        max_train_questions=None,
+        max_validation_questions=None,
+    )
+
+    assert {(example.event_ticker, example.market) for example in split.train} == {
+        ("train", "Alpha"),
+        ("train", "Beta"),
+    }
+    assert {(example.event_ticker, example.market) for example in split.validation} == {
+        ("validation", "Alpha"),
+        ("validation", "Beta"),
+    }
+    assert {example.submission_id for example in split.validation} == {"validation-first"}
+    assert split.excluded_crossing_events == 1
+
+
+def test_split_caps_are_deterministic(tmp_path: Path) -> None:
+    path = tmp_path / "prophet.csv"
+    rows = [
+        _row(
+            f"train-{index}",
+            f"train-id-{index}",
+            "2025-10-01T00:00:00+00:00",
+            "2025-10-19T00:00:00+00:00",
+        )
+        for index in range(10)
+    ]
+    rows.extend(
+        _row(
+            f"validation-{index}",
+            f"validation-id-{index}",
+            "2025-10-21T00:00:00+00:00",
+            "2025-10-22T00:00:00+00:00",
+        )
+        for index in range(10)
+    )
+    _write_csv(path, rows)
+
+    first = load_prophet_arena_split(
+        path,
+        split_time=datetime(2025, 10, 20, tzinfo=UTC),
+        max_train_questions=4,
+        max_validation_questions=3,
+        seed=7,
+    )
+    repeated = load_prophet_arena_split(
+        path,
+        split_time=datetime(2025, 10, 20, tzinfo=UTC),
+        max_train_questions=4,
+        max_validation_questions=3,
+        seed=7,
+    )
+
+    assert first == repeated
+    assert len(first.train) == 4
+    assert len(first.validation) == 3
+
+
+def test_loader_rejects_snapshots_after_market_close(tmp_path: Path) -> None:
+    path = tmp_path / "prophet.csv"
+    _write_csv(
+        path,
+        [
+            _row(
+                "invalid",
+                "invalid-id",
+                "2025-10-22T00:00:00+00:00",
+                "2025-10-21T00:00:00+00:00",
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="snapshot_time must precede close_time"):
+        load_prophet_arena_examples(path)

--- a/tinker_cookbook/recipes/forecasting/data_test.py
+++ b/tinker_cookbook/recipes/forecasting/data_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from .data import load_prophet_arena_examples, load_prophet_arena_split
+from .data import load_prophet_arena_examples, load_prophet_arena_split, parse_utc_datetime
 
 
 def _row(
@@ -55,6 +55,19 @@ def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
         writer = csv.DictWriter(output, fieldnames=list(rows[0]))
         writer.writeheader()
         writer.writerows(rows)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2025-10-20", datetime(2025, 10, 20, tzinfo=UTC)),
+        ("2025-10-20T00:00:00Z", datetime(2025, 10, 20, tzinfo=UTC)),
+        ("2025-10-20T00:00:00-07:00", datetime(2025, 10, 20, 7, tzinfo=UTC)),
+        ("2025-10-20T12:30:00+05:30", datetime(2025, 10, 20, 7, tzinfo=UTC)),
+    ],
+)
+def test_parse_utc_datetime(value: str, expected: datetime) -> None:
+    assert parse_utc_datetime(value) == expected
 
 
 def test_loader_uses_every_market_and_its_earliest_snapshot(tmp_path: Path) -> None:

--- a/tinker_cookbook/recipes/forecasting/env.py
+++ b/tinker_cookbook/recipes/forecasting/env.py
@@ -1,0 +1,288 @@
+"""Prophet Arena prompt, Brier reward, and Tinker RL dataset."""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import chz
+
+from tinker_cookbook import renderers
+from tinker_cookbook.renderers import get_text_content
+from tinker_cookbook.rl.message_env import EnvFromMessageEnv, MessageEnv, MessageStepResult
+from tinker_cookbook.rl.types import (
+    Env,
+    EnvGroupBuilder,
+    Metrics,
+    RLDataset,
+    RLDatasetBuilder,
+    Trajectory,
+)
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+from .data import (
+    DEFAULT_CACHE_DIR,
+    DEFAULT_DATASET_REVISION,
+    DEFAULT_MAX_TRAIN_QUESTIONS,
+    DEFAULT_MAX_VALIDATION_QUESTIONS,
+    DEFAULT_SPLIT_DATE,
+    ForecastExample,
+    fetch_prophet_arena,
+    load_prophet_arena_split,
+)
+
+logger = logging.getLogger(__name__)
+
+_FINAL_FORECAST_RE = re.compile(
+    r"""
+    \A\s*
+    (?:\*{1,2}|_{1,2})?
+    (?:(?:(?:final\s+)?(?:answer|forecast)|probability(?:\s+of\s+yes)?)\s*[:=]\s*)?
+    (?:\*{1,2}|_{1,2})?
+    (?P<value>[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)
+    \s*(?P<percent>%?)
+    (?:\*{1,2}|_{1,2})?
+    [.!]?
+    (?:\*{1,2}|_{1,2})?
+    \s*\Z
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def parse_forecast(response: str) -> float | None:
+    """Parse a probability from the response's final non-empty line."""
+    lines = [line for line in response.splitlines() if line.strip()]
+    if not lines:
+        return None
+    match = _FINAL_FORECAST_RE.fullmatch(lines[-1])
+    if match is None:
+        return None
+    probability = float(match.group("value"))
+    if match.group("percent"):
+        probability /= 100.0
+    return probability if 0.0 <= probability <= 1.0 else None
+
+
+def brier_reward(probability: float, outcome: int) -> float:
+    """Return ``1 - (p - y)^2``, an affine form of the binary Brier score."""
+    if not math.isfinite(probability) or not 0.0 <= probability <= 1.0:
+        raise ValueError(f"probability must be finite and in [0, 1], got {probability}")
+    if isinstance(outcome, bool) or outcome not in (0, 1):
+        raise ValueError(f"outcome must be 0 or 1, got {outcome}")
+    return 1.0 - (probability - outcome) ** 2
+
+
+def _score(probability: float | None, outcome: int) -> dict[str, float]:
+    if probability is None:
+        return {
+            "brier_reward": 0.0,
+            "accuracy": 0.0,
+            "format_valid": 0.0,
+        }
+
+    correctness = 0.5 if probability == 0.5 else float((probability > 0.5) == bool(outcome))
+    return {
+        "brier_reward": brier_reward(probability, outcome),
+        "accuracy": correctness,
+        "format_valid": 1.0,
+    }
+
+
+def render_prompt(example: ForecastExample) -> str:
+    """Render the forecasting fields attached to the recorded snapshot."""
+    # Do not add the resolved outcome or the market prices stored elsewhere in
+    # the row.
+    return f"""Forecast whether this market will resolve YES using information available through {example.snapshot_time.isoformat()}.
+
+Event:
+{example.event_title}
+
+Market:
+{example.market}
+
+Reference material:
+{example.reference_material}
+
+Resolution criteria:
+{example.resolution_criteria}
+
+Market close time: {example.close_time.isoformat()}
+
+Output only the probability of YES as a number between 0 and 1."""
+
+
+class ForecastEnv(MessageEnv):
+    """A single-turn binary forecast scored from its resolved outcome."""
+
+    def __init__(self, example: ForecastExample):
+        self.example = example
+        self.example_id = f"{example.submission_id}:{example.market}"
+
+    async def initial_observation(self) -> list[renderers.Message]:
+        return [{"role": "user", "content": render_prompt(self.example)}]
+
+    async def step(self, message: renderers.Message) -> MessageStepResult:
+        probability = parse_forecast(get_text_content(message))
+        scores = _score(probability, self.example.outcome)
+        return MessageStepResult(
+            reward=scores["brier_reward"],
+            episode_done=True,
+            next_messages=[],
+            logs={
+                "question_id": self.example_id,
+                "forecast": "invalid" if probability is None else f"{probability:.6f}",
+                "outcome": self.example.outcome,
+                **scores,
+            },
+        )
+
+
+@dataclass(frozen=True)
+class ForecastGroupBuilder(EnvGroupBuilder):
+    """Create one policy-gradient group from repeated forecasts of one market."""
+
+    example: ForecastExample
+    renderer: renderers.Renderer
+    group_size: int
+
+    async def make_envs(self) -> Sequence[Env]:
+        return [
+            EnvFromMessageEnv(
+                renderer=self.renderer,
+                message_env=ForecastEnv(self.example),
+                failed_parse_reward=0.0,
+                context_overflow_reward=0.0,
+            )
+            for _ in range(self.group_size)
+        ]
+
+    async def compute_group_rewards(
+        self,
+        trajectory_group: list[Trajectory],
+        env_group: Sequence[Env],
+    ) -> list[tuple[float, Metrics]]:
+        """Report each metric for valid, invalid, and truncated rollouts."""
+        del env_group
+        rewards_and_metrics: list[tuple[float, Metrics]] = []
+        for trajectory in trajectory_group:
+            logged_scores = next(
+                (
+                    transition.logs
+                    for transition in trajectory.transitions
+                    if "brier_reward" in transition.logs
+                ),
+                None,
+            )
+            scores = (
+                _score(None, self.example.outcome)
+                if logged_scores is None
+                else {
+                    key: float(logged_scores[key])
+                    for key in ("brier_reward", "accuracy", "format_valid")
+                }
+            )
+            rewards_and_metrics.append((0.0, scores))
+        return rewards_and_metrics
+
+    def logging_tags(self) -> list[str]:
+        category = self.example.category.casefold().replace(" ", "-")
+        return ["prophet-arena", category]
+
+
+class ForecastRLDataset(RLDataset):
+    """Batches of unique questions repeated for a configured number of epochs."""
+
+    def __init__(
+        self,
+        examples: Sequence[ForecastExample],
+        *,
+        batch_size: int,
+        group_size: int,
+        renderer: renderers.Renderer,
+        epochs: int = 1,
+    ):
+        if batch_size <= 0 or group_size <= 0 or epochs <= 0:
+            raise ValueError("batch_size, group_size, and epochs must be positive")
+        self.examples = tuple(examples)
+        self.batch_size = batch_size
+        self.group_size = group_size
+        self.renderer = renderer
+        self.epochs = epochs
+
+    def __len__(self) -> int:
+        return self.epochs * math.ceil(len(self.examples) / self.batch_size)
+
+    def get_batch(self, index: int) -> Sequence[EnvGroupBuilder]:
+        if not 0 <= index < len(self):
+            raise IndexError(f"batch index {index} outside [0, {len(self)})")
+        batches_per_epoch = math.ceil(len(self.examples) / self.batch_size)
+        start = (index % batches_per_epoch) * self.batch_size
+        return [
+            ForecastGroupBuilder(
+                example=example,
+                renderer=self.renderer,
+                group_size=self.group_size,
+            )
+            for example in self.examples[start : start + self.batch_size]
+        ]
+
+
+@chz.chz
+class ProphetArenaRLDatasetBuilder(RLDatasetBuilder):
+    """Serializable config that downloads, splits, and renders Prophet Arena."""
+
+    model_name_for_tokenizer: str
+    renderer_name: str
+    groups_per_batch: int
+    group_size: int
+    validation_group_size: int = 8
+    train_epochs: int = 3
+    data_path: str | None = None
+    data_cache_dir: str = DEFAULT_CACHE_DIR
+    dataset_revision: str = DEFAULT_DATASET_REVISION
+    split_date: str = DEFAULT_SPLIT_DATE
+    max_train_questions: int | None = DEFAULT_MAX_TRAIN_QUESTIONS
+    max_validation_questions: int | None = DEFAULT_MAX_VALIDATION_QUESTIONS
+    seed: int = 0
+
+    async def __call__(self) -> tuple[ForecastRLDataset, ForecastRLDataset]:
+        csv_path = (
+            fetch_prophet_arena(self.dataset_revision, self.data_cache_dir)
+            if self.data_path is None
+            else self.data_path
+        )
+        split = load_prophet_arena_split(
+            csv_path,
+            split_time=datetime.fromisoformat(self.split_date).replace(tzinfo=UTC),
+            max_train_questions=self.max_train_questions,
+            max_validation_questions=self.max_validation_questions,
+            seed=self.seed,
+        )
+        tokenizer = get_tokenizer(self.model_name_for_tokenizer)
+        renderer = renderers.get_renderer(self.renderer_name, tokenizer=tokenizer)
+        logger.info(
+            "Prophet Arena split: %d train, %d validation, %d crossing events excluded",
+            len(split.train),
+            len(split.validation),
+            split.excluded_crossing_events,
+        )
+        return (
+            ForecastRLDataset(
+                split.train,
+                batch_size=self.groups_per_batch,
+                group_size=self.group_size,
+                renderer=renderer,
+                epochs=self.train_epochs,
+            ),
+            ForecastRLDataset(
+                split.validation,
+                batch_size=self.groups_per_batch,
+                group_size=self.validation_group_size,
+                renderer=renderer,
+            ),
+        )

--- a/tinker_cookbook/recipes/forecasting/env.py
+++ b/tinker_cookbook/recipes/forecasting/env.py
@@ -7,7 +7,6 @@ import math
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
 
 import chz
 
@@ -33,6 +32,7 @@ from .data import (
     ForecastExample,
     fetch_prophet_arena,
     load_prophet_arena_split,
+    parse_utc_datetime,
 )
 
 logger = logging.getLogger(__name__)
@@ -258,7 +258,7 @@ class ProphetArenaRLDatasetBuilder(RLDatasetBuilder):
         )
         split = load_prophet_arena_split(
             csv_path,
-            split_time=datetime.fromisoformat(self.split_date).replace(tzinfo=UTC),
+            split_time=parse_utc_datetime(self.split_date, "split_date"),
             max_train_questions=self.max_train_questions,
             max_validation_questions=self.max_validation_questions,
             seed=self.seed,

--- a/tinker_cookbook/recipes/forecasting/env_test.py
+++ b/tinker_cookbook/recipes/forecasting/env_test.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from tinker_cookbook import renderers
+from tinker_cookbook.renderers import Message
+from tinker_cookbook.rl.types import Trajectory
+
+from .data import ForecastExample
+from .env import (
+    ForecastEnv,
+    ForecastGroupBuilder,
+    ForecastRLDataset,
+    brier_reward,
+    parse_forecast,
+    render_prompt,
+)
+
+
+def _example(outcome: int = 1) -> ForecastExample:
+    return ForecastExample(
+        submission_id="submission",
+        event_ticker="event",
+        event_title="Will the event happen?",
+        market="Event happens",
+        reference_material="Dated evidence available at the snapshot.",
+        resolution_criteria="Resolves YES if the event happens.",
+        snapshot_time=datetime(2025, 10, 20, tzinfo=UTC),
+        close_time=datetime(2025, 10, 21, tzinfo=UTC),
+        category="Other",
+        outcome=outcome,
+    )
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ("0", 0.0),
+        ("Brief reasoning.\n0.37\n", 0.37),
+        ("The event is certain.\n1.000", 1.0),
+        ("Reasoning.\n0.37", 0.37),
+        ("Probability: 0.37.", 0.37),
+        ("**0.37**", 0.37),
+        ("37%", 0.37),
+        ("Final answer: 0.37!", 0.37),
+        ("Reasoning.\nProbability: **0.37**", 0.37),
+        ("The market closes on 2025-10-21", None),
+        ("The market should resolve by 2026-01-01", None),
+        ("0.2 trailing", None),
+        ("0.2.", 0.2),
+        (".37", 0.37),
+        ("7e-1", 0.7),
+        ("-0.1", None),
+        ("1.2", None),
+    ],
+)
+def test_parse_forecast(response: str, expected: float | None) -> None:
+    assert parse_forecast(response) == expected
+
+
+def test_brier_reward_is_strictly_proper() -> None:
+    belief = 0.3
+
+    def expected_reward(report: float) -> float:
+        return belief * brier_reward(report, 1) + (1 - belief) * brier_reward(report, 0)
+
+    assert expected_reward(belief) > expected_reward(0.2)
+    assert expected_reward(belief) > expected_reward(0.5)
+
+
+def test_brier_reward_is_affine_negative_brier() -> None:
+    assert brier_reward(1.0, 1) == 1.0
+    assert brier_reward(0.5, 1) == 0.75
+    assert brier_reward(0.2, 0) == pytest.approx(0.96)
+    assert brier_reward(1.0, 0) == 0.0
+
+
+def test_prompt_excludes_outcome_and_market_prices() -> None:
+    prompt = render_prompt(_example())
+
+    assert "Will the event happen?" in prompt
+    assert "Event happens" in prompt
+    assert "Dated evidence available at the snapshot." in prompt
+    assert "2025-10-20T00:00:00+00:00" in prompt
+    assert "yes_ask" not in prompt
+    assert "outcome=1" not in prompt
+    assert "Output only the probability of YES" in prompt
+
+
+def test_valid_forecast_uses_brier_reward() -> None:
+    message: Message = {"role": "assistant", "content": "Reasoning.\n0.8"}
+    result = asyncio.run(ForecastEnv(_example()).step(message))
+
+    assert result.reward == pytest.approx(0.96)
+    assert result.logs["brier_reward"] == pytest.approx(0.96)
+    assert result.logs["accuracy"] == 1.0
+    assert result.logs["format_valid"] == 1.0
+
+
+def test_invalid_forecast_receives_zero_reward() -> None:
+    message: Message = {"role": "assistant", "content": "No numeric forecast."}
+    result = asyncio.run(ForecastEnv(_example()).step(message))
+
+    assert result.reward == 0.0
+    assert result.logs["format_valid"] == 0.0
+
+
+def test_training_dataset_repeats_complete_epochs() -> None:
+    examples = [_example(0), _example(1), _example(0)]
+    dataset = ForecastRLDataset(
+        examples,
+        batch_size=2,
+        group_size=1,
+        renderer=cast(renderers.Renderer, None),
+        epochs=3,
+    )
+
+    assert len(dataset) == 6
+    assert [
+        cast(ForecastGroupBuilder, builder).example for builder in dataset.get_batch(0)
+    ] == examples[:2]
+    assert [
+        cast(ForecastGroupBuilder, builder).example for builder in dataset.get_batch(2)
+    ] == examples[:2]
+    assert [
+        cast(ForecastGroupBuilder, builder).example for builder in dataset.get_batch(4)
+    ] == examples[:2]
+
+
+def test_group_metrics_include_truncated_rollouts() -> None:
+    valid = cast(
+        Trajectory,
+        SimpleNamespace(
+            transitions=[
+                SimpleNamespace(
+                    logs={
+                        "brier_reward": 0.96,
+                        "accuracy": 1.0,
+                        "format_valid": 1.0,
+                    }
+                )
+            ]
+        ),
+    )
+    truncated = cast(Trajectory, SimpleNamespace(transitions=[SimpleNamespace(logs={})]))
+    builder = ForecastGroupBuilder(
+        example=_example(),
+        renderer=cast(renderers.Renderer, None),
+        group_size=2,
+    )
+
+    results = asyncio.run(builder.compute_group_rewards([valid, truncated], []))
+
+    assert results == [
+        (
+            0.0,
+            {
+                "brier_reward": 0.96,
+                "accuracy": 1.0,
+                "format_valid": 1.0,
+            },
+        ),
+        (
+            0.0,
+            {
+                "brier_reward": 0.0,
+                "accuracy": 0.0,
+                "format_valid": 0.0,
+            },
+        ),
+    ]

--- a/tinker_cookbook/recipes/forecasting/train.py
+++ b/tinker_cookbook/recipes/forecasting/train.py
@@ -1,0 +1,171 @@
+"""Train Qwen3.8-27B with Tinker on binary Prophet Arena forecasts.
+
+The default run uses the Brier reward for 100 steps.
+
+    python -m tinker_cookbook.recipes.forecasting.train
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+import chz
+import tinker
+from tinker.types import LossFnType
+
+from tinker_cookbook import checkpoint_utils, cli_utils
+from tinker_cookbook.rl import train
+from tinker_cookbook.rl.rollout_strategy import RetryOnFailure
+from tinker_cookbook.stores.storage import storage_from_uri
+from tinker_cookbook.stores.training_store import TrainingRunStore
+
+from .data import (
+    DEFAULT_CACHE_DIR,
+    DEFAULT_DATASET_REVISION,
+    DEFAULT_MAX_TRAIN_QUESTIONS,
+    DEFAULT_MAX_VALIDATION_QUESTIONS,
+    DEFAULT_SPLIT_DATE,
+)
+from .env import ProphetArenaRLDatasetBuilder
+
+
+@chz.chz
+class Config:
+    # Model
+    model_name: str = "Qwen/Qwen3.8-27B"
+    renderer_name: str | None = "qwen3_8_low_reasoning"
+    load_checkpoint_path: str | None = None
+    lora_rank: int = 32
+
+    # Data
+    data_path: str | None = None
+    data_cache_dir: str = DEFAULT_CACHE_DIR
+    dataset_revision: str = DEFAULT_DATASET_REVISION
+    split_date: str = DEFAULT_SPLIT_DATE
+    max_train_questions: int | None = DEFAULT_MAX_TRAIN_QUESTIONS
+    max_validation_questions: int | None = DEFAULT_MAX_VALIDATION_QUESTIONS
+    train_epochs: int = 3
+    seed: int = 0
+
+    # RL
+    group_size: int = 32
+    groups_per_batch: int = 16
+    validation_group_size: int = 8
+    learning_rate: float = 8e-5
+    max_tokens: int = 24_576
+    temperature: float = 1.0
+    rollout_max_retries: int = 3
+    loss_fn: LossFnType = "importance_sampling"
+    max_steps: int | None = 100
+
+    # Evaluation and logging
+    eval_every: int = 20
+    save_every: int = 20
+    log_path: str | None = None
+    wandb_project: str | None = None
+    wandb_name: str | None = None
+    behavior_if_log_dir_exists: cli_utils.LogdirBehavior = "ask"
+    base_url: str | None = None
+
+
+async def _evaluate_final_checkpoint(
+    train_config: train.Config,
+    dataset_builder: ProphetArenaRLDatasetBuilder,
+) -> None:
+    """Evaluate the final weights when periodic evaluation stops before them."""
+    if train_config.eval_every <= 0:
+        return
+
+    checkpoint = checkpoint_utils.get_last_checkpoint(
+        train_config.log_path, required_key="sampler_path"
+    )
+    if checkpoint is None or checkpoint.batch is None or checkpoint.sampler_path is None:
+        raise RuntimeError("final sampler checkpoint was not saved")
+
+    store = TrainingRunStore(storage_from_uri(train_config.log_path))
+    if any(
+        metrics.get("step") == checkpoint.batch and "test/env/all/brier_reward" in metrics
+        for metrics in store.read_metrics()
+    ):
+        return
+
+    _, validation_dataset = await dataset_builder()
+    evaluator = train.RLTestSetEvaluator(
+        validation_dataset,
+        max_tokens=train_config.max_tokens,
+        strategy=train_config.effective_rollout_strategy(),
+    )
+    sampling_client = tinker.ServiceClient(base_url=train_config.base_url).create_sampling_client(
+        base_model=train_config.model_name,
+        model_path=checkpoint.sampler_path,
+    )
+    metrics = await train.run_evaluations_parallel(
+        [evaluator],
+        sampling_client,
+        train_config,
+        checkpoint.batch,
+        store=store,
+    )
+    store.write_metrics(metrics, step=checkpoint.batch)
+
+
+async def cli_main(cfg: Config) -> None:
+    renderer_name = await checkpoint_utils.resolve_renderer_name_from_checkpoint_or_default_async(
+        model_name=cfg.model_name,
+        explicit_renderer_name=cfg.renderer_name,
+        load_checkpoint_path=cfg.load_checkpoint_path,
+        base_url=cfg.base_url,
+    )
+    model_name = cfg.model_name.lower().replace("/", "-")
+    run_name = (
+        f"prophet-arena-{model_name}-bs{cfg.groups_per_batch}-"
+        f"gs{cfg.group_size}-lr{cfg.learning_rate}-{datetime.now().strftime('%Y-%m-%d-%H-%M')}"
+    )
+    log_path = cfg.log_path or f"/tmp/tinker-examples/prophet_arena_qwen_rl/{run_name}"
+
+    dataset_builder = ProphetArenaRLDatasetBuilder(
+        model_name_for_tokenizer=cfg.model_name,
+        renderer_name=renderer_name,
+        groups_per_batch=cfg.groups_per_batch,
+        group_size=cfg.group_size,
+        validation_group_size=cfg.validation_group_size,
+        train_epochs=cfg.train_epochs,
+        data_path=cfg.data_path,
+        data_cache_dir=cfg.data_cache_dir,
+        dataset_revision=cfg.dataset_revision,
+        split_date=cfg.split_date,
+        max_train_questions=cfg.max_train_questions,
+        max_validation_questions=cfg.max_validation_questions,
+        seed=cfg.seed,
+    )
+    train_config = train.Config(
+        model_name=cfg.model_name,
+        recipe_name="recipe_prophet_arena_qwen_rl",
+        renderer_name=renderer_name,
+        dataset_builder=dataset_builder,
+        log_path=log_path,
+        load_checkpoint_path=cfg.load_checkpoint_path,
+        lora_rank=cfg.lora_rank,
+        learning_rate=cfg.learning_rate,
+        loss_fn=cfg.loss_fn,
+        max_tokens=cfg.max_tokens,
+        temperature=cfg.temperature,
+        max_steps=cfg.max_steps,
+        eval_every=cfg.eval_every,
+        save_every=cfg.save_every,
+        wandb_project=cfg.wandb_project,
+        wandb_name=cfg.wandb_name or run_name,
+        base_url=cfg.base_url,
+        kl_penalty_coef=0.0,
+        compute_post_kl=False,
+        rollout_error_tolerance=RetryOnFailure(max_retries=cfg.rollout_max_retries),
+    )
+
+    cli_utils.check_log_dir(log_path, behavior_if_exists=cfg.behavior_if_log_dir_exists)
+    await train.main(train_config)
+    await _evaluate_final_checkpoint(train_config, dataset_builder)
+
+
+if __name__ == "__main__":
+    asyncio.run(cli_main(chz.entrypoint(Config)))

--- a/tinker_cookbook/recipes/forecasting/train.py
+++ b/tinker_cookbook/recipes/forecasting/train.py
@@ -16,7 +16,6 @@ from tinker.types import LossFnType
 
 from tinker_cookbook import checkpoint_utils, cli_utils
 from tinker_cookbook.rl import train
-from tinker_cookbook.rl.rollout_strategy import RetryOnFailure
 from tinker_cookbook.stores.storage import storage_from_uri
 from tinker_cookbook.stores.training_store import TrainingRunStore
 
@@ -55,7 +54,6 @@ class Config:
     learning_rate: float = 8e-5
     max_tokens: int = 24_576
     temperature: float = 1.0
-    rollout_max_retries: int = 3
     loss_fn: LossFnType = "importance_sampling"
     max_steps: int | None = 100
 
@@ -159,7 +157,6 @@ async def cli_main(cfg: Config) -> None:
         base_url=cfg.base_url,
         kl_penalty_coef=0.0,
         compute_post_kl=False,
-        rollout_error_tolerance=RetryOnFailure(max_retries=cfg.rollout_max_retries),
     )
 
     cli_utils.check_log_dir(log_path, behavior_if_exists=cfg.behavior_if_log_dir_exists)

--- a/tinker_cookbook/recipes/forecasting/train_test.py
+++ b/tinker_cookbook/recipes/forecasting/train_test.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from . import train as recipe
+from .env import ProphetArenaRLDatasetBuilder
+
+
+def test_final_checkpoint_is_evaluated_once(tmp_path: Path, monkeypatch) -> None:
+    checkpoint = SimpleNamespace(batch=100, sampler_path="tinker://run/sampler_weights/final")
+    monkeypatch.setattr(
+        recipe.checkpoint_utils, "get_last_checkpoint", lambda *args, **kwargs: checkpoint
+    )
+
+    class DatasetBuilder:
+        async def __call__(self):
+            return object(), "validation"
+
+    class ServiceClient:
+        def __init__(self, *, base_url):
+            assert base_url is None
+
+        def create_sampling_client(self, *, base_model, model_path):
+            assert base_model == "Qwen/Qwen3.8-27B"
+            assert model_path == checkpoint.sampler_path
+            return "sampling-client"
+
+    monkeypatch.setattr(recipe.tinker, "ServiceClient", ServiceClient)
+    monkeypatch.setattr(recipe.train, "RLTestSetEvaluator", lambda *args, **kwargs: "evaluator")
+
+    calls = 0
+
+    async def run_evaluations(evaluators, sampling_client, config, step, *, store):
+        nonlocal calls
+        calls += 1
+        assert evaluators == ["evaluator"]
+        assert sampling_client == "sampling-client"
+        assert step == 100
+        return {"test/env/all/brier_reward": 0.8}
+
+    monkeypatch.setattr(recipe.train, "run_evaluations_parallel", run_evaluations)
+    config = SimpleNamespace(
+        eval_every=20,
+        log_path=str(tmp_path),
+        max_tokens=24_576,
+        model_name="Qwen/Qwen3.8-27B",
+        base_url=None,
+        effective_rollout_strategy=lambda: "strategy",
+    )
+
+    train_config = cast(recipe.train.Config, config)
+    for _ in range(2):
+        asyncio.run(
+            recipe._evaluate_final_checkpoint(
+                train_config, cast(ProphetArenaRLDatasetBuilder, DatasetBuilder())
+            )
+        )
+
+    assert calls == 1


### PR DESCRIPTION
Train a model to make calibrated probability forecasts about real-world events, scored with a Brier reward. Questions come from the Prophet Arena subset, split chronologically so training outcomes were already known at the cutoff and validation outcomes were still in the future.

Adds the recipe under recipes/forecasting/, an entry in the recipes index, and a smoke test that the daily smoke-test-recipes matrix discovers automatically.

Credit to Zhicheng Sun for the recipe.