### PR TITLE
Add a recipe for serving multiple Tinker LoRAs on SGLang

### DIFF
--- a/tinker_cookbook/inference/sglang/README.md
+++ b/tinker_cookbook/inference/sglang/README.md
@@ -1,0 +1,200 @@
+# Serving multiple Tinker LoRAs on SGLang
+
+Turn `tinker://` checkpoints into adapters SGLang can load, serve them all from
+one process, and check that the served model matches what Tinker trained.
+
+Assumes you already have a container or pod running with SGLang available —
+`lmsysorg/sglang:latest` is a good default — and that the adapter directory is
+visible inside it.
+
+## Setup
+
+```bash
+pip install tinker-cookbook
+export TINKER_API_KEY=tml-...
+export HF_TOKEN=hf-...            # only for gated base models
+```
+
+Install this somewhere separate from the environment running SGLang.
+`tinker-cookbook` pins `transformers<=5.5.4` while current SGLang images ship a
+newer one, so installing it alongside the server downgrades transformers
+underneath it. Conversion and serving only ever exchange a directory of files.
+
+## 1. Convert your checkpoints
+
+```bash
+python -m tinker_cookbook.inference.sglang.prepare \
+  --base-model Qwen/Qwen3.8-27B \
+  --adapter lora1=tinker://<run-id>/sampler_weights/final \
+  --adapter lora2=tinker://<run-id>/sampler_weights/final
+```
+
+Each adapter is downloaded from the Tinker API, converted to PEFT format under
+`./adapters/<base-model>/<name>/`, and reported with its rank and target
+modules. The command prints the `--lora-paths` value to paste into step 2; pass
+`--lora-root` if the tree appears at a different path inside your container.
+
+Conversion reads the base model's parameter *names and shapes* — never its
+values — to remap Tinker's adapter keys, so it needs the base model locally. Set
+`HF_HUB_CACHE` to the cache your container uses and that download is paid once
+instead of twice, or pass a local directory as `--base-model` to skip the Hub.
+
+## 2. Launch
+
+Take whatever command you already use to serve the base model and add two
+flags to it: `--lora-paths` to point at the adapters, and `--max-loras-per-batch`
+to bound how many can be active in one batch.
+
+```bash
+sglang serve Qwen/Qwen3.8-27B \
+  --host 0.0.0.0 --port 30000 \
+  --lora-paths lora1=/adapters/Qwen__Qwen3.8-27B/lora1 \
+               lora2=/adapters/Qwen__Qwen3.8-27B/lora2 \
+  --max-loras-per-batch 4
+```
+
+Keep your own `--tp`, quantization, and attention settings alongside these.
+
+MoE models also need a LoRA-capable `--moe-runner-backend`. Several runners
+implement only the fused path and cannot apply expert LoRA, including the
+`flashinfer_trtllm` that SGLang picks by default on Blackwell. `triton` works;
+the Inkling rows below use the `experimental_sgl_*` runners.
+
+## 3. Query
+
+Pick the adapter per request. OpenAI-compatible route:
+
+```bash
+curl localhost:30000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "Qwen/Qwen3.8-27B:lora1",
+  "messages": [{"role": "user", "content": "hello"}]
+}'
+```
+
+Drop the `:lora1` suffix to hit the un-adapted base model. On the native
+`/generate` route the equivalent is `"lora_path": "lora1"`, or `null` for the
+base model — and both accept per-request lists, so one batch can mix adapters.
+
+## 4. Verify
+
+```bash
+python -m tinker_cookbook.inference.sglang.compare \
+  --base-model Qwen/Qwen3.8-27B --url http://localhost:30000 \
+  --adapter lora1=tinker://<run-id>/sampler_weights/final \
+  --adapter lora2=tinker://<run-id>/sampler_weights/final
+```
+
+Compares Tinker's logprobs against SGLang's on the same tokens and exits nonzero
+if they disagree, reporting which adapter failed and why. Three checks: each
+adapter is applied at all, each request is answered by the adapter it asked
+for, and each adapter's pooled distance from Tinker stays within twice the
+noise floor — what the two engines disagree by on the same tokens with no
+adapter anywhere, measured in the same run so quantized deployments are held
+to their own achievable bar rather than a constant.
+
+The floor needs a base id Tinker can sample. Where the checkpoint's own id is
+not sampleable (GLM-5.3), pass `--tinker-base` with one that is, e.g.
+`--tinker-base zai-org/GLM-5.3:peft:262144`; otherwise the closeness check
+reports itself unavailable and only the first two checks gate the exit code.
+
+## Verified models
+
+Each command below was run end to end on a 4xGB300 node: two adapters trained on
+Tinker, converted with `prepare`, served, and checked with `compare`.
+
+### Qwen/Qwen3.8-27B — dense
+
+Base command from the model's
+[cookbook page](https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-27B#hw=gb300&variant=default&quant=bf16&nodes=single&spec=none&tier=low-latency&ssmDtype=float32), with the LoRA flags added:
+
+```bash
+sglang serve Qwen/Qwen3.8-27B \
+  --trust-remote-code \
+  --kv-cache-dtype fp8_e4m3 \
+  --mem-fraction-static 0.85 \
+  --chunked-prefill-size 2048 \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --mamba-full-memory-ratio 4.59 \
+  --mamba-radix-cache-strategy extra_buffer \
+  --mamba-ssm-dtype float32 \
+  --lora-paths lora1=/adapters/Qwen__Qwen3.8-27B/lora1 \
+               lora2=/adapters/Qwen__Qwen3.8-27B/lora2 \
+  --max-loras-per-batch 3 \
+  --host 0.0.0.0 --port 30000
+```
+
+### thinkingmachines/Inkling-Small — MoE, shared-outer experts
+
+Base command from the model's
+[cookbook page](https://docs.sglang.io/cookbook/autoregressive/ThinkingMachines/Inkling-Small#hw=gb300&variant=lora&quant=bf16&strategy=balanced&nodes=single), with the LoRA paths filled in:
+
+```bash
+SGLANG_ENABLE_UNIFIED_RADIX_TREE=1 \
+SGLANG_EXPERIMENTAL_LORA_OPTI=1 \
+SGLANG_OPT_LORA_OVERLAP_MAIN_ALLOC=1 \
+SGLANG_OPT_USE_JIT_KERNEL_MOE_ALIGN=1 \
+sglang serve thinkingmachines/Inkling-Small \
+  --trust-remote-code --tp 4 \
+  --moe-runner-backend experimental_sgl_trtllm \
+  --attention-backend fa4 \
+  --enable-torch-symm-mem \
+  --mamba-radix-cache-strategy extra_buffer \
+  --mem-fraction-static 0.87 \
+  --swa-full-tokens-ratio 0.1 \
+  --mamba-full-memory-ratio 0.1 \
+  --enable-multimodal \
+  --reasoning-parser inkling --tool-call-parser inkling \
+  --disable-prefill-cuda-graph \
+  --lora-backend triton --lora-use-virtual-experts \
+  --max-loras-per-batch 3 \
+  --lora-paths lora1=/adapters/thinkingmachines__Inkling-Small/lora1 \
+               lora2=/adapters/thinkingmachines__Inkling-Small/lora2 \
+  --host 0.0.0.0 --port 30000
+```
+
+### thinkingmachines/Inkling — MoE, served from the NVFP4 checkpoint
+
+Same shape as above but from the [NVFP4 cell](https://docs.sglang.io/cookbook/autoregressive/ThinkingMachines/Inkling#hw=gb300&variant=lora&quant=nvfp4&strategy=balanced&nodes=single). The adapter is trained
+on the bf16 base model and served with w4a16:
+
+```bash
+SGLANG_ENABLE_UNIFIED_RADIX_TREE=1 \
+SGLANG_EXPERIMENTAL_LORA_OPTI=1 \
+SGLANG_OPT_LORA_OVERLAP_MAIN_ALLOC=1 \
+sglang serve thinkingmachines/Inkling-NVFP4 \
+  --trust-remote-code --tp 4 \
+  --quantization modelopt_fp4 \
+  --attention-backend fa4 --page-size 128 \
+  --fp4-gemm-backend marlin \
+  --moe-runner-backend experimental_sgl_marlin \
+  --enable-torch-symm-mem \
+  --mamba-radix-cache-strategy extra_buffer \
+  --mem-fraction-static 0.80 \
+  --swa-full-tokens-ratio 0.1 \
+  --mamba-full-memory-ratio 0.1 \
+  --enable-multimodal \
+  --reasoning-parser inkling --tool-call-parser inkling \
+  --disable-prefill-cuda-graph \
+  --lora-backend triton --lora-use-virtual-experts \
+  --max-loras-per-batch 3 \
+  --lora-paths lora1=/adapters/thinkingmachines__Inkling/lora1 \
+               lora2=/adapters/thinkingmachines__Inkling/lora2 \
+  --host 0.0.0.0 --port 30000
+```
+
+### zai-org/GLM-5.3 — MoE with sparse attention
+
+Base command from the model's [cookbook page](https://docs.sglang.io/cookbook/autoregressive/GLM/GLM-5.3#hw=gb300&variant=default&quant=fp8&strategy=low-latency&nodes=single), minus its speculative
+decoding flags, plus expert parallelism and the triton MoE runner for LoRA:
+
+```bash
+sglang serve zai-org/GLM-5.3 \
+  --tp 4 --ep-size 4 \
+  --mem-fraction-static 0.85 \
+  --moe-runner-backend triton \
+  --max-loras-per-batch 3 \
+  --lora-paths lora1=/adapters/zai-org__GLM-5.3/lora1 \
+               lora2=/adapters/zai-org__GLM-5.3/lora2 \
+  --host 0.0.0.0 --port 30000
+```

--- a/tinker_cookbook/inference/sglang/common.py
+++ b/tinker_cookbook/inference/sglang/common.py
@@ -1,0 +1,56 @@
+"""Shared helpers for serving Tinker LoRA adapters with SGLang.
+
+One SGLang server hosts one base model and many adapters. These helpers keep
+the on-disk layout, the in-container paths, and the ``--lora-paths`` argument in
+agreement, so the string ``prepare`` prints can be pasted into a launch command
+unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+DEFAULT_LORA_ROOT = "/adapters"
+"""Where the adapter tree is mounted inside the SGLang container."""
+
+
+def base_model_slug(base_model: str) -> str:
+    """Filesystem-safe directory name for a base model.
+
+    ``"Qwen/Qwen3.8-27B"`` becomes ``"Qwen__Qwen3.8-27B"``.
+    """
+    return base_model.replace("/", "__")
+
+
+def adapter_dir(root: str | Path, base_model: str, name: str) -> str:
+    """Directory holding one PEFT adapter, namespaced by its base model.
+
+    One SGLang server serves exactly one base model; grouping adapters per
+    base makes mixing bases in one ``--lora-paths`` hard to express.
+    """
+    return str(Path(root) / base_model_slug(base_model) / name)
+
+
+def parse_adapter_spec(spec: str) -> tuple[str, str]:
+    """Split a ``NAME=tinker://...`` command-line argument."""
+    name, sep, tinker_path = spec.partition("=")
+    if not sep or not name or not tinker_path:
+        raise ValueError(f"Expected NAME=tinker://..., got {spec!r}")
+    if not tinker_path.startswith("tinker://"):
+        raise ValueError(f"Adapter {name!r}: path must start with tinker://, got {tinker_path!r}")
+    return name, tinker_path
+
+
+def lora_paths_arg(
+    names: Iterable[str], base_model: str, lora_root: str = DEFAULT_LORA_ROOT
+) -> str:
+    """Build the ``--lora-paths`` value for a set of adapters on one base model."""
+    return " ".join(f"{name}={adapter_dir(lora_root, base_model, name)}" for name in names)
+
+
+def read_adapter_config(adapter_path: str | Path) -> tuple[int, list[str]]:
+    """Return ``(rank, target_modules)`` from a converted PEFT adapter."""
+    config = json.loads((Path(adapter_path) / "adapter_config.json").read_text())
+    return int(config["r"]), sorted(config.get("target_modules") or [])

--- a/tinker_cookbook/inference/sglang/compare.py
+++ b/tinker_cookbook/inference/sglang/compare.py
@@ -1,0 +1,455 @@
+"""Check that SGLang serves each Tinker adapter faithfully.
+
+    python -m tinker_cookbook.inference.sglang.compare \
+        --base-model Qwen/Qwen3.8-27B --url http://localhost:30000 \
+        --adapter lora1=tinker://<run-id>/sampler_weights/final \
+        --adapter lora2=tinker://<run-id>/sampler_weights/final
+
+For every prompt and adapter this samples greedily from SGLang, then scores the
+sampled tokens four ways -- SGLang with the adapter, SGLang with no adapter, and
+Tinker with each adapter and with none -- and reports three verdicts:
+
+``applied`` (per row)
+    The served output tracks Tinker's adapter more closely than it tracks the
+    un-adapted base model. This fails when SGLang silently drops part of the
+    adapter, which is what happens to a module whose weight keys resolve to no
+    parameter -- SGLang reserves the slot and never fills it.
+
+``routed`` (per row)
+    Of all the adapters, the served output tracks the one that was requested.
+    This fails when a request is answered with another adapter's weights. Needs
+    two or more adapters; reported as ``n/a`` with one.
+
+``close`` (per adapter, pooled over prompts)
+    The mean per-token distance from Tinker stays within a threshold derived
+    from the noise floor: what SGLang and Tinker disagree by on the very same
+    tokens with no adapter anywhere. Measured in the same run because the
+    floor is a property of the model and serving config -- 0.06 nats for bf16
+    Qwen3.8, ~15x that for FP8 GLM-5.3 -- so no constant could stand in for
+    it. ``--tolerance`` substitutes an absolute bound; ``--skip-closeness``
+    drops the verdict. The floor needs a base id Tinker can sample (GLM-5.3
+    needs ``--tinker-base`` with its ``:peft:`` variant); without one the
+    verdict reports itself unavailable, never silently passed.
+
+Distances are the mean absolute per-token logprob difference over the sampled
+tokens, in nats. Comparing scores on one fixed token sequence -- rather than
+comparing two independently sampled strings -- keeps sampling divergence out of
+the measurement.
+
+Note that ``routed`` can only discriminate between adapters that actually behave
+differently. Two adapters trained to near-identical behavior will produce
+near-identical logprobs, and the verdict becomes meaningless rather than wrong.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import math
+import sys
+from pathlib import Path
+from typing import cast
+
+import aiohttp
+import tinker
+
+from tinker_cookbook import model_info, renderers
+from tinker_cookbook.exceptions import ConfigurationError
+from tinker_cookbook.inference.sglang.common import parse_adapter_spec
+from tinker_cookbook.tokenizer_utils import get_tokenizer
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROMPTS = [
+    "What is the capital of France?",
+    "Explain gradient descent in one sentence.",
+    "Write a haiku about GPUs.",
+    "What is 17 times 24?",
+]
+MAX_TOKENS = 128
+REQUEST_TIMEOUT = 600
+
+# Closeness threshold = max(CLOSENESS_SLACK x floor mean, CLOSENESS_MIN).
+# Measured floors span 0.06 (Qwen3.8 bf16) to 0.90 nats (GLM-5.3 FP8), and
+# every correctly served adapter pooled below its own floor, so twice the
+# floor passes all with >=2x margin. CLOSENESS_MIN guards a near-zero floor.
+CLOSENESS_SLACK = 2.0
+CLOSENESS_MIN = 0.05
+
+
+def _abs_diffs(a: list[float | None], b: list[float | None]) -> list[float]:
+    """Per-token absolute differences, over positions where both sides scored.
+
+    Positions are compared by index, so every producer must keep ``None`` in
+    place rather than dropping it -- SGLang reports ``None`` for the first token
+    of a rescoring window, and Tinker for any token it did not score. Filtering
+    those out would shift one array against the other and silently compare each
+    position with its neighbour.
+    """
+    return [abs(x - y) for x, y in zip(a, b) if x is not None and y is not None]
+
+
+def _summarize(label: str, vals: list[float]) -> str:
+    """One line of distribution stats, for choosing a closeness threshold."""
+    if not vals:
+        return f"  {label:<22} (no comparable positions)"
+    v = sorted(vals)
+    n = len(v)
+
+    def pick(q: float) -> float:
+        return v[min(n - 1, int(n * q))]
+
+    return (
+        f"  {label:<22} n={n:<5} mean={sum(v) / n:8.4f}  median={pick(0.5):8.4f}"
+        f"  p90={pick(0.9):8.4f}  p95={pick(0.95):8.4f}  max={v[-1]:8.4f}"
+    )
+
+
+def _mean_abs_diff(a: list[float | None], b: list[float | None]) -> float:
+    """Mean over ``_abs_diffs``; ``inf`` when no position is comparable."""
+    diffs = _abs_diffs(a, b)
+    if not diffs:
+        return float("inf")
+    return sum(diffs) / len(diffs)
+
+
+def _logprob_values(entries: list[list[object]]) -> list[float | None]:
+    """Pull the logprob out of SGLang's ``[logprob, token_id, text]`` triples.
+
+    Keeps ``None`` entries so the result stays index-aligned with the tokens.
+    """
+    return [None if e[0] is None else float(cast(float, e[0])) for e in entries]
+
+
+def _token_ids(entries: list[list[object]]) -> list[int]:
+    return [int(cast(int, e[1])) for e in entries]
+
+
+def _meta_entries(result: dict[str, object], key: str) -> list[list[object]]:
+    """The ``[logprob, token_id, text]`` triples under ``meta_info[key]``."""
+    meta = cast(dict[str, object], result["meta_info"])
+    return cast(list[list[object]], meta[key])
+
+
+async def _generate(
+    session: aiohttp.ClientSession, url: str, body: dict[str, object]
+) -> list[dict[str, object]]:
+    async with session.post(f"{url}/generate", json=body) as resp:
+        resp.raise_for_status()
+        payload = await resp.json()
+    return payload if isinstance(payload, list) else [payload]
+
+
+async def _tinker_score(
+    client: tinker.SamplingClient, prompt: tinker.ModelInput, out_ids: list[int]
+) -> list[float | None]:
+    """Score the full prompt+output sequence with a Tinker sampling client.
+
+    ``logprobs[i]`` scores the token at absolute position i (``None`` at 0 and
+    wherever Tinker did not score), verified position-aligned with SGLang's
+    ``logprob_start_len: 0`` scoring — so callers slice ``[prompt.length:]``
+    for the sampled tokens. Beware: an off-by-one here hides on
+    near-deterministic continuations, where every logprob is ~0.
+    """
+    full = prompt.append(tinker.EncodedTextChunk(tokens=out_ids))
+    logprobs = await client.compute_logprobs_async(full)
+    return list(logprobs[: prompt.length + len(out_ids)])
+
+
+def _generation_prompt(base_model: str, tokenizer: object, prompt: str) -> tinker.ModelInput:
+    """Tokenize one user turn, ready for generation.
+
+    Prefers the cookbook renderer. Models the cookbook has no renderer for —
+    ``model_info`` raises ``ConfigurationError`` for them — fall back to the
+    tokenizer's own chat template, which is the other prompt path CLAUDE.md
+    sanctions. Either way both sides of the comparison get the same token ids,
+    so a logprob difference still reflects weights rather than formatting.
+
+    A fallback prompt is only as canonical as the checkpoint's HF chat template.
+    If Tinker trained the model against a different one, the prompt is somewhat
+    off-distribution — equally for Tinker and SGLang, so the distance between
+    them stays meaningful.
+    """
+    messages = [{"role": "user", "content": prompt}]
+    try:
+        renderer = renderers.get_renderer(
+            model_info.get_recommended_renderer_name(base_model), tokenizer
+        )
+    except ConfigurationError:
+        logger.warning(
+            "No cookbook renderer for %s; using the tokenizer's chat template instead.",
+            base_model,
+        )
+        encoded = tokenizer.apply_chat_template(  # type: ignore[attr-defined]
+            messages, tokenize=True, add_generation_prompt=True
+        )
+        ids = encoded if isinstance(encoded, list) else encoded["input_ids"]
+        while ids and isinstance(ids[0], list):
+            ids = ids[0]
+        return tinker.ModelInput.from_ints([int(t) for t in ids])
+    return renderer.build_generation_prompt(messages)
+
+
+async def run(
+    *,
+    base_model: str,
+    url: str,
+    adapters: list[tuple[str, str]],
+    prompts: list[str],
+    tolerance: float | None = None,
+    tinker_base: str | None = None,
+    skip_closeness: bool = False,
+) -> int:
+    names = [name for name, _ in adapters]
+    tokenizer = get_tokenizer(base_model)
+    prompt_inputs = [_generation_prompt(base_model, tokenizer, p) for p in prompts]
+    prompt_ids = [mi.to_ints() for mi in prompt_inputs]
+
+    service = tinker.ServiceClient()
+    # tinker_base pins which variant of the base model Tinker samples the adapter
+    # through. It must name the same base as the checkpoint: ``:peft:`` context
+    # variants are accepted, but a ``:sampling-nvfp4`` id is rejected for a
+    # checkpoint trained on the plain model, so it cannot be used to match
+    # Tinker's precision to a quantized SGLang deployment.
+    clients = {
+        name: service.create_sampling_client(model_path=path, base_model=tinker_base)
+        for name, path in adapters
+    }
+
+    # Tinker scoring the un-adapted base model: paired with SGLang's own
+    # base-model scoring of the same tokens, this is the engine-vs-engine
+    # noise floor the closeness threshold is derived from.
+    floor_client: tinker.SamplingClient | None = None
+    floor_base = tinker_base or base_model
+    try:
+        floor_client = service.create_sampling_client(base_model=floor_base)
+    except Exception as exc:  # any failure just disables the floor
+        logger.warning(
+            "No noise floor: Tinker will not sample base model %r (%s). Pass "
+            "--tinker-base with an id Tinker accepts to enable it.",
+            floor_base,
+            exc,
+        )
+
+    # One row per (prompt, adapter): all adapters share a single mixed batch, which
+    # is also how a real multi-adapter server sees traffic.
+    rows = [(p, a) for p in range(len(prompts)) for a in names]
+    timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        sampled = await _generate(
+            session,
+            url,
+            {
+                "input_ids": [prompt_ids[p] for p, _ in rows],
+                "lora_path": [a for _, a in rows],
+                "sampling_params": {"temperature": 0.0, "max_new_tokens": MAX_TOKENS},
+                "return_logprob": True,
+            },
+        )
+        out_ids: list[list[int]] = []
+        served: list[list[float | None]] = []
+        for result in sampled:
+            entries = _meta_entries(result, "output_token_logprobs")
+            out_ids.append(_token_ids(entries))
+            served.append(_logprob_values(entries))
+
+        # Re-score the same tokens with no adapter, from position 0. The
+        # output slice is the control behind the "applied" verdict; the prompt
+        # slice widens the noise floor, which matters for overfit adapters
+        # that stop after a handful of tokens.
+        scored = await _generate(
+            session,
+            url,
+            {
+                "input_ids": [prompt_ids[p] + out_ids[i] for i, (p, _) in enumerate(rows)],
+                "lora_path": [None] * len(rows),
+                "sampling_params": {"temperature": 0.0, "max_new_tokens": 0},
+                "return_logprob": True,
+                "logprob_start_len": [0] * len(rows),
+            },
+        )
+        base_full = [_logprob_values(_meta_entries(r, "input_token_logprobs")) for r in scored]
+        base_lps = [full[len(prompt_ids[p]) :] for full, (p, _) in zip(base_full, rows)]
+
+    # Reference logprobs from Tinker: every sampled sequence scored by every adapter.
+    reference_full = await asyncio.gather(
+        *[
+            _tinker_score(clients[ref_name], prompt_inputs[p], out_ids[i])
+            for i, (p, _requested) in enumerate(rows)
+            for ref_name in names
+        ]
+    )
+    reference = [
+        full[len(prompt_ids[rows[k // len(names)][0]]) :] for k, full in enumerate(reference_full)
+    ]
+    floor_ref: list[list[float | None]] | None = None
+    if floor_client is not None:
+        floor_ref = list(
+            await asyncio.gather(
+                *[
+                    _tinker_score(floor_client, prompt_inputs[p], out_ids[i])
+                    for i, (p, _requested) in enumerate(rows)
+                ]
+            )
+        )
+
+    failures = 0
+    row_failures = False
+    pooled_adapter: dict[str, list[float]] = {name: [] for name in names}
+    pooled_floor: list[float] = []
+    print(f"{'prompt':<8}{'adapter':<14}{'d(tinker)':>11}{'d(base)':>10}{'d(floor)':>10}  result")
+    for i, (p, requested) in enumerate(rows):
+        per_adapter = {
+            name: _mean_abs_diff(served[i], reference[i * len(names) + j])
+            for j, name in enumerate(names)
+        }
+        d_own = per_adapter[requested]
+        d_base = _mean_abs_diff(base_lps[i], reference[i * len(names) + names.index(requested)])
+        closest = min(per_adapter, key=lambda n: per_adapter[n])
+
+        pooled_adapter[requested] += _abs_diffs(
+            served[i], reference[i * len(names) + names.index(requested)]
+        )
+        floor_diffs: list[float] = []
+        if floor_ref is not None:
+            n_prompt = len(prompt_ids[p])
+            floor_diffs = _abs_diffs(base_full[i], floor_ref[i])
+            # Pool output-token diffs from every row, prompt-token diffs only
+            # from each prompt's first row -- the other rows re-score the same
+            # prompt positions and would count the same measurement twice.
+            pooled_floor += _abs_diffs(base_full[i][n_prompt:], floor_ref[i][n_prompt:])
+            if i % len(names) == 0:
+                pooled_floor += _abs_diffs(base_full[i][:n_prompt], floor_ref[i][:n_prompt])
+        d_floor = sum(floor_diffs) / len(floor_diffs) if floor_diffs else float("nan")
+
+        if d_own >= d_base:
+            result = (
+                "FAIL: lora not applied -- served logprobs are no closer to the fine-tune "
+                "than to the base model"
+            )
+        elif len(names) > 1 and closest != requested:
+            result = (
+                f"FAIL: wrong adapter -- served logprobs match {closest!r} "
+                f"({per_adapter[closest]:.4f}) better than {requested!r} ({d_own:.4f})"
+            )
+        else:
+            result = "ok"
+
+        if result != "ok":
+            failures += 1
+            row_failures = True
+        floor_cell = "       n/a" if math.isnan(d_floor) else f"{d_floor:>10.4f}"
+        print(f"{p:<8}{requested:<14}{d_own:>11.4f}{d_base:>10.4f}{floor_cell}  {result}")
+
+    # The closeness verdict pools per-token diffs: per-row means are a poor
+    # basis when an overfit adapter stops after two tokens and one argmax flip
+    # moves the mean by half a nat.
+    print("\n=== per-token |logprob difference|, pooled over prompts (nats) ===")
+    print(_summarize("floor (base vs base)", pooled_floor))
+    for name in names:
+        print(_summarize(f"{name} (adapter)", pooled_adapter[name]))
+
+    checks = len(rows)
+    print("\n=== close: pooled per-adapter mean vs threshold ===")
+    if skip_closeness:
+        print("  skipped (--skip-closeness)")
+    elif tolerance is not None or pooled_floor:
+        if tolerance is not None:
+            threshold = tolerance
+            print(f"  threshold = {threshold:.4f} (--tolerance)")
+        else:
+            floor_mean = sum(pooled_floor) / len(pooled_floor)
+            threshold = max(CLOSENESS_SLACK * floor_mean, CLOSENESS_MIN)
+            print(
+                f"  threshold = max({CLOSENESS_SLACK} x floor mean {floor_mean:.4f}, "
+                f"{CLOSENESS_MIN}) = {threshold:.4f}"
+            )
+        for name in names:
+            vals = pooled_adapter[name]
+            mean = sum(vals) / len(vals) if vals else float("inf")
+            checks += 1
+            if mean <= threshold:
+                print(f"  {name:<14}{mean:>8.4f}  ok")
+            else:
+                failures += 1
+                print(
+                    f"  {name:<14}{mean:>8.4f}  FAIL: exceeds {threshold:.4f} -- the "
+                    "adapter is applied but not faithfully; suspect scaling "
+                    "(lora_alpha), rank truncation, or a partially loaded module"
+                )
+    else:
+        print(
+            "  UNAVAILABLE -- Tinker cannot sample the base model, so there is no "
+            "noise floor to derive a threshold from. Pass --tinker-base with a "
+            "sampleable id (e.g. the :peft: variant), or --tolerance for an "
+            "absolute bound. Only applied/routed were checked."
+        )
+
+    print(f"\n{checks - failures}/{checks} checks passed")
+    if row_failures:
+        print(
+            "Compare the adapter's adapter_config.json against the target_modules the "
+            "server logs at startup. A module whose weight keys SGLang cannot resolve is "
+            "dropped in silence."
+        )
+    return 1 if failures else 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--base-model", required=True, help="HF model name or local directory")
+    parser.add_argument(
+        "--url", required=True, help="SGLang server URL, e.g. http://localhost:30000"
+    )
+    parser.add_argument(
+        "--adapter",
+        action="append",
+        required=True,
+        metavar="NAME=tinker://...",
+        help="Adapter to check; NAME must match the one given to --lora-paths",
+    )
+    parser.add_argument("--prompts", help="JSON file holding a list of prompt strings")
+    parser.add_argument(
+        "--tinker-base",
+        help=(
+            "Base-model variant Tinker should sample the adapters through, e.g. "
+            "a :sampling-nvfp4 id when SGLang is serving a quantized checkpoint. "
+            "Must name the same base as the adapters; defaults to the checkpoint's own."
+        ),
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        help=(
+            "Absolute closeness bound in nats, replacing the threshold derived from the "
+            "measured noise floor. The applied and routed checks run regardless."
+        ),
+    )
+    parser.add_argument(
+        "--skip-closeness",
+        action="store_true",
+        help="Only check applied and routed; skip the closeness verdict entirely.",
+    )
+    args = parser.parse_args()
+
+    prompts = json.loads(Path(args.prompts).read_text()) if args.prompts else DEFAULT_PROMPTS
+    adapters = [parse_adapter_spec(spec) for spec in args.adapter]
+    sys.exit(
+        asyncio.run(
+            run(
+                base_model=args.base_model,
+                url=args.url.rstrip("/"),
+                adapters=adapters,
+                prompts=prompts,
+                tolerance=args.tolerance,
+                tinker_base=args.tinker_base,
+                skip_closeness=args.skip_closeness,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tinker_cookbook/inference/sglang/compare.py
+++ b/tinker_cookbook/inference/sglang/compare.py
@@ -50,7 +50,7 @@ import logging
 import math
 import sys
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import aiohttp
 import tinker
@@ -58,7 +58,7 @@ import tinker
 from tinker_cookbook import model_info, renderers
 from tinker_cookbook.exceptions import ConfigurationError
 from tinker_cookbook.inference.sglang.common import parse_adapter_spec
-from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.tokenizer_utils import Tokenizer, get_tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +158,7 @@ async def _tinker_score(
     return list(logprobs[: prompt.length + len(out_ids)])
 
 
-def _generation_prompt(base_model: str, tokenizer: object, prompt: str) -> tinker.ModelInput:
+def _generation_prompt(base_model: str, tokenizer: Tokenizer, prompt: str) -> tinker.ModelInput:
     """Tokenize one user turn, ready for generation.
 
     Prefers the cookbook renderer. Models the cookbook has no renderer for —
@@ -172,7 +172,7 @@ def _generation_prompt(base_model: str, tokenizer: object, prompt: str) -> tinke
     off-distribution — equally for Tinker and SGLang, so the distance between
     them stays meaningful.
     """
-    messages = [{"role": "user", "content": prompt}]
+    messages: list[renderers.Message] = [{"role": "user", "content": prompt}]
     try:
         renderer = renderers.get_renderer(
             model_info.get_recommended_renderer_name(base_model), tokenizer
@@ -182,7 +182,9 @@ def _generation_prompt(base_model: str, tokenizer: object, prompt: str) -> tinke
             "No cookbook renderer for %s; using the tokenizer's chat template instead.",
             base_model,
         )
-        encoded = tokenizer.apply_chat_template(  # type: ignore[attr-defined]
+        # This branch exists for tokenizers outside the cookbook's typed
+        # surface, so the call is deliberately untyped.
+        encoded = cast(Any, tokenizer).apply_chat_template(
             messages, tokenize=True, add_generation_prompt=True
         )
         ids = encoded if isinstance(encoded, list) else encoded["input_ids"]
@@ -398,7 +400,7 @@ async def run(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument("--base-model", required=True, help="HF model name or local directory")
     parser.add_argument(
         "--url", required=True, help="SGLang server URL, e.g. http://localhost:30000"

--- a/tinker_cookbook/inference/sglang/prepare.py
+++ b/tinker_cookbook/inference/sglang/prepare.py
@@ -1,0 +1,234 @@
+"""Convert Tinker LoRA checkpoints into PEFT adapters that SGLang can serve.
+
+    python -m tinker_cookbook.inference.sglang.prepare \
+        --base-model Qwen/Qwen3.8-27B \
+        --adapter lora1=tinker://<run-id>/sampler_weights/final \
+        --adapter lora2=tinker://<run-id>/sampler_weights/final
+
+Downloads each checkpoint from the Tinker API, converts it to PEFT format under
+``--out``, and prints the ``--lora-paths`` value for the launch command.
+
+The conversion reads the base model's parameter *names and shapes* (never its
+values) to remap Tinker's internal adapter keys, so the base model is fetched
+from the Hugging Face cache. Point ``HF_HUB_CACHE`` at the same cache the SGLang
+container mounts and the download is paid once instead of twice; or pass a local
+directory as ``--base-model`` to skip the Hub entirely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+from tinker_cookbook import weights
+from tinker_cookbook.inference.sglang.common import (
+    DEFAULT_LORA_ROOT,
+    adapter_dir,
+    lora_paths_arg,
+    parse_adapter_spec,
+    read_adapter_config,
+)
+
+# LoRA keys the converter leaves pointing at a parameter that does not exist:
+# GLM-5.3 adapters say ``model.lm_head``, which matches no remap, and SGLang
+# then reserves an lm_head slot it silently never fills. Workaround; the real
+# fix belongs next to the existing remap in
+# ``weights/_merge_utils.build_name_remaps``, where it would also reach vLLM.
+_KEY_FIXUPS: tuple[tuple[str, str], ...] = (
+    ("base_model.model.model.lm_head.", "base_model.model.lm_head."),
+)
+
+
+def _apply_key_fixups(adapter_path: str) -> int:
+    """Rewrite known-bad LoRA keys in a converted adapter. Returns the count.
+
+    Only rewrites when the corrected key is absent, so an adapter that already
+    carries the right name is left alone.
+    """
+    from safetensors.torch import load_file, save_file
+
+    weights_file = Path(adapter_path) / "adapter_model.safetensors"
+    tensors = load_file(str(weights_file))
+    renamed = 0
+    for bad, good in _KEY_FIXUPS:
+        if any(k.startswith(good) for k in tensors):
+            continue
+        for key in [k for k in tensors if k.startswith(bad)]:
+            tensors[good + key[len(bad) :]] = tensors.pop(key)
+            renamed += 1
+    if renamed:
+        save_file(tensors, str(weights_file))
+    return renamed
+
+
+_EXPERT_KEY = re.compile(r"^(?P<pre>.*\.experts)\.(?P<idx>\d+)\.(?P<rest>.+\.lora_[AB])\.weight$")
+
+
+def _restore_shared_outer_experts(adapter_path: str) -> int:
+    """Undo the copying of a shared-outer expert factor, one copy per expert.
+
+    ``build_lora_adapter`` expands Tinker's 3D expert LoRA into one 2D tensor
+    per expert; for a shared-outer adapter (Inkling: ``expert_dim=1``) that
+    turns one tensor into N identical copies, which SGLang refuses as a mixed
+    format. Stack them back and collapse the expert dimension to 1 wherever
+    every slice is identical — lossless, they were exact copies. Returns the
+    number of expert groups rebuilt.
+    """
+    import torch
+    from safetensors.torch import load_file, save_file
+
+    weights_file = Path(adapter_path) / "adapter_model.safetensors"
+    tensors = load_file(str(weights_file))
+
+    groups: dict[str, dict[int, str]] = {}
+    for key in tensors:
+        if (m := _EXPERT_KEY.match(key)) is None:
+            continue
+        target = f"{m.group('pre')}.{m.group('rest')}.weight"
+        groups.setdefault(target, {})[int(m.group("idx"))] = key
+    if not groups:
+        return 0
+
+    for target, members in groups.items():
+        stacked = torch.stack([tensors[members[i]] for i in sorted(members)])
+        if all(torch.equal(stacked[0], stacked[i]) for i in range(1, stacked.shape[0])):
+            stacked = stacked[:1]
+        for key in members.values():
+            del tensors[key]
+        tensors[target] = stacked.contiguous()
+
+    save_file(tensors, str(weights_file))
+    return len(groups)
+
+
+def _rewrite_target_modules(adapter_path: str) -> list[str]:
+    """Re-derive target_modules from the weight keys after the rewrites above."""
+    from safetensors.torch import load_file
+
+    tensors = load_file(str(Path(adapter_path) / "adapter_model.safetensors"))
+    config_file = Path(adapter_path) / "adapter_config.json"
+    config = json.loads(config_file.read_text())
+    modules = sorted(
+        {k.rsplit(".lora_", 1)[0].rsplit(".", 1)[-1] for k in tensors if ".lora_" in k}
+    )
+    config["target_modules"] = modules
+    config_file.write_text(json.dumps(config, indent=2))
+    return modules
+
+
+# Module names as Tinker writes them, mapped to the names SGLang resolves.
+# Only the declared target name changes -- never the weights: SGLang's loader
+# reconciles weight keys itself (concatenating per-slice attention, renaming
+# w1/w3/w2). Rewriting attention weights to the fused name instead would hit
+# the merged-adapter path, which cannot hold four distinct lora_A factors.
+_SERVING_TARGET_NAMES: dict[str, str] = {
+    "in_proj_q": "in_proj_qkvz",
+    "in_proj_k": "in_proj_qkvz",
+    "in_proj_v": "in_proj_qkvz",
+    "in_proj_z": "in_proj_qkvz",
+    "wq_du": "qkvr",
+    "wk_dv": "qkvr",
+    "wv_dv": "qkvr",
+    "wr_du": "qkvr",
+    "w1": "gate_proj",
+    "w3": "up_proj",
+    "w2": "down_proj",
+}
+
+
+def _declare_serving_targets(adapter_path: str) -> int:
+    """Put the names SGLang resolves into target_modules, leaving weights alone."""
+    config_file = Path(adapter_path) / "adapter_config.json"
+    config = json.loads(config_file.read_text())
+    modules = list(config.get("target_modules") or [])
+    mapped = sorted({_SERVING_TARGET_NAMES.get(m, m) for m in modules})
+    if mapped == sorted(modules):
+        return 0
+    config["target_modules"] = mapped
+    config_file.write_text(json.dumps(config, indent=2))
+    return len({m for m in modules if m in _SERVING_TARGET_NAMES})
+
+
+def prepare_adapter(
+    *, base_model: str, tinker_path: str, name: str, out: str, overwrite: bool = False
+) -> str:
+    """Download one Tinker checkpoint and convert it to a PEFT adapter.
+
+    Returns the local directory holding the converted adapter.
+    """
+    output_path = adapter_dir(out, base_model, name)
+    if overwrite:
+        shutil.rmtree(output_path, ignore_errors=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        downloaded = weights.download(tinker_path=tinker_path, output_dir=tmp)
+        weights.build_lora_adapter(
+            base_model=base_model, adapter_path=downloaded, output_path=output_path
+        )
+    if renamed := _apply_key_fixups(output_path):
+        print(f"[prepare] {name}: repaired {renamed} lm_head key(s) (see _KEY_FIXUPS)")
+    changed = _restore_shared_outer_experts(output_path)
+    if changed:
+        modules = _rewrite_target_modules(output_path)
+        print(f"[prepare] {name}: rebuilt expert tensors -> target_modules={','.join(modules)}")
+    # Last: _rewrite_target_modules re-derives names from the weight keys, which
+    # are deliberately left as Tinker wrote them, so aliasing must follow it.
+    if aliased := _declare_serving_targets(output_path):
+        print(f"[prepare] {name}: declared {aliased} module(s) under the name SGLang resolves")
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--base-model", required=True, help="HF model name or local directory")
+    parser.add_argument(
+        "--adapter",
+        action="append",
+        required=True,
+        metavar="NAME=tinker://...",
+        help="Adapter to convert; repeat once per adapter",
+    )
+    parser.add_argument("--out", default="./adapters", help="Host directory for the adapter tree")
+    parser.add_argument(
+        "--lora-root",
+        default=DEFAULT_LORA_ROOT,
+        help="Where --out is mounted inside the container (used for the printed --lora-paths)",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Replace adapters that exist")
+    args = parser.parse_args()
+
+    adapters = [parse_adapter_spec(spec) for spec in args.adapter]
+    summaries: list[tuple[str, int, list[str]]] = []
+    for name, tinker_path in adapters:
+        print(f"[prepare] {name}: {tinker_path}")
+        path = prepare_adapter(
+            base_model=args.base_model,
+            tinker_path=tinker_path,
+            name=name,
+            out=args.out,
+            overwrite=args.overwrite,
+        )
+        rank, target_modules = read_adapter_config(path)
+        summaries.append((name, rank, target_modules))
+        print(f"[prepare] {name}: r={rank} target_modules={','.join(target_modules)}")
+
+    module_sets = {tuple(modules) for _, _, modules in summaries}
+    if len(module_sets) > 1:
+        print(
+            "\n[prepare] note: adapters do not target the same modules. SGLang applies the "
+            "union, so an adapter may be served with modules it was not trained on."
+        )
+
+    names = [name for name, _, _ in summaries]
+    print(f"\nAdapters written to {Path(args.out).resolve()}")
+    print(f"\nMount:\n  -v {Path(args.out).resolve()}:{args.lora_root}:ro")
+    print(
+        f"\nLaunch with:\n  --lora-paths {lora_paths_arg(names, args.base_model, args.lora_root)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tinker_cookbook/inference/sglang/prepare.py
+++ b/tinker_cookbook/inference/sglang/prepare.py
@@ -144,7 +144,7 @@ def _declare_serving_targets(adapter_path: str) -> int:
     """Put the names SGLang resolves into target_modules, leaving weights alone."""
     config_file = Path(adapter_path) / "adapter_config.json"
     config = json.loads(config_file.read_text())
-    modules = list(config.get("target_modules") or [])
+    modules: list[str] = list(config.get("target_modules") or [])
     mapped = sorted({_SERVING_TARGET_NAMES.get(m, m) for m in modules})
     if mapped == sorted(modules):
         return 0
@@ -182,7 +182,7 @@ def prepare_adapter(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument("--base-model", required=True, help="HF model name or local directory")
     parser.add_argument(
         "--adapter",

--- a/tinker_cookbook/weights/_adapter.py
+++ b/tinker_cookbook/weights/_adapter.py
@@ -223,8 +223,8 @@ def _warn_experimental_moe(profile: MergeProfile) -> None:
 
     if profile.model_family not in stable_moe_families:
         logger.warning(
-            "MoE expert LoRA serving for %s models is experimental in vLLM and "
-            "not yet supported in SGLang. The adapter will be produced but may "
+            "MoE expert LoRA serving for %s models is experimental in vLLM. "
+            "SGLang supports it. The adapter will be produced but may "
             "not work with all serving configurations.",
             profile.model_family,
         )


### PR DESCRIPTION
Adds `tinker_cookbook/inference/sglang/`: convert `tinker://` checkpoints into PEFT adapters SGLang can load, serve many of them from one server, and verify the served model against Tinker's own logprobs on the same tokens.

`prepare` downloads and converts each checkpoint, with three repairs on top of `build_lora_adapter`, all local to this recipe and none needing a patched SGLang: models that train attention one slice at a time (Qwen3.5/3.6/3.8, Inkling) get the fused module name declared in `target_modules` while the weights stay split, which is the form SGLang's loader concatenates for itself; shared-outer expert tensors, which conversion expands into one identical copy per expert, are collapsed back to the shared form SGLang auto-detects; and GLM-5.3's `model.lm_head` LoRA keys, which resolve to no parameter and are silently dropped, are renamed to the top-level `lm_head`.

`compare` runs three checks per served adapter: it is applied at all, requests are answered by the adapter they asked for, and its pooled per-token logprob distance from Tinker stays within twice the noise floor — what SGLang and Tinker disagree by on the same tokens with no adapter anywhere, measured in the same run so quantized deployments are held to their own achievable bar (measured floors span 0.06 nats for bf16 Qwen3.8 to 0.90 for FP8 GLM-5.3).

Verified end to end on a 4xGB300 node against unpatched SGLang, two adapters each: Qwen3.8-27B, Inkling-Small, Inkling served from its NVFP4 checkpoint, and GLM-5.3. The README records the exact launch command used for each.

Also corrects a log message in `weights/_adapter.py` that warned MoE expert LoRA may not serve — it does on SGLang; the caveat is vLLM's.
