### PR TITLE
Add fail-closed validation for bounded training runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ Tinker Cookbook also provides reusable building blocks:
 - [`hyperparam_utils`](tinker_cookbook/hyperparam_utils.py) — learning rate and hyperparameter scaling for LoRA training
 - [`eval`](tinker_cookbook/eval/) — benchmark framework and inline training evaluators (see [Evaluation](#evaluation-experimental) above)
 
+### Validate a bounded training run
+
+Before a larger launch, you can run a recipe with a small `max_steps` value and validate the
+artifacts it produced. The training command uses Tinker capacity. The validation command is
+read-only and does not call the Tinker API.
+
+```bash
+TINKER_CANARY_LOG="$(mktemp -d)"
+uv run python -m tinker_cookbook.recipes.sl_loop \
+  log_path="$TINKER_CANARY_LOG" batch_size=4 max_steps=1
+uv run python -m tinker_cookbook.preflight "$TINKER_CANARY_LOG" \
+  --metric train_mean_nll --sampler-checkpoint --minimum-step 0
+```
+
+Preflight exits with a nonzero status when metric records are missing, a required metric is not
+numeric and finite, a requested minimum step is absent, or a required final checkpoint record does
+not contain a non-empty `tinker://`-prefixed string. The recipe smoke harness can also capture record
+counts and a digest before resume. It rejects changed or truncated history and validates only the
+records added by the resumed run. A pass confirms only the declared shape and progress of the
+selected local records. It does not load a checkpoint, validate model quality, enforce a later launch,
+or prove large-run capacity.
+
 ## Claude Code Skills
 
 Tinker Cookbook ships with [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) that teach Claude how to use the Tinker API. Install them so Claude can help you write training code in any project:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,12 @@ import time
 
 import pytest
 
+from tinker_cookbook.preflight import (
+    PreflightConfig,
+    PreflightSnapshot,
+    validate_training_run,
+)
+
 # Timeout for each recipe (seconds). Override with SMOKE_TEST_TIMEOUT env var.
 DEFAULT_TIMEOUT = int(os.environ.get("SMOKE_TEST_TIMEOUT", "1800"))
 
@@ -19,7 +25,9 @@ def run_recipe(
     args: list[str] | None = None,
     timeout: int = DEFAULT_TIMEOUT,
     max_steps: int = DEFAULT_MAX_STEPS,
-):
+    preflight: PreflightConfig | None = None,
+    preflight_after: PreflightSnapshot | None = None,
+) -> str:
     """Run a recipe module for a limited number of steps and verify clean exit.
 
     Passes max_steps to the recipe so it exits naturally after N training steps.
@@ -30,7 +38,11 @@ def run_recipe(
         args: CLI arguments to pass to the module
         timeout: Maximum seconds to wait for the recipe to complete
         max_steps: Number of training steps to run (passed as CLI arg)
+        preflight: Optional evidence requirements checked after a clean exit
+        preflight_after: Optional artifact boundary captured before this command
     """
+    if preflight_after is not None and preflight is None:
+        raise ValueError("preflight_after requires preflight")
     cmd = ["uv", "run", "python", "-m", module] + (args or []) + [f"max_steps={max_steps}"]
     print(f"\n>>> {' '.join(cmd)}", flush=True)
 
@@ -85,8 +97,12 @@ def run_recipe(
     elapsed = time.monotonic() - start_time
 
     if proc.returncode == 0:
+        if preflight is not None:
+            report = validate_training_run(preflight, after=preflight_after)
+            if not report.passed:
+                pytest.fail(f"Recipe {module} failed preflight: {report.failure_summary()}")
         print(f"\n>>> PASSED: recipe completed cleanly in {elapsed:.0f}s", flush=True)
-        return
+        return "\n".join(output_lines)
 
     # Non-zero exit code
     last_lines = "\n".join(output_lines[-30:])

--- a/tests/recipes/test_recipe_chat_sl.py
+++ b/tests/recipes/test_recipe_chat_sl.py
@@ -1,33 +1,63 @@
 import pytest
 
 from tests.helpers import run_recipe
+from tinker_cookbook import checkpoint_utils
+from tinker_cookbook.preflight import PreflightConfig, capture_preflight_snapshot
+from tinker_cookbook.stores.storage import storage_from_uri
+from tinker_cookbook.stores.training_store import TrainingRunStore
 
 MODULE = "tinker_cookbook.recipes.chat_sl.train"
-LOG_PATH = "/tmp/tinker-smoke-test/chat_sl_resume"
 
 
 @pytest.mark.integration
-def test_chat_sl():
-    """Train SFT from scratch for 2 steps, saving a checkpoint at step 1."""
+def test_chat_sl_resume(tmp_path):
+    """Train from scratch, then load an intermediate checkpoint and continue."""
+    log_path = str(tmp_path / "chat_sl_resume")
     run_recipe(
         MODULE,
         [
             "behavior_if_log_dir_exists=delete",
-            f"log_path={LOG_PATH}",
+            f"log_path={log_path}",
             "save_every=1",
         ],
+        preflight=PreflightConfig(
+            log_path=log_path,
+            required_metric_keys=("train_mean_nll",),
+            require_sampler_checkpoint=True,
+            minimum_metric_step=1,
+        ),
     )
 
+    # Re-select step 1 so the second command resumes instead of treating the
+    # bounded run's final checkpoint as a completed epoch.
+    store = TrainingRunStore(storage_from_uri(log_path))
+    periodic_checkpoint = next(
+        record for record in store.read_checkpoint_records() if record.name == "000001"
+    )
+    store.write_checkpoint(periodic_checkpoint.to_dict())
+    resume_checkpoint = checkpoint_utils.get_last_checkpoint(log_path)
+    assert resume_checkpoint is not None
+    assert resume_checkpoint == periodic_checkpoint
+    assert resume_checkpoint.state_path is not None
 
-@pytest.mark.integration
-def test_chat_sl_resume():
-    """Resume SFT training from the checkpoint saved by test_chat_sl."""
-    run_recipe(
+    before_resume = capture_preflight_snapshot(log_path)
+    assert before_resume.metric_records == 2
+    assert before_resume.checkpoint_records == 3
+    resume_output = run_recipe(
         MODULE,
         [
             "behavior_if_log_dir_exists=resume",
-            f"log_path={LOG_PATH}",
+            f"log_path={log_path}",
             "save_every=1",
         ],
         max_steps=4,
+        preflight=PreflightConfig(
+            log_path=log_path,
+            required_metric_keys=("train_mean_nll",),
+            require_sampler_checkpoint=True,
+            minimum_metric_step=3,
+        ),
+        preflight_after=before_resume,
     )
+
+    assert f"Resumed training from {resume_checkpoint.state_path}" in resume_output

--- a/tinker_cookbook/preflight.py
+++ b/tinker_cookbook/preflight.py
@@ -1,0 +1,536 @@
+"""Fail-closed validation for bounded Tinker training runs.
+
+This module reads the artifacts that cookbook training loops already write. It does
+not call the Tinker API or start a training run. Use it after a small, explicit canary
+run to decide whether that run produced the evidence required for a larger launch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Literal, cast
+
+from tinker_cookbook.checkpoint_utils import CheckpointRecord
+from tinker_cookbook.stores.storage import Storage, storage_from_uri
+
+CheckStatus = Literal["passed", "failed"]
+
+
+@dataclass(frozen=True)
+class PreflightCheck:
+    """One evidence check in a preflight report."""
+
+    name: str
+    status: CheckStatus
+    summary: str
+    details: dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable form of the check."""
+        return {
+            "name": self.name,
+            "status": self.status,
+            "summary": self.summary,
+            "details": self.details,
+        }
+
+
+@dataclass(frozen=True)
+class PreflightConfig:
+    """Evidence requirements for one bounded training run.
+
+    ``log_path`` may be a local path or another URI supported by
+    :func:`tinker_cookbook.stores.storage.storage_from_uri`.
+    """
+
+    log_path: str
+    required_metric_keys: tuple[str, ...] = ()
+    require_state_checkpoint: bool = True
+    require_sampler_checkpoint: bool = False
+    require_final_checkpoint: bool = True
+    minimum_metric_step: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.log_path.strip():
+            raise ValueError("log_path must not be empty")
+        if any(not key.strip() for key in self.required_metric_keys):
+            raise ValueError("required_metric_keys must not contain empty values")
+        if self.minimum_metric_step is not None and (
+            isinstance(self.minimum_metric_step, bool)
+            or not isinstance(self.minimum_metric_step, int)
+            or self.minimum_metric_step < 0
+        ):
+            raise ValueError("minimum_metric_step must be a nonnegative integer")
+
+
+@dataclass(frozen=True)
+class PreflightSnapshot:
+    """Artifact prefixes captured before a command appends training evidence."""
+
+    log_path: str
+    metric_records: int
+    checkpoint_records: int
+    metric_prefix_bytes: int
+    checkpoint_prefix_bytes: int
+    metric_prefix_sha256: str
+    checkpoint_prefix_sha256: str
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """The launch decision and supporting checks for one run."""
+
+    log_path: str
+    checks: tuple[PreflightCheck, ...]
+
+    @property
+    def passed(self) -> bool:
+        """Return ``True`` only when every declared check passed."""
+        return all(check.status == "passed" for check in self.checks)
+
+    def failure_summary(self) -> str:
+        """Return failed check summaries as one stable message."""
+        return "; ".join(
+            f"{check.name}: {check.summary}" for check in self.checks if check.status == "failed"
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable form of the report."""
+        return {
+            "status": "passed" if self.passed else "failed",
+            "log_path": self.log_path,
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+def _non_finite_values(value: object, path: str) -> list[str]:
+    failures: list[str] = []
+    if isinstance(value, float) and not math.isfinite(value):
+        failures.append(path)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            failures.extend(_non_finite_values(item, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            failures.extend(_non_finite_values(item, f"{path}[{index}]"))
+    return failures
+
+
+def _read_or_empty(storage: Storage, path: str) -> bytes:
+    try:
+        return storage.read(path)
+    except FileNotFoundError:
+        return b""
+
+
+def _jsonl_lines(raw: bytes) -> list[tuple[int, bytes]]:
+    return [
+        (line_number, line)
+        for line_number, line in enumerate(raw.splitlines(), start=1)
+        if line.strip()
+    ]
+
+
+def capture_preflight_snapshot(log_path: str) -> PreflightSnapshot:
+    """Capture append-only artifact boundaries before running a recipe command."""
+    if not log_path.strip():
+        raise ValueError("log_path must not be empty")
+    storage = storage_from_uri(log_path)
+    metric_prefix = _read_or_empty(storage, "metrics.jsonl")
+    checkpoint_prefix = _read_or_empty(storage, "checkpoints.jsonl")
+    return PreflightSnapshot(
+        log_path=log_path,
+        metric_records=len(_jsonl_lines(metric_prefix)),
+        checkpoint_records=len(_jsonl_lines(checkpoint_prefix)),
+        metric_prefix_bytes=len(metric_prefix),
+        checkpoint_prefix_bytes=len(checkpoint_prefix),
+        metric_prefix_sha256=hashlib.sha256(metric_prefix).hexdigest(),
+        checkpoint_prefix_sha256=hashlib.sha256(checkpoint_prefix).hexdigest(),
+    )
+
+
+def _read_jsonl_strict(
+    storage: Storage,
+    path: str,
+    *,
+    start_record: int = 0,
+    prefix_bytes: int = 0,
+    prefix_sha256: str | None = None,
+) -> tuple[list[dict[str, object]], list[str]]:
+    raw = _read_or_empty(storage, path)
+    if prefix_sha256 is not None:
+        if len(raw) < prefix_bytes:
+            return [], [
+                f"{path}: artifact was truncated below the captured {prefix_bytes}-byte boundary"
+            ]
+        observed_prefix_sha256 = hashlib.sha256(raw[:prefix_bytes]).hexdigest()
+        if observed_prefix_sha256 != prefix_sha256:
+            return [], [f"{path}: artifact changed before the captured append boundary"]
+
+    indexed_lines = _jsonl_lines(raw)
+    if len(indexed_lines) < start_record:
+        return [], [
+            f"{path}: expected at least {start_record} prior record(s), found {len(indexed_lines)}"
+        ]
+
+    records: list[dict[str, object]] = []
+    failures: list[str] = []
+    for line_number, raw_line in indexed_lines[start_record:]:
+        try:
+            line = raw_line.decode("utf-8")
+        except UnicodeDecodeError as error:
+            failures.append(f"{path}:{line_number}: invalid UTF-8 at byte {error.start}")
+            continue
+        try:
+            value: object = json.loads(line)
+        except json.JSONDecodeError as error:
+            failures.append(f"{path}:{line_number}: invalid JSON at column {error.colno}")
+            continue
+        if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+            failures.append(f"{path}:{line_number}: expected a JSON object")
+            continue
+        records.append(cast(dict[str, object], value))
+    return records, failures
+
+
+def _checkpoint_records(
+    records: list[dict[str, object]], path: str, *, record_offset: int = 0
+) -> tuple[list[CheckpointRecord], list[str]]:
+    checkpoints: list[CheckpointRecord] = []
+    failures: list[str] = []
+    for index, record in enumerate(records, start=record_offset + 1):
+        try:
+            checkpoints.append(CheckpointRecord.from_dict(record))
+        except (KeyError, TypeError, ValueError) as error:
+            failures.append(f"{path}:record[{index}]: {type(error).__name__}")
+    return checkpoints, failures
+
+
+def _failure_preview(failures: list[str]) -> str:
+    preview = ", ".join(failures[:5])
+    if len(failures) > 5:
+        preview += f" and {len(failures) - 5} more"
+    return preview
+
+
+def _check_artifact_format(
+    failures: list[str], *, metric_record_start: int, checkpoint_record_start: int
+) -> PreflightCheck:
+    if failures:
+        return PreflightCheck(
+            name="Artifact format",
+            status="failed",
+            summary=f"Malformed artifact data at {_failure_preview(failures)}.",
+            details={
+                "failures": failures,
+                "metric_record_start": metric_record_start,
+                "checkpoint_record_start": checkpoint_record_start,
+            },
+        )
+    return PreflightCheck(
+        name="Artifact format",
+        status="passed",
+        summary="Selected metric and checkpoint records are valid JSONL objects.",
+        details={
+            "metric_record_start": metric_record_start,
+            "checkpoint_record_start": checkpoint_record_start,
+        },
+    )
+
+
+def _check_metrics(
+    metrics: list[dict[str, object]],
+    required_keys: tuple[str, ...],
+    minimum_step: int | None,
+) -> PreflightCheck:
+    if not metrics:
+        return PreflightCheck(
+            name="Training metrics",
+            status="failed",
+            summary="No metric records were found.",
+        )
+
+    required_key_set = tuple(sorted(set(required_keys)))
+    qualifying_metrics = [
+        (index, row)
+        for index, row in enumerate(metrics)
+        if minimum_step is None
+        or (
+            isinstance((step := row.get("step")), int)
+            and not isinstance(step, bool)
+            and step >= minimum_step
+        )
+    ]
+    reached_minimum_step = minimum_step is None or bool(qualifying_metrics)
+    missing_keys = (
+        sorted(
+            key for key in required_key_set if not any(key in row for _, row in qualifying_metrics)
+        )
+        if reached_minimum_step
+        else []
+    )
+    invalid_required_values = [
+        f"record[{index}].{key}"
+        for index, row in qualifying_metrics
+        for key in required_key_set
+        if key in row and (isinstance(row[key], bool) or not isinstance(row[key], (int, float)))
+    ]
+    non_finite = [
+        item
+        for index, row in enumerate(metrics)
+        for item in _non_finite_values(row, f"record[{index}]")
+    ]
+    observed_steps = [
+        step
+        for row in metrics
+        if isinstance((step := row.get("step")), int) and not isinstance(step, bool)
+    ]
+    maximum_step = max(observed_steps, default=None)
+    failures: list[str] = []
+    if missing_keys:
+        failures.append(f"missing required keys: {', '.join(missing_keys)}")
+    if invalid_required_values:
+        failures.append(
+            f"required metric values are not numeric at {_failure_preview(invalid_required_values)}"
+        )
+    if non_finite:
+        failures.append(f"non-finite values at {_failure_preview(non_finite)}")
+    if not reached_minimum_step:
+        failures.append(f"no metric record reached minimum step {minimum_step}")
+
+    if failures:
+        return PreflightCheck(
+            name="Training metrics",
+            status="failed",
+            summary="; ".join(failures) + ".",
+            details={
+                "records": len(metrics),
+                "missing_keys": missing_keys,
+                "invalid_required_values": invalid_required_values,
+                "non_finite_values": non_finite,
+                "minimum_step": minimum_step,
+                "maximum_step": maximum_step,
+            },
+        )
+
+    key_summary = f" Required keys: {', '.join(required_key_set)}." if required_key_set else ""
+    evidence_summary = (
+        "declared required metrics are numeric and all numeric values are finite"
+        if required_key_set
+        else "all numeric values are finite"
+    )
+    return PreflightCheck(
+        name="Training metrics",
+        status="passed",
+        summary=(f"Found {len(metrics)} selected record(s); {evidence_summary}.{key_summary}"),
+        details={
+            "records": len(metrics),
+            "required_keys": list(required_key_set),
+            "minimum_step": minimum_step,
+            "maximum_step": maximum_step,
+        },
+    )
+
+
+def _is_final_checkpoint(record: CheckpointRecord) -> bool:
+    # Older cookbook loops used the name "final" before they wrote a final flag.
+    return record.final is True or (record.final is None and record.name == "final")
+
+
+def _checkpoint_with_key(
+    records: list[CheckpointRecord],
+    key: Literal["state_path", "sampler_path"],
+    require_final: bool,
+) -> CheckpointRecord | None:
+    eligible = [
+        record
+        for record in records
+        if record.has(key) and (not require_final or _is_final_checkpoint(record))
+    ]
+    return eligible[-1] if eligible else None
+
+
+def _check_checkpoint(
+    records: list[CheckpointRecord],
+    *,
+    key: Literal["state_path", "sampler_path"],
+    label: str,
+    require_final: bool,
+) -> PreflightCheck:
+    checkpoint = _checkpoint_with_key(records, key, require_final)
+    if checkpoint is None:
+        final_label = " final" if require_final else ""
+        return PreflightCheck(
+            name=label,
+            status="failed",
+            summary=f"No{final_label} checkpoint with {key} was found.",
+            details={"records": len(records), "required_key": key},
+        )
+
+    path = checkpoint.get(key)
+    if not isinstance(checkpoint.name, str) or not checkpoint.name.strip():
+        return PreflightCheck(
+            name=label,
+            status="failed",
+            summary="Checkpoint record has an invalid name.",
+            details={"required_key": key, "reason": "expected a non-empty string name"},
+        )
+    if (
+        not isinstance(path, str)
+        or not path.startswith("tinker://")
+        or not path.removeprefix("tinker://").strip()
+    ):
+        return PreflightCheck(
+            name=label,
+            status="failed",
+            summary=f"Checkpoint {checkpoint.name} has an invalid {key}.",
+            details={
+                "name": checkpoint.name,
+                "required_key": key,
+                "reason": "expected a non-empty tinker://-prefixed string",
+            },
+        )
+    return PreflightCheck(
+        name=label,
+        status="passed",
+        summary=(
+            f"Found checkpoint record {checkpoint.name} with a non-empty tinker://-prefixed string."
+        ),
+        details={"name": checkpoint.name, "path": path, "final": _is_final_checkpoint(checkpoint)},
+    )
+
+
+def validate_training_run(
+    config: PreflightConfig, *, after: PreflightSnapshot | None = None
+) -> PreflightReport:
+    """Validate selected metrics and checkpoint records without calling Tinker."""
+    if after is not None and after.log_path != config.log_path:
+        raise ValueError("snapshot log_path must match config log_path")
+
+    metric_record_start = after.metric_records if after is not None else 0
+    checkpoint_record_start = after.checkpoint_records if after is not None else 0
+    storage = storage_from_uri(config.log_path)
+    metrics, metric_format_failures = _read_jsonl_strict(
+        storage,
+        "metrics.jsonl",
+        start_record=metric_record_start,
+        prefix_bytes=after.metric_prefix_bytes if after is not None else 0,
+        prefix_sha256=after.metric_prefix_sha256 if after is not None else None,
+    )
+    raw_checkpoints, checkpoint_format_failures = _read_jsonl_strict(
+        storage,
+        "checkpoints.jsonl",
+        start_record=checkpoint_record_start,
+        prefix_bytes=after.checkpoint_prefix_bytes if after is not None else 0,
+        prefix_sha256=after.checkpoint_prefix_sha256 if after is not None else None,
+    )
+    checkpoint_records, checkpoint_record_failures = _checkpoint_records(
+        raw_checkpoints, "checkpoints.jsonl", record_offset=checkpoint_record_start
+    )
+
+    checks = [
+        _check_artifact_format(
+            metric_format_failures + checkpoint_format_failures + checkpoint_record_failures,
+            metric_record_start=metric_record_start,
+            checkpoint_record_start=checkpoint_record_start,
+        ),
+        _check_metrics(metrics, config.required_metric_keys, config.minimum_metric_step),
+    ]
+    if config.require_state_checkpoint:
+        checks.append(
+            _check_checkpoint(
+                checkpoint_records,
+                key="state_path",
+                label="Training-state checkpoint",
+                require_final=config.require_final_checkpoint,
+            )
+        )
+    if config.require_sampler_checkpoint:
+        checks.append(
+            _check_checkpoint(
+                checkpoint_records,
+                key="sampler_path",
+                label="Sampler checkpoint",
+                require_final=config.require_final_checkpoint,
+            )
+        )
+
+    return PreflightReport(log_path=config.log_path, checks=tuple(checks))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate the artifacts from a bounded Tinker training run."
+    )
+    parser.add_argument("log_path", help="Training log path or supported storage URI.")
+    parser.add_argument(
+        "--metric",
+        action="append",
+        default=[],
+        dest="required_metric_keys",
+        help="Metric key that must exist. Repeat for more than one key.",
+    )
+    parser.add_argument(
+        "--state-checkpoint",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Require a training-state checkpoint (default: true).",
+    )
+    parser.add_argument(
+        "--sampler-checkpoint",
+        action="store_true",
+        help="Require a recorded non-empty tinker://-prefixed sampler checkpoint string.",
+    )
+    parser.add_argument(
+        "--final-checkpoint",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Require requested checkpoint types on a final record (default: true).",
+    )
+    parser.add_argument(
+        "--minimum-step",
+        type=_nonnegative_int,
+        default=None,
+        dest="minimum_metric_step",
+        help="Require at least one metric record at or above this step.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    return parser
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a nonnegative integer")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the command-line validator and return a process exit code."""
+    args = _build_parser().parse_args(argv)
+    report = validate_training_run(
+        PreflightConfig(
+            log_path=args.log_path,
+            required_metric_keys=tuple(args.required_metric_keys),
+            require_state_checkpoint=args.state_checkpoint,
+            require_sampler_checkpoint=args.sampler_checkpoint,
+            require_final_checkpoint=args.final_checkpoint,
+            minimum_metric_step=args.minimum_metric_step,
+        )
+    )
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        label = "PASS" if report.passed else "FAIL"
+        print(f"TINKER PREFLIGHT: {label}")
+        for check in report.checks:
+            print(f"{check.status.upper():6} {check.name}: {check.summary}")
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tinker_cookbook/preflight_test.py
+++ b/tinker_cookbook/preflight_test.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from tinker_cookbook.preflight import (
+    PreflightConfig,
+    capture_preflight_snapshot,
+    main,
+    validate_training_run,
+)
+from tinker_cookbook.stores.storage import storage_from_uri
+from tinker_cookbook.stores.training_store import TrainingRunStore
+
+FINAL_STATE_CHECKPOINT: dict[str, object] = {
+    "name": "final",
+    "final": True,
+    "state_path": "tinker://run/state/final",
+}
+
+
+def _store(path: str) -> TrainingRunStore:
+    return TrainingRunStore(storage_from_uri(path))
+
+
+def _write_metric_run(
+    path: str, metrics: dict[str, object], *, step: int | None = None
+) -> TrainingRunStore:
+    store = _store(path)
+    store.write_metrics(metrics, step=step)
+    store.write_checkpoint(FINAL_STATE_CHECKPOINT)
+    return store
+
+
+def _write_passing_run(path: str) -> None:
+    store = _store(path)
+    store.write_metrics({"train_mean_nll": 1.25, "nested": {"grad_norm": 0.5}}, step=0)
+    store.write_checkpoint(
+        {
+            "name": "final",
+            "final": True,
+            "state_path": "tinker://run/state/final",
+            "sampler_path": "tinker://run/sampler_weights/final",
+        }
+    )
+
+
+def test_validate_training_run_passes_with_declared_evidence(tmp_path) -> None:
+    _write_passing_run(str(tmp_path))
+
+    report = validate_training_run(
+        PreflightConfig(
+            log_path=str(tmp_path),
+            required_metric_keys=("train_mean_nll",),
+            require_sampler_checkpoint=True,
+        )
+    )
+
+    assert report.passed
+    assert [check.name for check in report.checks] == [
+        "Artifact format",
+        "Training metrics",
+        "Training-state checkpoint",
+        "Sampler checkpoint",
+    ]
+
+
+def test_validate_training_run_fails_when_metrics_are_missing(tmp_path) -> None:
+    _store(str(tmp_path)).write_checkpoint(FINAL_STATE_CHECKPOINT)
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+
+    assert not report.passed
+    assert "No metric records" in report.failure_summary()
+
+
+def test_validate_training_run_fails_on_non_finite_nested_metric(tmp_path) -> None:
+    _write_metric_run(
+        str(tmp_path),
+        {"train_mean_nll": 1.0, "optimizer": {"grad_norm": float("nan")}},
+    )
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+
+    assert not report.passed
+    assert "record[0].optimizer.grad_norm" in report.failure_summary()
+
+
+def test_validate_training_run_fails_on_malformed_artifact_line(tmp_path) -> None:
+    store = _store(str(tmp_path))
+    store.storage.write(
+        "metrics.jsonl",
+        b'{"step": 0, "train_mean_nll": 1.0}\n{"step": broken}\n',
+    )
+    store.write_checkpoint(FINAL_STATE_CHECKPOINT)
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+
+    assert not report.passed
+    assert "metrics.jsonl:2" in report.failure_summary()
+
+
+def test_validate_training_run_fails_when_required_metric_is_missing(tmp_path) -> None:
+    _write_passing_run(str(tmp_path))
+
+    report = validate_training_run(
+        PreflightConfig(log_path=str(tmp_path), required_metric_keys=("reward",))
+    )
+
+    assert not report.passed
+    assert "missing required keys: reward" in report.failure_summary()
+
+
+@pytest.mark.parametrize("invalid_value", ["not-a-number", True, None])
+def test_validate_training_run_rejects_non_numeric_required_metrics(
+    tmp_path, invalid_value: object
+) -> None:
+    _write_metric_run(str(tmp_path), {"train_mean_nll": invalid_value}, step=0)
+
+    report = validate_training_run(
+        PreflightConfig(log_path=str(tmp_path), required_metric_keys=("train_mean_nll",))
+    )
+
+    assert not report.passed
+    assert "required metric values are not numeric" in report.failure_summary()
+
+
+def test_validate_training_run_accepts_integer_required_metric(tmp_path) -> None:
+    _write_metric_run(str(tmp_path), {"reward": 1}, step=0)
+
+    report = validate_training_run(
+        PreflightConfig(log_path=str(tmp_path), required_metric_keys=("reward",))
+    )
+
+    assert report.passed
+
+
+def test_validate_training_run_can_require_metric_progress(tmp_path) -> None:
+    _write_passing_run(str(tmp_path))
+
+    stale = validate_training_run(PreflightConfig(log_path=str(tmp_path), minimum_metric_step=1))
+    _store(str(tmp_path)).write_metrics({"train_mean_nll": 1.0}, step=1)
+    current = validate_training_run(PreflightConfig(log_path=str(tmp_path), minimum_metric_step=1))
+
+    assert not stale.passed
+    assert "minimum step 1" in stale.failure_summary()
+    assert current.passed
+
+
+def test_required_metric_must_appear_at_or_after_minimum_step(tmp_path) -> None:
+    store = _store(str(tmp_path))
+    store.write_metrics({"train_mean_nll": 1.0}, step=0)
+    store.write_metrics({"time_total": 2.0}, step=3)
+    store.write_checkpoint(FINAL_STATE_CHECKPOINT)
+
+    report = validate_training_run(
+        PreflightConfig(
+            log_path=str(tmp_path),
+            required_metric_keys=("train_mean_nll",),
+            minimum_metric_step=3,
+        )
+    )
+
+    assert not report.passed
+    assert "missing required keys: train_mean_nll" in report.failure_summary()
+
+
+def test_snapshot_requires_metrics_and_checkpoints_appended_after_capture(tmp_path) -> None:
+    _write_passing_run(str(tmp_path))
+    snapshot = capture_preflight_snapshot(str(tmp_path))
+    store = _store(str(tmp_path))
+    store.write_metrics({"train_mean_nll": 1.0}, step=3)
+
+    stale_checkpoint = validate_training_run(
+        PreflightConfig(
+            log_path=str(tmp_path),
+            required_metric_keys=("train_mean_nll",),
+            require_sampler_checkpoint=True,
+            minimum_metric_step=3,
+        ),
+        after=snapshot,
+    )
+
+    store.write_checkpoint(
+        {
+            "name": "final",
+            "final": True,
+            "state_path": "tinker://run/state/resumed-final",
+            "sampler_path": "tinker://run/sampler_weights/resumed-final",
+        }
+    )
+    current_evidence = validate_training_run(
+        PreflightConfig(
+            log_path=str(tmp_path),
+            required_metric_keys=("train_mean_nll",),
+            require_sampler_checkpoint=True,
+            minimum_metric_step=3,
+        ),
+        after=snapshot,
+    )
+
+    assert not stale_checkpoint.passed
+    assert "No final checkpoint" in stale_checkpoint.failure_summary()
+    assert current_evidence.passed
+
+
+def test_snapshot_rejects_truncated_artifact_history(tmp_path) -> None:
+    _write_passing_run(str(tmp_path))
+    snapshot = capture_preflight_snapshot(str(tmp_path))
+    storage = storage_from_uri(str(tmp_path))
+    storage.write("metrics.jsonl", b"")
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)), after=snapshot)
+
+    assert not report.passed
+    assert "artifact was truncated" in report.failure_summary()
+
+
+def test_snapshot_rejects_rewritten_and_regrown_artifact_history(tmp_path) -> None:
+    _write_passing_run(str(tmp_path))
+    snapshot = capture_preflight_snapshot(str(tmp_path))
+    storage = storage_from_uri(str(tmp_path))
+    old_metrics = storage.read("metrics.jsonl")
+    old_checkpoints = storage.read("checkpoints.jsonl")
+    storage.write("metrics.jsonl", b'{"step": 0, "replacement": 1}\n' + old_metrics)
+    storage.write(
+        "checkpoints.jsonl",
+        b'{"name": "replacement", "state_path": "tinker://replacement"}\n' + old_checkpoints,
+    )
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)), after=snapshot)
+
+    assert not report.passed
+    assert "artifact changed before the captured append boundary" in report.failure_summary()
+
+
+def test_snapshot_rejects_a_different_log_path(tmp_path) -> None:
+    first_path = tmp_path / "first"
+    second_path = tmp_path / "second"
+    snapshot = capture_preflight_snapshot(str(first_path))
+
+    with pytest.raises(ValueError, match="snapshot log_path"):
+        validate_training_run(PreflightConfig(log_path=str(second_path)), after=snapshot)
+
+
+@pytest.mark.parametrize("invalid_step", [-1, True, "1"])
+def test_preflight_config_rejects_invalid_minimum_step(tmp_path, invalid_step: object) -> None:
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        PreflightConfig(log_path=str(tmp_path), minimum_metric_step=cast(int, invalid_step))
+
+
+def test_validate_training_run_can_require_sampler_checkpoint(tmp_path) -> None:
+    _write_metric_run(str(tmp_path), {"train_mean_nll": 1.0})
+
+    report = validate_training_run(
+        PreflightConfig(log_path=str(tmp_path), require_sampler_checkpoint=True)
+    )
+
+    assert not report.passed
+    assert "sampler_path" in report.failure_summary()
+
+
+@pytest.mark.parametrize("invalid_path", ["", "https://example.com/checkpoint", 123])
+def test_validate_training_run_rejects_invalid_checkpoint_uris(
+    tmp_path, invalid_path: object
+) -> None:
+    store = _store(str(tmp_path))
+    store.write_metrics({"train_mean_nll": 1.0})
+    store.write_checkpoint({"name": "final", "final": True, "state_path": invalid_path})
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+
+    assert not report.passed
+    assert "invalid state_path" in report.failure_summary()
+
+
+def test_validate_training_run_rejects_invalid_checkpoint_name(tmp_path) -> None:
+    store = _store(str(tmp_path))
+    store.write_metrics({"train_mean_nll": 1.0})
+    store.write_checkpoint({"name": "", "final": True, "state_path": "tinker://run/state/final"})
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+
+    assert not report.passed
+    assert "invalid name" in report.failure_summary()
+
+
+def test_checkpoint_validation_does_not_claim_server_lookup(tmp_path) -> None:
+    store = _store(str(tmp_path))
+    store.write_metrics({"train_mean_nll": 1.0})
+    store.write_checkpoint(
+        {"name": "final", "final": True, "state_path": "tinker://not-server-validated"}
+    )
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+
+    assert report.passed
+    checkpoint_check = next(
+        check for check in report.checks if check.name == "Training-state checkpoint"
+    )
+    assert "prefixed string" in checkpoint_check.summary
+
+
+def test_validate_training_run_rejects_periodic_checkpoint_when_final_is_required(
+    tmp_path,
+) -> None:
+    store = _store(str(tmp_path))
+    store.write_metrics({"train_mean_nll": 1.0})
+    store.write_checkpoint(
+        {"name": "step-1", "final": False, "state_path": "tinker://run/state/step-1"}
+    )
+
+    strict = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+    permissive = validate_training_run(
+        PreflightConfig(log_path=str(tmp_path), require_final_checkpoint=False)
+    )
+
+    assert not strict.passed
+    assert permissive.passed
+
+
+def test_validate_training_run_accepts_legacy_final_checkpoint_name(tmp_path) -> None:
+    store = _store(str(tmp_path))
+    store.write_metrics({"train_mean_nll": 1.0})
+    store.write_checkpoint({"name": "final", "state_path": "tinker://run/state/final"})
+
+    report = validate_training_run(PreflightConfig(log_path=str(tmp_path)))
+
+    assert report.passed
+
+
+def test_main_returns_nonzero_for_blocked_run(tmp_path, capsys) -> None:
+    exit_code = main([str(tmp_path), "--metric", "train_mean_nll"])
+
+    assert exit_code == 1
+    assert "TINKER PREFLIGHT: FAIL" in capsys.readouterr().out
+
+
+def test_main_reports_invalid_minimum_step_as_usage_error(tmp_path, capsys) -> None:
+    with pytest.raises(SystemExit) as error:
+        main([str(tmp_path), "--minimum-step", "-1"])
+
+    assert error.value.code == 2
+    assert "must be a nonnegative integer" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- add a read-only `tinker_cookbook.preflight` validator for bounded training-run artifacts
- fail on malformed JSONL, missing metrics, non-finite numeric metrics, missing required metric keys, or missing declared checkpoint types
- wire the validator into the Chat SFT smoke test so a clean process exit is not the only success condition
- document a one-step canary and validation flow

## Why

The recipe smoke harness currently proves that a bounded recipe process exits cleanly. The follow-up list in #409 also called out metric verification as future work. This change adds that common evidence contract without starting a run, calling the Tinker API, or replacing the existing smoke harness.

## Behavior

`PreflightConfig` declares the log path, required metric keys, and required checkpoint types. `validate_training_run` returns a typed report. The module command prints the report and exits nonzero on failure.

Final checkpoints are recognized through the current `final` field and the legacy `name=final` convention.

## Claim boundary

A pass confirms only the declared bounded run artifacts. It does not validate model quality, a future resume, checkpoint inference, backend capacity, or large-run throughput.

## Test plan

- [x] `uvx pre-commit run --all-files`
- [x] `uv run pyright tinker_cookbook`
- [x] `uv run pytest tinker_cookbook/preflight_test.py tinker_cookbook/stores/training_store_test.py -q` — 44 passed
- [x] read-only validation against existing one-step Qwen3.8 SFT artifacts, including finite `train_mean_nll`, final state, and final sampler records
- [ ] full local unit suite: 2,244 passed, 151 skipped, 2 xfailed, with one failure in the existing deprecated `write_rollout_summaries_jsonl` test outside this diff
