### PR TITLE
Use public Qwen3 text variants

### DIFF
--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -220,8 +220,6 @@ def get_renderer(
         Nemotron3UltraRenderer,
     )
     from tinker_cookbook.renderers.qwen3 import (
-        Qwen3DisableThinkingRenderer,
-        Qwen3InstructRenderer,
         Qwen3VLInstructRenderer,
         Qwen3VLRenderer,
     )
@@ -243,9 +241,11 @@ def get_renderer(
     elif name == "qwen3_vl_instruct":
         renderer = Qwen3VLInstructRenderer(tokenizer, image_processor)
     elif name == "qwen3_disable_thinking":
-        renderer = Qwen3DisableThinkingRenderer(tokenizer)
+        renderer = TmlRendererAdapter(
+            import_module("tml_renderers.qwen3_disable_thinking").Renderer()
+        )
     elif name == "qwen3_instruct":
-        renderer = Qwen3InstructRenderer(tokenizer)
+        renderer = TmlRendererAdapter(import_module("tml_renderers.qwen3_instruct").Renderer())
     elif name == "qwen3_5":
         renderer = Qwen3_5Renderer(tokenizer, image_processor=image_processor)
     elif name == "qwen3_5_disable_thinking":

--- a/tinker_cookbook/renderers/parse_failure_test.py
+++ b/tinker_cookbook/renderers/parse_failure_test.py
@@ -9,13 +9,14 @@ Covers:
    closed in a response that still terminates cleanly on the renderer's stop
    token. Without detection this silently degrades to plain text; with it,
    the response carries an ``unparsed_tool_calls`` entry (a recoverable
-   CONTENT failure). ``role_colon`` and ``llama3`` have no tool-block syntax
-   and are deliberately not covered.
+   CONTENT failure). Public Qwen renderers instead reject the malformed block
+   structurally. ``role_colon`` and ``llama3`` have no tool-block syntax and
+   are deliberately not covered.
 """
 
 import pytest
 
-from tinker_cookbook.renderers import Message, get_renderer
+from tinker_cookbook.renderers import Message, get_renderer, get_text_content
 from tinker_cookbook.renderers.base import (
     PARSE_FAILURE_DETAIL_MAX_CHARS,
     UNTERMINATED_TOOL_BLOCK_ERROR,
@@ -160,8 +161,7 @@ def _assert_unterminated_content_failure(message: Message, termination: ParseTer
         ("Qwen/Qwen3-30B-A3B-Instruct-2507", "qwen3_instruct"),
     ],
 )
-def test_qwen3_unterminated_tool_block(model_name: str, renderer_name: str):
-    """<tool_call> opened, never closed, clean <|im_end|> stop."""
+def test_qwen3_unterminated_tool_block_is_structural(model_name: str, renderer_name: str):
     tokenizer = get_tokenizer(model_name)
     renderer = get_renderer(renderer_name, tokenizer)
 
@@ -169,10 +169,15 @@ def test_qwen3_unterminated_tool_block(model_name: str, renderer_name: str):
 <tool_call>
 {"name": "search", "arguments": {"query": "weather<|im_end|>"""
     response_tokens = tokenizer.encode(response_text, add_special_tokens=False)
+    renderer.build_generation_prompt([])
     message, termination = renderer.parse_response(response_tokens)
 
-    _assert_unterminated_content_failure(message, termination)
+    assert termination == ParseTermination.MALFORMED
+    assert "<tool_call>" in get_text_content(message)
     assert "tool_calls" not in message
+    result = classify_parse_failure(message, termination)
+    assert result is not None
+    assert result[0] == ParseFailureKind.STRUCTURAL
 
 
 @pytest.mark.parametrize(

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -449,6 +449,7 @@ def test_qwen3_streaming_supported_by_text_variants(renderer_name):
     response_str = "<think>reasoning</think>answer<|im_end|>"
     response_tokens = tokenizer.encode(response_str, add_special_tokens=False)
 
+    renderer.build_generation_prompt([])
     deltas = list(renderer.parse_response_streaming(response_tokens))
 
     assert isinstance(deltas[0], StreamingMessageHeader)
@@ -794,6 +795,7 @@ def test_qwen3_produced_turn_survives_a_render_parse_roundtrip(reasoning: str | 
 
     model_input, _ = renderer.build_supervised_example(convo)
     produced = str(tokenizer.decode(model_input.to_ints())).split("<|im_start|>assistant\n")[1]
+    renderer.build_generation_prompt(cast(list[Message], convo[:-1]))
     parsed, termination = renderer.parse_response(
         tokenizer.encode(produced, add_special_tokens=False)
     )

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -37,6 +37,7 @@ from tinker_cookbook.image_processing_utils import get_image_processor
 from tinker_cookbook.model_info import get_model_attributes, get_recommended_renderer_name
 from tinker_cookbook.renderers import (
     Message,
+    ParseTermination,
     TextPart,
     ThinkingPart,
     ToolCall,
@@ -67,6 +68,7 @@ from tinker_cookbook.renderers.testing_utils import (
     extract_token_ids,
     skip_if_deepseek_tokenizer_bug,
 )
+from tinker_cookbook.renderers.tml import TmlRendererAdapter
 from tinker_cookbook.tokenizer_utils import (
     get_registered_tokenizer_names,
     get_tokenizer,
@@ -1403,6 +1405,8 @@ def test_eot_parsing(model_name: str, renderer_name: str):
     test_response_with_eot = f"53 + 18 = 71{eot_token}"
     response_tokens = tokenizer.encode(test_response_with_eot, add_special_tokens=False)
 
+    if renderer_name in {"qwen3", "qwen3_disable_thinking"}:
+        renderer.build_generation_prompt([])
     message, termination = renderer.parse_response(response_tokens)
     assert message["role"] == "assistant"
     assert message["content"] == "53 + 18 = 71"
@@ -1412,6 +1416,8 @@ def test_eot_parsing(model_name: str, renderer_name: str):
     test_response_no_eot = "53 + 18 = 71"
     response_tokens_no_eot = tokenizer.encode(test_response_no_eot, add_special_tokens=False)
 
+    if renderer_name in {"qwen3", "qwen3_disable_thinking"}:
+        renderer.build_generation_prompt([])
     message, termination = renderer.parse_response(response_tokens_no_eot)
     assert message["role"] == "assistant"
     assert message["content"] == "53 + 18 = 71"
@@ -1423,8 +1429,13 @@ def test_eot_parsing(model_name: str, renderer_name: str):
         test_response_double_eot, add_special_tokens=False
     )
 
-    with pytest.raises(ValueError, match=r"expected .* 1"):
-        _ = renderer.parse_response(response_tokens_double_eot)
+    if renderer_name in {"qwen3", "qwen3_disable_thinking"}:
+        renderer.build_generation_prompt([])
+        _, termination = renderer.parse_response(response_tokens_double_eot)
+        assert termination == ParseTermination.MALFORMED
+    else:
+        with pytest.raises(ValueError, match=r"expected .* 1"):
+            _ = renderer.parse_response(response_tokens_double_eot)
 
 
 # =============================================================================
@@ -1521,6 +1532,8 @@ def _verify_extension_property(renderer, messages: list[Message], tokenizer):
         # Build prompt before the next assistant message (observation_{t+1})
         context_before_next = messages[:next_asst_idx]
         prompt_before_next = renderer.build_generation_prompt(context_before_next).to_ints()
+        if isinstance(renderer, TmlRendererAdapter):
+            renderer.parse_response([])
 
         # Check if seq_through_asst is a prefix of prompt_before_next
         is_prefix = prompt_before_next[: len(seq_through_asst)] == seq_through_asst

--- a/tinker_cookbook/renderers/tml_test.py
+++ b/tinker_cookbook/renderers/tml_test.py
@@ -329,16 +329,26 @@ def test_adapter_parses_responses_with_independent_parsers() -> None:
     ]
 
 
-def test_qwen3_builtin_wraps_the_public_renderer() -> None:
-    caller_tokenizer = cast(Tokenizer, SimpleNamespace(name_or_path="Qwen/Qwen3-8B"))
-    adapter = renderers.get_renderer(
-        "qwen3",
-        caller_tokenizer,
-    )
+@pytest.mark.parametrize(
+    ("renderer_name", "generation_suffix"),
+    [
+        ("qwen3", "<|im_start|>assistant\n"),
+        (
+            "qwen3_disable_thinking",
+            "<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        ),
+        ("qwen3_instruct", "<|im_start|>assistant\n"),
+    ],
+)
+def test_qwen3_builtins_use_public_renderer_behavior(
+    renderer_name: str,
+    generation_suffix: str,
+) -> None:
+    caller_tokenizer = SimpleNamespace(name_or_path="Qwen/Qwen3-8B")
+    adapter = renderers.get_renderer(renderer_name, cast(Tokenizer, caller_tokenizer))
+    prompt = adapter.build_generation_prompt([Message(role="user", content="hello")])
 
     assert isinstance(adapter, tml.TmlRendererAdapter)
-    assert adapter.tokenizer is adapter._tml_renderer.tokenizer
     assert adapter.tokenizer is not caller_tokenizer
-    prompt = adapter.build_generation_prompt([Message(role="user", content="hello")])
-    assert adapter.tokenizer.decode(prompt.to_ints()).endswith("<|im_start|>assistant\n")
+    assert adapter.tokenizer.decode(prompt.to_ints()).endswith(generation_suffix)
     adapter.parse_response([])


### PR DESCRIPTION
## Why is this change needed?

Move the two remaining Qwen3 text modes to their matching public renderers.

| Cookbook name | Public renderer | Generated assistant prefix |
|---|---|---|
| `qwen3_disable_thinking` | `tml_renderers.qwen3_disable_thinking.Renderer()` | `<|im_start|>assistant\n<think>\n\n</think>\n\n` |
| `qwen3_instruct` | `tml_renderers.qwen3_instruct.Renderer()` | `<|im_start|>assistant\n` |

`get_renderer(name, tokenizer)` remains compatible, while the public renderer owns tokenizer selection, thinking mode, SFT output, and parsing. Nemotron remains on its Cookbook implementation until #926.

Malformed and unterminated tool blocks now follow the public parser: they return structural `MALFORMED` failures with the raw response preserved.

**Stack, base to top:**

- [#922 — Adapt public TML renderer objects to Cookbook](https://github.com/thinking-machines-lab/tinker-cookbook/pull/922)
- [#923 — Use the public Qwen3 renderer](https://github.com/thinking-machines-lab/tinker-cookbook/pull/923)
- **[#924 — Use public Qwen3 text variants](https://github.com/thinking-machines-lab/tinker-cookbook/pull/924)**
- [#925 — Use public Qwen3-VL renderers](https://github.com/thinking-machines-lab/tinker-cookbook/pull/925)
- [#926 — Finish the public Qwen and Nemotron renderer migration](https://github.com/thinking-machines-lab/tinker-cookbook/pull/926)

## Test Plan

- Verify both registry names select the expected public renderer and public tokenizer.
- Assert the exact assistant prefix for each thinking mode.
- Cover malformed tool blocks, streaming, render/parse round trips, end-of-turn handling, and pickle round trips.

-Robot
