### PR TITLE
Rewrite verifiers_rl recipe for the verifiers v1 stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,9 @@ trackio = [
     "trackio<1.0.0",
 ]
 verifiers = [
-    # The recipe drives the verifiers v1 stack (`verifiers.v1`), introduced in
-    # verifiers 0.3; the pre-0.3 classic API is not supported.
-    "verifiers>=0.3.1,<0.5",
+    # The recipe drives the verifiers v1 stack (`verifiers.v1`); the pre-0.3
+    # legacy API is not supported.
+    "verifiers>=0.3.1",
     "openai>=1.0.0",
 ]
 inspect = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,9 @@ trackio = [
     "trackio<1.0.0",
 ]
 verifiers = [
-    "verifiers>=0.1.9,<0.1.10",
+    # The recipe drives the verifiers v1 stack (`verifiers.v1`), introduced in
+    # verifiers 0.3; the pre-0.3 classic API is not supported.
+    "verifiers>=0.3.1,<0.5",
     "openai>=1.0.0",
 ]
 inspect = [

--- a/tinker_cookbook/recipes/verifiers_rl/README.md
+++ b/tinker_cookbook/recipes/verifiers_rl/README.md
@@ -23,7 +23,7 @@ Two `vf_env_args` pins worth knowing:
 - `{"agent": {"harness": {"id": "null"}}}` runs a plain chat agent on a taskset that doesn't bundle its own harness (the fallback harness is `bash`, a coding agent).
 - `{"agent": {"runtime": {"type": "subprocess"}}}` runs harness programs as local subprocesses. The verifiers default runtime provisions Prime sandboxes, which costs money and is capped per account — pin `subprocess` (or `docker`) for local training unless you want that isolation.
 
-`chat_template_kwargs` (JSON) is threaded to the `tml-renderers` renderer that tokenizes each turn — e.g. `{"enable_thinking": false}` to switch Qwen thinking off so short `max_tokens` budgets aren't consumed by reasoning.
+`chat_template_kwargs` (JSON) is passed through verifiers' train client to the chat template of the [`renderers`](https://github.com/PrimeIntellect-ai/renderers) package that tokenizes each turn — e.g. `{"enable_thinking": false}` to switch Qwen thinking off so short `max_tokens` budgets aren't consumed by reasoning.
 
 You can also evaluate offline:
 
@@ -35,10 +35,10 @@ This recipe requires `verifiers>=0.3.1`, installed by `pip install 'tinker_cookb
 
 ## How it plugs in
 
-verifiers' train client renders each turn to token IDs with `tml-renderers` and POSTs them to a vLLM-style `/inference/v1/generate` endpoint, expecting sampled token IDs and per-token logprobs back. That endpoint is the one seam where an inference engine plugs into the v1 rollout stack, so this recipe serves it locally over a `tinker.SamplingClient` (`tinker_generate.TinkerGenerateServer`) — harness programs, interception, renderer bridging, scoring, and trace/token bookkeeping are all verifiers running natively. Each rollout comes back as a `vf.Episode` whose agent trace carries the exact sampled token IDs and logprobs, which `verifiers_env.convert_episodes_to_trajectory_group` turns into tinker trajectories.
+verifiers' train client renders each turn to token IDs with Prime Intellect's `renderers` package (a verifiers dependency, distinct from this cookbook's `tinker_cookbook.renderers`) and POSTs them to a vLLM-style `/inference/v1/generate` endpoint, expecting sampled token IDs and per-token logprobs back. That endpoint is the one seam where an inference engine plugs into the v1 rollout stack, so this recipe serves it locally over a `tinker.SamplingClient` (`tinker_generate.TinkerGenerateServer`) — harness programs, interception, renderer bridging, scoring, and trace/token bookkeeping are all verifiers running natively. Each rollout comes back as a `vf.Episode` whose agent trace carries the exact sampled token IDs and logprobs, which `verifiers_env.convert_episodes_to_trajectory_group` turns into tinker trajectories.
 
-The recipe trains single-agent environments (one agent trace per episode, one branch per trace); multi-agent or branching envs are rejected with an explicit error.
+The recipe trains single-agent environments (one agent trace per episode, one trainable branch per trace); multi-agent or branching envs, and traces whose agent is not the policy, are rejected with an explicit error. An episode or trace that verifiers marks failed stays in its group as an empty trajectory with a `rollout_failed` metric, so reward centering sees the failure; a sampled token without a logprob is an error, never a guess.
 
 **Potential footgun:**
 
-- The tokenizer/renderer used for sampling is resolved from the base model name by `tml-renderers` (pinned via `renderer_model_name`). For reasoning-mode subtleties (e.g. Qwen thinking sections being stripped or re-rendered by the chat template), check the resolved renderer's behavior against your environment's parsers before ascribing reward drops to the policy.
+- The tokenizer/renderer used for sampling is resolved from the base model name by verifiers' `renderers` dependency (pinned via `renderer_model_name`), not by this cookbook's own renderers. For reasoning-mode subtleties (e.g. Qwen thinking sections being stripped or re-rendered by the chat template), check the resolved renderer's behavior against your environment's parsers before ascribing reward drops to the policy.

--- a/tinker_cookbook/recipes/verifiers_rl/README.md
+++ b/tinker_cookbook/recipes/verifiers_rl/README.md
@@ -1,28 +1,29 @@
 # RL Training with Tinker + Environments Hub (Verifiers)
 
-[Verifiers](https://github.com/primeintellect-ai/verifiers) is a library for creating RL environments for LLMs, including many community implementations featured on Prime Intellect's [Environments Hub](https://app.primeintellect.ai/dashboard/environments). This recipe allows all text-based environments from the Environments Hub to be used with Tinker for RL training.
+[Verifiers](https://github.com/primeintellect-ai/verifiers) is a library for creating RL environments for LLMs, including many community implementations featured on Prime Intellect's [Environments Hub](https://app.primeintellect.ai/dashboard/environments). This recipe runs Hub environments against Tinker for RL training, driving the verifiers v1 stack (`verifiers.v1`) natively.
 
-To use this recipe, you need to have your chosen environment module (a self-contained Python package) installed in your project. You can install environments from the Environments Hub using the `prime` CLI:
+To use this recipe, you need to have your chosen environment (a self-contained Python package exporting a verifiers taskset) installed in your project. You can install environments from the Environments Hub using the `prime` CLI:
 
 ```bash
 uv tool install prime # or pipx install prime
 prime env install user/env-id # ex. prime env install primeintellect/reverse-text
 ```
 
-Examples:
-
-- [primeintellect/reverse-text](https://app.primeintellect.ai/dashboard/environments/primeintellect/reverse-text)
-- [primeintellect/alphabet-sort](https://app.primeintellect.ai/dashboard/environments/primeintellect/alphabet-sort)
-- [primeintellect/math-python](https://app.primeintellect.ai/dashboard/environments/primeintellect/math-python)
-- [will/wordle](https://app.primeintellect.ai/dashboard/environments/will/wordle)
-
-You can then run the recipe with the following command, where `vf_env_id` is the ID (just `env-id`) of the environment, and `vf_env_args` is an optional JSON string of arguments to pass when loading the environment.
+You can then run the recipe with the following command, where `vf_env_id` is the ID (just `env-id`) of the environment, and `vf_env_args` is an optional JSON object of `vf.EnvConfig` overrides merged over the taskset id — for example, per-task config under `{"taskset": {"task": {...}}}`, or agent-seat pins under `{"agent": {...}}`:
 
 ```bash
-python -m tinker_cookbook.recipes.verifiers_rl.train vf_env_id=env-id vf_env_args='{}' ...
+python -m tinker_cookbook.recipes.verifiers_rl.train \
+    vf_env_id=reverse-text \
+    vf_env_args='{"agent": {"harness": {"id": "null"}, "runtime": {"type": "subprocess"}}}' \
+    chat_template_kwargs='{"enable_thinking": false}' ...
 ```
 
-The reverse-text example as configured should climb from ~0.4 to ~0.6 in 32 steps.
+Two `vf_env_args` pins worth knowing:
+
+- `{"agent": {"harness": {"id": "null"}}}` runs a plain chat agent on a taskset that doesn't bundle its own harness (the fallback harness is `bash`, a coding agent).
+- `{"agent": {"runtime": {"type": "subprocess"}}}` runs harness programs as local subprocesses. The verifiers default runtime provisions Prime sandboxes, which costs money and is capped per account — pin `subprocess` (or `docker`) for local training unless you want that isolation.
+
+`chat_template_kwargs` (JSON) is threaded to the `tml-renderers` renderer that tokenizes each turn — e.g. `{"enable_thinking": false}` to switch Qwen thinking off so short `max_tokens` budgets aren't consumed by reasoning.
 
 You can also evaluate offline:
 
@@ -30,8 +31,14 @@ You can also evaluate offline:
 python -m tinker_cookbook.recipes.verifiers_rl.evaluate vf_env_id=env-id vf_env_args='{}' ...
 ```
 
-This recipe also includes a standalone `AsyncOpenAI`-compatible client implemented with Tinker, which can be adapted for other applications.
+This recipe requires `verifiers>=0.3.1`, installed by `pip install 'tinker_cookbook[verifiers]'`.
+
+## How it plugs in
+
+verifiers' train client renders each turn to token IDs with `tml-renderers` and POSTs them to a vLLM-style `/inference/v1/generate` endpoint, expecting sampled token IDs and per-token logprobs back. That endpoint is the one seam where an inference engine plugs into the v1 rollout stack, so this recipe serves it locally over a `tinker.SamplingClient` (`tinker_generate.TinkerGenerateServer`) — harness programs, interception, renderer bridging, scoring, and trace/token bookkeeping are all verifiers running natively. Each rollout comes back as a `vf.Episode` whose agent trace carries the exact sampled token IDs and logprobs, which `verifiers_env.convert_episodes_to_trajectory_group` turns into tinker trajectories.
+
+The recipe trains single-agent environments (one agent trace per episode, one branch per trace); multi-agent or branching envs are rejected with an explicit error.
 
 **Potential footgun:**
 
-- Some Environments Hub implementations involve users writing their own `<think>` parsers (e.g. for use with reasoning RL starting on Instruct models). Despite being Instruct models, the Qwen3 models/tokenizers all use the same tokenizer chat template, which will strip any observed `<think>` sections automatically (which may be inadvertently penalized by reward functions). Users should either modify the renderer, tokenizer chat template, or environment module if observing issues with thinking sections from Qwen3 models.
+- The tokenizer/renderer used for sampling is resolved from the base model name by `tml-renderers` (pinned via `renderer_model_name`). For reasoning-mode subtleties (e.g. Qwen thinking sections being stripped or re-rendered by the chat template), check the resolved renderer's behavior against your environment's parsers before ascribing reward drops to the policy.

--- a/tinker_cookbook/recipes/verifiers_rl/evaluate.py
+++ b/tinker_cookbook/recipes/verifiers_rl/evaluate.py
@@ -158,7 +158,8 @@ class CLIConfig:
     max_concurrent: int = 32
     max_tokens: int = 1024
     temperature: float = 1.0
-    # JSON chat-template kwargs threaded to the tml renderer that tokenizes
+    # JSON chat-template kwargs passed through verifiers' train client to the
+    # `renderers` chat template that tokenizes
     # each turn, e.g. '{"enable_thinking": false}' for Qwen thinking control.
     chat_template_kwargs: str | None = None
 

--- a/tinker_cookbook/recipes/verifiers_rl/evaluate.py
+++ b/tinker_cookbook/recipes/verifiers_rl/evaluate.py
@@ -7,59 +7,73 @@ import time
 import chz
 import numpy as np
 import tinker
-import verifiers as vf
-from verifiers.utils.message_utils import messages_to_printable
+import verifiers.v1 as vf
 
-from tinker_cookbook import checkpoint_utils, model_info, renderers
-from tinker_cookbook.recipes.verifiers_rl.tinker_openai import TinkerAsyncOpenAIClient
-from tinker_cookbook.tokenizer_utils import get_tokenizer
+from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
+from tinker_cookbook.recipes.verifiers_rl.verifiers_env import load_vf_env
 from tinker_cookbook.utils.git_rev import recipe_user_metadata
 
 
+def _message_text(message: vf.Message) -> str:
+    content = message.content
+    if isinstance(content, str):
+        return content
+    parts = [text for part in content or [] if (text := getattr(part, "text", None))]
+    return "\n".join(parts)
+
+
+def _episode_reward(episode: vf.Episode) -> float:
+    return sum(trace.reward for trace in episode.traces)
+
+
 def log_results(
-    results: vf.GenerateOutputs,
+    episodes_by_example: list[list[vf.Episode]],
     vf_env_id: str,
     model_name: str,
-    num_examples: int,
-    rollouts_per_example: int,
     time_s: float,
 ):
+    episodes = [episode for group in episodes_by_example for episode in group]
+    rewards_by_example = [[_episode_reward(e) for e in group] for group in episodes_by_example]
+    rewards = [reward for group in rewards_by_example for reward in group]
+    metric_names = sorted(
+        {
+            name
+            for episode in episodes
+            for trace in episode.traces
+            for name, value in trace.metrics.items()
+            if value is not None
+        }
+    )
+
     print(f"Evaluation completed in {time_s:.2f} seconds")
     print("--- Evaluation ---")
     print(f"Environment: {vf_env_id}")
     print(f"Model: {model_name}")
-    print(f"Examples: {num_examples}")
-    print(f"Rollouts per example: {rollouts_per_example}")
+    print(f"Examples: {len(episodes_by_example)}")
+    print(f"Rollouts per example: {len(episodes_by_example[0]) if episodes_by_example else 0}")
+    failed = sum(1 for episode in episodes if not episode.ok)
+    if failed:
+        print(f"Failed episodes: {failed}/{len(episodes)}")
     print("--- Example ---")
-    printable_prompts = [messages_to_printable(p) for p in results["prompt"]]
-    printable_completions = [messages_to_printable(c) for c in results["completion"]]
-    vf.print_prompt_completions_sample(
-        prompts=printable_prompts,
-        completions=printable_completions,
-        errors=[],  # Required argument added in verifiers 0.1.9
-        rewards=results["reward"],
-        step=0,
-    )
+    for episode in episodes[:1]:
+        for trace in episode.traces:
+            for message in trace.messages:
+                print(f"[{message.role}] {_message_text(message)}")
     print("--- All ---")
     print("Rewards:")
-    print(
-        f"reward: avg - {sum(results['reward']) / len(results['reward']):.3f}, std - {np.std(results['reward']):.3f}"
-    )
-    r = rollouts_per_example
-    n = len(results["reward"]) // r
-    for i in range(r):
-        # rounded to 3 decimal places
-        trials = [round(results["reward"][(i * n) + j], 3) for j in range(n)]
-        out = f"r{i + 1}: {trials}"
-        print(out)
-    for k in results["metrics"]:
-        v = results["metrics"][k]
-        print(f"{k}: avg - {sum(v) / len(v):.3f}, std - {np.std(v):.3f}")
-        for i in range(r):
-            # rounded to 3 decimal places
-            trials = [round(v[(i * n) + j], 3) for j in range(n)]
-            out = f"r{i + 1}: {trials}"
-            print(out)
+    print(f"reward: avg - {np.mean(rewards):.3f}, std - {np.std(rewards):.3f}")
+    rollouts_per_example = max((len(group) for group in rewards_by_example), default=0)
+    for r in range(rollouts_per_example):
+        trials = [round(group[r], 3) for group in rewards_by_example if r < len(group)]
+        print(f"r{r + 1}: {trials}")
+    for name in metric_names:
+        values = [
+            float(value)
+            for episode in episodes
+            for trace in episode.traces
+            if (value := trace.metrics.get(name)) is not None
+        ]
+        print(f"{name}: avg - {np.mean(values):.3f}, std - {np.std(values):.3f}")
 
 
 async def evaluate(
@@ -72,7 +86,8 @@ async def evaluate(
     max_tokens: int,
     temperature: float,
     model_path: str | None = None,
-):
+    chat_template_kwargs: dict | None = None,
+) -> list[list[vf.Episode]]:
     service = tinker.ServiceClient(
         user_metadata=recipe_user_metadata("eval_verifiers_rl"),
     )
@@ -92,17 +107,8 @@ async def evaluate(
     if model_name is None:
         raise ValueError("model_name or model_path must be provided")
 
-    env = vf.load_environment(vf_env_id, **vf_env_args)
-    tokenizer = get_tokenizer(model_name)
-    renderer_name = None
-    if model_path is not None:
-        renderer_name = await checkpoint_utils.get_renderer_name_from_checkpoint_async(
-            service, model_path
-        )
-    if renderer_name is None:
-        renderer_name = model_info.get_recommended_renderer_name(model_name)
-    print(f"Using renderer: {renderer_name}")
-    renderer = renderers.get_renderer(renderer_name, tokenizer)
+    vf_env = load_vf_env(vf_env_id, vf_env_args)
+    tasks = list(vf_env.taskset.head(num_examples))
 
     # Create sampling client from checkpoint path or base model
     if model_path:
@@ -110,29 +116,35 @@ async def evaluate(
     else:
         sampling = service.create_sampling_client(base_model=model_name)
 
-    client = TinkerAsyncOpenAIClient(sampling, renderer, tokenizer)
+    semaphore = asyncio.Semaphore(max_concurrent)
     start_time = time.time()
-    results = env.evaluate_sync(
-        client=client,
-        model=model_name,
-        num_examples=num_examples,
-        rollouts_per_example=rollouts_per_example,
-        max_concurrent=max_concurrent,
-        sampling_args={
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-        },
-    )
+    async with TinkerGenerateServer(sampling) as server, vf_env.serving():
+        ctx = vf.ModelContext(
+            model=model_name,
+            client=server.train_client_config(model_name),
+            sampling=vf.SamplingConfig.model_validate(
+                {
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    **(
+                        {"chat_template_kwargs": chat_template_kwargs}
+                        if chat_template_kwargs
+                        else {}
+                    ),
+                }
+            ),
+        )
+        slots_by_example = [vf_env.slots(task, rollouts_per_example) for task in tasks]
+        episodes = await asyncio.gather(
+            *(vf_env.run_slot(slot, ctx, semaphore) for slots in slots_by_example for slot in slots)
+        )
     end_time = time.time()
-    log_results(
-        results,
-        vf_env_id,
-        model_name,
-        num_examples,
-        rollouts_per_example,
-        end_time - start_time,
-    )
-    return results
+    episodes_by_example = [
+        episodes[i * rollouts_per_example : (i + 1) * rollouts_per_example]
+        for i in range(len(tasks))
+    ]
+    log_results(episodes_by_example, vf_env_id, model_name, end_time - start_time)
+    return episodes_by_example
 
 
 @chz.chz
@@ -140,12 +152,15 @@ class CLIConfig:
     model_name: str | None = None  # Base model name (auto-detected from checkpoint if not provided)
     model_path: str | None = None  # Path to checkpoint (e.g., from checkpoints.jsonl sampler_path)
     vf_env_id: str = "reverse-text"
-    vf_env_args: str | None = None  # JSON string
+    vf_env_args: str | None = None  # JSON vf.EnvConfig data merged over the taskset id
     num_examples: int = 5
     rollouts_per_example: int = 3
     max_concurrent: int = 32
     max_tokens: int = 1024
     temperature: float = 1.0
+    # JSON chat-template kwargs threaded to the tml renderer that tokenizes
+    # each turn, e.g. '{"enable_thinking": false}' for Qwen thinking control.
+    chat_template_kwargs: str | None = None
 
 
 async def cli_main(config: CLIConfig):
@@ -160,6 +175,9 @@ async def cli_main(config: CLIConfig):
         max_tokens=config.max_tokens,
         temperature=config.temperature,
         model_path=config.model_path,
+        chat_template_kwargs=(
+            json.loads(config.chat_template_kwargs) if config.chat_template_kwargs else None
+        ),
     )
 
 

--- a/tinker_cookbook/recipes/verifiers_rl/tinker_generate.py
+++ b/tinker_cookbook/recipes/verifiers_rl/tinker_generate.py
@@ -24,6 +24,15 @@ from aiohttp import web
 logger = logging.getLogger(__name__)
 
 
+_SAMPLING_KEYS = frozenset(
+    {"max_tokens", "temperature", "top_p", "top_k", "seed", "stop_token_ids"}
+)
+"""Request keys mapped onto ``tinker.SamplingParams``."""
+_WIRE_KEYS = frozenset({"logprobs", "skip_special_tokens"})
+"""Keys the renderers client always sends for token-in/token-out bookkeeping; the
+endpoint always returns per-token logprobs and raw token ids, so they carry no choice."""
+
+
 class TinkerGenerateServer:
     """Serves vLLM's token-in/token-out generate API over Tinker sampling.
 
@@ -115,6 +124,14 @@ class TinkerGenerateServer:
                 status=400,
             )
         sampling_params = body.get("sampling_params") or {}
+        unsupported = sorted(set(sampling_params) - _SAMPLING_KEYS - _WIRE_KEYS)
+        if unsupported:
+            # verifiers passes provider-specific sampling keys through; silently
+            # dropping one would run a different distribution than requested.
+            return web.json_response(
+                {"error": f"unsupported sampling_params for the Tinker endpoint: {unsupported}"},
+                status=400,
+            )
         stop = sampling_params.get("stop_token_ids") or None
         max_tokens = sampling_params.get("max_tokens")
         params = tinker.SamplingParams(

--- a/tinker_cookbook/recipes/verifiers_rl/tinker_generate.py
+++ b/tinker_cookbook/recipes/verifiers_rl/tinker_generate.py
@@ -1,0 +1,166 @@
+"""A local ``/inference/v1/generate`` endpoint backed by Tinker sampling.
+
+The verifiers v1 train client (``vf.TrainClientConfig``) renders each turn to
+token IDs with ``tml-renderers`` and POSTs them to a vLLM
+``/inference/v1/generate`` endpoint, expecting sampled token IDs and per-token
+logprobs back. That endpoint is the one seam where an inference engine plugs
+into the v1 rollout stack, so this module serves its wire format over a
+``tinker.SamplingClient`` — everything else (harness programs, interception,
+renderer bridging, trace/token bookkeeping) is verifiers running natively.
+
+The server binds a random loopback port; ``train_client_config()`` returns the
+``vf.TrainClientConfig`` that points a rollout at it.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+import tinker
+import verifiers.v1 as vf
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+class TinkerGenerateServer:
+    """Serves vLLM's token-in/token-out generate API over Tinker sampling.
+
+    The sampling client is swappable (``set_sampling_client``) so an RL loop
+    can point the same endpoint at each new policy checkpoint without
+    rebuilding the verifiers client stack that connects to it.
+    """
+
+    def __init__(self, sampling_client: tinker.SamplingClient | None = None) -> None:
+        self._sampling_client = sampling_client
+        self._runner: web.AppRunner | None = None
+        self.base_url = ""
+
+    def set_sampling_client(self, sampling_client: tinker.SamplingClient) -> None:
+        """Point the endpoint at a new policy checkpoint."""
+        self._sampling_client = sampling_client
+
+    async def start(self) -> None:
+        app = web.Application(client_max_size=256 * 1024 * 1024)
+        app.router.add_post("/inference/v1/generate", self._handle_generate)
+        app.router.add_get("/v1/models", self._handle_models)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        host, port = self._runner.addresses[0][:2]
+        # The `/v1` suffix matches vLLM's OpenAI-style base URL; the train
+        # client strips it before POSTing to `/inference/v1/generate` and keeps
+        # it for `GET /v1/models`.
+        self.base_url = f"http://{host}:{port}/v1"
+        logger.info("Tinker generate endpoint listening on %s", self.base_url)
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+        self.base_url = ""
+
+    async def __aenter__(self) -> TinkerGenerateServer:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.stop()
+
+    def train_client_config(self, renderer_model_name: str) -> vf.TrainClientConfig:
+        """The verifiers client config that samples through this endpoint.
+
+        ``renderer_model_name`` pins the tokenizer/renderer that the train
+        client builds prompts with; it must match the Tinker base model being
+        sampled, or token IDs would come from one vocabulary and go to another.
+        """
+        if not self.base_url:
+            raise RuntimeError("server is not running; call start() first")
+        return vf.TrainClientConfig.model_validate(
+            {
+                "base_url": self.base_url,
+                # No key is checked; the var is named so the default
+                # PRIME_API_KEY config resolution does not kick in for this
+                # loopback endpoint.
+                "api_key_var": "TINKER_GENERATE_API_KEY",
+                "renderer_model_name": renderer_model_name,
+            }
+        )
+
+    async def _handle_models(self, request: web.Request) -> web.Response:
+        # Served so the train client's max_model_len discovery gets a clean
+        # answer. No `max_model_len` is advertised (Tinker does not expose
+        # one), so the client-side overflow pre-flight stays disabled and
+        # overlong prompts surface as engine errors instead.
+        del request
+        return web.json_response({"object": "list", "data": []})
+
+    async def _handle_generate(self, request: web.Request) -> web.Response:
+        if self._sampling_client is None:
+            return web.json_response(
+                {"error": "no sampling client attached to the generate endpoint"},
+                status=503,
+            )
+        body = await request.json()
+        token_ids = body.get("token_ids")
+        if not isinstance(token_ids, list) or not token_ids:
+            return web.json_response(
+                {"error": "request must carry a non-empty `token_ids` list"}, status=400
+            )
+        if body.get("features"):
+            return web.json_response(
+                {"error": "multimodal `features` are not supported by the Tinker endpoint"},
+                status=400,
+            )
+        sampling_params = body.get("sampling_params") or {}
+        stop = sampling_params.get("stop_token_ids") or None
+        max_tokens = sampling_params.get("max_tokens")
+        params = tinker.SamplingParams(
+            max_tokens=int(max_tokens) if max_tokens is not None else None,
+            temperature=float(sampling_params.get("temperature", 1.0)),
+            top_p=float(sampling_params.get("top_p", 1.0)),
+            top_k=int(sampling_params.get("top_k", -1)),
+            seed=sampling_params.get("seed"),
+            stop=[int(t) for t in stop] if stop else None,
+        )
+        try:
+            result = await self._sampling_client.sample_async(
+                prompt=tinker.ModelInput.from_ints([int(t) for t in token_ids]),
+                num_samples=1,
+                sampling_params=params,
+            )
+        except Exception as e:
+            # Surface as a 500 so the verifiers client records a model error on
+            # the trace (and retries per its policy) instead of crashing the
+            # rollout stack.
+            logger.exception("Tinker sampling failed")
+            return web.json_response({"error": f"{type(e).__name__}: {e}"}, status=500)
+        sequence = result.sequences[0]
+        completion_ids = [int(t) for t in sequence.tokens]
+        logprobs = sequence.logprobs
+        if logprobs is None or len(logprobs) != len(completion_ids):
+            return web.json_response(
+                {"error": "Tinker sampling returned no per-token logprobs"}, status=500
+            )
+        return web.json_response(
+            {
+                "request_id": uuid.uuid4().hex,
+                "choices": [
+                    {
+                        "index": 0,
+                        "token_ids": completion_ids,
+                        # Tinker's stop_reason is already "stop" | "length",
+                        # matching vLLM's finish_reason vocabulary.
+                        "finish_reason": sequence.stop_reason,
+                        "logprobs": {
+                            "content": [
+                                {"token": f"token_id:{token}", "logprob": float(logprob)}
+                                for token, logprob in zip(completion_ids, logprobs)
+                            ]
+                        },
+                    }
+                ],
+            }
+        )

--- a/tinker_cookbook/recipes/verifiers_rl/tinker_generate.py
+++ b/tinker_cookbook/recipes/verifiers_rl/tinker_generate.py
@@ -1,7 +1,7 @@
 """A local ``/inference/v1/generate`` endpoint backed by Tinker sampling.
 
 The verifiers v1 train client (``vf.TrainClientConfig``) renders each turn to
-token IDs with ``tml-renderers`` and POSTs them to a vLLM
+token IDs with Prime Intellect's ``renderers`` package and POSTs them to a vLLM
 ``/inference/v1/generate`` endpoint, expecting sampled token IDs and per-token
 logprobs back. That endpoint is the one seam where an inference engine plugs
 into the v1 rollout stack, so this module serves its wire format over a

--- a/tinker_cookbook/recipes/verifiers_rl/tinker_generate_test.py
+++ b/tinker_cookbook/recipes/verifiers_rl/tinker_generate_test.py
@@ -135,3 +135,29 @@ async def test_train_client_config_points_at_the_server() -> None:
         ):
             assert response.status == 200
             assert (await response.json())["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_unsupported_sampling_params() -> None:
+    """A sampling key the endpoint cannot honor is an error, never a silent drop."""
+    from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
+
+    fake = _FakeSamplingClient()
+    async with TinkerGenerateServer(fake) as server:  # type: ignore[arg-type]
+        status, data = await _post_generate(
+            server,
+            {
+                "token_ids": [1, 2, 3],
+                "sampling_params": {
+                    "max_tokens": 8,
+                    "logprobs": 1,
+                    "skip_special_tokens": False,
+                    "repetition_penalty": 1.1,
+                    "stop": ["</answer>"],
+                },
+            },
+        )
+
+    assert status == 400
+    assert "repetition_penalty" in data["error"] and "stop" in data["error"]
+    assert fake.calls == []

--- a/tinker_cookbook/recipes/verifiers_rl/tinker_generate_test.py
+++ b/tinker_cookbook/recipes/verifiers_rl/tinker_generate_test.py
@@ -1,0 +1,137 @@
+"""Tests for the Tinker-backed /inference/v1/generate endpoint (no API calls)."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import aiohttp
+import pytest
+
+try:
+    import verifiers.v1 as _verifiers  # noqa: F401
+
+    _has_verifiers = True
+except ImportError:
+    _has_verifiers = False
+
+pytestmark = pytest.mark.skipif(not _has_verifiers, reason="verifiers not installed")
+
+
+class _FakeSamplingClient:
+    """Records sample_async calls and returns a fixed sequence."""
+
+    def __init__(self, stop_reason: str = "stop") -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.stop_reason = stop_reason
+
+    async def sample_async(self, prompt, num_samples, sampling_params):
+        self.calls.append(
+            {"prompt": prompt, "num_samples": num_samples, "sampling_params": sampling_params}
+        )
+        sequence = SimpleNamespace(
+            tokens=[7, 8, 9], logprobs=[-0.1, -0.2, -0.3], stop_reason=self.stop_reason
+        )
+        return SimpleNamespace(sequences=[sequence])
+
+
+async def _post_generate(server, body: dict) -> tuple[int, dict]:
+    url = server.base_url.removesuffix("/v1") + "/inference/v1/generate"
+    async with aiohttp.ClientSession() as session, session.post(url, json=body) as response:
+        return response.status, await response.json()
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_vllm_wire_format() -> None:
+    from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
+
+    fake = _FakeSamplingClient()
+    async with TinkerGenerateServer(fake) as server:  # type: ignore[arg-type]
+        status, data = await _post_generate(
+            server,
+            {
+                "model": "tinker",
+                "token_ids": [1, 2, 3],
+                "sampling_params": {
+                    "max_tokens": 32,
+                    "temperature": 0.7,
+                    "stop_token_ids": [42],
+                    # Always sent by the renderer client; must be ignored.
+                    "logprobs": 1,
+                    "skip_special_tokens": False,
+                },
+            },
+        )
+
+    assert status == 200
+    [choice] = data["choices"]
+    assert choice["token_ids"] == [7, 8, 9]
+    assert choice["finish_reason"] == "stop"
+    # The renderer client requires one logprob entry per completion token,
+    # each tagged "token_id:<id>".
+    entries = choice["logprobs"]["content"]
+    assert [entry["token"] for entry in entries] == ["token_id:7", "token_id:8", "token_id:9"]
+    assert [entry["logprob"] for entry in entries] == [-0.1, -0.2, -0.3]
+
+    [call] = fake.calls
+    assert call["prompt"].to_ints() == [1, 2, 3]
+    assert call["num_samples"] == 1
+    params = call["sampling_params"]
+    assert params.max_tokens == 32
+    assert params.temperature == 0.7
+    assert params.stop == [42]
+
+
+@pytest.mark.asyncio
+async def test_generate_maps_length_stop_reason() -> None:
+    from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
+
+    async with TinkerGenerateServer(_FakeSamplingClient(stop_reason="length")) as server:  # type: ignore[arg-type]
+        _, data = await _post_generate(
+            server, {"model": "tinker", "token_ids": [1], "sampling_params": {}}
+        )
+    assert data["choices"][0]["finish_reason"] == "length"
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_bad_requests() -> None:
+    from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
+
+    async with TinkerGenerateServer(_FakeSamplingClient()) as server:  # type: ignore[arg-type]
+        status, _ = await _post_generate(server, {"model": "tinker", "token_ids": []})
+        assert status == 400
+        status, _ = await _post_generate(
+            server, {"model": "tinker", "token_ids": [1], "features": {"mm_hashes": []}}
+        )
+        assert status == 400
+
+
+@pytest.mark.asyncio
+async def test_generate_without_sampling_client_is_503() -> None:
+    from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
+
+    async with TinkerGenerateServer() as server:
+        status, _ = await _post_generate(server, {"model": "tinker", "token_ids": [1]})
+    assert status == 503
+
+
+@pytest.mark.asyncio
+async def test_train_client_config_points_at_the_server() -> None:
+    import verifiers.v1 as vf
+
+    from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
+
+    server = TinkerGenerateServer()
+    with pytest.raises(RuntimeError, match="not running"):
+        server.train_client_config("Qwen/Qwen3.5-4B")
+    async with server:
+        config = server.train_client_config("Qwen/Qwen3.5-4B")
+        assert isinstance(config, vf.TrainClientConfig)
+        assert config.base_url == server.base_url
+        assert config.renderer_model_name == "Qwen/Qwen3.5-4B"
+
+        # The models listing the train client probes for max_model_len.
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(server.base_url + "/models") as response,
+        ):
+            assert response.status == 200
+            assert (await response.json())["data"] == []

--- a/tinker_cookbook/recipes/verifiers_rl/train.py
+++ b/tinker_cookbook/recipes/verifiers_rl/train.py
@@ -4,23 +4,26 @@ import asyncio
 import json
 import logging
 from datetime import datetime
-from typing import Any, cast
+from typing import cast
 
 import chz
-from verifiers.utils.async_utils import maybe_semaphore
+import verifiers.v1 as vf
 
-from tinker_cookbook import cli_utils, model_info, renderers
+from tinker_cookbook import cli_utils
 from tinker_cookbook.completers import TinkerTokenCompleter, TokenCompleter
-from tinker_cookbook.recipes.verifiers_rl.tinker_openai import TinkerAsyncOpenAIClient
+from tinker_cookbook.recipes.verifiers_rl.tinker_generate import TinkerGenerateServer
 from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
     VerifiersEnvGroupBuilder,
     VerifiersRLDatasetBuilder,
-    convert_states_to_trajectory_group,
+    convert_episodes_to_trajectory_group,
+    get_vf_env,
+    load_vf_env,
+    set_vf_env,
 )
 from tinker_cookbook.rl import rollouts, train
+from tinker_cookbook.rl.rollout_limits import TerminationRewardPolicy
 from tinker_cookbook.rl.rollout_strategy import RolloutStrategy
 from tinker_cookbook.rl.types import EnvGroupBuilder, TrajectoryGroup
-from tinker_cookbook.tokenizer_utils import Tokenizer, get_tokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +37,7 @@ class CLIConfig:
 
     # environment configuration
     vf_env_id: str = "reverse-text"
-    vf_env_args: str | None = None  # JSON string
+    vf_env_args: str | None = None  # JSON vf.EnvConfig data merged over the taskset id
     dataset_n: int = -1
     dataset_seed: int | None = None
 
@@ -45,9 +48,11 @@ class CLIConfig:
     learning_rate: float = 1e-5
     max_tokens: int = 512
     temperature: float = 1.0
+    # JSON chat-template kwargs threaded to the tml renderer that tokenizes
+    # each turn, e.g. '{"enable_thinking": false}' for Qwen thinking control.
+    chat_template_kwargs: str | None = None
     kl_penalty_coef: float = 0.0
-    max_concurrent_generation: int = -1
-    max_concurrent_scoring: int = -1
+    max_concurrent_rollouts: int = 32
 
     # logging configuration
     eval_every: int = 0
@@ -60,7 +65,7 @@ class CLIConfig:
     max_steps: int | None = None
 
 
-async def cli_main(cli_config: CLIConfig, env: Any | None):
+async def cli_main(cli_config: CLIConfig, env: vf.Env | None):
     model_name_short = cli_config.model_name.replace("/", "-")
     date_and_time = datetime.now().strftime("%Y-%m-%d-%H-%M")
     run_name = (
@@ -72,62 +77,54 @@ async def cli_main(cli_config: CLIConfig, env: Any | None):
     cli_utils.check_log_dir(log_path, behavior_if_exists=cli_config.behavior_if_log_dir_exists)
 
     env_args = json.loads(cli_config.vf_env_args) if cli_config.vf_env_args else {}
+    sampling_extra = (
+        {"chat_template_kwargs": json.loads(cli_config.chat_template_kwargs)}
+        if cli_config.chat_template_kwargs
+        else {}
+    )
+    vf_env = env or get_vf_env()
+    if vf_env is None:
+        vf_env = load_vf_env(cli_config.vf_env_id, env_args)
+    set_vf_env(vf_env)
 
-    shared_client: TinkerAsyncOpenAIClient | None = None
-    shared_renderer: renderers.Renderer | None = None
-    local_tokenizer: Tokenizer | None = None
+    generate_server = TinkerGenerateServer()
+    # Bounds concurrent episodes across the whole batch (each live episode is a
+    # harness program plus a sampling stream).
+    rollout_semaphore = asyncio.Semaphore(cli_config.max_concurrent_rollouts)
 
-    async def custom_do_group_rollout(
+    async def verifiers_do_group_rollout(
         builder: EnvGroupBuilder,
         policy: TokenCompleter,
         strategy: RolloutStrategy | None = None,
+        termination: TerminationRewardPolicy | None = None,
     ) -> TrajectoryGroup:
-        # `strategy` is accepted for signature compatibility but unused: the
-        # verifiers environment runs and scores the whole group itself.
-        del strategy
-        nonlocal shared_client, shared_renderer, local_tokenizer
-
-        # initialize tokenizer and renderer lazily
-        if local_tokenizer is None:
-            local_tokenizer = get_tokenizer(cli_config.model_name)
-        if shared_renderer is None:
-            renderer_name = cli_config.renderer_name or model_info.get_recommended_renderer_name(
-                cli_config.model_name
-            )
-            shared_renderer = renderers.get_renderer(renderer_name, local_tokenizer)
-
-        sampling_client = cast(TinkerTokenCompleter, policy).sampling_client
-        if shared_client is None:
-            shared_client = TinkerAsyncOpenAIClient(
-                sampling_client, shared_renderer, local_tokenizer
-            )
-        else:
-            shared_client.set_sampling_client(sampling_client)
-
-        vf_builder = cast(VerifiersEnvGroupBuilder, builder)
-        rollout_inputs = vf_builder.get_rollout_inputs(cli_config.group_size)
-
-        gen_sem = await maybe_semaphore(cli_config.max_concurrent_generation)
-        score_sem = await maybe_semaphore(cli_config.max_concurrent_scoring)
-
-        states = await vf_builder.vf_env.run_group(
-            group_inputs=rollout_inputs,
-            client=shared_client,
-            model="tinker",
-            gen_sampling_args={
-                "max_tokens": cli_config.max_tokens,
-                "temperature": cli_config.temperature,
-            },
-            gen_sem=gen_sem,
-            score_sem=score_sem,
+        # `strategy` and `termination` are accepted for signature compatibility
+        # but unused: the verifiers environment runs and scores each episode
+        # itself.
+        del strategy, termination
+        generate_server.set_sampling_client(cast(TinkerTokenCompleter, policy).sampling_client)
+        ctx = vf.ModelContext(
+            model=cli_config.model_name,
+            client=generate_server.train_client_config(cli_config.model_name),
+            sampling=vf.SamplingConfig.model_validate(
+                {
+                    "max_tokens": cli_config.max_tokens,
+                    "temperature": cli_config.temperature,
+                    **sampling_extra,
+                }
+            ),
         )
-
-        return convert_states_to_trajectory_group(states)
+        vf_builder = cast(VerifiersEnvGroupBuilder, builder)
+        slots = vf_builder.vf_env.slots(vf_builder.task, cli_config.group_size)
+        episodes = await asyncio.gather(
+            *(vf_builder.vf_env.run_slot(slot, ctx, rollout_semaphore) for slot in slots)
+        )
+        return convert_episodes_to_trajectory_group(episodes)
 
     # Override do_group_rollout in the rollouts module, where the rollout
     # pipeline resolves it. (Rebinding the name re-exported on rl.train has
     # no effect on calls made inside tinker_cookbook.rl.rollouts.)
-    rollouts.do_group_rollout = custom_do_group_rollout
+    rollouts.do_group_rollout = verifiers_do_group_rollout
 
     dataset_builder = VerifiersRLDatasetBuilder(
         vf_env_id=cli_config.vf_env_id,
@@ -157,7 +154,8 @@ async def cli_main(cli_config: CLIConfig, env: Any | None):
         max_steps=cli_config.max_steps,
     )
 
-    await train.main(config)
+    async with generate_server, vf_env.serving():
+        await train.main(config)
 
 
 if __name__ == "__main__":

--- a/tinker_cookbook/recipes/verifiers_rl/train.py
+++ b/tinker_cookbook/recipes/verifiers_rl/train.py
@@ -48,7 +48,8 @@ class CLIConfig:
     learning_rate: float = 1e-5
     max_tokens: int = 512
     temperature: float = 1.0
-    # JSON chat-template kwargs threaded to the tml renderer that tokenizes
+    # JSON chat-template kwargs passed through verifiers' train client to the
+    # `renderers` chat template that tokenizes
     # each turn, e.g. '{"enable_thinking": false}' for Qwen thinking control.
     chat_template_kwargs: str | None = None
     kl_penalty_coef: float = 0.0

--- a/tinker_cookbook/recipes/verifiers_rl/verifiers_env.py
+++ b/tinker_cookbook/recipes/verifiers_rl/verifiers_env.py
@@ -73,10 +73,14 @@ def _trace_metrics(trace: vf.Trace, failed: bool = False) -> Metrics:
 def _episode_to_trajectory(episode: vf.Episode) -> tuple[Trajectory, float, Metrics]:
     """One episode -> (trajectory, final reward, metrics).
 
-    A failed episode (no trace, or a trace with no sampled tokens) becomes an
-    empty trajectory with a one-hot ``rollout_failed`` metric: it contributes
-    no training tokens but stays in the group, so reward centering sees the
-    failure instead of the group silently shrinking.
+    A failed episode (not ``ok``, no trace, a trace that is not ``ok``, or a
+    trace with no sampled tokens) becomes an empty trajectory with a one-hot
+    ``rollout_failed`` metric: it contributes no training tokens but stays in
+    the group, so reward centering sees the failure instead of the group
+    silently shrinking. Standing this recipe cannot train (a non-trainable
+    agent, or a trace whose only branches are non-trainable) is rejected rather
+    than skipped, for the same reason; a non-trainable branch beside the real
+    path is excluded, as verifiers intends.
     """
     failed = Trajectory(
         transitions=[
@@ -97,14 +101,30 @@ def _episode_to_trajectory(episode: vf.Episode) -> tuple[Trajectory, float, Metr
             "single-agent verifiers environments (one trace per episode)"
         )
     trace = episode.traces[0]
-    branches = trace.branches
+    if not trace.agent.trainable:
+        raise ValueError(
+            f"trace from agent {trace.agent.name!r} is not trainable; this recipe trains "
+            "single-agent verifiers environments whose one agent is the policy"
+        )
+    if not episode.ok or not trace.ok:
+        return failed, trace.reward, _trace_metrics(trace, failed=True)
+    # verifiers marks a rejected compaction attempt (a leaf the harness never
+    # resumed from) as a non-trainable branch since #2521 (after 0.3.1); earlier
+    # releases have no compaction, so every branch there is trainable.
+    branches = [b for b in trace.branches if getattr(b, "trainable", True)]
     if len(branches) > 1:
         raise ValueError(
-            f"trace has {len(branches)} branches; this recipe trains linear rollouts "
-            "(one root-to-leaf path per trace)"
+            f"trace has {len(branches)} trainable branches; this recipe trains linear "
+            "rollouts (one root-to-leaf path per trace)"
         )
     if not branches:
+        if trace.branches:
+            raise ValueError(
+                "trace's only branches are compaction attempts the harness never resumed "
+                "from; verifiers marks them non-trainable and this recipe cannot train them"
+            )
         return failed, trace.reward, _trace_metrics(trace, failed=True)
+    branch = branches[0]
 
     # Walk the branch: every sampled node is one action, and its observation is
     # the full token context before it (previous nodes plus the node's own
@@ -112,7 +132,7 @@ def _episode_to_trajectory(episode: vf.Episode) -> tuple[Trajectory, float, Metr
     # other by prefix, which trajectory_to_data merges into a single datum.
     spans: list[tuple[list[int], list[int], list[float]]] = []
     context: list[int] = []
-    for node in branches[0].nodes:
+    for node in branch.nodes:
         num_sampled = sum(node.mask)
         if not node.sampled or num_sampled == 0:
             context.extend(node.token_ids)
@@ -122,10 +142,14 @@ def _episode_to_trajectory(episode: vf.Episode) -> tuple[Trajectory, float, Metr
                 "sampled tokens are not a suffix of the assistant node; cannot map "
                 "this trace onto (observation, action) transitions"
             )
+        if len(node.logprobs) != num_sampled:
+            raise ValueError(
+                f"assistant node carries {len(node.logprobs)} logprobs for {num_sampled} "
+                "sampled tokens; the generate endpoint must return one logprob per token"
+            )
         scaffold = node.token_ids[: len(node.token_ids) - num_sampled]
         sampled = node.token_ids[len(node.token_ids) - num_sampled :]
-        logprobs = list(node.logprobs) if node.logprobs else [0.0] * num_sampled
-        spans.append((context + scaffold, sampled, logprobs))
+        spans.append((context + scaffold, sampled, list(node.logprobs)))
         context.extend(node.token_ids)
 
     if not spans:

--- a/tinker_cookbook/recipes/verifiers_rl/verifiers_env.py
+++ b/tinker_cookbook/recipes/verifiers_rl/verifiers_env.py
@@ -1,3 +1,12 @@
+"""Bridge between the verifiers v1 stack and the tinker RL data model.
+
+An environment is a ``vf.Env`` (taskset + agents + episode shape). One tinker
+group = one ``vf.Task`` rolled out ``group_size`` times, each rollout a
+``vf.Episode`` whose single agent trace carries the sampled token IDs and
+logprobs on its message graph. ``convert_episodes_to_trajectory_group`` turns
+those into a ``TrajectoryGroup``.
+"""
+
 from __future__ import annotations
 
 from collections.abc import Sequence
@@ -5,11 +14,12 @@ from contextvars import ContextVar
 
 import chz
 import tinker
-import verifiers as vf
+import verifiers.v1 as vf
 
 from tinker_cookbook.completers import TokensWithLogprobs
 from tinker_cookbook.rl.types import (
     EnvGroupBuilder,
+    Metrics,
     RLDataset,
     RLDatasetBuilder,
     Trajectory,
@@ -17,59 +27,132 @@ from tinker_cookbook.rl.types import (
     Transition,
 )
 
-_vf_env_ctx: ContextVar[vf.Environment | None] = ContextVar("vf_env", default=None)
+_vf_env_ctx: ContextVar[vf.Env | None] = ContextVar("vf_env", default=None)
 
 
-def set_vf_env(env: vf.Environment) -> None:
+def set_vf_env(env: vf.Env) -> None:
     """Set the verifiers environment for the current context."""
     _vf_env_ctx.set(env)
 
 
-def get_vf_env() -> vf.Environment | None:
+def get_vf_env() -> vf.Env | None:
     """Get the verifiers environment from the current context."""
     return _vf_env_ctx.get()
 
 
-def convert_states_to_trajectory_group(states: list[vf.State]) -> TrajectoryGroup:
-    """Convert verifiers States to tinker TrajectoryGroup."""
+def _deep_merge(base: dict, override: dict) -> dict:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_vf_env(vf_env_id: str, vf_env_args: dict | None = None) -> vf.Env:
+    """Load a verifiers environment for the installed taskset ``vf_env_id``.
+
+    ``vf_env_args`` is raw ``vf.EnvConfig`` data merged over the taskset id —
+    e.g. ``{"agent": {"harness": {"id": "null"}}}`` to run a plain chat agent,
+    or ``{"taskset": {"task": {...}}}`` for per-task config.
+    """
+    raw = _deep_merge({"taskset": {"id": vf_env_id}}, vf_env_args or {})
+    return vf.load_environment(vf.resolve_env_config(raw))
+
+
+def _trace_metrics(trace: vf.Trace, failed: bool = False) -> Metrics:
+    metrics: Metrics = {
+        name: float(value) for name, value in trace.metrics.items() if value is not None
+    }
+    if failed:
+        metrics["rollout_failed"] = 1.0
+    return metrics
+
+
+def _episode_to_trajectory(episode: vf.Episode) -> tuple[Trajectory, float, Metrics]:
+    """One episode -> (trajectory, final reward, metrics).
+
+    A failed episode (no trace, or a trace with no sampled tokens) becomes an
+    empty trajectory with a one-hot ``rollout_failed`` metric: it contributes
+    no training tokens but stays in the group, so reward centering sees the
+    failure instead of the group silently shrinking.
+    """
+    failed = Trajectory(
+        transitions=[
+            Transition(
+                ob=tinker.ModelInput.empty(),
+                ac=TokensWithLogprobs(tokens=[], maybe_logprobs=[]),
+                reward=0.0,
+                episode_done=True,
+            )
+        ],
+        final_ob=tinker.ModelInput.empty(),
+    )
+    if not episode.traces:
+        return failed, 0.0, {"rollout_failed": 1.0}
+    if len(episode.traces) > 1:
+        raise ValueError(
+            f"episode carries {len(episode.traces)} agent traces; this recipe trains "
+            "single-agent verifiers environments (one trace per episode)"
+        )
+    trace = episode.traces[0]
+    branches = trace.branches
+    if len(branches) > 1:
+        raise ValueError(
+            f"trace has {len(branches)} branches; this recipe trains linear rollouts "
+            "(one root-to-leaf path per trace)"
+        )
+    if not branches:
+        return failed, trace.reward, _trace_metrics(trace, failed=True)
+
+    # Walk the branch: every sampled node is one action, and its observation is
+    # the full token context before it (previous nodes plus the node's own
+    # unsampled generation-prompt scaffold). Observations therefore extend each
+    # other by prefix, which trajectory_to_data merges into a single datum.
+    spans: list[tuple[list[int], list[int], list[float]]] = []
+    context: list[int] = []
+    for node in branches[0].nodes:
+        num_sampled = sum(node.mask)
+        if not node.sampled or num_sampled == 0:
+            context.extend(node.token_ids)
+            continue
+        if not all(node.mask[len(node.mask) - num_sampled :]):
+            raise ValueError(
+                "sampled tokens are not a suffix of the assistant node; cannot map "
+                "this trace onto (observation, action) transitions"
+            )
+        scaffold = node.token_ids[: len(node.token_ids) - num_sampled]
+        sampled = node.token_ids[len(node.token_ids) - num_sampled :]
+        logprobs = list(node.logprobs) if node.logprobs else [0.0] * num_sampled
+        spans.append((context + scaffold, sampled, logprobs))
+        context.extend(node.token_ids)
+
+    if not spans:
+        return failed, trace.reward, _trace_metrics(trace, failed=True)
+    transitions = [
+        Transition(
+            ob=tinker.ModelInput.from_ints(observation),
+            ac=TokensWithLogprobs(tokens=action, maybe_logprobs=logprobs),
+            reward=0.0,
+            episode_done=index == len(spans) - 1,
+        )
+        for index, (observation, action, logprobs) in enumerate(spans)
+    ]
+    trajectory = Trajectory(transitions=transitions, final_ob=tinker.ModelInput.from_ints(context))
+    return trajectory, trace.reward, _trace_metrics(trace)
+
+
+def convert_episodes_to_trajectory_group(episodes: Sequence[vf.Episode]) -> TrajectoryGroup:
+    """Convert one group's episodes into a tinker TrajectoryGroup."""
     trajectories_G: list[Trajectory] = []
     final_rewards_G: list[float] = []
-    metrics_G: list[dict[str, float | int]] = []
-
-    for state in states:
-        transitions: list[Transition] = []
-        trajectory_steps = state.get("trajectory", [])
-
-        for i, step in enumerate(trajectory_steps):
-            tokens_data = step.get("tokens")
-            if tokens_data is not None:
-                prompt_ids = tokens_data.get("prompt_ids", [])
-                ob = tinker.ModelInput.from_ints(prompt_ids)
-                completion_ids = tokens_data.get("completion_ids", [])
-                completion_logprobs = tokens_data.get("completion_logprobs", [])
-                ac = TokensWithLogprobs(
-                    tokens=completion_ids,
-                    maybe_logprobs=completion_logprobs,
-                )
-            else:
-                ob = tinker.ModelInput.empty()
-                ac = TokensWithLogprobs(tokens=[], maybe_logprobs=[])
-
-            is_last = i == len(trajectory_steps) - 1
-            transition = Transition(
-                ob=ob,
-                ac=ac,
-                reward=0.0,
-                episode_done=is_last,
-                metrics={},
-            )
-            transitions.append(transition)
-
-        trajectory = Trajectory(transitions=transitions, final_ob=tinker.ModelInput.empty())
+    metrics_G: list[Metrics] = []
+    for episode in episodes:
+        trajectory, reward, metrics = _episode_to_trajectory(episode)
         trajectories_G.append(trajectory)
-        final_rewards_G.append(state.get("reward") or 0.0)
-        metrics_G.append(state.get("metrics") or {})
-
+        final_rewards_G.append(reward)
+        metrics_G.append(metrics)
     return TrajectoryGroup(
         trajectories_G=trajectories_G,
         final_rewards_G=final_rewards_G,
@@ -78,36 +161,21 @@ def convert_states_to_trajectory_group(states: list[vf.State]) -> TrajectoryGrou
 
 
 class VerifiersRLDataset(RLDataset):
-    def __init__(
-        self,
-        rows: list[dict],
-        vf_env: vf.Environment,
-        groups_per_batch: int,
-    ):
-        self.rows = rows
+    def __init__(self, tasks: list[vf.Task], vf_env: vf.Env, groups_per_batch: int):
+        self.tasks = tasks
         self.vf_env = vf_env
         self.groups_per_batch = groups_per_batch
 
     def __len__(self) -> int:
-        return (len(self.rows) + self.groups_per_batch - 1) // self.groups_per_batch
+        return (len(self.tasks) + self.groups_per_batch - 1) // self.groups_per_batch
 
     def get_batch(self, index: int) -> Sequence[EnvGroupBuilder]:
         start = index * self.groups_per_batch
-        end = min(len(self.rows), start + self.groups_per_batch)
-        builders: list[EnvGroupBuilder] = []
-        for j in range(start, end):
-            row = self.rows[j]
-            builders.append(
-                VerifiersEnvGroupBuilder(
-                    vf_env=self.vf_env,
-                    prompt=row["prompt"],
-                    example_id=row["example_id"],
-                    task=row["task"],
-                    answer=row.get("answer", ""),
-                    info=row.get("info", {}),
-                )
-            )
-        return builders
+        end = min(len(self.tasks), start + self.groups_per_batch)
+        return [
+            VerifiersEnvGroupBuilder(vf_env=self.vf_env, task=self.tasks[j])
+            for j in range(start, end)
+        ]
 
 
 @chz.chz
@@ -121,86 +189,55 @@ class VerifiersRLDatasetBuilder(RLDatasetBuilder):
     async def __call__(self) -> tuple[RLDataset, RLDataset | None]:
         vf_env = get_vf_env()
         if vf_env is None:
-            vf_env = vf.load_environment(self.vf_env_id, **self.vf_env_args)
+            vf_env = load_vf_env(self.vf_env_id, self.vf_env_args)
             set_vf_env(vf_env)
-        ds = vf_env.get_dataset(n=self.dataset_n, seed=self.dataset_seed)
-        rows = [
-            {
-                "prompt": ds["prompt"][i],
-                "example_id": ds["example_id"][i],
-                "task": ds["task"][i],
-                **({"answer": ds["answer"][i]} if "answer" in ds.column_names else {}),
-                **({"info": ds["info"][i]} if "info" in ds.column_names else {}),
-            }
-            for i in range(len(ds))
-        ]
-        return VerifiersRLDataset(rows, vf_env, self.groups_per_batch), None
+        taskset = vf_env.taskset
+        if self.dataset_n >= 0:
+            taskset = taskset.head(self.dataset_n)
+        elif taskset.INFINITE:
+            raise ValueError(f"taskset {self.vf_env_id!r} is infinite; bound it with dataset_n")
+        if self.dataset_seed is not None:
+            taskset = taskset.shuffle(self.dataset_seed)
+        tasks = list(taskset)
+        return VerifiersRLDataset(tasks, vf_env, self.groups_per_batch), None
 
 
 class VerifiersEnvGroupBuilder(EnvGroupBuilder):
-    """EnvGroupBuilder for the verifiers library integration.
+    """EnvGroupBuilder for the verifiers integration: one task, rolled out
+    ``group_size`` times by ``train.py``'s group rollout override.
 
-    Pickle support: ``vf.Environment`` is not pickleable. On deserialization,
-    it is recovered from the ``_vf_env_ctx`` context variable (set via
-    ``set_vf_env()``). Raises ``RuntimeError`` if the context variable is not
-    set — this is expected in cross-process scenarios since the verifiers
-    integration currently requires single-process execution (the
-    ``custom_do_group_rollout`` in train.py is a closure over shared state).
+    Pickle support: ``vf.Env`` holds live serving resources and is not
+    pickleable. On deserialization it is recovered from the ``_vf_env_ctx``
+    context variable (set via ``set_vf_env()``). Raises ``RuntimeError`` if the
+    context variable is not set — expected in cross-process scenarios, since
+    this integration requires single-process execution (the group rollout
+    override in train.py is a closure over shared state).
     """
 
-    def __init__(
-        self,
-        vf_env: vf.Environment,
-        prompt: vf.Messages,
-        example_id: int,
-        task: str,
-        answer: str = "",
-        info: dict | None = None,
-    ):
+    def __init__(self, vf_env: vf.Env, task: vf.Task):
         self.vf_env = vf_env
-        self.prompt = prompt
-        self.example_id = example_id
         self.task = task
-        self.answer = answer
-        self.info = info or {}
 
     def __getstate__(self) -> dict:
-        """Exclude non-pickleable vf.Environment from pickle state."""
         state = self.__dict__.copy()
         state["vf_env"] = None
         return state
 
     def __setstate__(self, state: dict) -> None:
-        """Restore vf.Environment from the context variable on unpickle."""
         vf_env = state.pop("vf_env", None) or get_vf_env()
         if vf_env is None:
             raise RuntimeError(
-                "VerifiersEnvGroupBuilder unpickled without a vf.Environment. "
-                "In cross-process scenarios (ProcessPoolExecutor, Ray), the worker "
-                "process must call set_vf_env(vf.load_environment(...)) before "
-                "unpickling builders. See verifiers_rl/train.py for reference."
+                "VerifiersEnvGroupBuilder unpickled without a vf.Env. In cross-process "
+                "scenarios (ProcessPoolExecutor, Ray), the worker process must call "
+                "set_vf_env(load_vf_env(...)) before unpickling builders. See "
+                "verifiers_rl/train.py for reference."
             )
         self.vf_env = vf_env
-        self.prompt = state["prompt"]
-        self.example_id = state["example_id"]
         self.task = state["task"]
-        self.answer = state["answer"]
-        self.info = state["info"]
-
-    def get_rollout_inputs(self, group_size: int) -> list[vf.RolloutInput]:
-        return [
-            vf.RolloutInput(
-                prompt=self.prompt,
-                answer=self.answer,
-                task=self.task,
-                info=self.info,
-                example_id=self.example_id,
-            )
-            for _ in range(group_size)
-        ]
 
     async def make_envs(self):
-        return []  # unused when using custom_do_group_rollout
+        return []  # unused: train.py overrides the group rollout wholesale
 
     def logging_tags(self) -> list[str]:
-        return [self.task] if self.task else []
+        name = self.task.data.name
+        return [name] if name else []

--- a/tinker_cookbook/recipes/verifiers_rl/verifiers_env_test.py
+++ b/tinker_cookbook/recipes/verifiers_rl/verifiers_env_test.py
@@ -1,0 +1,195 @@
+"""Tests for the verifiers episode -> tinker trajectory conversion (no API calls)."""
+
+import pytest
+
+try:
+    import verifiers.v1 as _verifiers  # noqa: F401
+
+    _has_verifiers = True
+except ImportError:
+    _has_verifiers = False
+
+pytestmark = pytest.mark.skipif(not _has_verifiers, reason="verifiers not installed")
+
+
+def _user_node(token_ids: list[int], parent: int | None = None):
+    import verifiers.v1 as vf
+
+    return vf.MessageNode(
+        parent=parent,
+        message=vf.UserMessage(content="q"),
+        sampled=False,
+        token_ids=token_ids,
+        mask=[False] * len(token_ids),
+    )
+
+
+def _assistant_node(
+    parent: int,
+    scaffold: list[int],
+    sampled: list[int],
+    logprobs: list[float],
+):
+    import verifiers.v1 as vf
+
+    return vf.MessageNode(
+        parent=parent,
+        message=vf.AssistantMessage(content="a"),
+        sampled=True,
+        token_ids=scaffold + sampled,
+        mask=[False] * len(scaffold) + [True] * len(sampled),
+        logprobs=logprobs,
+    )
+
+
+def _episode(nodes, rewards=None, metrics=None):
+    import verifiers.v1 as vf
+
+    trace = vf.Trace(
+        task=vf.TraceTask(type="Task", data=vf.TaskData(idx=0)),
+        agent=vf.AgentInfo(config=vf.AgentConfig()),
+        nodes=nodes,
+        rewards=rewards or {},
+        metrics=metrics or {},
+        is_completed=True,
+        ok=True,
+    )
+    episode = vf.Episode(task=trace.task, traces=[trace], ok=True)
+    return episode
+
+
+class TestConvertEpisodesToTrajectoryGroup:
+    def test_single_turn_episode(self) -> None:
+        import verifiers.v1 as vf
+
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1, 2, 3]),
+                _assistant_node(parent=0, scaffold=[4, 5], sampled=[6, 7], logprobs=[-0.1, -0.2]),
+            ],
+            rewards={"correct": vf.Reward(score=1.0)},
+            metrics={"accuracy": 1.0, "unscored": None},
+        )
+        group = convert_episodes_to_trajectory_group([episode])
+
+        assert group.final_rewards_G == [1.0]
+        assert group.metrics_G == [{"accuracy": 1.0}]
+        [trajectory] = group.trajectories_G
+        [transition] = trajectory.transitions
+        # The observation is the full context: prompt plus the assistant
+        # node's unsampled generation-prompt scaffold.
+        assert transition.ob.to_ints() == [1, 2, 3, 4, 5]
+        assert transition.ac.tokens == [6, 7]
+        assert transition.ac.maybe_logprobs == [-0.1, -0.2]
+        assert transition.episode_done
+        assert trajectory.final_ob.to_ints() == [1, 2, 3, 4, 5, 6, 7]
+
+    def test_multi_turn_episode_extends_by_prefix(self) -> None:
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1, 2]),
+                _assistant_node(parent=0, scaffold=[3], sampled=[4, 5], logprobs=[-0.1, -0.2]),
+                _user_node([6, 7], parent=1),
+                _assistant_node(parent=2, scaffold=[8], sampled=[9], logprobs=[-0.3]),
+            ]
+        )
+        group = convert_episodes_to_trajectory_group([episode])
+
+        [trajectory] = group.trajectories_G
+        first, second = trajectory.transitions
+        assert first.ob.to_ints() == [1, 2, 3]
+        assert first.ac.tokens == [4, 5]
+        assert not first.episode_done
+        # The second observation extends the first observation+action, so
+        # trajectory_to_data can merge the turns into one datum.
+        assert second.ob.to_ints() == [1, 2, 3, 4, 5, 6, 7, 8]
+        assert second.ac.tokens == [9]
+        assert second.ac.maybe_logprobs == [-0.3]
+        assert second.episode_done
+
+    def test_weighted_rewards_sum(self) -> None:
+        import verifiers.v1 as vf
+
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2], logprobs=[-0.1]),
+            ],
+            rewards={
+                "correct": vf.Reward(score=1.0),
+                "style": vf.Reward(score=0.5, weight=0.2),
+                "unscored": None,
+            },
+        )
+        group = convert_episodes_to_trajectory_group([episode])
+        assert group.final_rewards_G == [pytest.approx(1.1)]
+
+    def test_failed_episode_stays_in_group(self) -> None:
+        """An episode that produced no trace trains on nothing but keeps its
+        group slot, so reward centering sees the failure."""
+        import verifiers.v1 as vf
+
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        ok = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2], logprobs=[-0.1]),
+            ],
+            rewards={"correct": vf.Reward(score=1.0)},
+        )
+        failed = vf.Episode(task=ok.task, traces=[], ok=False)
+        group = convert_episodes_to_trajectory_group([ok, failed])
+
+        assert group.final_rewards_G == [1.0, 0.0]
+        assert group.metrics_G[1] == {"rollout_failed": 1.0}
+        [transition] = group.trajectories_G[1].transitions
+        assert transition.ac.tokens == []
+        assert transition.episode_done
+
+    def test_multi_agent_episode_is_rejected(self) -> None:
+        import verifiers.v1 as vf
+
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(nodes=[_user_node([1])])
+        episode.traces.append(
+            vf.Trace(
+                task=episode.task,
+                agent=vf.AgentInfo(config=vf.AgentConfig(), name="judge"),
+            )
+        )
+        with pytest.raises(ValueError, match="single-agent"):
+            convert_episodes_to_trajectory_group([episode])
+
+    def test_branched_trace_is_rejected(self) -> None:
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        # Two assistant leaves off the same user root: two branches.
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2], logprobs=[-0.1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[3], logprobs=[-0.2]),
+            ]
+        )
+        with pytest.raises(ValueError, match="branches"):
+            convert_episodes_to_trajectory_group([episode])

--- a/tinker_cookbook/recipes/verifiers_rl/verifiers_env_test.py
+++ b/tinker_cookbook/recipes/verifiers_rl/verifiers_env_test.py
@@ -264,6 +264,39 @@ class TestConvertEpisodesToTrajectoryGroup:
         with pytest.raises(ValueError, match="logprobs"):
             convert_episodes_to_trajectory_group([episode])
 
+    def test_failed_slot_yields_no_datum_and_keeps_centering(self) -> None:
+        """Through the cookbook's own advantage and datum assembly: the failed
+        slot contributes no training datum, but its zero reward still centers
+        the successful slot's advantage."""
+        import verifiers.v1 as vf
+
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+        from tinker_cookbook.rl.data_processing import (
+            assemble_training_data,
+            compute_advantages,
+        )
+
+        ok = _episode(
+            nodes=[
+                _user_node([1, 2]),
+                _assistant_node(parent=0, scaffold=[3], sampled=[4, 5], logprobs=[-0.1, -0.2]),
+            ],
+            rewards={"correct": vf.Reward(score=1.0)},
+        )
+        failed = vf.Episode(task=ok.task, traces=[], ok=False)
+        group = convert_episodes_to_trajectory_group([ok, failed])
+        advantages = compute_advantages([group])
+        data, metadata = assemble_training_data([group], advantages)
+
+        assert advantages[0].tolist() == [pytest.approx(0.5), pytest.approx(-0.5)]
+        assert metadata == [{"group_idx": 0, "traj_idx": 0}]
+        [datum] = data
+        # The datum is the right-shifted input with left-shifted targets.
+        assert datum.model_input.to_ints() == [1, 2, 3, 4]
+        assert datum.loss_fn_inputs["target_tokens"].tolist() == [2, 3, 4, 5]
+
 
 def _branch_standing_available() -> bool:
     import verifiers.v1 as vf

--- a/tinker_cookbook/recipes/verifiers_rl/verifiers_env_test.py
+++ b/tinker_cookbook/recipes/verifiers_rl/verifiers_env_test.py
@@ -193,3 +193,133 @@ class TestConvertEpisodesToTrajectoryGroup:
         )
         with pytest.raises(ValueError, match="branches"):
             convert_episodes_to_trajectory_group([episode])
+
+    def test_errored_trace_is_failed(self) -> None:
+        """A trace that errored keeps its tokens on the graph but must not train."""
+        import verifiers.v1 as vf
+
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2], logprobs=[-0.1]),
+            ],
+            rewards={"correct": vf.Reward(score=0.0)},
+            metrics={"accuracy": 0.0},
+        )
+        episode.traces[0].ok = False
+        group = convert_episodes_to_trajectory_group([episode])
+
+        assert group.final_rewards_G == [0.0]
+        assert group.metrics_G == [{"accuracy": 0.0, "rollout_failed": 1.0}]
+        [transition] = group.trajectories_G[0].transitions
+        assert transition.ac.tokens == []
+
+    def test_failed_episode_standing_wins_over_ok_trace(self) -> None:
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2], logprobs=[-0.1]),
+            ]
+        )
+        episode.ok = False
+        group = convert_episodes_to_trajectory_group([episode])
+        assert group.metrics_G == [{"rollout_failed": 1.0}]
+        assert group.trajectories_G[0].transitions[0].ac.tokens == []
+
+    def test_non_trainable_agent_is_rejected(self) -> None:
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2], logprobs=[-0.1]),
+            ]
+        )
+        episode.traces[0].agent.trainable = False
+        with pytest.raises(ValueError, match="not trainable"):
+            convert_episodes_to_trajectory_group([episode])
+
+    def test_missing_logprobs_raise(self) -> None:
+        """The endpoint must return one logprob per sampled token; never invent them."""
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2, 3], logprobs=[]),
+            ]
+        )
+        with pytest.raises(ValueError, match="logprobs"):
+            convert_episodes_to_trajectory_group([episode])
+
+
+def _branch_standing_available() -> bool:
+    import verifiers.v1 as vf
+
+    return "trainable" in vf.Branch.model_fields
+
+
+@pytest.mark.skipif(
+    not _has_verifiers or not _branch_standing_available(),
+    reason="verifiers release without branch standing (pre-#2521)",
+)
+class TestNonTrainableBranches:
+    """A rejected compaction attempt is a dangling leaf verifiers marks non-trainable."""
+
+    @staticmethod
+    def _compaction_attempt(parent: int, sampled: list[int], logprobs: list[float]):
+        import verifiers.v1 as vf
+
+        node = _assistant_node(parent=parent, scaffold=[], sampled=sampled, logprobs=logprobs)
+        # Built from data so this file also type-checks against releases without
+        # semantic edges; the class is skipped there at runtime.
+        return vf.MessageNode.model_validate(
+            {
+                **node.model_dump(),
+                "semantic_parents": [{"node": parent, "type": "compaction_attempt"}],
+            }
+        )
+
+    def test_rejected_attempt_beside_real_path_is_excluded(self) -> None:
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                _assistant_node(parent=0, scaffold=[], sampled=[2], logprobs=[-0.1]),
+                self._compaction_attempt(parent=0, sampled=[9], logprobs=[-0.9]),
+            ]
+        )
+        assert [getattr(b, "trainable", None) for b in episode.traces[0].branches] == [True, False]
+        group = convert_episodes_to_trajectory_group([episode])
+        [transition] = group.trajectories_G[0].transitions
+        assert transition.ac.tokens == [2]
+
+    def test_only_rejected_attempts_is_rejected(self) -> None:
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            convert_episodes_to_trajectory_group,
+        )
+
+        episode = _episode(
+            nodes=[
+                _user_node([1]),
+                self._compaction_attempt(parent=0, sampled=[9], logprobs=[-0.9]),
+            ]
+        )
+        assert [getattr(b, "trainable", None) for b in episode.traces[0].branches] == [False]
+        with pytest.raises(ValueError, match="compaction"):
+            convert_episodes_to_trajectory_group([episode])

--- a/tinker_cookbook/recipes/verifiers_rl/verifiers_pickle_test.py
+++ b/tinker_cookbook/recipes/verifiers_rl/verifiers_pickle_test.py
@@ -1,9 +1,11 @@
 """Tests for picklability of VerifiersEnvGroupBuilder."""
 
+import pickle
+
 import pytest
 
 try:
-    import verifiers as _verifiers  # noqa: F401
+    import verifiers.v1 as _verifiers  # noqa: F401
 
     _has_verifiers = True
 except ImportError:
@@ -13,21 +15,40 @@ except ImportError:
 @pytest.mark.skipif(not _has_verifiers, reason="verifiers not installed")
 class TestVerifiersEnvGroupBuilderPickle:
     def test_pickle_excludes_vf_env(self) -> None:
-        """VerifiersEnvGroupBuilder excludes vf_env from pickle state."""
+        """VerifiersEnvGroupBuilder excludes the live vf.Env from pickle state."""
         from unittest.mock import MagicMock
+
+        import verifiers.v1 as vf
 
         from tinker_cookbook.recipes.verifiers_rl.verifiers_env import VerifiersEnvGroupBuilder
 
-        builder = VerifiersEnvGroupBuilder(
-            vf_env=MagicMock(),
-            prompt=[{"role": "user", "content": "What is 2+2?"}],
-            example_id=42,
-            task="arithmetic",
-            answer="4",
-        )
+        task = vf.Task(vf.TaskData(idx=42, name="arithmetic", prompt="What is 2+2?"))
+        builder = VerifiersEnvGroupBuilder(vf_env=MagicMock(), task=task)
         state = builder.__getstate__()
         assert state["vf_env"] is None
-        assert state["prompt"] == [{"role": "user", "content": "What is 2+2?"}]
-        assert state["example_id"] == 42
-        assert state["task"] == "arithmetic"
-        assert state["answer"] == "4"
+        assert state["task"].data.idx == 42
+        assert state["task"].data.prompt == "What is 2+2?"
+
+    def test_unpickle_recovers_env_from_context(self) -> None:
+        from unittest.mock import MagicMock
+
+        import verifiers.v1 as vf
+
+        from tinker_cookbook.recipes.verifiers_rl.verifiers_env import (
+            VerifiersEnvGroupBuilder,
+            set_vf_env,
+        )
+
+        task = vf.Task(vf.TaskData(idx=7, name="arithmetic"))
+        builder = VerifiersEnvGroupBuilder(vf_env=MagicMock(), task=task)
+        payload = pickle.dumps(builder)
+
+        context_env = MagicMock()
+        set_vf_env(context_env)
+        try:
+            restored = pickle.loads(payload)
+        finally:
+            set_vf_env(None)  # type: ignore[arg-type]
+        assert restored.vf_env is context_env
+        assert restored.task.data.idx == 7
+        assert restored.logging_tags() == ["arithmetic"]


### PR DESCRIPTION
## Summary

Rewrites `recipes/verifiers_rl` for the verifiers v1 stack (`verifiers>=0.3.1`). The legacy API the recipe used (`load_environment(**kwargs)`, `run_group`, `evaluate_sync`) is gone from verifiers main.

- The recipe serves Tinker sampling as a vLLM-style `/inference/v1/generate` endpoint (`tinker_generate.py`). verifiers' train client renders each turn to token ids with its `renderers` dependency, posts them, and gets sampled token ids and per-token logprobs back; harness programs, interception, scoring and trace bookkeeping are all verifiers running natively.
- Each rollout returns a `vf.Episode`; `verifiers_env.py` converts the single agent trace into a Tinker trajectory. A failed episode or trace stays in its group as an empty trajectory with a `rollout_failed` metric, so reward centering sees it. A sampled token without a logprob is an error, never a guess. Non-trainable branches (rejected compaction attempts, verifiers #2521) are excluded; a trace whose agent is not the policy is rejected.
- Scope: single-agent, linear (one trainable branch per trace), text-only. Multi-agent or branching envs, multimodal `features`, and sampling parameters the endpoint cannot honor are rejected explicitly with 400s or `ValueError`s rather than approximated.
- `vf_env_args` is raw `vf.EnvConfig` data merged over the taskset id, so agent harness and runtime pins (`{"agent": {"harness": {"id": "null"}, "runtime": {"type": "subprocess"}}}`) and per-task config flow through unchanged. The verifiers default runtime provisions Prime sandboxes; the README says so and shows the local pins.
- Dependency: `verifiers>=0.3.1` with no upper bound; `openai` unchanged. `tml-renderers` is not on this path.

Supersedes #831 (same recipe, written against verifiers 0.2.0; left open for the maintainers' disposition). Overlaps #709, which fixes the monkeypatch point of the legacy recipe this rewrite replaces.

## Validation

All model-free; nothing ran against Tinker.

- Unit tests in `recipes/verifiers_rl/*_test.py` against installed verifiers 0.3.1 (19 passed, 2 skipped: the branch-standing tests need a field added after 0.3.1) and against verifiers main `04b0bf55` (21 passed).
- An offline fixture ran the real path on both versions: `vf.load_environment` of a local four-task addition taskset, the real `null` harness in the `subprocess` runtime, verifiers' train client rendering with `renderers` against a cached Qwen tokenizer, this server over a fake `sample_async` returning fixed token ids and logprobs, two `run_slot` episodes, then the converter, `compute_advantages` and `assemble_training_data`. Both episodes ok; rewards `{1.0, 0.0}` from the taskset's own reward; advantages `{+0.5, -0.5}`; each datum is the rendered prompt (byte-equal to what the fake received) plus the fake's tokens, with the fake's logprobs.
- `ruff check`, `ruff format --check`, `pyright` on the recipe: clean on both versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
