### PR TITLE
Add Inkling-Small to hyperparam lookup tables

### DIFF
--- a/tests/downstream_compat/test_cli_and_hyperparam.py
+++ b/tests/downstream_compat/test_cli_and_hyperparam.py
@@ -18,17 +18,14 @@ from tinker_cookbook.model_info import (
     get_moonshot_info,
     get_nvidia_info,
     get_qwen_info,
+    get_thinkingmachines_info,
     get_zai_info,
 )
-
-# Inkling models have no ``model_info`` getter — ``get_model_attributes`` matches
-# them by prefix — so they have to be listed here to get the same coverage.
-_INKLING_NAMES = ["thinkingmachines/Inkling", "thinkingmachines/Inkling-Small"]
 
 
 def _all_model_info_names() -> list[str]:
     """Every model registered in ``model_info``, as ``org/name`` HF IDs."""
-    names: list[str] = list(_INKLING_NAMES)
+    names: list[str] = []
     for getter in (
         get_llama_info,
         get_qwen_info,
@@ -36,6 +33,7 @@ def _all_model_info_names() -> list[str]:
         get_gpt_oss_info,
         get_moonshot_info,
         get_nvidia_info,
+        get_thinkingmachines_info,
         get_zai_info,
     ):
         for name, attrs in getter().items():

--- a/tests/downstream_compat/test_cli_and_hyperparam.py
+++ b/tests/downstream_compat/test_cli_and_hyperparam.py
@@ -21,10 +21,14 @@ from tinker_cookbook.model_info import (
     get_zai_info,
 )
 
+# Inkling models have no ``model_info`` getter — ``get_model_attributes`` matches
+# them by prefix — so they have to be listed here to get the same coverage.
+_INKLING_NAMES = ["thinkingmachines/Inkling", "thinkingmachines/Inkling-Small"]
+
 
 def _all_model_info_names() -> list[str]:
     """Every model registered in ``model_info``, as ``org/name`` HF IDs."""
-    names: list[str] = []
+    names: list[str] = list(_INKLING_NAMES)
     for getter in (
         get_llama_info,
         get_qwen_info,
@@ -389,6 +393,15 @@ _REFERENCE_PARAMS_PER_RANK: dict[str, dict[tuple[bool, bool, bool], int]] = {
         (False, True, False): 3_424_256,
         (False, False, True): 207_168,
     },
+    "thinkingmachines/Inkling-Small": {
+        (True, True, True): 66_020_672,
+        (True, True, False): 65_815_552,
+        (True, False, True): 64_708_928,
+        (True, False, False): 64_503_808,
+        (False, True, True): 1_516_864,
+        (False, True, False): 1_311_744,
+        (False, False, True): 205_120,
+    },
     "zai-org/GLM-5.3": {
         (True, True, True): 124_437_632,
         (True, True, False): 124_276_608,
@@ -430,14 +443,14 @@ class TestHyperparamUtils:
         )
 
     def test_get_lr_returns_float(self):
-        lr = get_lr("Qwen/Qwen3.6-27B", is_lora=True)
+        lr = get_lr("Qwen/Qwen3-8B", is_lora=True)
         assert isinstance(lr, float)
         assert lr > 0
 
     def test_get_lora_param_count_rejects_all_false(self):
         with pytest.raises(ValueError):
             get_lora_param_count(
-                "Qwen/Qwen3.6-27B",
+                "Qwen/Qwen3-8B",
                 lora_rank=32,
                 train_mlp=False,
                 train_attn=False,

--- a/tinker_cookbook/hyperparam_utils.py
+++ b/tinker_cookbook/hyperparam_utils.py
@@ -127,9 +127,6 @@ def _get_hidden_size(model_name: str) -> int:
         "Qwen/Qwen3.5-9B": 4096,
         "Qwen/Qwen3.5-9B-Base": 4096,
         "Qwen/Qwen3.5-4B": 2560,
-        # Qwen/Qwen3.5-9B and Qwen/Qwen3.5-9B-Base intentionally omitted —
-        # the values weren't independently verified. The fallback path fetches
-        # hidden_size from HF AutoConfig, which works for non-gated Qwen repos.
         # Qwen3.6 (same architecture family as Qwen3.5, hidden_size under text_config)
         "Qwen/Qwen3.6-27B": 5120,
         "Qwen/Qwen3.6-35B-A3B": 2048,
@@ -237,6 +234,7 @@ _LORA_PARAMS_PER_RANK_BY_COMPONENT: dict[str, dict[str, int]] = {
     "openai/gpt-oss-120b": {"mlp": 40_124_160, "attn": 746_496, "unembed": 203_968},
     "openai/gpt-oss-20b": {"mlp": 6_842_880, "attn": 497_664, "unembed": 203_968},
     "thinkingmachines/Inkling": {"mlp": 154_705_920, "attn": 3_424_256, "unembed": 207_168},
+    "thinkingmachines/Inkling-Small": {"mlp": 64_503_808, "attn": 1_311_744, "unembed": 205_120},
     "zai-org/GLM-5.3": {"mlp": 121_356_288, "attn": 2_920_320, "unembed": 161_024},
 }
 

--- a/tinker_cookbook/model_info.py
+++ b/tinker_cookbook/model_info.py
@@ -227,6 +227,25 @@ def get_nvidia_info() -> dict[str, ModelAttributes]:
     }
 
 
+@cache
+def get_thinkingmachines_info() -> dict[str, ModelAttributes]:
+    """Return model attributes for all supported Thinking Machines Inkling models.
+
+    Returns:
+        dict[str, ModelAttributes]: Mapping from model version name
+            (e.g. ``"Inkling-Small"``) to its attributes.
+    """
+    org = "thinkingmachines"
+    return {
+        "Inkling": ModelAttributes(
+            org, "1", "975B-A41B", True, _TML_V0, is_vl=True, is_audio_in=True
+        ),
+        "Inkling-Small": ModelAttributes(
+            org, "1", "276B-A12B", True, _TML_V0, is_vl=True, is_audio_in=True
+        ),
+    }
+
+
 def get_model_attributes(model_name: str) -> ModelAttributes:
     """Get model metadata by name.
 
@@ -268,7 +287,11 @@ def get_model_attributes(model_name: str) -> ModelAttributes:
         return get_nvidia_info()[model_version_full]
     elif model_name.startswith("thinkingmachines/Inkling"):
         # Inkling models are rendered by the standalone tml-renderers package.
-        # Version/size parsing is TBD; use the full model version for now.
+        if model_version_full in get_thinkingmachines_info():
+            return get_thinkingmachines_info()[model_version_full]
+        # Any ``Inkling*`` id without a table entry is assumed to share the renderer
+        # and modality support, so fall back to defaults rather than raising. Size
+        # and version are unknown in that case; use the model version for both.
         return ModelAttributes(
             organization=org,
             version_str=model_version_full,

--- a/tinker_cookbook/model_info_test.py
+++ b/tinker_cookbook/model_info_test.py
@@ -135,23 +135,54 @@ class TestGlm5_3:
         ]
 
 
-class TestTmlModels:
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "thinkingmachines/Inkling",
-            "thinkingmachines/Inkling:peft:131072",
-        ],
-    )
-    def test_tml_renderers_models_use_tml_v0_renderer(self, model_name: str):
-        assert get_recommended_renderer_name(model_name) == "tml_v0"
+class TestInkling:
+    """Inkling models are rendered by the standalone tml-renderers package rather
+    than a cookbook renderer, and are the only lineup members taking audio input."""
 
-    def test_inkling_attributes_route_to_tml_renderers(self):
+    def test_inkling_uses_tml_v0_renderer(self):
+        assert get_recommended_renderer_name("thinkingmachines/Inkling") == "tml_v0"
+
+    def test_inkling_peft_suffix_uses_tml_v0_renderer(self):
+        assert get_recommended_renderer_name("thinkingmachines/Inkling:peft:262144") == "tml_v0"
+
+    def test_inkling_attributes(self):
         attrs = get_model_attributes("thinkingmachines/Inkling")
+        assert attrs.organization == "thinkingmachines"
+        assert attrs.version_str == "1"
+        assert attrs.size_str == "975B-A41B"
         assert attrs.is_chat is True
         assert attrs.is_vl is True
         assert attrs.is_audio_in is True
-        assert attrs.recommended_renderers == ("tml_v0",)
+        assert get_recommended_renderer_names("thinkingmachines/Inkling") == ["tml_v0"]
+
+    def test_inkling_small_uses_tml_v0_renderer(self):
+        assert get_recommended_renderer_name("thinkingmachines/Inkling-Small") == "tml_v0"
+
+    def test_inkling_small_peft_suffix_uses_tml_v0_renderer(self):
+        assert (
+            get_recommended_renderer_name("thinkingmachines/Inkling-Small:peft:262144") == "tml_v0"
+        )
+
+    def test_inkling_small_attributes(self):
+        attrs = get_model_attributes("thinkingmachines/Inkling-Small")
+        assert attrs.organization == "thinkingmachines"
+        assert attrs.version_str == "1"
+        assert attrs.size_str == "276B-A12B"
+        assert attrs.is_chat is True
+        assert attrs.is_vl is True
+        assert attrs.is_audio_in is True
+        assert get_recommended_renderer_names("thinkingmachines/Inkling-Small") == ["tml_v0"]
+
+    def test_untabled_inkling_id_falls_back_to_prefix_defaults(self):
+        """An Inkling id with no table entry still resolves, so a later addition
+        to the lineup works before it is tabled instead of raising.
+        """
+        attrs = get_model_attributes("thinkingmachines/Inkling-2")
+        assert attrs.organization == "thinkingmachines"
+        assert attrs.is_chat is True
+        assert attrs.is_vl is True
+        assert attrs.is_audio_in is True
+        assert get_recommended_renderer_names("thinkingmachines/Inkling-2") == ["tml_v0"]
 
 
 class TestWarnIfRendererNotRecommended:


### PR DESCRIPTION
Measured LoRA param counts for Inkling-Small and covered both Inkling models in the hyperparam tests, which model_info's prefix match had left invisible.