### PR TITLE
Use the public Qwen3 renderer

### DIFF
--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -6,6 +6,7 @@ Use viz_sft_dataset to visualize the output of different renderers. E.g.,
 """
 
 from collections.abc import Callable
+from importlib import import_module
 from typing import Any
 
 from tinker_cookbook.exceptions import RendererError
@@ -221,13 +222,13 @@ def get_renderer(
     from tinker_cookbook.renderers.qwen3 import (
         Qwen3DisableThinkingRenderer,
         Qwen3InstructRenderer,
-        Qwen3Renderer,
         Qwen3VLInstructRenderer,
         Qwen3VLRenderer,
     )
     from tinker_cookbook.renderers.qwen3_5 import Qwen3_5DisableThinkingRenderer, Qwen3_5Renderer
     from tinker_cookbook.renderers.qwen3_8 import Qwen3_8DisableThinkingRenderer, Qwen3_8Renderer
     from tinker_cookbook.renderers.role_colon import RoleColonRenderer
+    from tinker_cookbook.renderers.tml import TmlRendererAdapter
     from tinker_cookbook.renderers.tml_v0 import TmlV0Renderer
 
     renderer: Renderer
@@ -236,7 +237,7 @@ def get_renderer(
     elif name == "llama3":
         renderer = Llama3Renderer(tokenizer)
     elif name == "qwen3":
-        renderer = Qwen3Renderer(tokenizer)
+        renderer = TmlRendererAdapter(import_module("tml_renderers.qwen3").Renderer())
     elif name == "qwen3_vl":
         renderer = Qwen3VLRenderer(tokenizer, image_processor)
     elif name == "qwen3_vl_instruct":

--- a/tinker_cookbook/renderers/tml_test.py
+++ b/tinker_cookbook/renderers/tml_test.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
 from tml_renderers import chat as tml_chat
 from tml_renderers.renderer import Renderer as PublicRenderer
 
+import tinker_cookbook.renderers as renderers
 from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers import tml
 from tinker_cookbook.renderers.base import (
@@ -21,6 +23,7 @@ from tinker_cookbook.renderers.base import (
     TrainOnWhat,
 )
 from tinker_cookbook.renderers.tml_conversions import TmlRenderInput
+from tinker_cookbook.tokenizer_utils import Tokenizer
 
 
 class _Tokenizer:
@@ -324,3 +327,18 @@ def test_adapter_parses_responses_with_independent_parsers() -> None:
         [[7, 42]],
         [[8, 42]],
     ]
+
+
+def test_qwen3_builtin_wraps_the_public_renderer() -> None:
+    caller_tokenizer = cast(Tokenizer, SimpleNamespace(name_or_path="Qwen/Qwen3-8B"))
+    adapter = renderers.get_renderer(
+        "qwen3",
+        caller_tokenizer,
+    )
+
+    assert isinstance(adapter, tml.TmlRendererAdapter)
+    assert adapter.tokenizer is adapter._tml_renderer.tokenizer
+    assert adapter.tokenizer is not caller_tokenizer
+    prompt = adapter.build_generation_prompt([Message(role="user", content="hello")])
+    assert adapter.tokenizer.decode(prompt.to_ints()).endswith("<|im_start|>assistant\n")
+    adapter.parse_response([])

--- a/tinker_cookbook/renderers/tool_calling_test.py
+++ b/tinker_cookbook/renderers/tool_calling_test.py
@@ -13,6 +13,7 @@ import tinker
 
 from tinker_cookbook.renderers import (
     Message,
+    ParseTermination,
     RenderContext,
     ToolCall,
     get_renderer,
@@ -43,32 +44,14 @@ from tinker_cookbook.tokenizer_utils import get_tokenizer
     ],
 )
 def test_qwen3_tool_response_rendering(model_name: str, renderer_name: str):
-    """Test that Qwen3 renders tool responses with user role and tool_response tags.
-
-    Per the Qwen3 chat template, tool messages should render as
-    <|im_start|>user with content wrapped in <tool_response> tags.
-    """
     tokenizer = get_tokenizer(model_name)
     renderer = get_renderer(renderer_name, tokenizer)
 
     tool_message: Message = {"role": "tool", "content": '{"weather": "sunny", "high": 72}'}
 
-    ctx = RenderContext(idx=0, is_last=False, prev_message=None)
-    rendered = renderer.render_message(tool_message, ctx)
-    header = rendered.header
-    assert header is not None, "Expected header in rendered message"
-    output = rendered.output
-    assert len(output) > 0, "Expected output in rendered message"
+    output_str = tokenizer.decode(renderer.build_generation_prompt([tool_message]).to_ints())
 
-    header_str = tokenizer.decode(list(header.tokens))
-    # output[0] is an EncodedTextChunk for text-only messages
-    output_chunk = output[0]
-    assert isinstance(output_chunk, tinker.EncodedTextChunk), "Expected EncodedTextChunk"
-    output_str = tokenizer.decode(list(output_chunk.tokens))
-
-    # Tool messages should be rendered as "user" role
-    assert "<|im_start|>user" in header_str
-    # Content should be wrapped in tool_response tags
+    assert "<|im_start|>user" in output_str
     assert "<tool_response>" in output_str
     assert "</tool_response>" in output_str
     assert '"weather": "sunny"' in output_str
@@ -113,6 +96,7 @@ weather in NYC
 </tool_call><|im_end|>"""
 
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    renderer.build_generation_prompt([])
     message, success = renderer.parse_response(response_tokens)
 
     assert success.is_clean
@@ -168,6 +152,7 @@ LA
 </tool_call><|im_end|>"""
 
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    renderer.build_generation_prompt([])
     message, success = renderer.parse_response(response_tokens)
 
     assert success.is_clean
@@ -236,60 +221,40 @@ def test_deepseek_parse_tool_call():
 # =============================================================================
 
 
-def test_qwen3_parse_invalid_tool_call_json():
-    """Test that invalid JSON in tool call is captured as unparsed_tool_calls."""
-    model_name = "Qwen/Qwen3-8B"
-    tokenizer = get_tokenizer(model_name)
-    renderer = get_renderer("qwen3", tokenizer)
-
-    # Invalid JSON in tool call
-    response_text = """<tool_call>
+@pytest.mark.parametrize(
+    "response_text,raw_fragments",
+    [
+        (
+            """<tool_call>
 {invalid json here}
-</tool_call><|im_end|>"""
-
-    response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
-    message, success = renderer.parse_response(response_tokens)
-
-    # Parse succeeds, but tool call is captured as unparsed
-    assert success.is_clean
-    assert "tool_calls" not in message or len(message.get("tool_calls", [])) == 0
-    assert "unparsed_tool_calls" in message
-    assert len(message["unparsed_tool_calls"]) == 1
-    assert "Invalid JSON" in message["unparsed_tool_calls"][0].error
-    # Raw text should contain the original tool call
-    assert "<tool_call>" in message["unparsed_tool_calls"][0].raw_text
-
-
-def test_qwen3_mixed_valid_invalid_tool_calls():
-    """Test parsing when some tool calls are valid and some are invalid.
-
-    Valid tool calls should be parsed, invalid ones captured in unparsed_tool_calls.
-    """
-    model_name = "Qwen/Qwen3-8B"
-    tokenizer = get_tokenizer(model_name)
-    renderer = get_renderer("qwen3", tokenizer)
-
-    # First tool call is valid, second has invalid JSON
-    response_text = """I'll try both.
+</tool_call><|im_end|>""",
+            ("<tool_call>",),
+        ),
+        (
+            """I'll try both.
 <tool_call>
 {"name": "search", "arguments": {"query": "weather"}}
 </tool_call>
 <tool_call>
 {bad json here}
-</tool_call><|im_end|>"""
+</tool_call><|im_end|>""",
+            ("search", "{bad json here}"),
+        ),
+    ],
+)
+def test_qwen3_parse_invalid_tool_call_json(response_text: str, raw_fragments: tuple[str, ...]):
+    model_name = "Qwen/Qwen3-8B"
+    tokenizer = get_tokenizer(model_name)
+    renderer = get_renderer("qwen3", tokenizer)
 
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    renderer.build_generation_prompt([])
     message, success = renderer.parse_response(response_tokens)
 
-    assert success.is_clean
-    # Valid tool call should be parsed
-    assert "tool_calls" in message
-    assert len(message["tool_calls"]) == 1
-    assert message["tool_calls"][0].function.name == "search"
-    # Invalid tool call should be in unparsed_tool_calls
-    assert "unparsed_tool_calls" in message
-    assert len(message["unparsed_tool_calls"]) == 1
-    assert "Invalid JSON" in message["unparsed_tool_calls"][0].error
+    assert success == ParseTermination.MALFORMED
+    assert "tool_calls" not in message or len(message.get("tool_calls", [])) == 0
+    for fragment in raw_fragments:
+        assert fragment in get_text_content(message)
 
 
 @skip_deepseek_tokenizer_bug


### PR DESCRIPTION
## Why is this change needed?

Route the stable `get_renderer("qwen3", tokenizer)` name through `tml_renderers.qwen3.Renderer`.

```diff
- Qwen3Renderer(caller_tokenizer)
+ TmlRendererAdapter(tml_renderers.qwen3.Renderer())
```

The caller API stays unchanged. The public renderer now owns the tokenizer, prompt format, SFT output, stop value, and parser; the compatibility tokenizer argument is no longer used for rendering.

One parsing behavior changes intentionally: malformed tool-call JSON now returns `MALFORMED` with the raw response preserved as assistant text. It no longer reports a clean parse with Cookbook-only recovery metadata.

**Stack, base to top:**

- [#922 — Adapt public TML renderer objects to Cookbook](https://github.com/thinking-machines-lab/tinker-cookbook/pull/922)
- **[#923 — Use the public Qwen3 renderer](https://github.com/thinking-machines-lab/tinker-cookbook/pull/923)**
- [#924 — Use public Qwen3 text variants](https://github.com/thinking-machines-lab/tinker-cookbook/pull/924)
- [#925 — Use public Qwen3-VL renderers](https://github.com/thinking-machines-lab/tinker-cookbook/pull/925)
- [#926 — Finish the public Qwen and Nemotron renderer migration](https://github.com/thinking-machines-lab/tinker-cookbook/pull/926)

## Test Plan

- Verify `qwen3` returns `TmlRendererAdapter`, uses the public tokenizer, and emits the public Qwen3 assistant prefix.
- Cover valid tool calls and parameterized malformed or mixed tool-call blocks.
- Verify malformed raw text is preserved and classified as `MALFORMED`.

-Robot
