### PR TITLE
Use public Qwen3-VL renderers

### DIFF
--- a/tinker_cookbook/renderers/__init__.py
+++ b/tinker_cookbook/renderers/__init__.py
@@ -6,7 +6,6 @@ Use viz_sft_dataset to visualize the output of different renderers. E.g.,
 """
 
 from collections.abc import Callable
-from importlib import import_module
 from typing import Any
 
 from tinker_cookbook.exceptions import RendererError
@@ -163,7 +162,9 @@ def get_renderer(
             - ``"gpt_oss_high_reasoning"``: GPT-OSS with high reasoning
             - Custom renderers registered via ``register_renderer()``
         tokenizer (Tokenizer): The tokenizer to use.
-        image_processor (ImageProcessor | None): Required for VL renderers.
+        image_processor (ImageProcessor | None): Image processor for legacy VL renderers.
+            Public TML renderers, including Qwen3-VL, own their image tokenization and ignore
+            this compatibility argument.
         model_name (str | None): Model name for pickle metadata. If None,
             falls back to ``tokenizer.name_or_path``. Provide this explicitly
             when the tokenizer was loaded with a remapped name (e.g., Llama 3
@@ -184,8 +185,7 @@ def get_renderer(
         ])
 
     Raises:
-        RendererError: If the renderer name is unknown or if a VL renderer
-            is requested without an image_processor.
+        RendererError: If the renderer name is unknown.
     """
 
     def _stamp_pickle_metadata(renderer: Renderer) -> Renderer:
@@ -200,6 +200,14 @@ def get_renderer(
         return _stamp_pickle_metadata(factory(tokenizer, image_processor))
 
     # Import renderer classes lazily to avoid circular imports and keep exports minimal
+    from tml_renderers import (
+        qwen3,
+        qwen3_disable_thinking,
+        qwen3_instruct,
+        qwen3_vl,
+        qwen3_vl_instruct,
+    )
+
     from tinker_cookbook.renderers.deepseek_v3 import (
         DeepSeekV3DisableThinkingRenderer,
         DeepSeekV3ThinkingRenderer,
@@ -219,10 +227,6 @@ def get_renderer(
         Nemotron3UltraPreserveThinkingRenderer,
         Nemotron3UltraRenderer,
     )
-    from tinker_cookbook.renderers.qwen3 import (
-        Qwen3VLInstructRenderer,
-        Qwen3VLRenderer,
-    )
     from tinker_cookbook.renderers.qwen3_5 import Qwen3_5DisableThinkingRenderer, Qwen3_5Renderer
     from tinker_cookbook.renderers.qwen3_8 import Qwen3_8DisableThinkingRenderer, Qwen3_8Renderer
     from tinker_cookbook.renderers.role_colon import RoleColonRenderer
@@ -235,17 +239,15 @@ def get_renderer(
     elif name == "llama3":
         renderer = Llama3Renderer(tokenizer)
     elif name == "qwen3":
-        renderer = TmlRendererAdapter(import_module("tml_renderers.qwen3").Renderer())
+        renderer = TmlRendererAdapter(qwen3.Renderer())
     elif name == "qwen3_vl":
-        renderer = Qwen3VLRenderer(tokenizer, image_processor)
+        renderer = TmlRendererAdapter(qwen3_vl.Renderer())
     elif name == "qwen3_vl_instruct":
-        renderer = Qwen3VLInstructRenderer(tokenizer, image_processor)
+        renderer = TmlRendererAdapter(qwen3_vl_instruct.Renderer())
     elif name == "qwen3_disable_thinking":
-        renderer = TmlRendererAdapter(
-            import_module("tml_renderers.qwen3_disable_thinking").Renderer()
-        )
+        renderer = TmlRendererAdapter(qwen3_disable_thinking.Renderer())
     elif name == "qwen3_instruct":
-        renderer = TmlRendererAdapter(import_module("tml_renderers.qwen3_instruct").Renderer())
+        renderer = TmlRendererAdapter(qwen3_instruct.Renderer())
     elif name == "qwen3_5":
         renderer = Qwen3_5Renderer(tokenizer, image_processor=image_processor)
     elif name == "qwen3_5_disable_thinking":

--- a/tinker_cookbook/renderers/qwen3_test.py
+++ b/tinker_cookbook/renderers/qwen3_test.py
@@ -264,7 +264,11 @@ def test_qwen3_disable_thinking_4turn():
 
     messages = _get_basic_4turn()
 
-    model_input, _ = renderer.build_supervised_example(messages)
+    examples = renderer.build_supervised_examples(messages)
+    assert len(examples) == 2
+    model_input, _ = examples[-1]
+    with pytest.raises(NotImplementedError, match="use build_supervised_examples"):
+        renderer.build_supervised_example(messages)
     tinker_tokens = model_input.to_ints()
     tinker_decoded = tokenizer.decode(tinker_tokens)
 

--- a/tinker_cookbook/renderers/renderer_pickle_test.py
+++ b/tinker_cookbook/renderers/renderer_pickle_test.py
@@ -15,19 +15,21 @@ from tinker_cookbook.tokenizer_utils import Tokenizer, get_tokenizer
 
 # Models that don't require special access / are commonly available in CI.
 # Each entry is (renderer_name, model_name).
-_TEXT_RENDERERS = [
+_PICKLE_RENDERERS = [
     ("role_colon", "Qwen/Qwen3.5-9B-Base"),
     ("llama3", "meta-llama/Llama-3.1-8B-Instruct"),
     ("qwen3", "Qwen/Qwen3-8B"),
     ("qwen3_disable_thinking", "Qwen/Qwen3-8B"),
     ("qwen3_instruct", "Qwen/Qwen3-8B"),
+    ("qwen3_vl", "Qwen/Qwen3-8B"),
+    ("qwen3_vl_instruct", "Qwen/Qwen3-8B"),
     ("deepseekv3", "deepseek-ai/DeepSeek-V3-0324"),
     ("deepseekv3_disable_thinking", "deepseek-ai/DeepSeek-V3-0324"),
     ("deepseekv3_thinking", "deepseek-ai/DeepSeek-V3-0324"),
 ]
 
 
-@pytest.fixture(params=_TEXT_RENDERERS, ids=[r[0] for r in _TEXT_RENDERERS])
+@pytest.fixture(params=_PICKLE_RENDERERS, ids=[r[0] for r in _PICKLE_RENDERERS])
 def renderer_and_model(request: pytest.FixtureRequest) -> tuple[str, str]:
     return request.param
 

--- a/tinker_cookbook/renderers/renderers_test.py
+++ b/tinker_cookbook/renderers/renderers_test.py
@@ -1570,10 +1570,6 @@ _EXTENSION_PROPERTY_TEST_PARAMS = [
     ("meta-llama/Llama-3.1-8B-Instruct", "llama3", {}, get_basic_4turn_conversation),
     # RoleColon with basic multi-turn (doesn't support tools)
     ("meta-llama/Llama-3.1-8B-Instruct", "role_colon", {}, get_basic_4turn_conversation),
-    # Qwen3 Instruct with basic multi-turn
-    ("Qwen/Qwen3-8B", "qwen3_instruct", {}, get_basic_4turn_conversation),
-    # Qwen3 Instruct with tool calls
-    ("Qwen/Qwen3-8B", "qwen3_instruct", {}, get_multiturn_tool_conversation),
     # Qwen3 with strip_thinking_from_history=False (preserves thinking)
     (
         "Qwen/Qwen3-8B",

--- a/tinker_cookbook/renderers/tml_test.py
+++ b/tinker_cookbook/renderers/tml_test.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
+import tinker
+from PIL import Image
 from tml_renderers import chat as tml_chat
 from tml_renderers.renderer import Renderer as PublicRenderer
 
@@ -12,6 +14,7 @@ import tinker_cookbook.renderers as renderers
 from tinker_cookbook.exceptions import RendererError
 from tinker_cookbook.renderers import tml
 from tinker_cookbook.renderers.base import (
+    ImagePart,
     Message,
     ParseTermination,
     RenderContext,
@@ -89,13 +92,7 @@ class _Renderer:
         self.parsers.append(parser)
         return parser
 
-    def render_for_sft(
-        self,
-        messages: TmlRenderInput,
-        *,
-        split_non_extension_history: bool = True,
-    ) -> list[tml_chat.TrainingExample]:
-        del split_non_extension_history
+    def render_for_sft(self, messages: TmlRenderInput) -> list[tml_chat.TrainingExample]:
         self.sft_input = messages
         return [
             tml_chat.TrainingExample(
@@ -352,3 +349,49 @@ def test_qwen3_builtins_use_public_renderer_behavior(
     assert adapter.tokenizer is not caller_tokenizer
     assert adapter.tokenizer.decode(prompt.to_ints()).endswith(generation_suffix)
     adapter.parse_response([])
+
+
+@pytest.mark.parametrize("renderer_name", ["qwen3_vl", "qwen3_vl_instruct"])
+def test_qwen3_vl_builtins_use_public_renderer_for_images(renderer_name: str) -> None:
+    caller_tokenizer = SimpleNamespace(name_or_path="Qwen/Qwen3-8B")
+    caller_image_processor = object()
+    adapter = renderers.get_renderer(
+        renderer_name,
+        cast(Tokenizer, caller_tokenizer),
+        caller_image_processor,
+    )
+    image = Image.new("RGB", (224, 224), color="red")
+    prompt_messages = [
+        Message(
+            role="user",
+            content=[
+                TextPart(type="text", text="What is this?"),
+                ImagePart(type="image", image=image),
+            ],
+        )
+    ]
+
+    prompt = adapter.build_generation_prompt(prompt_messages)
+    (image_chunk,) = [
+        chunk for chunk in prompt.chunks if isinstance(chunk, tinker.types.ImageChunk)
+    ]
+
+    assert isinstance(adapter, tml.TmlRendererAdapter)
+    assert adapter.tokenizer is not caller_tokenizer
+    assert image_chunk.format == "jpeg"
+    assert image_chunk.data.startswith(b"\xff\xd8")
+    assert image_chunk.expected_tokens == 64
+    adapter.parse_response([])
+
+    model_input, weights = adapter.build_supervised_example(
+        [*prompt_messages, Message(role="assistant", content="It is red.")]
+    )
+    sft_image_index = next(
+        i
+        for i, chunk in enumerate(model_input.chunks)
+        if isinstance(chunk, tinker.types.ImageChunk)
+    )
+    image_offset = sum(chunk.length for chunk in model_input.chunks[:sft_image_index])
+
+    assert weights[image_offset : image_offset + 64].tolist() == [0.0] * 64
+    assert weights[image_offset + 64 :].sum() > 0


### PR DESCRIPTION
## Why is this change needed?

Move both Qwen3-VL registry names to public renderers with renderer-owned image tokenization.

| Cookbook name | Before | After |
|---|---|---|
| `qwen3_vl` | Cookbook `Qwen3VLRenderer` | `tml_renderers.qwen3_vl.Renderer()` |
| `qwen3_vl_instruct` | Cookbook `Qwen3VLInstructRenderer` | `tml_renderers.qwen3_vl_instruct.Renderer()` |

The factory still accepts tokenizer and image-processor arguments for compatibility, but the public renderer owns both tokenizers. The concrete image contract is:

```text
224×224 image → one JPEG ImageChunk → 64 image tokens → zero loss on those 64 positions
```

Public renderers may produce multiple SFT examples. `build_supervised_examples` preserves all of them; the singular compatibility method raises unless exactly one example is returned.

**Stack, base to top:**

- [#922 — Adapt public TML renderer objects to Cookbook](https://github.com/thinking-machines-lab/tinker-cookbook/pull/922)
- [#923 — Use the public Qwen3 renderer](https://github.com/thinking-machines-lab/tinker-cookbook/pull/923)
- [#924 — Use public Qwen3 text variants](https://github.com/thinking-machines-lab/tinker-cookbook/pull/924)
- **[#925 — Use public Qwen3-VL renderers](https://github.com/thinking-machines-lab/tinker-cookbook/pull/925)**
- [#926 — Finish the public Qwen and Nemotron renderer migration](https://github.com/thinking-machines-lab/tinker-cookbook/pull/926)

## Test Plan

- Verify both VL names return the expected public renderer and ignore the compatibility tokenizer and image processor.
- Render a real image and assert JPEG transport, 64 image tokens, and zero loss on the image span.
- Verify a four-turn conversation returns two SFT examples and the singular API rejects that result.
- Cover pickle round trips for both VL configurations.

-Robot
